### PR TITLE
Bugfix #800

### DIFF
--- a/framework/Web/UI/ActiveControls/TCallbackPageStateTracker.php
+++ b/framework/Web/UI/ActiveControls/TCallbackPageStateTracker.php
@@ -187,7 +187,7 @@ class TCallbackPageStateTracker
 	 */
 	protected function updateStyle($style)
 	{
-		if ($style['CssClass'] !== null) {
+		if ($style['CssClass'] !== null && is_string($style['CssClass'])) {
 			$this->client()->setAttribute($this->_control, 'class', $style['CssClass']);
 		}
 		if (is_array($style['Style']) && count($style['Style']) > 0) {


### PR DESCRIPTION
According to #800 this is a working solution.

When the bug appear $style['CssClass']  is an empty stdClass (set on line 103 of TStyleDiff). So If we check if it's a string, the control CSS class was not overwrite anymore .