### PR TITLE
reset the condition when empty

### DIFF
--- a/framework/Data/DataGateway/TSqlCriteria.php
+++ b/framework/Data/DataGateway/TSqlCriteria.php
@@ -128,7 +128,7 @@ class TSqlCriteria extends TComponent
 	{
 		if(empty($value)) {
 			// reset the condition
-			$this->_condition = '';
+			$this->_condition = null;
 			return;
 		}
 


### PR DESCRIPTION
According to the issu 549, there are an error in the new commit. It must not be

if(empty($value)) {
// reset the condition
$this->_condition = '';
return;
}

but:

if(empty($value)) {
// reset the condition
$this->_condition = null;
return;
}