### PR TITLE
Fix validators on some subclasses; Fix #683

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,8 @@
 ## Version 4.x - in development
 
-BUG: Issue #669 - Wrong Gettext class filename (Marcin Haba / gani)
+BUG: Issue #669 - Wrong Gettext class filename (gani)
 BUG: Issue #675 - TDatePicker position problems with jQuery 3.3 (ctrlaltca)
+BUG: Issue #683 - TRequiredFieldValidator doesn't work with TActiveListBox (gani, ctrlaltca)
 
 ## Version 4.0.1 - Apr 1, 2018
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,10 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
 
+Upgrading from v4.0.1
+---------------------
+- List controls (eg. TDropDownList) now renders empty PromptValues. Before, they would use PromptText in order to fill PromptValue when empty or not specified.
+
 Upgrading from v4.0.0
 ---------------------
 - Prado 4.0.1 requires Php >= 5.4.0

--- a/framework/Web/Javascripts/source/prado/validator/validation3.js
+++ b/framework/Web/Javascripts/source/prado/validator/validation3.js
@@ -1172,9 +1172,11 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 getRawValidationValue : function(control)
 	 {
 	 	if(!control)
-	 		control = this.control
+	 		control = this.control;
 	 	switch(this.options.ControlType)
 	 	{
+			case 'TCheckBox':
+				return control.checked;
 	 		case 'TDatePicker':
 	 			if(control.type == "text")
 	 			{
@@ -1199,18 +1201,15 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 			if(typeof tinyMCE != "undefined")
 					tinyMCE.triggerSave();
 				return control.value;
+			case 'TCheckBoxList':
+			case 'TListBox':
+ 				return this.getFirstSelectedListValue();
 			case 'TRadioButton':
-			case 'TActiveRadioButton':
 				if(this.options.GroupName)
 					return this.getRadioButtonGroupValue();
-			case 'TCheckBox':
-			case 'TActiveCheckBox':
-				return control.checked;
-	 		default:
-	 			if(this.isListControlType())
-	 				return this.getFirstSelectedListValue();
-	 			else
-		 			return jQuery(control).val();
+			case 'TReCaptcha2':
+ 			default:
+	 			return jQuery(control).val();
 	 	}
 	 },
 
@@ -1226,26 +1225,21 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 {
 	 	var value = this.getRawValidationValue(control);
 		if(!control)
-			control = this.control
+			control = this.control;
 		switch(this.options.ControlType)
 		{
-			case 'TDatePicker':
-				return value;
-			case 'THtmlArea':
-			case 'THtmlArea4':
-				return this.trim(value);
-			case 'TRadioButton':
 			case 'TCheckBox':
-			case 'TActiveCheckBox':
-			case 'TActiveRadioButton':
+			case 'TCheckBoxList':
+			case 'TDatePicker':
+			case 'TListBox':
+			case 'TRadioButton':
 				return value;
             case 'TReCaptcha2':
                 return document.getElementById(this.options.ResponseFieldName).value;
+			case 'THtmlArea':
+			case 'THtmlArea4':
 			default:
-				if(this.isListControlType())
-					return value;
-				else
-					return this.trim(value);
+				return this.trim(value);
 		}
 	 },
 
@@ -1315,7 +1309,8 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	{
 		switch(this.options.ControlType)
 		{
-			case 'TCheckBoxList': case 'TRadioButtonList':
+			case 'TCheckBoxList':
+			case 'TRadioButtonList':
 				var elements = [];
 				for(var i = 0; i < this.options.TotalItems; i++)
 				{
@@ -1353,17 +1348,6 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 			return type == "checkbox" || type == "radio";
 		}
 		return false;
-	},
-
-	/**
-	 * Check if control to validate is a TListControl type.
-	 * @function {boolean} ?
-	 * @return True if control to validate is a TListControl type.
-	 */
-	isListControlType : function()
-	{
-		var list = ['TCheckBoxList', 'TRadioButtonList', 'TListBox'];
-		return (jQuery.inArray(this.options.ControlType, list)!=-1);
 	},
 
 	/**
@@ -2023,7 +2007,7 @@ Prado.WebUI.TReCaptcha2 = jQuery.klass(Prado.WebUI.Control,
         for (key in options) { this[key] = options[key]; }
         this.options['callback'] = jQuery.proxy(this.callback,this);
         this.options['expired-callback'] = jQuery.proxy(this.callbackExpired,this);
-        
+
         Prado.WebUI.TReCaptcha2Instances[this.element.id] = this;
     },
     build: function()

--- a/framework/Web/UI/WebControls/TBaseValidator.php
+++ b/framework/Web/UI/WebControls/TBaseValidator.php
@@ -95,7 +95,18 @@ abstract class TBaseValidator extends TLabel implements IValidator
 	 * them specially.
 	 * @var array list of control class names
 	 */
-	private static $_clientClass = ['THtmlArea', 'THtmlArea4', 'TDatePicker', 'TListBox', 'TCheckBoxList'];
+	private static $_clientClass = [
+		// normal controls needing special handling to extract their values
+		'Prado\Web\UI\WebControls\TCheckBox' => 'TCheckBox',
+		'Prado\Web\UI\WebControls\TDatePicker' => 'TDatePicker',
+		'Prado\Web\UI\WebControls\THtmlArea' => 'THtmlArea',
+		'Prado\Web\UI\WebControls\THtmlArea4' => 'THtmlArea4',
+		'Prado\Web\UI\WebControls\TReCaptcha2' => 'TReCaptcha2',
+		// list controls
+		'Prado\Web\UI\WebControls\TCheckBoxList' => 'TCheckBoxList',
+		'Prado\Web\UI\WebControls\TListBox' => 'TListBox',
+		'Prado\Web\UI\WebControls\TRadioButton' => 'TRadioButton',
+	];
 
 	/**
 	 * Constructor.
@@ -193,9 +204,9 @@ abstract class TBaseValidator extends TLabel implements IValidator
 	 */
 	private function getClientControlClass($control)
 	{
-		foreach (self::$_clientClass as $type) {
-			if ($control instanceof $type) {
-				return $type;
+		foreach (self::$_clientClass as $fullName => $shortName) {
+			if ($control instanceof $fullName) {
+				return $shortName;
 			}
 		}
 		$reflectionClass = new \ReflectionClass($control);

--- a/framework/Web/UI/WebControls/TListControl.php
+++ b/framework/Web/UI/WebControls/TListControl.php
@@ -725,7 +725,7 @@ abstract class TListControl extends TDataBoundControl implements \Prado\IDataRen
 	}
 
 	/**
-	 * @param string $value the prompt selection value. If empty, {@link getPromptText PromptText} will be used as the value.
+	 * @param string $value the prompt selection value.
 	 * @see setPromptText
 	 * @since 3.1.1
 	 */
@@ -766,10 +766,7 @@ abstract class TListControl extends TDataBoundControl implements \Prado\IDataRen
 	{
 		$text = $this->getPromptText();
 		$value = $this->getPromptValue();
-		if ($value === '') {
-			$value = $text;
-		}
-		if ($value !== '') {
+		if ($value !== '' || $text !== '') {
 			$writer->addAttribute('value', $value);
 			$writer->renderBeginTag('option');
 			$writer->write(THttpUtility::htmlEncode($text));


### PR DESCRIPTION
Client side validators needs special handling to extract values from some special controls (eg. lists). After the "big namespace update" this code worked in our tests, but failed to correctly detect subclasses of these special controls.
This PR reworks the code in order to fix the issue and clean up  a bit the mess.

Also, an additional change removes the usage of `PromptText` as a fallback for `PromptValue` if not specified. This was introduced for browser support, but it looks like modern browsers can handle empty values just fine, while this behavior tricks our validators.