### PR TITLE
TParameterModule::init() bug when using cache

### DIFF
--- a/framework/Util/TParameterModule.php
+++ b/framework/Util/TParameterModule.php
@@ -69,9 +69,9 @@ class TParameterModule extends TModule
 				$cacheKey='TParameterModule:'.$this->_paramFile;
 				if(($configFile=$cache->get($cacheKey))===false)
 				{
-					$cacheFile=new TXmlDocument;
-					$cacheFile->loadFromFile($this->_paramFile);
-					$cache->set($cacheKey,$cacheFile,0,new TFileCacheDependency($this->_paramFile));
+					$configFile=new TXmlDocument;
+					$configFile->loadFromFile($this->_paramFile);
+					$cache->set($cacheKey,$configFile,0,new TFileCacheDependency($this->_paramFile));
 				}
 			}
 			else


### PR DESCRIPTION
TParameterModule init() does not load the parameters to the application when the cache is empty ( for example it was restarted or emptied) just saves the loaded values into the cache.
The values is loaded into the $cacheFile variable, but the code later processes the $configFile variable ( this->loadParameters($configFile); ) what is obviously empty.
The second call was ok, as the values comes from the cache.
