### PR TITLE
Remove fatal error on autoload fail

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,21 +1,22 @@
 Version 3.3.1 XXX XX, 2016
 
+BUG: Issue #540 - Fix TActiveFileUpload on IE11 (ctrlaltca)
+BUG: Issue #574 - Fix TActiveCustomValidator validation after error (ctrlaltca)
+BUG: Issue #582 - Prado autoloader breaks class_exists conditionals (ctrlaltca)
 BUG: TJuiAutoComplete: fix parsing of suggestions (ctrlaltca)
 BUG: Fix callback for controls with PostState=false (ctrlaltca)
 BUG: Fix stopping even propagation on javascript events (ctrlaltca)
-BUG: Issue #574 - Fix TActiveCustomValidator validation after error (ctrlaltca)
 BUG: Fix callback loading for dynamically created JuiControls (ctrlaltca)
 BUG: Fix ClientSide.RequestTimeOut on active controls (ctrlaltca)
 BUG: Fix error reporting for not-existing property set on TJuiControl (ctrlaltca)
 BUG: TJuiDialog: avoid "cannot call methods on dialog prior to initialization" error (ctrlaltca)
-BUG: Issue #540 - Fix TActiveFileUpload on IE11 (ctrlaltca)
+BUG: Fix callback update of TActiveCheckBoxList when initially empty (LCSKJ)
+ENH: Issue #562 - Added TClientStyleSheet::PradoStyles (ctrlaltca)
 ENH: Issue #569 - Improved TJavascriptLogger / browser console logging of errors (ctrlaltca)
 ENH: Applied some misc optimizations to class serialization (ctrlaltca)
 ENH: Intercept fatal errors using register_shutdown_function (ctrlaltca)
 ENH: Activecontrols: avoid updating client side if the value didn't change (ctrlaltca)
 ENH: Added TReCaptcha2 / TReCaptcha2Validator (camilohaze)
-BUG: Fix callback update of TActiveCheckBoxList when initially empty (LCSKJ)
-ENH: Issue #562 - Added TClientStyleSheet::PradoStyles (ctrlaltca)
 
 Version 3.3.0 February 15, 2016
 

--- a/framework/PradoBase.php
+++ b/framework/PradoBase.php
@@ -105,8 +105,6 @@ class PradoBase
 	public static function autoload($className)
 	{
 		include_once($className.self::CLASS_FILE_EXT);
-		if(!class_exists($className,false) && !interface_exists($className,false))
-			self::fatalError("Class file for '$className' cannot be found.");
 	}
 
 	/**


### PR DESCRIPTION
Prado emits a fatal error when its autoloader fails to load a class.
This is a pain when using 3rd party libraries that implements their own autoloader, since Prado breaks the autoloading chain avoiding other libraries from autoloading their classes.
Also, any code using class_exists() without setting to false the “autoload” parameter is prone to cause fatal error.

Now that Prado registers a shutdown function, it’s able to handle this situation without the need of a fatal error, so just remove it.

Fix #582
