### PR TITLE
Unified __construct chain, added/corrected some documentation.

### DIFF
--- a/framework/Caching/TDirectoryCacheDependency.php
+++ b/framework/Caching/TDirectoryCacheDependency.php
@@ -46,6 +46,7 @@ class TDirectoryCacheDependency extends TCacheDependency
 	public function __construct($directory)
 	{
 		$this->setDirectory($directory);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Caching/TFileCacheDependency.php
+++ b/framework/Caching/TFileCacheDependency.php
@@ -34,6 +34,7 @@ class TFileCacheDependency extends TCacheDependency
 	public function __construct($fileName)
 	{
 		$this->setFileName($fileName);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Caching/TGlobalStateCacheDependency.php
+++ b/framework/Caching/TGlobalStateCacheDependency.php
@@ -36,6 +36,7 @@ class TGlobalStateCacheDependency extends TCacheDependency
 	public function __construct($name)
 	{
 		$this->setStateName($name);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TDummyDataSource.php
+++ b/framework/Collections/TDummyDataSource.php
@@ -36,6 +36,7 @@ class TDummyDataSource extends \Prado\TComponent implements \IteratorAggregate, 
 	public function __construct($count)
 	{
 		$this->_count = $count;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -70,6 +70,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 			$this->copyFrom($data);
 		}
 		$this->setReadOnly($readOnly);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -78,6 +78,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 			$this->copyFrom($data);
 		}
 		$this->setReadOnly($readOnly);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TPagedListFetchDataEventParameter.php
+++ b/framework/Collections/TPagedListFetchDataEventParameter.php
@@ -43,6 +43,7 @@ class TPagedListFetchDataEventParameter extends \Prado\TEventParameter
 		$this->_pageIndex = $pageIndex;
 		$this->_offset = $offset;
 		$this->_limit = $limit;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TPagedListPageChangedEventParameter.php
+++ b/framework/Collections/TPagedListPageChangedEventParameter.php
@@ -31,6 +31,7 @@ class TPagedListPageChangedEventParameter extends \Prado\TEventParameter
 	public function __construct($oldPage)
 	{
 		$this->_oldPage = $oldPage;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * TPriorityList, TPriorityListIterator classes
+ * TPriorityList class
  *
  * @author Brad Anderson <javalizard@gmail.com>
  * @link https://github.com/pradosoft/prado
@@ -81,7 +81,7 @@ class TPriorityList extends TList
 	/**
 	 * Constructor.
 	 * Initializes the list with an array or an iterable object.
-	 * @param null|array|\Iterator $data the intial data. Default is null, meaning no initial data.
+	 * @param null|array|\Iterator $data the initial data. Default is null, meaning no initial data.
 	 * @param bool $readOnly whether the list is read-only
 	 * @param numeric $defaultPriority the default priority of items without specified priorities.
 	 * @param int $precision the precision of the numeric priorities

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -93,6 +93,7 @@ class TPriorityMap extends TMap
 	 */
 	public function __construct($data = null, $readOnly = false, $defaultPriority = 10, $precision = 8)
 	{
+		parent::__construct();
 		if ($data !== null) {
 			$this->copyFrom($data);
 		}

--- a/framework/Collections/TQueue.php
+++ b/framework/Collections/TQueue.php
@@ -58,6 +58,7 @@ class TQueue extends \Prado\TComponent implements \IteratorAggregate, \Countable
 		if ($data !== null) {
 			$this->copyFrom($data);
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Collections/TStack.php
+++ b/framework/Collections/TStack.php
@@ -57,6 +57,7 @@ class TStack extends \Prado\TComponent implements \IteratorAggregate, \Countable
 		if ($data !== null) {
 			$this->copyFrom($data);
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/ActiveRecord/TActiveRecord.php
+++ b/framework/Data/ActiveRecord/TActiveRecord.php
@@ -233,6 +233,7 @@ abstract class TActiveRecord extends \Prado\TComponent
 		if (!empty($data)) { //$data may be an object
 			$this->copyFrom($data);
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/ActiveRecord/TActiveRecordGateway.php
+++ b/framework/Data/ActiveRecord/TActiveRecordGateway.php
@@ -60,6 +60,7 @@ class TActiveRecordGateway extends \Prado\TComponent
 	public function __construct(TActiveRecordManager $manager)
 	{
 		$this->_manager = $manager;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/Common/Oracle/TOracleTableInfo.php
+++ b/framework/Data/Common/Oracle/TOracleTableInfo.php
@@ -45,6 +45,7 @@ class TOracleTableInfo extends \Prado\TComponent
 		$this->_primaryKeys = $primary;
 		$this->_foreignKeys = $foreign;
 		$this->_columns = new TMap;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/Common/TDbCommandBuilder.php
+++ b/framework/Data/Common/TDbCommandBuilder.php
@@ -35,6 +35,7 @@ class TDbCommandBuilder extends \Prado\TComponent
 	{
 		$this->setDbConnection($connection);
 		$this->setTableInfo($tableInfo);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/Common/TDbMetaData.php
+++ b/framework/Data/Common/TDbMetaData.php
@@ -44,6 +44,7 @@ abstract class TDbMetaData extends \Prado\TComponent
 	public function __construct($conn)
 	{
 		$this->_connection = $conn;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/Common/TDbTableColumn.php
+++ b/framework/Data/Common/TDbTableColumn.php
@@ -32,6 +32,7 @@ class TDbTableColumn extends \Prado\TComponent
 	public function __construct($columnInfo)
 	{
 		$this->_info = $columnInfo;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/Common/TDbTableInfo.php
+++ b/framework/Data/Common/TDbTableInfo.php
@@ -50,6 +50,7 @@ class TDbTableInfo extends \Prado\TComponent
 		$this->_primaryKeys = $primary;
 		$this->_foreignKeys = $foreign;
 		$this->_columns = new TMap;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/DataGateway/TDataGatewayCommand.php
+++ b/framework/Data/DataGateway/TDataGatewayCommand.php
@@ -48,6 +48,7 @@ class TDataGatewayCommand extends \Prado\TComponent
 	public function __construct($builder)
 	{
 		$this->_builder = $builder;
+		parent::__construct();
 	}
 	/**
 	 * @return TDbTableInfo

--- a/framework/Data/DataGateway/TDataGatewayEventParameter.php
+++ b/framework/Data/DataGateway/TDataGatewayEventParameter.php
@@ -27,6 +27,7 @@ class TDataGatewayEventParameter extends \Prado\TEventParameter
 	{
 		$this->_command = $command;
 		$this->_criteria = $criteria;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/DataGateway/TDataGatewayResultEventParameter.php
+++ b/framework/Data/DataGateway/TDataGatewayResultEventParameter.php
@@ -28,6 +28,7 @@ class TDataGatewayResultEventParameter extends \Prado\TEventParameter
 	{
 		$this->_command = $command;
 		$this->_result = $result;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/DataGateway/TSqlCriteria.php
+++ b/framework/Data/DataGateway/TSqlCriteria.php
@@ -62,6 +62,7 @@ class TSqlCriteria extends \Prado\TComponent
 		$this->_ordersBy->setCaseSensitive(true);
 
 		$this->setCondition($condition);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/DataGateway/TTableGateway.php
+++ b/framework/Data/DataGateway/TTableGateway.php
@@ -99,6 +99,7 @@ class TTableGateway extends \Prado\TComponent
 		} else {
 			throw new TDbException('dbtablegateway_invalid_table_info');
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/SqlMap/Configuration/TParameterMap.php
+++ b/framework/Data/SqlMap/Configuration/TParameterMap.php
@@ -51,6 +51,7 @@ class TParameterMap extends \Prado\TComponent
 	{
 		$this->_properties = new TList;
 		$this->_propertyMap = new TMap;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/SqlMap/Configuration/TResultMap.php
+++ b/framework/Data/SqlMap/Configuration/TResultMap.php
@@ -54,6 +54,7 @@ class TResultMap extends \Prado\TComponent
 	public function __construct()
 	{
 		$this->_columns = new TMap;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/SqlMap/Configuration/TResultProperty.php
+++ b/framework/Data/SqlMap/Configuration/TResultProperty.php
@@ -65,6 +65,7 @@ class TResultProperty extends \Prado\TComponent
 		if ($resultMap instanceof TResultMap) {
 			$this->_hostResultMapID = $resultMap->getID();
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/SqlMap/Statements/TCachingStatement.php
+++ b/framework/Data/SqlMap/Statements/TCachingStatement.php
@@ -27,6 +27,7 @@ class TCachingStatement extends \Prado\TComponent implements IMappedStatement
 	public function __construct(TMappedStatement $statement)
 	{
 		$this->_mappedStatement = $statement;
+		parent::__construct();
 	}
 
 	public function getID()

--- a/framework/Data/SqlMap/Statements/TMappedStatement.php
+++ b/framework/Data/SqlMap/Statements/TMappedStatement.php
@@ -131,6 +131,7 @@ class TMappedStatement extends \Prado\TComponent implements IMappedStatement
 		$this->_statement = $statement;
 		$this->_command = new TPreparedCommand();
 		$this->initialGroupByResults();
+		parent::__construct();
 	}
 
 	public function getSqlString()

--- a/framework/Data/SqlMap/Statements/TResultSetListItemParameter.php
+++ b/framework/Data/SqlMap/Statements/TResultSetListItemParameter.php
@@ -28,6 +28,7 @@ class TResultSetListItemParameter extends \Prado\TComponent
 		$this->_resultObject = $result;
 		$this->_parameterObject = $parameter;
 		$this->_list = &$list;
+		parent::__construct();
 	}
 
 	public function getResult()

--- a/framework/Data/SqlMap/Statements/TResultSetMapItemParameter.php
+++ b/framework/Data/SqlMap/Statements/TResultSetMapItemParameter.php
@@ -30,6 +30,7 @@ class TResultSetMapItemParameter extends \Prado\TComponent
 		$this->_value = $value;
 		$this->_parameterObject = $parameter;
 		$this->_map = &$map;
+		parent::__construct();
 	}
 
 	public function getKey()

--- a/framework/Data/SqlMap/Statements/TSimpleDynamicSql.php
+++ b/framework/Data/SqlMap/Statements/TSimpleDynamicSql.php
@@ -27,6 +27,7 @@ class TSimpleDynamicSql extends TStaticSql
 	public function __construct($mappings)
 	{
 		$this->_mappings = $mappings;
+		parent::__construct();
 	}
 
 	public function replaceDynamicParameter($sql, $parameter)

--- a/framework/Data/SqlMap/TSqlMapGateway.php
+++ b/framework/Data/SqlMap/TSqlMapGateway.php
@@ -40,6 +40,7 @@ class TSqlMapGateway extends \Prado\TComponent
 	public function __construct($manager)
 	{
 		$this->_manager = $manager;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/SqlMap/TSqlMapManager.php
+++ b/framework/Data/SqlMap/TSqlMapManager.php
@@ -66,6 +66,7 @@ class TSqlMapManager extends \Prado\TComponent
 		$this->_resultMaps = new TMap;
 		$this->_parameterMaps = new TMap;
 		$this->_cacheModels = new TMap;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/TDbCommand.php
+++ b/framework/Data/TDbCommand.php
@@ -56,6 +56,7 @@ class TDbCommand extends \Prado\TComponent
 	{
 		$this->_connection = $connection;
 		$this->setText($text);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/TDbConnection.php
+++ b/framework/Data/TDbConnection.php
@@ -131,6 +131,7 @@ class TDbConnection extends \Prado\TComponent
 		$this->_username = $username;
 		$this->_password = $password;
 		$this->_charset = $charset;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/TDbDataReader.php
+++ b/framework/Data/TDbDataReader.php
@@ -51,6 +51,7 @@ class TDbDataReader extends \Prado\TComponent implements \Iterator
 	{
 		$this->_statement = $command->getPdoStatement();
 		$this->_statement->setFetchMode(PDO::FETCH_ASSOC);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Data/TDbTransaction.php
+++ b/framework/Data/TDbTransaction.php
@@ -54,6 +54,7 @@ class TDbTransaction extends \Prado\TComponent
 	{
 		$this->_connection = $connection;
 		$this->setActive(true);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Security/TAuthorizationRule.php
+++ b/framework/Security/TAuthorizationRule.php
@@ -133,6 +133,7 @@ class TAuthorizationRule extends \Prado\TComponent
 				$this->_ipRules[] = $ipRule;
 			}
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Security/TUser.php
+++ b/framework/Security/TUser.php
@@ -51,6 +51,7 @@ class TUser extends \Prado\TComponent implements IUser
 		$this->_state = [];
 		$this->_manager = $manager;
 		$this->setName($manager->getGuestName());
+		parent::__construct();
 	}
 
 	/**

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -310,6 +310,7 @@ class TApplication extends \Prado\TComponent
 		$this->_services = [$this->getPageServiceID() => ['TPageService', [], null]];
 
 		Prado::setPathOfAlias('Application', $this->_basePath);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/TComponentReflection.php
+++ b/framework/TComponentReflection.php
@@ -54,6 +54,7 @@ class TComponentReflection extends \Prado\TComponent
 		} else {
 			throw new TInvalidDataTypeException('componentreflection_class_invalid');
 		}
+		parent::__construct();
 		$this->reflect();
 	}
 

--- a/framework/Util/TClassBehaviorEventParameter.php
+++ b/framework/Util/TClassBehaviorEventParameter.php
@@ -42,6 +42,7 @@ class TClassBehaviorEventParameter extends \Prado\TEventParameter
 		$this->_name = $name;
 		$this->_behavior = $behavior;
 		$this->_priority = $priority;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Util/TParameterModule.php
+++ b/framework/Util/TParameterModule.php
@@ -32,6 +32,7 @@ use Prado\Xml\TXmlElement;
  * <parameters>
  *   <parameter id="param1" value="paramValue1" />
  *   <parameter id="param2" Property1="Value1" Property2="Value2" ... />
+ *   <parameter id="param3" Class="MyDataObject" Property1="Value1" Property2="Value2" ... />
  * </parameters>
  * </code>
  *
@@ -41,11 +42,15 @@ use Prado\Xml\TXmlElement;
  * <module class="Prado\Util\TParameterModule">
  *   <parameter id="param1" value="paramValue1" />
  *   <parameter id="param2" Property1="Value1" Property2="Value2" ... />
+ *   <parameter id="param3" Class="MyDataObject" Property1="Value1" Property2="Value2" ... />
  * </module>
  * </code>
  *
  * If a parameter is defined both in the external file and within the module
  * tag, the former takes precedence.
+ *
+ * When a parameter has an Class Attribute, the parameter is instanced as an object
+ * of the specified class and the attribute=value pairs are then set on the object.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Carl G. Mathisen <carlgmathisen@gmail.com>

--- a/framework/Util/TRpcClient.php
+++ b/framework/Util/TRpcClient.php
@@ -69,6 +69,7 @@ class TRpcClient extends \Prado\TApplicationComponent
 	{
 		$this->_serverUrl = $serverUrl;
 		$this->_isNotification = TPropertyValue::ensureBoolean($isNotification);
+		parent::__construct();
 	}
 
 	// methods

--- a/framework/Web/Services/TPageConfiguration.php
+++ b/framework/Web/Services/TPageConfiguration.php
@@ -60,6 +60,7 @@ class TPageConfiguration extends \Prado\TComponent
 	public function __construct($pagePath)
 	{
 		$this->_pagePath = $pagePath;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/Services/TRpcApiProvider.php
+++ b/framework/Web/Services/TRpcApiProvider.php
@@ -62,7 +62,7 @@ abstract class TRpcApiProvider extends \Prado\TModule
 	public function __construct(TRpcServer $rpcServer)
 	{
 		$this->rpcServer = $rpcServer;
-
+		parent::__construct();
 		foreach ($this->registerMethods() as $_methodName => $_methodDetails) {
 			$this->rpcServer->addRpcMethod($_methodName, $_methodDetails);
 		}

--- a/framework/Web/Services/TRpcServer.php
+++ b/framework/Web/Services/TRpcServer.php
@@ -38,6 +38,7 @@ class TRpcServer extends \Prado\TModule
 	public function __construct(TRpcProtocol $protocolHandler)
 	{
 		$this->handler = $protocolHandler;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/Services/TSoapService.php
+++ b/framework/Web/Services/TSoapService.php
@@ -108,6 +108,7 @@ class TSoapService extends \Prado\TService
 	public function __construct()
 	{
 		$this->setID('soap');
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/THttpCookie.php
+++ b/framework/Web/THttpCookie.php
@@ -67,6 +67,7 @@ class THttpCookie extends \Prado\TComponent
 	{
 		$this->_name = $name;
 		$this->_value = $value;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/THttpCookieCollection.php
+++ b/framework/Web/THttpCookieCollection.php
@@ -41,6 +41,7 @@ class THttpCookieCollection extends \Prado\Collections\TList
 	public function __construct($owner = null)
 	{
 		$this->_o = $owner;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/THttpResponseAdapter.php
+++ b/framework/Web/THttpResponseAdapter.php
@@ -34,6 +34,7 @@ class THttpResponseAdapter extends \Prado\TApplicationComponent
 	public function __construct($response)
 	{
 		$this->_response = $response;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/TUri.php
+++ b/framework/Web/TUri.php
@@ -105,6 +105,7 @@ class TUri extends \Prado\TComponent
 		} else {
 			throw new TInvalidDataValueException('uri_format_invalid', $uri);
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/TUrlMappingPattern.php
+++ b/framework/Web/TUrlMappingPattern.php
@@ -167,6 +167,7 @@ class TUrlMappingPattern extends \Prado\TComponent
 	public function __construct(TUrlManager $manager)
 	{
 		$this->_manager = $manager;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/ActiveControls/TActiveDataGridPagerEventParameter.php
+++ b/framework/Web/UI/ActiveControls/TActiveDataGridPagerEventParameter.php
@@ -32,5 +32,6 @@ class TActiveDataGridPagerEventParameter extends TDataGridPagerEventParameter
 	public function __construct(TActiveDataGridPager $pager)
 	{
 		$this->_pager = $pager;
+		parent::__construct($pager);
 	}
 }

--- a/framework/Web/UI/ActiveControls/TBaseActiveControl.php
+++ b/framework/Web/UI/ActiveControls/TBaseActiveControl.php
@@ -48,6 +48,7 @@ class TBaseActiveControl extends \Prado\TComponent
 	{
 		$this->_control = $control;
 		$this->_options = new TMap;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/ActiveControls/TCallbackClientScript.php
+++ b/framework/Web/UI/ActiveControls/TCallbackClientScript.php
@@ -79,6 +79,7 @@ class TCallbackClientScript extends \Prado\TApplicationComponent
 	public function __construct()
 	{
 		$this->_actions = new TList;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/ActiveControls/TCallbackEventParameter.php
+++ b/framework/Web/UI/ActiveControls/TCallbackEventParameter.php
@@ -53,6 +53,7 @@ class TCallbackEventParameter extends \Prado\TEventParameter
 	{
 		$this->_response = $response;
 		$this->_parameter = $parameter;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/JuiControls/TJuiAutoCompleteTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiAutoCompleteTemplate.php
@@ -29,6 +29,7 @@ class TJuiAutoCompleteTemplate extends \Prado\TComponent implements ITemplate
 	public function __construct($template)
 	{
 		$this->_template = $template;
+		parent::__construct();
 	}
 	/**
 	 * Instantiates the template.

--- a/framework/Web/UI/JuiControls/TJuiSelectableTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiSelectableTemplate.php
@@ -29,6 +29,7 @@ class TJuiSelectableTemplate extends \Prado\TComponent implements ITemplate
 	public function __construct($template)
 	{
 		$this->_template = $template;
+		parent::__construct();
 	}
 	/**
 	 * Instantiates the template.

--- a/framework/Web/UI/JuiControls/TJuiSortableTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiSortableTemplate.php
@@ -29,6 +29,7 @@ class TJuiSortableTemplate extends \Prado\TComponent implements ITemplate
 	public function __construct($template)
 	{
 		$this->_template = $template;
+		parent::__construct();
 	}
 	/**
 	 * Instantiates the template.

--- a/framework/Web/UI/TBroadcastEventParameter.php
+++ b/framework/Web/UI/TBroadcastEventParameter.php
@@ -36,6 +36,7 @@ class TBroadcastEventParameter extends \Prado\TEventParameter
 	{
 		$this->_name = $name;
 		$this->_param = $parameter;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/TClientScriptManager.php
+++ b/framework/Web/UI/TClientScriptManager.php
@@ -127,6 +127,7 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	public function __construct(TPage $owner)
 	{
 		$this->_page = $owner;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/TCommandEventParameter.php
+++ b/framework/Web/UI/TCommandEventParameter.php
@@ -36,6 +36,7 @@ class TCommandEventParameter extends \Prado\TEventParameter
 	{
 		$this->_name = $name;
 		$this->_param = $parameter;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/TCompositeLiteral.php
+++ b/framework/Web/UI/TCompositeLiteral.php
@@ -54,6 +54,7 @@ class TCompositeLiteral extends \Prado\TComponent implements IRenderable, IBinda
 				$this->_items[$id] = $item;
 			}
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/TControlAdapter.php
+++ b/framework/Web/UI/TControlAdapter.php
@@ -36,6 +36,7 @@ class TControlAdapter extends \Prado\TApplicationComponent
 	public function __construct($control)
 	{
 		$this->_control = $control;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/THtmlWriter.php
+++ b/framework/Web/UI/THtmlWriter.php
@@ -83,6 +83,7 @@ class THtmlWriter extends \Prado\TApplicationComponent implements \Prado\IO\ITex
 	public function __construct($writer)
 	{
 		$this->_writer = $writer;
+		parent::__construct();
 	}
 
 	public function getWriter()

--- a/framework/Web/UI/TPage.php
+++ b/framework/Web/UI/TPage.php
@@ -186,6 +186,7 @@ class TPage extends TTemplateControl
 	public function __construct()
 	{
 		$this->setPage($this);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -129,6 +129,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 		$this->_startingLine = $startingLine;
 		$this->_content = $template;
 		$this->_hashCode = md5($template);
+		parent::__construct();
 		$this->parse($template);
 		$this->_content = null; // reset to save memory
 	}

--- a/framework/Web/UI/TTheme.php
+++ b/framework/Web/UI/TTheme.php
@@ -86,6 +86,7 @@ class TTheme extends \Prado\TApplicationComponent implements ITheme
 		$this->_themeUrl = $themeUrl;
 		$this->_themePath = realpath($themePath);
 		$this->_name = basename($themePath);
+		parent::__construct();
 		$cacheValid = false;
 		// TODO: the following needs to be cleaned up (Qiang)
 		if (($cache = $this->getApplication()->getCache()) !== null) {

--- a/framework/Web/UI/WebControls/TBulletedListEventParameter.php
+++ b/framework/Web/UI/WebControls/TBulletedListEventParameter.php
@@ -34,6 +34,7 @@ class TBulletedListEventParameter extends \Prado\TEventParameter
 	public function __construct($index)
 	{
 		$this->_index = $index;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridColumnCollection.php
+++ b/framework/Web/UI/WebControls/TDataGridColumnCollection.php
@@ -42,6 +42,7 @@ class TDataGridColumnCollection extends \Prado\Collections\TList
 	public function __construct(TDataGrid $owner)
 	{
 		$this->_o = $owner;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridItem.php
+++ b/framework/Web/UI/WebControls/TDataGridItem.php
@@ -68,6 +68,7 @@ class TDataGridItem extends TTableRow implements \Prado\Web\UI\INamingContainer
 		} elseif ($itemType === TListItemType::Footer) {
 			$this->setTableSection(TTableRowSection::Footer);
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridItemEventParameter.php
+++ b/framework/Web/UI/WebControls/TDataGridItemEventParameter.php
@@ -41,6 +41,7 @@ class TDataGridItemEventParameter extends \Prado\TEventParameter
 	public function __construct(TDataGridItem $item)
 	{
 		$this->_item = $item;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridPageChangedEventParameter.php
+++ b/framework/Web/UI/WebControls/TDataGridPageChangedEventParameter.php
@@ -49,6 +49,7 @@ class TDataGridPageChangedEventParameter extends \Prado\TEventParameter
 	{
 		$this->_source = $source;
 		$this->_newIndex = $newPageIndex;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridPager.php
+++ b/framework/Web/UI/WebControls/TDataGridPager.php
@@ -35,6 +35,7 @@ class TDataGridPager extends TPanel implements \Prado\Web\UI\INamingContainer
 	public function __construct($dataGrid)
 	{
 		$this->_dataGrid = $dataGrid;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridPagerEventParameter.php
+++ b/framework/Web/UI/WebControls/TDataGridPagerEventParameter.php
@@ -41,6 +41,7 @@ class TDataGridPagerEventParameter extends \Prado\TEventParameter
 	public function __construct(TDataGridPager $pager)
 	{
 		$this->_pager = $pager;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataGridSortCommandEventParameter.php
+++ b/framework/Web/UI/WebControls/TDataGridSortCommandEventParameter.php
@@ -49,6 +49,7 @@ class TDataGridSortCommandEventParameter extends \Prado\TEventParameter
 	{
 		$this->_source = $source;
 		$this->_sortExpression = $param->getCommandParameter();
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataSourceView.php
+++ b/framework/Web/UI/WebControls/TDataSourceView.php
@@ -28,6 +28,7 @@ abstract class TDataSourceView extends \Prado\TComponent
 	{
 		$this->_owner = $owner;
 		$this->_name = $viewName;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDropDownListColumn.php
+++ b/framework/Web/UI/WebControls/TDropDownListColumn.php
@@ -65,6 +65,7 @@ class TDropDownListColumn extends TDataGridColumn
 	public function __construct()
 	{
 		$this->_listControl = new TDropDownList;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TFileUploadItem.php
+++ b/framework/Web/UI/WebControls/TFileUploadItem.php
@@ -52,6 +52,7 @@ class TFileUploadItem extends \Prado\TComponent
 		$this->_fileType = $fileType;
 		$this->_errorCode = $errorCode;
 		$this->_localName = $localName;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/THtmlArea.php
+++ b/framework/Web/UI/WebControls/THtmlArea.php
@@ -203,6 +203,7 @@ class THtmlArea extends TTextBox
 	{
 		$this->setWidth('470px');
 		$this->setHeight('250px');
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/THtmlArea4.php
+++ b/framework/Web/UI/WebControls/THtmlArea4.php
@@ -176,6 +176,7 @@ class THtmlArea4 extends TTextBox
 	{
 		$this->setWidth('600px');
 		$this->setHeight('250px');
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TImageClickEventParameter.php
+++ b/framework/Web/UI/WebControls/TImageClickEventParameter.php
@@ -44,6 +44,7 @@ class TImageClickEventParameter extends \Prado\TEventParameter
 	{
 		$this->_x = $x;
 		$this->_y = $y;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TImageMapEventParameter.php
+++ b/framework/Web/UI/WebControls/TImageMapEventParameter.php
@@ -33,6 +33,7 @@ class TImageMapEventParameter extends \Prado\TEventParameter
 	public function __construct($postBackValue)
 	{
 		$this->_postBackValue = $postBackValue;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TListItem.php
+++ b/framework/Web/UI/WebControls/TListItem.php
@@ -64,6 +64,7 @@ class TListItem extends \Prado\TComponent
 		$this->setValue($value);
 		$this->setEnabled($enabled);
 		$this->setSelected($selected);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TOutputCacheTextWriterMulti.php
+++ b/framework/Web/UI/WebControls/TOutputCacheTextWriterMulti.php
@@ -29,8 +29,8 @@ class TOutputCacheTextWriterMulti extends TTextWriter
 
 	public function __construct(array $writers)
 	{
-		//parent::__construct();
 		$this->_writers = $writers;
+		parent::__construct();
 	}
 
 	public function write($s)

--- a/framework/Web/UI/WebControls/TPagerPageChangedEventParameter.php
+++ b/framework/Web/UI/WebControls/TPagerPageChangedEventParameter.php
@@ -46,6 +46,7 @@ class TPagerPageChangedEventParameter extends \Prado\TEventParameter
 	{
 		$this->_source = $source;
 		$this->_newIndex = $newPageIndex;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TReadOnlyDataSource.php
+++ b/framework/Web/UI/WebControls/TReadOnlyDataSource.php
@@ -31,6 +31,7 @@ class TReadOnlyDataSource extends TDataSourceControl
 		}
 		$this->_dataSource = $dataSource;
 		$this->_dataMember = $dataMember;
+		parent::__construct();
 	}
 
 	public function getView($viewName)

--- a/framework/Web/UI/WebControls/TRepeaterItemEventParameter.php
+++ b/framework/Web/UI/WebControls/TRepeaterItemEventParameter.php
@@ -38,6 +38,7 @@ class TRepeaterItemEventParameter extends \Prado\TEventParameter
 	public function __construct($item)
 	{
 		$this->_item = $item;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TServerValidateEventParameter.php
+++ b/framework/Web/UI/WebControls/TServerValidateEventParameter.php
@@ -44,6 +44,7 @@ class TServerValidateEventParameter extends \Prado\TEventParameter
 	{
 		$this->_value = $value;
 		$this->setIsValid($isValid);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TWebControlDecorator.php
+++ b/framework/Web/UI/WebControls/TWebControlDecorator.php
@@ -135,6 +135,7 @@ class TWebControlDecorator extends \Prado\TComponent
 	{
 		$this->_control = $control;
 		$this->_internalonly = $onlyinternal;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TWizardNavigationEventParameter.php
+++ b/framework/Web/UI/WebControls/TWizardNavigationEventParameter.php
@@ -44,6 +44,7 @@ class TWizardNavigationEventParameter extends \Prado\TEventParameter
 	{
 		$this->_currentStep = $currentStep;
 		$this->_nextStep = $currentStep;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TWizardNavigationTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardNavigationTemplate.php
@@ -31,6 +31,7 @@ class TWizardNavigationTemplate extends \Prado\TComponent implements ITemplate
 	public function __construct($wizard)
 	{
 		$this->_wizard = $wizard;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TWizardStepCollection.php
+++ b/framework/Web/UI/WebControls/TWizardStepCollection.php
@@ -36,6 +36,7 @@ class TWizardStepCollection extends \Prado\Collections\TList
 	public function __construct(TWizard $wizard)
 	{
 		$this->_wizard = $wizard;
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TXmlTransform.php
+++ b/framework/Web/UI/WebControls/TXmlTransform.php
@@ -59,6 +59,7 @@ class TXmlTransform extends \Prado\Web\UI\TControl
 		if (!class_exists('XSLTProcessor', false)) {
 			throw new TConfigurationException('xmltransform_xslextension_required');
 		}
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Xml/TXmlDocument.php
+++ b/framework/Xml/TXmlDocument.php
@@ -79,9 +79,9 @@ class TXmlDocument extends TXmlElement
 	 */
 	public function __construct($version = '1.0', $encoding = '')
 	{
-		parent::__construct('');
 		$this->setVersion($version);
 		$this->setEncoding($encoding);
+		parent::__construct('');
 	}
 
 	/**

--- a/framework/Xml/TXmlElement.php
+++ b/framework/Xml/TXmlElement.php
@@ -59,6 +59,7 @@ class TXmlElement extends \Prado\TComponent
 	public function __construct($tagName)
 	{
 		$this->setTagName($tagName);
+		parent::__construct();
 	}
 
 	/**

--- a/framework/Xml/TXmlElementList.php
+++ b/framework/Xml/TXmlElementList.php
@@ -36,6 +36,7 @@ class TXmlElementList extends \Prado\Collections\TList
 	public function __construct(TXmlElement $owner)
 	{
 		$this->_o = $owner;
+		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
These __construct chains are at the end after the variables are set but before any significant functionality.  this allows behaviors to access the Objects' properties and affect any further action.

There is a spelling correction and a php documentation addition for what already is in the system and just needed better documentation.