### PR TITLE
incremental update Corrections, speedups-caching, and Themes using TSkinTemplate without validation

### DIFF
--- a/framework/TApplicationComponent.php
+++ b/framework/TApplicationComponent.php
@@ -10,6 +10,8 @@
 
 namespace Prado;
 
+use Prado\TApplicationMode;
+
 /**
  * TApplicationComponent class
  *
@@ -33,6 +35,7 @@ namespace Prado;
  */
 class TApplicationComponent extends \Prado\TComponent
 {
+	public const APP_COMPONENT_FX_CACHE = 'prado:applicationcomponent:fxcache';
 	/**
 	 * TApplicationComponents auto listen to global events.
 	 *
@@ -41,6 +44,40 @@ class TApplicationComponent extends \Prado\TComponent
 	public function getAutoGlobalListen()
 	{
 		return true;
+	}
+	
+	/**
+	 * This caches the 'fx' events for PRADO classes in the global state
+	 * @param object $class
+	 * @return string[] fx events from a specific class
+	 */
+	protected function getClassFxEvents($class)
+	{
+		$app = $this->getApplication();
+		$className = $cache = null;
+		if ($app && (($mode = $app->getMode()) === TApplicationMode::Normal || $mode === TApplicationMode::Performance) && ($cache = $app->getCache())) {
+			static $_classfx = null;
+			if ($_classfx === null) {
+				$_classfx = $cache->get(self::APP_COMPONENT_FX_CACHE) ?? [];
+			}
+			$className = get_class($class);
+			if (isset($_classfx[$className])) {
+				return $_classfx[$className];
+			}
+		}
+		$fx = parent::getClassFxEvents($class);
+		if ($cache) {
+			if ($pos = strrpos($className, '\\')) {
+				$baseClassName = substr($className, $pos + 1);
+			} else {
+				$baseClassName = $className;
+			}
+			if (isset(Prado::$classMap[$baseClassName])) {
+				$_classfx[$className] = $fx;
+				$cache->set(self::APP_COMPONENT_FX_CACHE, $_classfx);
+			}
+		}
+		return $fx;
 	}
 	
 	/**

--- a/framework/Util/Behaviors/TMapRouteBehavior.php
+++ b/framework/Util/Behaviors/TMapRouteBehavior.php
@@ -39,11 +39,9 @@ use Prado\Util\TBehavior;
 class TMapRouteBehavior extends TBehavior
 {
 	/**
-	 * @var string the parameter to check for when there are changes.  This
-	 * is public because this call shouldn't add any other getter/setter functions.
-	 * it is possible for the Parameter to change its key
+	 * @var string the parameter to check for when there are changes.
 	 */
-	public $_parameter;
+	private $_parameter;
 	
 	/**
 	 * @var callable the parameter to check for when there are changes
@@ -103,5 +101,22 @@ class TMapRouteBehavior extends TBehavior
 			call_user_func($this->_handler, $key, null);
 		}
 		return $callchain->dyRemoveItem($key, $value);
+	}
+	
+	/**
+	 * @return string parameter
+	 */
+	public function getParameter()
+	{
+		return $this->_parameter;
+	}
+	
+	/**
+	 *
+	 * @param mixed $param
+	 */
+	public function setParameter($param)
+	{
+		$this->_parameter = $param;
 	}
 }

--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -1073,6 +1073,29 @@ jQuery.extend(String.prototype, {
 								+ ((digits > 0) ? "." + m[7] : "");
 		var num = parseFloat(cleanInput);
 		return (isNaN(num) ? null : num);
+	},
+	
+	/**
+	 * Appends 'px' at the end if it is not there.
+	 * @function {string} ?
+	 * @returns string with 'px' at the end
+	 * @since 4.2.0
+	 */
+	px : function() {
+		return this.endsWith('px') ? this : this + 'px';
+	}
+});
+
+jQuery.extend(Number.prototype,
+{
+	/**
+	 * Appends 'px' at the end of the number.
+	 * @function {string} ?
+	 * @returns string with number plus 'px' at the end
+	 * @since 4.2.0
+	 */
+	px : function() {
+		return this + 'px';
 	}
 });
 

--- a/framework/Web/UI/TSkinTemplate.php
+++ b/framework/Web/UI/TSkinTemplate.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * TSkinTemplate class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ * @package Prado\Web\UI
+ */
+
+namespace Prado\Web\UI;
+
+/**
+ * TSkinTemplate implements TTemplate but without class and attribute validation.
+ * This class is the implementation of skin files in themes. Skin errors are thrown
+ * on setting object skin properties rather than on parsing the skin.  Skins can
+ * have class objects that are not implemented to be more portable.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @package Prado\Web\UI
+ * @since 4.2.0
+ */
+class TSkinTemplate extends TTemplate
+{
+	/**
+	 * Constructor.
+	 * turns off attribute validation
+	 * @param string $template the template string
+	 * @param string $contextPath the template context directory
+	 * @param null|string $tplFile the template file, null if no file
+	 * @param int $startingLine the line number that parsing starts from (internal use)
+	 * @param bool $sourceTemplate whether this template is a source template, i.e., this template is loaded from
+	 * some external storage rather than from within another template.
+	 */
+	public function __construct($template, $contextPath, $tplFile = null, $startingLine = 0, $sourceTemplate = true)
+	{
+		$this->setAttributeValidation(false);
+		parent::__construct($template, $contextPath, $tplFile, $startingLine, $sourceTemplate);
+	}
+}

--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -98,6 +98,9 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	 */
 	private $_content;
 	/**
+	 * @var bool tells whether the class and attributes should be validated before moving on	 */
+	private $_attributevalidation = true;
+	/**
 	 * @var bool whether this template is a source template
 	 */
 	private $_sourceTemplate = true;
@@ -181,6 +184,24 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	public function &getItems()
 	{
 		return $this->_tpl;
+	}
+	
+	/**
+	 * @return bool whether or not validation of the template is active
+	 * @since 4.2.0
+	 */
+	public function getAttributeValidation()
+	{
+		return $this->_attributevalidation;
+	}
+
+	/**
+	 * @param bool $value whether or not validation of the template is active
+	 * @since 4.2.0
+	 */
+	public function setAttributeValidation($value)
+	{
+		$this->_attributevalidation = $value;
 	}
 
 	/**
@@ -794,6 +815,9 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 			$className = substr($type, $pos + 1);
 		} else {
 			$className = $type;
+		}
+		if (!$this->_attributevalidation) {
+			return $className;
 		}
 		$class = new \ReflectionClass($className);
 		if (is_subclass_of($className, '\Prado\Web\UI\TControl') || $className === '\Prado\Web\UI\TControl') {

--- a/framework/Web/UI/TTheme.php
+++ b/framework/Web/UI/TTheme.php
@@ -26,7 +26,8 @@ use Prado\TApplicationMode;
  * whose name has the extension ".skin" are parsed and saved as controls skins.
  *
  * A skin is essentially a list of initial property values that are to be applied
- * to a control when the skin is applied.
+ * to a control when the skin is applied.  {@link TSkinTemplate} is used to
+ * turn off class and attribute validation.
  * Each type of control can have multiple skins identified by the SkinID.
  * If a skin does not have SkinID, it is the default skin that will be applied
  * to controls that do not specify particular SkinID.
@@ -147,7 +148,7 @@ class TTheme extends \Prado\TApplicationComponent implements ITheme
 				} elseif (basename($file, '.js') !== $file) {
 					$this->_jsFiles[] = $themeUrl . DIRECTORY_SEPARATOR . $file;
 				} elseif (basename($file, self::SKIN_FILE_EXT) !== $file) {
-					$template = new TTemplate(file_get_contents($themePath . DIRECTORY_SEPARATOR . $file), $themePath, $themePath . '/' . $file);
+					$template = new TSkinTemplate(file_get_contents($themePath . DIRECTORY_SEPARATOR . $file), $themePath, $themePath . '/' . $file);
 					foreach ($template->getItems() as $skin) {
 						if (!isset($skin[2])) {  // a text string, ignored
 							continue;

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -436,6 +436,7 @@ return [
 'TPageStateFormatter' => 'Prado\Web\UI\TPageStateFormatter',
 'TPageStatePersister' => 'Prado\Web\UI\TPageStatePersister',
 'TSessionPageStatePersister' => 'Prado\Web\UI\TSessionPageStatePersister',
+'TSkinTemplate' => 'Prado\Web\UI\TSkinTemplate',
 'TTemplate' => 'Prado\Web\UI\TTemplate',
 'TTemplateControl' => 'Prado\Web\UI\TTemplateControl',
 'TTemplateControlInheritable' => 'Prado\Web\UI\TTemplateControlInheritable',

--- a/tests/unit/Util/Behaviors/TMapRouteBehaviorTest.php
+++ b/tests/unit/Util/Behaviors/TMapRouteBehaviorTest.php
@@ -131,4 +131,11 @@ class TMapRouteBehaviorTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(1, $this->_value);
 	}
 	
+
+	public function testParameter()
+	{
+		self::assertNull($this->obj->getParameter());
+		$this->obj->setParameter('key1');
+		self::assertEquals('key1', $this->obj->getParameter());
+	}
 }

--- a/tests/unit/Util/Behaviors/TMapRouteBehaviorTest.php
+++ b/tests/unit/Util/Behaviors/TMapRouteBehaviorTest.php
@@ -40,7 +40,7 @@ class TMapRouteBehaviorTest extends PHPUnit\Framework\TestCase
 	{
 		$this->map = null;
 		$this->behavior = null;
-		$this->behavior = null;
+		$this->behaviorall = null;
 	}
 
 	public function testConstruct()
@@ -134,8 +134,8 @@ class TMapRouteBehaviorTest extends PHPUnit\Framework\TestCase
 
 	public function testParameter()
 	{
-		self::assertNull($this->obj->getParameter());
-		$this->obj->setParameter('key1');
-		self::assertEquals('key1', $this->obj->getParameter());
+		self::assertEquals('key1', $this->behavior->getParameter());
+		$this->behavior->setParameter('key2');
+		self::assertEquals('key2', $this->behavior->getParameter());
 	}
 }

--- a/tests/unit/Web/UI/TTemplateTest.php
+++ b/tests/unit/Web/UI/TTemplateTest.php
@@ -4,9 +4,37 @@
 
 class TTemplateTest extends PHPUnit\Framework\TestCase
 {
+	protected $obj;
+	
+	private $_baseClass;
+
+	protected function setUp(): void
+	{
+		$this->_baseClass = $this->getTestClass();
+		$this->obj = new $this->_baseClass('', '');
+	}
+
+	protected function tearDown(): void
+	{
+		$this->obj = null;
+	}
+	
+	protected function getTestClass()
+	{
+		return 'Prado\\Web\\UI\\TTemplate';
+	}
+	
 	public function testConstruct()
 	{
 		throw new PHPUnit\Framework\IncompleteTestError();
+	}
+
+	public function testAttributeValidation()
+	{
+		$this->obj->setAttributeValidation(false);
+		self::assertFalse($this->obj->getAttributeValidation());
+		$this->obj->setAttributeValidation(true);
+		self::assertTrue($this->obj->getAttributeValidation());
 	}
 
 	public function testGetTemplateFile()

--- a/tests/unit/Web/UI/TUSkinTemplateTest.php
+++ b/tests/unit/Web/UI/TUSkinTemplateTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * TUSkinTemplateTest for testing TSkinTemplate
+ * the reason for the odd naming is that it needs to be after TTemplateTest to extend the class.
+ */
+
+class TUSkinTemplateTest extends TTemplateTest
+{
+	protected function getTestClass()
+	{
+		return 'Prado\\Web\\UI\\TSkinTemplate';
+	}
+	
+	public function testConstruct()
+	{
+		self::assertFalse($this->obj->getAttributeValidation());
+	}
+}


### PR DESCRIPTION
This is a general update to

- TMapRouteBehavior- changes the public variable to a private variable with getter/setter. It adds the method to the owner but that shouldn't be an issue.
- Adds a Javascript extension to Number and String adding the method px() that adds "px' to the end of a number or string.  The string checks if px is at the end and if not, adds it.  This should make conversion from numbers and strings to css pixel sizes more standardized and uniform.
- TApplicationComponent adds caching the fx events in the application cache when in normal or performance mode.
- TTemplate adds attribute validation property.
- TSkinTemplate sets TTemplate attribute validation to false
- TThemes use TSkinTemplate rather than TTemplate for skins #737
