### PR TITLE
Fix for tab control removing all extra css classes from tabs

### DIFF
--- a/framework/Web/Javascripts/source/prado/controls/tabpanel.js
+++ b/framework/Web/Javascripts/source/prado/controls/tabpanel.js
@@ -25,10 +25,10 @@ Prado.WebUI.TTabPanel = jQuery.klass(Prado.WebUI.Control,
 				if (view)
 					if(this.hiddenField.value == i)
 					{
-						element.className=this.activeCssClass;
+						jQuery(element).addClass(this.activeCssClass).removeClass(this.normalCssClass);
 						jQuery(view).show();
 					} else {
-						element.className=this.normalCssClass;
+						jQuery(element).addClass(this.normalCssClass).removeClass(this.activeCssClass);
 						jQuery(view).hide();
 					}
 			}


### PR DESCRIPTION
TTabControl's client-side wrapper has previously wiped out all extra
classes from tab views. Behaviour changed to reflect that of the
elementClicked()'s.
