### PR TITLE
Update TSqlCriteria.php for fix phpdoc

### DIFF
--- a/framework/Data/DataGateway/TSqlCriteria.php
+++ b/framework/Data/DataGateway/TSqlCriteria.php
@@ -182,7 +182,7 @@ class TSqlCriteria extends \Prado\TComponent
 	}
 
 	/**
-	 * @param \ArrayAccess|array $value named parameters.
+	 * @param array|\ArrayAccess $value named parameters.
 	 */
 	public function setParameters($value)
 	{

--- a/framework/Data/DataGateway/TSqlCriteria.php
+++ b/framework/Data/DataGateway/TSqlCriteria.php
@@ -182,7 +182,7 @@ class TSqlCriteria extends \Prado\TComponent
 	}
 
 	/**
-	 * @param \ArrayAccess $value named parameters.
+	 * @param \ArrayAccess|array $value named parameters.
 	 */
 	public function setParameters($value)
 	{


### PR DESCRIPTION
The phpdoc comment was not correct. the functions can accept array an ArrayAccess but only Array access as defined on the comment. So my IDE inform me than it's not correct when I pass an array in the functions