### PR TITLE
Serialize all inputs to catch inputs outside <form>

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,8 +1,10 @@
 Version 3.3.2 xxx, 2016
 
 BUG: Issue #592 - Fix TActiveMultiView brokwn on 3.3.1 (ctrlaltca)
-ENH: Issue #591 Support for hyphenated attributes via <prop:*></prop:*> template syntax (emkael)
+BUG: Issue #588 - Fix reading values of controls inside TJuiDialog (ctrlaltca)
+ENH: Issue #591 - Support for hyphenated attributes via <prop:*></prop:*> template syntax (emkael)
 ENH: Allow TStyle behaviors (LCSKJ)
+
 
 Version 3.3.1 April 19, 2016
 

--- a/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
@@ -298,7 +298,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		if(this.options.PostInputs != false)
 		{
 			var form = this.getForm();
-			return jQuery(form).serialize() + '&' + jQuery.param(data);
+			return jQuery('input, select, textarea').serialize() + '&' + jQuery.param(data);
 		} else {
 			var pagestate = jQuery("#"+Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE);
 			if(pagestate)


### PR DESCRIPTION
Prado currently uses jQuery's [serialize](https://api.jquery.com/serialize/) function on the <form> object to collect <input> values and send them to php on postbacks and callbacks.

We recently introduced [TJuiDialog](http://www.pradoframework.net/demos/quickstart/?page=JuiControls.Widgets#TJuiDialog) based on jQueryUI's dialog control. To avoid positioning problems, the control removes it contents from the document and appends them back as a direct child of <body>.

Here it comes bug #588: any control inside TJuiDialog is no more child of the <form>, so its value won't be sent to php anymore. The simplest fixes are:
 1. force the TJuiDialog back inside the form (possibly risky as it could break the layout);
 2. serialize any input on the page even if it's not inside the <form> (breaks multi-form per page, that we didn't support anyway).

This PR implements the second concept, and is currently being used successfully by @szroma.
If you have any comment before this gets merged, you are welcomed to comment here.