### PR TITLE
Adapt for compatibility with PHP 8.1

### DIFF
--- a/framework/Web/UI/ActiveControls/TCallbackResponseWriter.php
+++ b/framework/Web/UI/ActiveControls/TCallbackResponseWriter.php
@@ -40,7 +40,7 @@ class TCallbackResponseWriter extends TTextWriter
 	public function __construct()
 	{
 		parent::__construct();
-		$this->_boundary = sprintf('%x', crc32(uniqid(null, true)));
+		$this->_boundary = sprintf('%x', crc32(uniqid("", true)));
 	}
 
 	/**


### PR DESCRIPTION
Hello, I found this bug when I try to migrate in master version with PHP 8.1 .

uniqid don't allow null at parameter anymore...