### PR TITLE
Fix: do json_decode before decoding UTF8 to globalisations charset

### DIFF
--- a/framework/Web/UI/ActiveControls/TActivePageAdapter.php
+++ b/framework/Web/UI/ActiveControls/TActivePageAdapter.php
@@ -294,7 +294,7 @@ class TActivePageAdapter extends TControlAdapter
 	}
 
 	/**
-	 * Gets callback parameter. JSON encoding is assumed.
+	 * Gets callback parameter. 
 	 * @return string postback event parameter
 	 */
 	public function getCallbackEventParameter()
@@ -302,8 +302,7 @@ class TActivePageAdapter extends TControlAdapter
 		if($this->_callbackEventParameter===null)
 		{
 			$param = $this->getRequest()->itemAt(TPage::FIELD_CALLBACK_PARAMETER);
-			if(strlen($param) > 0)
-				$this->_callbackEventParameter=TJavaScript::jsonDecode((string)$param);
+			$this->_callbackEventParameter=$param;
 		}
 		return $this->_callbackEventParameter;
 	}

--- a/framework/Web/UI/TPage.php
+++ b/framework/Web/UI/TPage.php
@@ -302,6 +302,10 @@ class TPage extends TTemplateControl
 
 		$this->setAdapter(new TActivePageAdapter($this));
 
+        $callbackEventParameter = $this->getRequest()->itemAt(TPage::FIELD_CALLBACK_PARAMETER);
+        if(strlen($callbackEventParameter) > 0)
+            $this->_postData[TPage::FIELD_CALLBACK_PARAMETER]=TJavaScript::jsonDecode((string)$callbackEventParameter);
+
         // Decode Callback postData from UTF-8 to current Charset
         if (($g=$this->getApplication()->getGlobalization(false))!==null &&
             strtoupper($enc=$g->getCharset())!='UTF-8')


### PR DESCRIPTION
This fixes incorrect decoding of json responses from callback requests. 

Without this change prado cannot decode json data from controls like TActiveDropDownList when using a charset different from utf-8 with Prados globalisation.

(Fixes #492)
