### PR TITLE
Fix #638

### DIFF
--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -446,11 +446,14 @@ Prado.Element =
 
 	focus : function(element)
 	{
-		jQuery(document).ajaxStop(function () {
+		if(jQuery.active > 0)
+		{
 			setTimeout(function(){
 				jQuery("#"+element).focus();
 			}, 100);
-		});
+		} else {			
+			jQuery("#"+element).focus();
+		}
 	},
 
 	/**


### PR DESCRIPTION
When a validator with `FocusOnError=true` triggers, don’t call `Prado.Element.focus()` on the element but just focus it.
Currently the `Prado.Element.focus()` only works on ajax callbacks and it will probably need some rework.