### PR TITLE
#815 Cron trigger on first run fix, repeat running fix, and removed time zone code

### DIFF
--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -104,7 +104,7 @@ class TShellApplication extends \Prado\TApplication
 		$this->registerOption('quiet', [$this, 'setQuietMode'], 'Quiets the output to <level> [1..3], default 1', '=<level>');
 		$this->registerOptionAlias('q', 'quiet');
 
-		$this->attachEventHandler('onBeginRequest', [$this, 'processArguments'], 0);
+		$this->attachEventHandler('onInitComplete', [$this, 'processArguments'], 20);
 
 		parent::run();
 	}

--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -63,12 +63,12 @@ class TShellApplication extends \Prado\TApplication
 	protected $_options = [];
 
 	/**
-	 * @var array<array> application command optionAliases of the short letter(s) and option name
+	 * @var array<string, string> application command optionAliases of the short letter(s) and option name
 	 */
 	protected $_optionAliases = [];
 
 	/**
-	 * @var array<string, [string, string]> The option help text and help values
+	 * @var array<array> The option help text and help values
 	 */
 	protected $_optionsData = [];
 

--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -18,6 +18,7 @@ use Prado\Shell\Actions\TPhpShellAction;
 use Prado\IO\ITextWriter;
 use Prado\IO\TOutputWriter;
 use Prado\Shell\TShellWriter;
+use Prado\TPropertyValue;
 
 /**
  * TShellApplication class.
@@ -67,6 +68,11 @@ class TShellApplication extends \Prado\TApplication
 	protected $_optionAliases = [];
 
 	/**
+	 * @var array<string, [string, string]> The option help text and help values
+	 */
+	protected $_optionsData = [];
+
+	/**
 	 * @var bool is the application help printed
 	 */
 	protected $_helpPrinted = false;
@@ -95,7 +101,10 @@ class TShellApplication extends \Prado\TApplication
 
 		$this->_outWriter = new TShellWriter(new TOutputWriter());
 
-		$this->attachEventHandler('onInitComplete', [$this, 'processArguments']);
+		$this->registerOption('quiet', [$this, 'setQuietMode'], 'Quiets the output to <level> [1..3], default 1', '=<level>');
+		$this->registerOptionAlias('q', 'quiet');
+
+		$this->attachEventHandler('onBeginRequest', [$this, 'processArguments'], 0);
 
 		parent::run();
 	}
@@ -275,11 +284,14 @@ class TShellApplication extends \Prado\TApplication
 	 * This registers shell command line options and the setter callback
 	 * @param string $name name of the option at the command line
 	 * @param callable $setCallback the callback to set the property
+	 * @param string $description Short description of the option
+	 * @param string $values value after the option, eg "=<level>"
 	 * @since 4.2.0
 	 */
-	public function registerOption($name, $setCallback)
+	public function registerOption($name, $setCallback, $description = '', $values = '')
 	{
 		$this->_options[$name] = $setCallback;
+		$this->_optionsData[$name] = [TPropertyValue::ensureString($description), TPropertyValue::ensureString($values)];
 	}
 
 
@@ -363,8 +375,15 @@ class TShellApplication extends \Prado\TApplication
 		$outWriter->writeLine("example: prado-cli cron/tasks");
 		$outWriter->writeLine();
 		$outWriter->writeLine("The following options are available:");
-		$outWriter->writeLine(str_pad("  -d=<folder>", 20) . "Loads the configuration.xml/php from <folder>");
-		$outWriter->writeLine(str_pad("  -q=<level>", 20) . "Quiets the output to <level> [1..3]");
+		$outWriter->writeLine(str_pad("  -d=<folder>", 20) . " Loads the configuration.xml/php from <folder>");
+		foreach ($this->_options as $option => $callable) {
+			$data = $this->_optionsData[$option];
+			$outWriter->writeLine(str_pad(" --{$option}{$data[1]}", 20) . ' ' . $data[0]);
+		}
+		foreach ($this->_optionAliases as $alias => $option) {
+			$data = $this->_optionsData[$option] ?? ['', ''];
+			$outWriter->writeLine(str_pad("  -{$alias}{$data[1]}", 20) . " is an alias for --" . $option);
+		}
 		$outWriter->writeLine();
 		$outWriter->writeLine("The following commands are available:");
 		foreach ($this->_actions as $action) {

--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -63,7 +63,7 @@ class TShellApplication extends \Prado\TApplication
 	protected $_options = [];
 
 	/**
-	 * @var array<string, string> application command optionAliases of the short letter(s) and option name
+	 * @var array<array> application command optionAliases of the short letter(s) and option name
 	 */
 	protected $_optionAliases = [];
 

--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -121,11 +121,11 @@ class TShellApplication extends \Prado\TApplication
 	/**
 	 * This checks if shell environment is from a system CronTab.
 	 * @return bool is the shell environment in crontab
-	 * @since 4.2.3
+	 * @since 4.2.2
 	 */
 	public static function detectCronTabShell()
 	{
-		return php_sapi_name() == 'cli' && !getenv('LANG') && !getenv('TERM') && !getenv('TERM_PROGRAM');
+		return php_sapi_name() == 'cli' && (!($term = getenv('TERM')) || $term == 'unknown');
 	}
 
 	/**

--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -119,6 +119,16 @@ class TShellApplication extends \Prado\TApplication
 	}
 
 	/**
+	 * This checks if shell environment is from a system CronTab.
+	 * @return bool is the shell environment in crontab
+	 * @since 4.2.3
+	 */
+	public static function detectCronTabShell()
+	{
+		return php_sapi_name() == 'cli' && !getenv('LANG') && !getenv('TERM') && !getenv('TERM_PROGRAM');
+	}
+
+	/**
 	 * This processes the arguments entered into the cli.  This is processed after
 	 * the application is initialized and modules can
 	 * @param object $sender

--- a/framework/Shell/TShellLoginBehavior.php
+++ b/framework/Shell/TShellLoginBehavior.php
@@ -54,9 +54,9 @@ class TShellLoginBehavior extends \Prado\Util\TBehavior
 	{
 		parent::attach($owner);
 		if (($app = Prado::getApplication()) instanceof \Prado\Shell\TShellApplication) {
-			$app->registerOption('user', [$this, 'setUsername']);
+			$app->registerOption('user', [$this, 'setUsername'], 'Application login User name', '=<user>');
 			$app->registerOptionAlias('u', 'user');
-			$app->registerOption('password', [$this, 'setPassword']);
+			$app->registerOption('password', [$this, 'setPassword'], 'Application login Password', '=<password>');
 			$app->registerOptionAlias('p', 'password');
 		}
 	}
@@ -86,7 +86,7 @@ class TShellLoginBehavior extends \Prado\Util\TBehavior
 	public function shellApplicationLogin($sender, $param)
 	{
 		$app = Prado::getApplication();
-		if (php_sapi_name() !== 'cli' || !($app instanceof \Prado\Shell\TShellApplication)) {
+		if (php_sapi_name() !== 'cli' || !($app instanceof \Prado\Shell\TShellApplication) || !$this->getEnabled()) {
 			return;
 		}
 		$writer = $app->getWriter();
@@ -105,7 +105,7 @@ class TShellLoginBehavior extends \Prado\Util\TBehavior
 				$writer->flush();
 				$this->_password = $this->readPassword();
 			} else {
-				$writer->writeLine();
+				$writer->writeLine("**********");
 			}
 		}
 		$password = $this->_password;

--- a/framework/Shell/TShellWriter.php
+++ b/framework/Shell/TShellWriter.php
@@ -259,8 +259,8 @@ class TShellWriter extends \Prado\TComponent implements \Prado\IO\ITextWriter
 			$str .= PHP_EOL;
 		}
 		$last = count($table['headers'] ?? $table['rows'][0]) - 1;
-		$lastcolumn = 0;
 		foreach ($table['rows'] as $row => $data) {
+			$lastcolumn = 0;
 			if (isset($data['span'])) {
 				$str .= $data['span'];
 			} else {

--- a/framework/Util/Behaviors/TBehaviorParameterLoader.php
+++ b/framework/Util/Behaviors/TBehaviorParameterLoader.php
@@ -24,7 +24,7 @@ use Prado\TPropertyValue;
  * <code>
  * <application id="prado-app">
  *		<parameters>
- *		<parameter id="pagethemebehaviorloader" class="Prado\Util\Behaviors\TBehaviorParameterLoader" BehaviorName="testBehavior" BehaviorClass="Prado\Util\Behaviors\TParameterizeBehavior" Priority="10" AttachToClass="Prado\Web\UI\TPage" Parameter="ThemeName" Property="Theme" DefaultValue="America/Los Angeles" />
+ *		<parameter id="pagethemebehaviorloader" class="Prado\Util\Behaviors\TBehaviorParameterLoader" BehaviorName="testBehavior" BehaviorClass="Prado\Util\Behaviors\TParameterizeBehavior" Priority="10" AttachToClass="Prado\Web\UI\TPage" Parameter="ThemeName" Property="Theme" DefaultValue="ColoradoBlue2022" />
  *		<parameters>
  * 	  ...
  * </code>

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -17,6 +17,7 @@ use Prado\Prado;
 use Prado\Security\IUserManager;
 use Prado\Security\Permissions\IPermissions;
 use Prado\Security\Permissions\TPermissionEvent;
+use Prado\Shell\TShellApplication;
 use Prado\TPropertyValue;
 use Prado\Util\TLogger;
 use Prado\Xml\TXmlElement;
@@ -391,6 +392,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 	 */
 	public function processPendingTasks()
 	{
+		$inCronTab = TShellApplication::detectCronTabShell();
 		$pendingTasks = $this->getPendingTasks();
 		$numtasks = count($pendingTasks);
 		$startMinute = floor(time() / 60);
@@ -398,7 +400,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 		$this->logCron($numtasks);
 		if ($numtasks) {
 			foreach ($pendingTasks as $key => $task) {
-				if ($startMinute != floor(time() / 60)) {
+				if ($inCronTab && $startMinute != floor(time() / 60)) {
 					break;
 				}
 				$this->runTask($task);

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -498,7 +498,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 
 		$this->getApplication()->setGlobalState(self::TASKS_INFO, $tasksInfo, []);
 	}
-		
+
 	/**
 	 * Logs the end of the task.
 	 * @param TCronTask $task

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -393,6 +393,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 	public function processPendingTasks()
 	{
 		$inCronTab = TShellApplication::detectCronTabShell();
+		$this->filterStaleTasks();
 		$pendingTasks = $this->getPendingTasks();
 		$numtasks = count($pendingTasks);
 		$startMinute = floor(time() / 60);
@@ -406,7 +407,6 @@ class TCronModule extends \Prado\TModule implements IPermissions
 				$this->runTask($task);
 			}
 		}
-		$this->filterStaleTasks();
 
 		return $numtasks;
 	}
@@ -427,9 +427,13 @@ class TCronModule extends \Prado\TModule implements IPermissions
 	protected function filterStaleTasks()
 	{
 		// Filter out any stale tasks in the global state that aren't in config
-		$tasksInfo = $this->getApplication()->getGlobalState(self::TASKS_INFO, []);
+		$app = $this->getApplication();
+		$tasksInfo = $app->getGlobalState(self::TASKS_INFO, []);
+		$count = count($tasksInfo);
 		$tasksInfo = array_intersect_key($tasksInfo, $this->_tasks);
-		$this->getApplication()->setGlobalState(self::TASKS_INFO, $tasksInfo, []);
+		if ($count != count($tasksInfo)) {
+			$app->setGlobalState(self::TASKS_INFO, $tasksInfo, []);
+		}
 	}
 
 	/**

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -393,10 +393,14 @@ class TCronModule extends \Prado\TModule implements IPermissions
 	{
 		$pendingTasks = $this->getPendingTasks();
 		$numtasks = count($pendingTasks);
+		$startMinute = floor(time() / 60);
 
 		$this->logCron($numtasks);
 		if ($numtasks) {
 			foreach ($pendingTasks as $key => $task) {
+				if ($startMinute != floor(time() / 60)) {
+					break;
+				}
 				$this->runTask($task);
 			}
 		}

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -502,7 +502,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 		$task->setProcessCount($count);
 		$task->setLastExecTime($time);
 
-		$this->getApplication()->setGlobalState(self::TASKS_INFO, $tasksInfo, []);
+		$this->getApplication()->setGlobalState(self::TASKS_INFO, $tasksInfo, [], true);
 	}
 
 	/**
@@ -528,7 +528,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 	 */
 	public function setLastCronTime($time)
 	{
-		$this->getApplication()->setGlobalState(self::LAST_CRON_TIME, TPropertyValue::ensureFloat($time), 0);
+		$this->getApplication()->setGlobalState(self::LAST_CRON_TIME, TPropertyValue::ensureFloat($time), 0, true);
 	}
 
 	/**

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -331,7 +331,9 @@ class TCronModule extends \Prado\TModule implements IPermissions
 	}
 
 	/**
-	 * when instancing and then loading the tasks, this sets the persisting data of the task
+	 * when instancing and then loading the tasks, this sets the persisting data of
+	 * the task from the global state.  When there is no instance in the global state,
+	 * the lastExecTime is initialized.
 	 * @param string $name name of the task.
 	 * @param TCronTask $task the task object.
 	 * @return bool updated the taskInfo with persistent data.
@@ -343,6 +345,12 @@ class TCronModule extends \Prado\TModule implements IPermissions
 			$task->setLastExecTime($tasksInfo[$name]['lastExecTime']);
 			$task->setProcessCount($tasksInfo[$name]['processCount']);
 			return true;
+		} else {
+			$task->resetTaskLastExecTime();
+			$task->setProcessCount(0);
+			$tasksInfo[$name]['lastExecTime'] = $task->getLastExecTime();
+			$tasksInfo[$name]['processCount'] = 0;
+			$this->getApplication()->setGlobalState(self::TASKS_INFO, $tasksInfo, []);
 		}
 		return false;
 	}

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -60,7 +60,7 @@ use Prado\Xml\TXmlDocument;
  * @since 4.2.0
  * @method void dyLogCron($numtasks)
  * @method void dyLogCronTask($task, $username)
- * @method void dyUpdateTaskInfo($task)
+ * @method void dyLogCronTaskEnd($task)
  * @method bool dyRegisterShellAction($returnValue)
  * @method \Prado\Shell\TShellWriter getOutputWriter()
  * @see https://crontab.guru For more info on Crontab Schedule Expressions.
@@ -458,8 +458,9 @@ class TCronModule extends \Prado\TModule implements IPermissions
 		}
 
 		$this->logCronTask($task, $username);
-		$task->execute($this);
 		$this->updateTaskInfo($task);
+		$task->execute($this);
+		$this->logCronTaskEnd($task);
 
 		if ($user) {
 			if ($restore_user) {
@@ -496,9 +497,16 @@ class TCronModule extends \Prado\TModule implements IPermissions
 		$task->setLastExecTime($time);
 
 		$this->getApplication()->setGlobalState(self::TASKS_INFO, $tasksInfo, []);
-
+	}
+		
+	/**
+	 * Logs the end of the task.
+	 * @param TCronTask $task
+	 */
+	protected function logCronTaskEnd($task)
+	{
 		Prado::log('Ending cron task (' . $task->getName() . ', ' . $task->getTask() . ')', TLogger::INFO, 'Prado.Cron.TCronModule');
-		$this->dyUpdateTaskInfo($task);
+		$this->dyLogCronTaskEnd($task);
 	}
 
 	/**

--- a/framework/Util/Cron/TCronTask.php
+++ b/framework/Util/Cron/TCronTask.php
@@ -198,7 +198,7 @@ abstract class TCronTask extends TApplicationComponent
 	}
 
 	/**
-	 * @return numeric|null time of the next trigger after the lastExecTime, null if none.
+	 * @return null|numeric time of the next trigger after the lastExecTime, null if none.
 	 */
 	public function getNextTriggerTime()
 	{

--- a/framework/Util/Cron/TCronTask.php
+++ b/framework/Util/Cron/TCronTask.php
@@ -175,16 +175,35 @@ abstract class TCronTask extends TApplicationComponent
 	 */
 	public function setLastExecTime($v)
 	{
-		$this->_lastexectime = TPropertyValue::ensureInteger($v);
+		if ($v !== null) {
+			$this->_lastexectime = TPropertyValue::ensureInteger($v);
+		} else {
+			$this->_lastexectime = null;
+		}
 	}
 
 	/**
-	 * @return numeric time of the next trigger after the lastExecTime
+	 * Resets the lastExecTime to either null or, if there is a next trigger
+	 * time from time(), sets lastExecTime to now.  This prevents erroneously
+	 * triggering repeating tasks on first cron from existing prior triggers
+	 * from time=0.
+	 */
+	public function resetTaskLastExecTime()
+	{
+		$now = time();
+		$schedule = $this->getScheduler();
+		$nextTriggerTime = $schedule->getNextTriggerTime($now);
+		$this->_lastexectime = ($nextTriggerTime === null) ? null :
+			(($schedule->getNextTriggerTime(0) == $nextTriggerTime) ? null : $now);
+	}
+
+	/**
+	 * @return numeric|null time of the next trigger after the lastExecTime, null if none.
 	 */
 	public function getNextTriggerTime()
 	{
 		$s = $this->getScheduler();
-		return $s->getNextTriggerTime($this->_lastexectime);
+		return $s->getNextTriggerTime($this->_lastexectime ?? 0);
 	}
 
 	/**
@@ -192,7 +211,8 @@ abstract class TCronTask extends TApplicationComponent
 	 */
 	public function getIsPending()
 	{
-		return time() >= $this->getNextTriggerTime();
+		$trigger = $this->getNextTriggerTime();
+		return $trigger !== null && time() >= $trigger;
 	}
 
 	/**

--- a/framework/Util/Cron/TDbCronModule.php
+++ b/framework/Util/Cron/TDbCronModule.php
@@ -384,11 +384,17 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 			return;
 		}
 		$numtasks = count($runtimeTasks);
-		$this->logCron($numtasks);
+		$cronlogger = $this->asa(TCronModule::SHELL_LOG_BEHAVIOR);
+		if ($cronlogger) {
+			$enabled = $cronlogger->getEnabled();
+			$cronlogger->setEnabled(false);
+		}
 		foreach ($runtimeTasks as $key => $task) {
 			$this->runTask($task);
 		}
-		$this->filterStaleTasks();
+		if ($cronlogger) {
+			$cronlogger->setEnabled($enabled);
+		}
 		return $numtasks;
 	}
 

--- a/framework/Util/Cron/TDbCronModule.php
+++ b/framework/Util/Cron/TDbCronModule.php
@@ -340,9 +340,6 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 		$cmd->bindValue(":task", serialize($task), PDO::PARAM_STR);
 		$cmd->bindValue(":name", $task->getName(), PDO::PARAM_STR);
 		$cmd->execute();
-
-		Prado::log('Ending cron task (' . $task->getName() . ', ' . get_class($task) . ')', TLogger::INFO, 'Prado.Cron.TCronModule');
-		$this->dyUpdateTaskInfo($task);
 	}
 
 	/**

--- a/framework/Util/Cron/TDbCronModule.php
+++ b/framework/Util/Cron/TDbCronModule.php
@@ -347,9 +347,10 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 	 */
 	protected function filterStaleTasks()
 	{
+		$this->ensureTasks();
 		$configTasks = $this->_taskRows;
 
-		//remove active tasks
+		//remove non-configuration tasks
 		foreach ($this->_taskRows as $name => $data) {
 			if ($data['active']) {
 				unset($configTasks[$name]);

--- a/framework/Util/Cron/TDbCronModule.php
+++ b/framework/Util/Cron/TDbCronModule.php
@@ -158,6 +158,8 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 	}
 
 	/**
+	 * Sets the lastExecTime and processCount for a task from the DB.
+	 * Also resets the lastExecTime when not in the DB
 	 * @param string $name name of the task to get Persistent Data from
 	 * @param object $task
 	 * @return bool is the persistent data set or not
@@ -165,13 +167,9 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 	protected function setPersistentData($name, $task)
 	{
 		if (isset($this->_taskRows[$name])) {
-			$time = $task->getLastExecTime();
-			$count = $task->getProcessCount();
-			$task->setLastExecTime((int) $this->_taskRows[$name]['lastexectime']);
+			$task->setLastExecTime($this->_taskRows[$name]['lastexectime']);
 			$task->setProcessCount((int) $this->_taskRows[$name]['processcount']);
 			if (serialize($task) !== $this->_taskRows[$name]['options']) {
-				$task->setLastExecTime($time);
-				$task->setProcessCount($count);
 				$this->updateTaskInternal($task);
 				return false;
 			}
@@ -532,6 +530,7 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 		} catch (TInvalidDataValueException $e) {
 			return false;
 		}
+		$task->resetTaskLastExecTime();
 
 		$cmd = $this->getDbConnection()->createCommand(
 			"INSERT INTO {$this->_tableName} " .
@@ -599,11 +598,15 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 		} catch (TInvalidDataValueException $e) {
 			return false;
 		}
+		$schedule = $task->getSchedule();
+		if ($schedule != $this->_taskRows[$name]['schedule']) {
+			$task->resetTaskLastExecTime();
+		}
 
 		$cmd = $this->getDbConnection()->createCommand(
 			"UPDATE {$this->_tableName} SET schedule=:schedule, task=:task, moduleid=:mid, username=:username, options=:options, processcount=:count, lastexectime=:time WHERE name=:name AND active IS NOT NULL"
 		);
-		$cmd->bindValue(":schedule", $schedule = $task->getSchedule(), PDO::PARAM_STR);
+		$cmd->bindValue(":schedule", $schedule, PDO::PARAM_STR);
 		$cmd->bindValue(":task", $taskExec = $task->getTask(), PDO::PARAM_STR);
 		$cmd->bindValue(":mid", $mid = $task->getModuleId(), PDO::PARAM_STR);
 		$cmd->bindValue(":username", $username = $task->getUserName(), PDO::PARAM_STR);
@@ -662,8 +665,7 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 	{
 		$this->ensureTable();
 		$this->ensureTasks(false);
-
-		$name = is_string($untask) ? $untask : $untask->getName();
+		$name = is_subclass_of($untask, 'Prado\Util\Cron\TCronTask') ? $untask->getName() : $untask;
 		if (isset($this->_configTasks[$name])) {
 			return false;
 		}

--- a/framework/Util/Cron/TShellCronLogBehavior.php
+++ b/framework/Util/Cron/TShellCronLogBehavior.php
@@ -138,7 +138,7 @@ class TShellCronLogBehavior extends TBehavior
 	 * @param \Prado\Util\TCallChain $callchain the chain of methods
 	 * @return mixed
 	 */
-	public function dyUpdateTaskInfo($task, $callchain)
+	public function dyLogCronTaskEnd($task, $callchain)
 	{
 		$this->_outWriter->writeLine("Ending Task {$task->getName()}\n");
 

--- a/framework/Util/Cron/TShellCronLogBehavior.php
+++ b/framework/Util/Cron/TShellCronLogBehavior.php
@@ -142,6 +142,6 @@ class TShellCronLogBehavior extends TBehavior
 	{
 		$this->_outWriter->writeLine("Ending Task {$task->getName()}\n");
 
-		return $callchain->dyUpdateTaskInfo($task);
+		return $callchain->dyLogCronTaskEnd($task);
 	}
 }

--- a/framework/Util/Cron/TTimeScheduler.php
+++ b/framework/Util/Cron/TTimeScheduler.php
@@ -37,9 +37,26 @@ use Prado\Exceptions\TInvalidDataValueException;
  * Russian, Hindi, and Arabic and their abbreviations.  The Days of the Week supports English, German,
  * Spanish, French, Italian, Russian, and Hindi and their abbreviations.
  *
+ * There are schedule shortcuts:
+ *     '@yearly' => '0 0 1 1 ?'
+ *     '@annually' => '0 0 1 1 ?'
+ *     '@monthly' => '0 0 1 * ?'
+ *     '@weekly' => '0 0 ? * 0'
+ *     '@midnight' => '0 0 * * ?'
+ *     '@daily' => '0 0 * * ?'
+ *     '@hourly' => '0 * * * ?'
+ *
+ * An efficient one-off task at a specified unix time can be scheduled with
+ * '@(\d)' where \d is the unix time in the local php instance time zone.
+ * This minimizes costly validation, parsing, and nextTriggerTime processing.
+ * This allows for a higher cron task throughput to handle more cron tasks.
+ *
+ * e.g. '@1668165071' for 2022-11-11 11:11:11 and will trigger after the
+ * specified time at '12 11 11 11 ? 2022.'
+ *
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 4.2.0
- *
+ * @see https://crontab.guru For more info on Crontab Schedule Expressions.
  */
 class TTimeScheduler extends \Prado\TComponent
 {
@@ -67,6 +84,9 @@ class TTimeScheduler extends \Prado\TComponent
 
 	/** The cron schedule */
 	private $_schedule;
+
+	/** efficient one off trigger time */
+	protected $_triggerTime;
 
 	/** the parsed attributes of the schedule */
 	private $_attr = [];
@@ -107,6 +127,9 @@ class TTimeScheduler extends \Prado\TComponent
 				]
 		];
 
+	/** validation is computed only once */
+	private static $_validatorCache;
+
 	/**
 	 * @return string This returns the cron schedule
 	 */
@@ -130,58 +153,91 @@ class TTimeScheduler extends \Prado\TComponent
 		$schedule = trim($schedule);
 		$this->_schedule = $schedule;
 		$this->_attr = [];
-		$minute = '(?:[0-9]|[1-5][0-9])';
-		$minuteStar = '\*(?:\/(?:[1-9]|[1-5][0-9]))?';
-		$minuteRegex = $minute . '(?:\-(?:[1-9]|[1-5][0-9]))?(?:\/(?:[1-9]|[1-5][0-9]))?';
-		$hour = '(?:[0-9]|1[0-9]|2[0-3])';
-		$hourStar = '\*(?:\/(?:[1-9]|1[0-9]|2[0-3]))?';
-		$hourRegex = $hour . '(?:\-(?:[1-9]|1[0-9]|2[0-3]))?(?:\/(?:[1-9]|1[0-9]|2[0-3]))?';
-		$dom = '(?:(?:[1-9]|[12][0-9]|3[01])W?)';
-		$domWOW = '(?:[1-9]|[12][0-9]|3[01])';
-		$domStar = '\*(?:\/(?:[1-9]|[12][0-9]|3[01]))?';
-		$domRegex = '(?:' . $dom . '(?:\-' . $dom . ')?(?:\/' . $domWOW . ')?|' . '(?:L(?:\-[1-5])?)' . ')';
-		$month = '(?:[1-9]|1[012]|' .
-			self::$_keywords[self::MONTH_OF_YEAR][1] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][2] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][3] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][4] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][5] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][6] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][7] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][8] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][9] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][10] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][11] . '|' .
-			self::$_keywords[self::MONTH_OF_YEAR][12] . ')';
-		$monthStar = '\*(?:\/(?:[1-9]|1[012]))?';
-		$monthRegex = $month . '(?:\-' . $month . ')?(?:\/(?:[1-9]|1[012]))?';
-		$dow = '(?:[0-6]|' .
-			self::$_keywords[self::DAY_OF_WEEK][0] . '|' .
-			self::$_keywords[self::DAY_OF_WEEK][1] . '|' .
-			self::$_keywords[self::DAY_OF_WEEK][2] . '|' .
-			self::$_keywords[self::DAY_OF_WEEK][3] . '|' .
-			self::$_keywords[self::DAY_OF_WEEK][4] . '|' .
-			self::$_keywords[self::DAY_OF_WEEK][5] . '|' .
-			self::$_keywords[self::DAY_OF_WEEK][6] . ')';
-		$dowStar = '\*(?:\/[0-6])?';
-		$dowRegex = '(?:[0-6]L|' . $dow . '(?:(?:\-' . $dow . ')?(?:\/[0-6])?|#[1-5])?)';
-		$year = '(?:19[7-9][0-9]|20[0-9][0-9])';
-		$yearStar = '\*(?:\/[0-9]?[0-9])?';
-		$yearRegex = $year . '(?:\-' . $year . ')?(?:\/[0-9]?[0-9])?';
-		$regex = '/^(?:(@(?:annually|yearly|monthly|weekly|daily|hourly))|' .
-			'(?#minute)((?:' . $minuteStar . '|' . $minuteRegex . ')(?:\,(?:' . $minuteStar . '|' . $minuteRegex . '))*)[\s]+' .
-			'(?#hour)((?:' . $hourStar . '|' . $hourRegex . ')(?:\,(?:' . $hourStar . '|' . $hourRegex . '))*)[\s]+' .
-			'(?#DoM)(\?|(?:(?:' . $domStar . '|' . $domRegex . ')(?:,(?:' . $domStar . '|' . $domRegex . '))*))[\s]+' .
-			'(?#month)((?:' . $monthStar . '|' . $monthRegex . ')(?:\,(?:' . $monthStar . '|' . $monthRegex . '))*)[\s]+' .
-			'(?#DoW)(\?|(?:' . $dowStar . '|' . $dowRegex . ')(?:\,(?:' . $dowStar . '|' . $dowRegex . '))*)' .
-			'(?#year)(?:[\s]+' .
-				'((?:' . $yearStar . '|' . $yearRegex . ')(?:\,(?:' . $yearStar . '|' . $yearRegex . '))*)' .
-			')?' .
-		')$/i';
+		if (strlen($schedule) > 2 && $schedule[0] == '@') {
+			if (is_numeric($triggerTime = substr($schedule, 1))) {
+				$this->_triggerTime = (int) $triggerTime;
+				return;
+			}
+		}
+
+		if (self::$_validatorCache) {
+			$minuteValidator = self::$_validatorCache['m'];
+			$hourValidator = self::$_validatorCache['h'];
+			$domValidator = self::$_validatorCache['dom'];
+			$monthValidator = self::$_validatorCache['mo'];
+			$dowValidator = self::$_validatorCache['dow'];
+			$yearValidator = self::$_validatorCache['y'];
+			$fullValidator = self::$_validatorCache['f'];
+		} else {
+			$minute = '(?:[0-9]|[1-5][0-9])';
+			$minuteStar = '\*(?:\/(?:[1-9]|[1-5][0-9]))?';
+			$minuteRegex = $minute . '(?:\-(?:[1-9]|[1-5][0-9]))?(?:\/(?:[1-9]|[1-5][0-9]))?';
+			$hour = '(?:[0-9]|1[0-9]|2[0-3])';
+			$hourStar = '\*(?:\/(?:[1-9]|1[0-9]|2[0-3]))?';
+			$hourRegex = $hour . '(?:\-(?:[1-9]|1[0-9]|2[0-3]))?(?:\/(?:[1-9]|1[0-9]|2[0-3]))?';
+			$dom = '(?:(?:[1-9]|[12][0-9]|3[01])W?)';
+			$domWOW = '(?:[1-9]|[12][0-9]|3[01])';
+			$domStar = '\*(?:\/(?:[1-9]|[12][0-9]|3[01]))?';
+			$domRegex = '(?:' . $dom . '(?:\-' . $dom . ')?(?:\/' . $domWOW . ')?|' . '(?:L(?:\-[1-5])?)' . ')';
+			$month = '(?:[1-9]|1[012]|' .
+				self::$_keywords[self::MONTH_OF_YEAR][1] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][2] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][3] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][4] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][5] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][6] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][7] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][8] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][9] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][10] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][11] . '|' .
+				self::$_keywords[self::MONTH_OF_YEAR][12] . ')';
+			$monthStar = '\*(?:\/(?:[1-9]|1[012]))?';
+			$monthRegex = $month . '(?:\-' . $month . ')?(?:\/(?:[1-9]|1[012]))?';
+			$dow = '(?:[0-6]|' .
+				self::$_keywords[self::DAY_OF_WEEK][0] . '|' .
+				self::$_keywords[self::DAY_OF_WEEK][1] . '|' .
+				self::$_keywords[self::DAY_OF_WEEK][2] . '|' .
+				self::$_keywords[self::DAY_OF_WEEK][3] . '|' .
+				self::$_keywords[self::DAY_OF_WEEK][4] . '|' .
+				self::$_keywords[self::DAY_OF_WEEK][5] . '|' .
+				self::$_keywords[self::DAY_OF_WEEK][6] . ')';
+			$dowStar = '\*(?:\/[0-6])?';
+			$dowRegex = '(?:[0-6]L|' . $dow . '(?:(?:\-' . $dow . ')?(?:\/[0-6])?|#[1-5])?)';
+			$year = '(?:19[7-9][0-9]|20[0-9][0-9])';
+			$yearStar = '\*(?:\/[0-9]?[0-9])?';
+			$yearRegex = $year . '(?:\-' . $year . ')?(?:\/[0-9]?[0-9])?';
+			$fullValidator = '/^(?:(@(?:annually|yearly|monthly|weekly|daily|hourly))|' .
+				'(?#minute)((?:' . $minuteStar . '|' . $minuteRegex . ')(?:\,(?:' . $minuteStar . '|' . $minuteRegex . '))*)[\s]+' .
+				'(?#hour)((?:' . $hourStar . '|' . $hourRegex . ')(?:\,(?:' . $hourStar . '|' . $hourRegex . '))*)[\s]+' .
+				'(?#DoM)(\?|(?:(?:' . $domStar . '|' . $domRegex . ')(?:,(?:' . $domStar . '|' . $domRegex . '))*))[\s]+' .
+				'(?#month)((?:' . $monthStar . '|' . $monthRegex . ')(?:\,(?:' . $monthStar . '|' . $monthRegex . '))*)[\s]+' .
+				'(?#DoW)(\?|(?:' . $dowStar . '|' . $dowRegex . ')(?:\,(?:' . $dowStar . '|' . $dowRegex . '))*)' .
+				'(?#year)(?:[\s]+' .
+					'((?:' . $yearStar . '|' . $yearRegex . ')(?:\,(?:' . $yearStar . '|' . $yearRegex . '))*)' .
+				')?' .
+			')$/i';
+
+			$minuteValidator = '/^(\*|' . $minute . ')(?:\-(' . $minute . '))?(?:\/(' . $minute . '))?$/i';
+			$hourValidator = '/^(\*|' . $hour . ')(?:\-(' . $hour . '))?(?:\/(' . $hour . '))?$/i';
+			$domValidator = '/^(\*|\?|L|' . $domWOW . ')(W)?(?:\-(' . $domWOW . ')(W)?)?(?:\/(' . $domWOW . '))?$/i';
+			$monthValidator = '/^(\*|' . $month . ')(?:\-(' . $month . '))?(?:\/(' . $month . '))?$/i';
+			$dowValidator = '/^(\*|\?|' . $dow . ')(L)?(?:\-(' . $dow . ')(L)?)?(?:\/(' . $dow . '))?(?:#([1-5]))?$/i';
+			$yearValidator = '/^(\*|' . $year . ')(?:\-(' . $year . '))?(?:\/([1-9]?[0-9]))?$/i';
+			self::$_validatorCache = [
+					'm' => $minuteValidator,
+					'h' => $hourValidator,
+					'dom' => $domValidator,
+					'mo' => $monthValidator,
+					'dow' => $dowValidator,
+					'y' => $yearValidator,
+					'f' => $fullValidator
+				];
+		}
 
 		$i = 0;
 		do {
-			if (!preg_match($regex, $schedule, $matches)) {
+			if (!preg_match($fullValidator, $schedule, $matches)) {
 				throw new TInvalidDataValueException('timescheduler_invalid_string', $schedule);
 			}
 			if ($matches[1]) {
@@ -195,7 +251,7 @@ class TTimeScheduler extends \Prado\TComponent
 
 		$this->_attr[self::MINUTE] = [];
 		foreach (explode(',', $matches[2]) as $match) {
-			if (preg_match('/^(\*|' . $minute . ')(?:\-(' . $minute . '))?(?:\/(' . $minute . '))?$/i', $match, $m2)) {
+			if (preg_match($minuteValidator, $match, $m2)) {
 				if ($m2[1] === '*') {
 					$data = ['min' => 0, 'end' => 59];
 				} else {
@@ -214,7 +270,7 @@ class TTimeScheduler extends \Prado\TComponent
 
 		$this->_attr[self::HOUR] = [];
 		foreach (explode(',', $matches[3]) as $match) {
-			if (preg_match('/^(\*|' . $hour . ')(?:\-(' . $hour . '))?(?:\/(' . $hour . '))?$/i', $match, $m2)) {
+			if (preg_match($hourValidator, $match, $m2)) {
 				if ($m2[1] === '*') {
 					$data = ['hour' => 0, 'end' => 23];
 				} else {
@@ -233,7 +289,7 @@ class TTimeScheduler extends \Prado\TComponent
 
 		$this->_attr[self::DAY_OF_MONTH] = [];
 		foreach (explode(',', $matches[4]) as $match) {
-			if (preg_match('/^(\*|\?|L|' . $domWOW . ')(W)?(?:\-(' . $domWOW . ')(W)?)?(?:\/(' . $domWOW . '))?$/i', $match, $m2)) {
+			if (preg_match($domValidator, $match, $m2)) {
 				$data = ['dom' => $m2[1]]; // *, ?, \d, L
 				$data['domWeekday'] = $m2[2] ?? null;
 				$data['end'] = $m2[3] ?? ($m2[1] != 'L' ? $m2[1] : null);
@@ -251,7 +307,7 @@ class TTimeScheduler extends \Prado\TComponent
 
 		$this->_attr[self::MONTH_OF_YEAR] = [];
 		foreach (explode(',', $matches[5]) as $match) {
-			if (preg_match('/^(\*|' . $month . ')(?:\-(' . $month . '))?(?:\/(' . $month . '))?$/i', $match, $m2)) {
+			if (preg_match($monthValidator, $match, $m2)) {
 				if ($m2[1] === '*') {
 					$data = ['moy' => 1, 'end' => 12];
 				} else {
@@ -270,7 +326,7 @@ class TTimeScheduler extends \Prado\TComponent
 
 		$this->_attr[self::DAY_OF_WEEK] = [];
 		foreach (explode(',', $matches[6]) as $match) {
-			if (preg_match('/^(\*|\?|' . $dow . ')(L)?(?:\-(' . $dow . ')(L)?)?(?:\/(' . $dow . '))?(?:#([1-5]))?$/i', $match, $m2)) {
+			if (preg_match($dowValidator, $match, $m2)) {
 				if ($m2[1] === '*' || $m2[1] === '?') {
 					$data = ['dow' => 0, 'end' => 6];
 				} else {
@@ -293,7 +349,7 @@ class TTimeScheduler extends \Prado\TComponent
 		$this->_attr[self::YEAR] = [];
 		$matches[7] = $matches[7] ?? '*';
 		foreach (explode(',', $matches[7]) as $match) {
-			if (preg_match('/^(\*|' . $year . ')(?:\-(' . $year . '))?(?:\/([1-9]?[0-9]))?$/i', $match, $m2)) {
+			if (preg_match($yearValidator, $match, $m2)) {
 				if ($m2[1] === '*') {
 					$data = ['year' => self::YEAR_MIN];
 					$data['end'] = self::YEAR_MAX;
@@ -520,7 +576,7 @@ class TTimeScheduler extends \Prado\TComponent
 	protected function getYearsArray()
 	{
 		$ya = [];
-		for ($i = self::YEAR_MIN; $i <= self::YEAR_MAX; $i++) {
+		for ($i = self::YEAR_MIN - 1; $i <= self::YEAR_MAX; $i++) {
 			$ya['' . $i] = 0;
 		}
 		foreach ($this->_attr[self::YEAR] as $m) {
@@ -544,14 +600,18 @@ class TTimeScheduler extends \Prado\TComponent
 		if ($priortime === null || $this->_schedule === null) {
 			return null;
 		}
-		$restoreZone = date_default_timezone_get();
-		date_default_timezone_set("UTC");
 		if ($priortime === false) {
 			$priortime = time();
-		}
-		if (!is_numeric($priortime)) {
+		} elseif (!is_numeric($priortime)) {
 			$priortime = strtotime($priortime);
 		}
+		if ($this->_triggerTime !== null) {
+			if ($priortime >= $this->_triggerTime) {
+				return null;
+			}
+			return $this->_triggerTime;
+		}
+
 		$lastdata = getdate($priortime);
 
 		$oyear = $year = $lastdata['year'];
@@ -663,7 +723,6 @@ class TTimeScheduler extends \Prado\TComponent
 						$month = 1;
 						$year++;
 						if ($year > self::YEAR_MAX) {
-							date_default_timezone_set($restoreZone);
 							return null;
 						}
 					}
@@ -693,7 +752,6 @@ class TTimeScheduler extends \Prado\TComponent
 		} else {
 			$time = strtotime("$nyear-$nmonth-$nday $nhour:$nmin:00");
 		}
-		date_default_timezone_set($restoreZone);
 		return $time;
 	}
 }

--- a/framework/Util/Cron/TTimeScheduler.php
+++ b/framework/Util/Cron/TTimeScheduler.php
@@ -153,7 +153,7 @@ class TTimeScheduler extends \Prado\TComponent
 		$schedule = trim($schedule);
 		$this->_schedule = $schedule;
 		$this->_attr = [];
-		if (strlen($schedule) > 2 && $schedule[0] == '@') {
+		if (strlen($schedule) > 1 && $schedule[0] == '@') {
 			if (is_numeric($triggerTime = substr($schedule, 1))) {
 				$this->_triggerTime = (int) $triggerTime;
 				return;

--- a/framework/Util/Cron/TTimeScheduler.php
+++ b/framework/Util/Cron/TTimeScheduler.php
@@ -52,7 +52,7 @@ use Prado\Exceptions\TInvalidDataValueException;
  * This allows for a higher cron task throughput to handle more cron tasks.
  *
  * e.g. '@1668165071' for 2022-11-11 11:11:11 and will trigger after the
- * specified time at '12 11 11 11 ? 2022.'
+ * specified time at '12 11 11 11 ? 2022'.
  *
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 4.2.0

--- a/framework/Util/TCallChain.php
+++ b/framework/Util/TCallChain.php
@@ -30,7 +30,7 @@ use Prado\Collections\TList;
  * @method string dyFlush()
  * @method mixed dyLogCron(int $numtasks)
  * @method mixed dyLogCronTask(\Prado\Util\Cron\TCronTask $task, string $username)
- * @method mixed dyUpdateTaskInfo(Prado\Util\Cron\TCronTask $task)
+ * @method mixed dyLogCronTaskEnd(Prado\Util\Cron\TCronTask $task)
  */
 class TCallChain extends TList implements IDynamicMethods
 {

--- a/framework/Web/UI/TTheme.php
+++ b/framework/Web/UI/TTheme.php
@@ -146,7 +146,7 @@ class TTheme extends \Prado\TApplicationComponent implements ITheme
 				} elseif (basename($file, '.js') !== $file) {
 					$this->_jsFiles[] = $themeUrl . DIRECTORY_SEPARATOR . $file;
 				} elseif (basename($file, self::SKIN_FILE_EXT) !== $file) {
-					$template = new TSkinTemplate(file_get_contents($themePath . DIRECTORY_SEPARATOR . $file), $themePath, $themePath . '/' . $file);
+					$template = new TSkinTemplate(file_get_contents($themePath . DIRECTORY_SEPARATOR . $file), $themePath, $themePath . DIRECTORY_SEPARATOR . $file);
 					foreach ($template->getItems() as $skin) {
 						if (!isset($skin[2])) {  // a text string, ignored
 							continue;

--- a/tests/unit/Util/Cron/ClearCronTest.php
+++ b/tests/unit/Util/Cron/ClearCronTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+class ClearCronTest extends PHPUnit\Framework\TestCase
+{
+	protected function setUp(): void
+	{
+	}
+
+	protected function tearDown(): void
+	{
+	}
+
+	public function testLog()
+	{
+		// Initialize the Cron DB by deleting any remnants of prior tests
+		// Remnants of prior tests (and errors [by not cleaning up]) can screw up the current round of tests.
+		// So we delete the prior test cron.jobs db to start in a clean place.
+		@unlink(Prado::getApplication()->getRuntimePath() . DIRECTORY_SEPARATOR . 'cron.jobs');
+		self::assertTrue(true);
+	}
+}

--- a/tests/unit/Util/Cron/TCronModuleTest.php
+++ b/tests/unit/Util/Cron/TCronModuleTest.php
@@ -334,26 +334,26 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 	public function testGetTasks()
 	{
 		$jobs = [
-			['name' => 'testTask1', 'schedule' => '1 * * * *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
-			['name' => 'testTask2', 'schedule' => '2 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1', 'username' => 'admin1'],
-			['name' => 'testTask3', 'schedule' => '3 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTask4', 'schedule' => '4 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTask1', 'schedule' => '1 0 1 1 *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
+			['name' => 'testTask2', 'schedule' => '2 0 1 1 * 2000', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1', 'username' => 'admin1'],
+			['name' => 'testTask3', 'schedule' => '3 0 1 1 * 2099', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
+			['name' => 'testTask4', 'schedule' => '4 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
 		];
 		$this->obj->init($jobs);
 		$tasks = $this->obj->getRawTasks();
 		self::assertNotNull($tasks);
 		self::assertEquals(4, count($tasks));
-		self::assertEquals('1 * * * *', $tasks['testTask1']['schedule']);
+		self::assertEquals('1 0 1 1 *', $tasks['testTask1']['schedule']);
 		self::assertEquals('TTestCronModuleTask', $tasks['testTask1']['task']);
 		self::assertEquals('value1', $tasks['testTask1']['propertya']);
 		self::assertEquals('admin', $tasks['testTask1']['username']);
 		self::assertEquals('GT_module', $tasks['testTask1']['moduleid']);
-		self::assertEquals('2 * * * *', $tasks['testTask2']['schedule']);
+		self::assertEquals('2 0 1 1 * 2000', $tasks['testTask2']['schedule']);
 		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method1', $tasks['testTask2']['task']);
 		self::assertEquals('admin1', $tasks['testTask2']['username']);
-		self::assertEquals('3 * * * *', $tasks['testTask3']['schedule']);
+		self::assertEquals('3 0 1 1 * 2099', $tasks['testTask3']['schedule']);
 		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method2(true)', $tasks['testTask3']['task']);
-		self::assertEquals('4 * * * *', $tasks['testTask4']['schedule']);
+		self::assertEquals('4 0 1 1 *', $tasks['testTask4']['schedule']);
 		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method3(86400)', $tasks['testTask4']['task']);
 		
 		$tasks = $this->obj->getTasks();
@@ -362,22 +362,22 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		
 		self::assertEquals(4, count($tasks));
 		self::assertInstanceOf('TTestCronModuleTask', $tasks['testTask1']);
-		self::assertEquals('1 * * * *', $tasks['testTask1']->getSchedule());
+		self::assertEquals('1 0 1 1 *', $tasks['testTask1']->getSchedule());
 		self::assertEquals('testTask1', $tasks['testTask1']->getName());
 		self::assertEquals('admin', $tasks['testTask1']->getUserName());
 		self::assertEquals('GT_module', $tasks['testTask1']->getModuleId());
 		self::assertEquals('value1', $tasks['testTask1']->getPropertyA());
-		self::assertEquals('2 * * * *', $tasks['testTask2']->getSchedule());
+		self::assertEquals('2 0 1 1 * 2000', $tasks['testTask2']->getSchedule());
 		self::assertEquals('testTask2', $tasks['testTask2']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask2']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask2']->getModuleId());
 		self::assertEquals('method1', $tasks['testTask2']->getMethod());
-		self::assertEquals('3 * * * *', $tasks['testTask3']->getSchedule());
+		self::assertEquals('3 0 1 1 * 2099', $tasks['testTask3']->getSchedule());
 		self::assertEquals('testTask3', $tasks['testTask3']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask3']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask3']->getModuleId());
 		self::assertEquals('method2(true)', $tasks['testTask3']->getMethod());
-		self::assertEquals('4 * * * *', $tasks['testTask4']->getSchedule());
+		self::assertEquals('4 0 1 1 *', $tasks['testTask4']->getSchedule());
 		self::assertEquals('testTask4', $tasks['testTask4']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask4']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask4']->getModuleId());
@@ -391,24 +391,24 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask4']);
 		
 		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask1']->getLastExecTime());
+		self::assertTrue(abs($tasks['testTask1']->getLastExecTime() - time()) < 2);
 		self::assertEquals(0, $tasks['testTask2']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask2']->getLastExecTime());
+		self::assertNull($tasks['testTask2']->getLastExecTime());
 		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask3']->getLastExecTime());
+		self::assertNull($tasks['testTask3']->getLastExecTime());
 		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask4']->getLastExecTime());
+		self::assertTrue(abs($tasks['testTask4']->getLastExecTime() - time()) < 2);
 		
 		//check updateTaskInfo - test persistent data
-		self::assertEquals(4, $this->obj->processPendingTasks());
+		self::assertEquals(1, $this->obj->processPendingTasks());
 		
-		self::assertEquals(1, $tasks['testTask1']->getProcessCount());
+		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask1']->getLastExecTime() < 2);
 		self::assertEquals(1, $tasks['testTask2']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask2']->getLastExecTime() < 2);
-		self::assertEquals(1, $tasks['testTask3']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask3']->getLastExecTime() < 2);
-		self::assertEquals(1, $tasks['testTask4']->getProcessCount());
+		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
+		self::assertNull($tasks['testTask3']->getLastExecTime());
+		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask4']->getLastExecTime() < 2);
 		
 		// check 
@@ -420,13 +420,13 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		
 		$tasks = $this->obj->getTasks();
 		
-		self::assertEquals(1, $tasks['testTask1']->getProcessCount());
+		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask1']->getLastExecTime() < 2);
 		self::assertEquals(1, $tasks['testTask2']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask2']->getLastExecTime() < 2);
-		self::assertEquals(1, $tasks['testTask3']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask3']->getLastExecTime() < 2);
-		self::assertEquals(1, $tasks['testTask4']->getProcessCount());
+		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
+		self::assertEquals(0, $tasks['testTask3']->getLastExecTime());
+		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask4']->getLastExecTime() < 2);
 	}
 	
@@ -453,7 +453,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		self::assertEquals('admin', $tasks['testTask1']->getUserName());
 		self::assertEquals('GT_module', $tasks['testTask1']->getModuleId());
 		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask1']->getLastExecTime());
+		self::assertTrue((microtime(true) - $tasks['testTask1']->getLastExecTime()) < 2);
 		self::assertEquals('value1', $tasks['testTask1']->getPropertyA());
 		self::assertEquals('2 * * * ?', $tasks['testTask2']->getSchedule());
 		self::assertEquals('testTask2', $tasks['testTask2']->getName());
@@ -461,35 +461,39 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		self::assertEquals('CMT_UserManager3', $tasks['testTask2']->getModuleId());
 		self::assertEquals('method1', $tasks['testTask2']->getMethod());
 		self::assertEquals(0, $tasks['testTask2']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask2']->getLastExecTime());
+		self::assertTrue((microtime(true) - $tasks['testTask2']->getLastExecTime()) < 2);
 		self::assertEquals('3 * * * ?', $tasks['testTask3']->getSchedule());
 		self::assertEquals('testTask3', $tasks['testTask3']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask3']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask3']->getModuleId());
 		self::assertEquals('method2(true)', $tasks['testTask3']->getMethod());
 		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask3']->getLastExecTime());
+		self::assertTrue((microtime(true) - $tasks['testTask3']->getLastExecTime()) < 2);
 		self::assertEquals('4 * * * ?', $tasks['testTask4']->getSchedule());
 		self::assertEquals('testTask4', $tasks['testTask4']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask4']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask4']->getModuleId());
 		self::assertEquals('method3(86400)', $tasks['testTask4']->getMethod());
 		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask4']->getLastExecTime());
+		self::assertTrue((microtime(true) - $tasks['testTask4']->getLastExecTime()) < 2);
 	}
 	
 	protected function checkPersistentData()
 	{
 		// checks the task info where it is stored.
 		$tasksInfo = Prado::getApplication()->getGlobalState(TCronModule::TASKS_INFO, []);
-		self::assertEquals(1, $tasksInfo['testTask1']['processCount']);
+		self::assertTrue(isset($tasksInfo['testTask1']));
+		self::assertEquals(0, $tasksInfo['testTask1']['processCount']);
 		self::assertTrue(microtime(true) - $tasksInfo['testTask1']['lastExecTime'] < 2);
+		self::assertTrue(isset($tasksInfo['testTask2']));
 		self::assertEquals(1, $tasksInfo['testTask2']['processCount']);
 		self::assertTrue(microtime(true) - $tasksInfo['testTask2']['lastExecTime'] < 2);
-		self::assertEquals(1, $tasksInfo['testTask3']['processCount']);
-		self::assertTrue(microtime(true) - $tasksInfo['testTask3']['lastExecTime'] < 2);
-		self::assertEquals(1, $tasksInfo['testTask4']['processCount']);
-		self::assertTrue(microtime(true) - $tasksInfo['testTask4']['lastExecTime'] < 2);
+		self::assertTrue(isset($tasksInfo['testTask3']));
+		self::assertEquals(0, $tasksInfo['testTask3']['processCount']);
+		self::assertTrue(0 - $tasksInfo['testTask3']['lastExecTime'] < 2);
+		self::assertTrue(isset($tasksInfo['testTask4']));
+		self::assertEquals(0, $tasksInfo['testTask4']['processCount']);
+		self::assertTrue(0 - $tasksInfo['testTask4']['lastExecTime'] < 2);
 	}
 	
 	public function testGetPendingTasks()
@@ -498,17 +502,21 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			['name' => 'testTask1', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronModuleTask'],
 			['name' => 'testTask2', 'schedule' => '0 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1'],
 			['name' => 'testTask3', 'schedule' => '0 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTask4', 'schedule' => '0 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTask4', 'schedule' => '0 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)'],
+			['name' => 'testTask5', 'schedule' => '0 0 1 1 * ' . TTimeScheduler::YEAR_MAX, 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)'],
+			['name' => 'testTask6', 'schedule' => '0 0 1 1 * 2000', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		]);
 		$pendingTasks = $this->obj->getPendingTasks();
-		self::assertEquals(4, count($pendingTasks));
-		self::assertInstanceOf('TTestCronModuleTask', $pendingTasks['testTask1']);
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $pendingTasks['testTask2']);
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $pendingTasks['testTask3']);
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $pendingTasks['testTask4']);
-		
-		self::assertEquals(4, $this->obj->processPendingTasks());
-		
+		self::assertEquals(1, count($pendingTasks));
+		self::assertFalse(isset($pendingTasks['testTask1']));
+		self::assertFalse(isset($pendingTasks['testTask2']));
+		self::assertFalse(isset($pendingTasks['testTask3']));
+		self::assertFalse(isset($pendingTasks['testTask4']));
+		self::assertFalse(isset($pendingTasks['testTask5']));
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $pendingTasks['testTask6']);
+
+		self::assertEquals(1, $this->obj->processPendingTasks());
+
 		$pendingTasks = $this->obj->getPendingTasks();
 		self::assertEquals(0, count($pendingTasks));
 		self::assertEquals(0, $this->obj->processPendingTasks());
@@ -566,8 +574,8 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 	public function testProcessPendingTasks()
 	{
 		$jobs = [
-			['name' => 'testTask1', 'schedule' => '0 0 1 1 ?', 'task' => 'TTestCronModuleTask'],
-			['name' => 'testTask2', 'schedule' => '0 0 1 1 ?', 'task' => 'TTestCronModuleTask']
+			['name' => 'testTask1', 'schedule' => '0 0 1 1 ? 2000', 'task' => 'TTestCronModuleTask'],
+			['name' => 'testTask2', 'schedule' => '0 0 1 1 ? 2020', 'task' => 'TTestCronModuleTask']
 		];
 		$this->obj->init($jobs);
 		$tasks = $this->obj->getTasks();
@@ -606,7 +614,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 	public function testRunTask()
 	{
 		{ // no UserManager
-			$jobs = [['name' => 'testTask1', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronUserTask']];
+			$jobs = [['name' => 'testTask1', 'schedule' => '0 0 1 1 * 2020', 'task' => 'TTestCronUserTask']];
 			$this->obj->init($jobs);
 			self::assertEquals(1, $this->obj->processPendingTasks());
 			$task = $this->obj->getTask('testTask1');
@@ -621,7 +629,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		$app->setUser($user);
 		
 		{ // without UserManager, current user is task executor, and needs to restore.
-			$jobs = [['name' => 'testTask2', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronUserTask']];
+			$jobs = [['name' => 'testTask2', 'schedule' => '0 0 1 1 * 2020', 'task' => 'TTestCronUserTask']];
 			$this->obj = new $this->baseClass();
 			$this->obj->init($jobs);
 			self::assertEquals(1, $this->obj->processPendingTasks());
@@ -638,7 +646,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		
 		{	//app user is restored 
 			//Task with no user ID, default module user
-			$jobs = [['name' => 'testTask1', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronUserTask']];
+			$jobs = [['name' => 'testTask1', 'schedule' => '0 0 1 1 * 2020', 'task' => 'TTestCronUserTask']];
 			$this->obj = new $this->baseClass();
 			$this->obj->setUserManager($users);
 			$this->obj->init($jobs);
@@ -648,7 +656,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			self::assertEquals($user, $app->getUser());
 		}
 		{	//task with user id
-			$jobs = [['name' => 'testTask2', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronUserTask', 'username' => 'admin']];
+			$jobs = [['name' => 'testTask2', 'schedule' => '0 0 1 1 * 2020', 'task' => 'TTestCronUserTask', 'username' => 'admin']];
 			$this->obj = new $this->baseClass();
 			$this->obj->setUserManager($users);
 			$this->obj->init($jobs);
@@ -659,7 +667,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		}
 		
 		{	//task with bad user id
-			$jobs = [['name' => 'testTask1', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronUserTask', 'username' => 'admin2']];
+			$jobs = [['name' => 'testTask1', 'schedule' => '0 0 1 1 * 2020', 'task' => 'TTestCronUserTask', 'username' => 'admin2']];
 			$this->obj = new $this->baseClass();
 			$this->obj->setUserManager($users);
 			$this->obj->init($jobs);
@@ -670,7 +678,7 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		}
 		
 		{	//task with bad user id, and bad default user id
-			$jobs = [['name' => 'testTask2', 'schedule' => '0 0 1 1 *', 'task' => 'TTestCronUserTask', 'username' => 'admin2']];
+			$jobs = [['name' => 'testTask2', 'schedule' => '0 0 1 1 * 2020', 'task' => 'TTestCronUserTask', 'username' => 'admin2']];
 			$this->obj = new $this->baseClass();
 			$this->obj->setUserManager($users);
 			$this->obj->setDefaultUserName('cron2');

--- a/tests/unit/Util/Cron/TCronModuleTest.php
+++ b/tests/unit/Util/Cron/TCronModuleTest.php
@@ -334,82 +334,114 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 	public function testGetTasks()
 	{
 		$jobs = [
-			['name' => 'testTask1', 'schedule' => '1 0 1 1 *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
-			['name' => 'testTask2', 'schedule' => '2 0 1 1 * 2000', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1', 'username' => 'admin1'],
-			['name' => 'testTask3', 'schedule' => '3 0 1 1 * 2099', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTask4', 'schedule' => '4 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => $tn1 = 'testTask1', 'schedule' => '1 0 1 1 *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
+			['name' => $tn2 = 'testTask2', 'schedule' => '2 0 1 1 * 2000', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1', 'username' => 'admin1'],
+			['name' => $tn3 = 'testTask3', 'schedule' => '3 0 1 1 * 2099', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
+			['name' => $tn4 = 'testTask4', 'schedule' => '4 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)'],
+			['name' => $tn5 = 'minute2', 'schedule' => '1 0 1 1 * 2000', 'task' => 'TTestCronModuleTask', 'username' => 'cron'],
+			['name' => $tn6 = 'testMessage2', 'schedule' => '1 0 1 1 * 2000', 'task' => 'TTestCronModuleTask', 'username' => 'root1'],
+			['name' => $tn7 = 'minute10', 'schedule' => '1 0 1 1 * 2000', 'task' => 'TTestCronModuleTask', 'username' => 'admin']
 		];
 		$this->obj->init($jobs);
 		$tasks = $this->obj->getRawTasks();
 		self::assertNotNull($tasks);
-		self::assertEquals(4, count($tasks));
-		self::assertEquals('1 0 1 1 *', $tasks['testTask1']['schedule']);
-		self::assertEquals('TTestCronModuleTask', $tasks['testTask1']['task']);
-		self::assertEquals('value1', $tasks['testTask1']['propertya']);
-		self::assertEquals('admin', $tasks['testTask1']['username']);
-		self::assertEquals('GT_module', $tasks['testTask1']['moduleid']);
-		self::assertEquals('2 0 1 1 * 2000', $tasks['testTask2']['schedule']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method1', $tasks['testTask2']['task']);
-		self::assertEquals('admin1', $tasks['testTask2']['username']);
-		self::assertEquals('3 0 1 1 * 2099', $tasks['testTask3']['schedule']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method2(true)', $tasks['testTask3']['task']);
-		self::assertEquals('4 0 1 1 *', $tasks['testTask4']['schedule']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method3(86400)', $tasks['testTask4']['task']);
+		self::assertEquals(count($jobs), count($tasks));
+			
+		self::assertEquals($jobs[0]['name'], $tasks[$tn1]['name']);
+		self::assertEquals($jobs[0]['schedule'], $tasks[$tn1]['schedule']);
+		self::assertEquals($jobs[0]['task'], $tasks[$tn1]['task']);
+		self::assertEquals($jobs[0]['propertya'], $tasks[$tn1]['propertya']);
+		self::assertEquals($jobs[0]['username'], $tasks[$tn1]['username']);
+		self::assertEquals($jobs[0]['moduleid'], $tasks[$tn1]['moduleid']);
+		self::assertEquals($jobs[1]['name'], $tasks[$tn2]['name']);
+		self::assertEquals($jobs[1]['schedule'], $tasks[$tn2]['schedule']);
+		self::assertEquals($jobs[1]['task'], $tasks[$tn2]['task']);
+		self::assertEquals($jobs[1]['username'], $tasks[$tn2]['username']);
+		self::assertEquals($jobs[2]['name'], $tasks[$tn3]['name']);
+		self::assertEquals($jobs[2]['schedule'], $tasks[$tn3]['schedule']);
+		self::assertEquals($jobs[2]['task'], $tasks[$tn3]['task']);
+		self::assertEquals($jobs[3]['name'], $tasks[$tn4]['name']);
+		self::assertEquals($jobs[3]['schedule'], $tasks[$tn4]['schedule']);
+		self::assertEquals($jobs[3]['task'], $tasks[$tn4]['task']);
+		self::assertEquals($jobs[4]['name'], $tasks[$tn5]['name']);
+		self::assertEquals($jobs[4]['schedule'], $tasks[$tn5]['schedule']);
+		self::assertEquals($jobs[4]['task'], $tasks[$tn5]['task']);
+		self::assertEquals($jobs[5]['name'], $tasks[$tn6]['name']);
+		self::assertEquals($jobs[5]['schedule'], $tasks[$tn6]['schedule']);
+		self::assertEquals($jobs[5]['task'], $tasks[$tn6]['task']);
+		self::assertEquals($jobs[6]['name'], $tasks[$tn7]['name']);
+		self::assertEquals($jobs[6]['schedule'], $tasks[$tn7]['schedule']);
+		self::assertEquals($jobs[6]['task'], $tasks[$tn7]['task']);
 		
 		$tasks = $this->obj->getTasks();
 		
 		self::assertNotNull($tasks);
 		
-		self::assertEquals(4, count($tasks));
-		self::assertInstanceOf('TTestCronModuleTask', $tasks['testTask1']);
-		self::assertEquals('1 0 1 1 *', $tasks['testTask1']->getSchedule());
-		self::assertEquals('testTask1', $tasks['testTask1']->getName());
-		self::assertEquals('admin', $tasks['testTask1']->getUserName());
-		self::assertEquals('GT_module', $tasks['testTask1']->getModuleId());
-		self::assertEquals('value1', $tasks['testTask1']->getPropertyA());
-		self::assertEquals('2 0 1 1 * 2000', $tasks['testTask2']->getSchedule());
-		self::assertEquals('testTask2', $tasks['testTask2']->getName());
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask2']);
-		self::assertEquals('CMT_UserManager3', $tasks['testTask2']->getModuleId());
-		self::assertEquals('method1', $tasks['testTask2']->getMethod());
-		self::assertEquals('3 0 1 1 * 2099', $tasks['testTask3']->getSchedule());
-		self::assertEquals('testTask3', $tasks['testTask3']->getName());
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask3']);
-		self::assertEquals('CMT_UserManager3', $tasks['testTask3']->getModuleId());
-		self::assertEquals('method2(true)', $tasks['testTask3']->getMethod());
-		self::assertEquals('4 0 1 1 *', $tasks['testTask4']->getSchedule());
-		self::assertEquals('testTask4', $tasks['testTask4']->getName());
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask4']);
-		self::assertEquals('CMT_UserManager3', $tasks['testTask4']->getModuleId());
-		self::assertEquals('method3(86400)', $tasks['testTask4']->getMethod());
+		self::assertEquals(count($jobs), count($tasks));
+		self::assertInstanceOf($jobs[0]['task'], $tasks[$tn1]);
+		self::assertEquals($jobs[0]['schedule'], $tasks[$tn1]->getSchedule());
+		self::assertEquals($tn1, $tasks[$tn1]->getName());
+		self::assertEquals($jobs[0]['username'], $tasks[$tn1]->getUserName());
+		self::assertEquals($jobs[0]['moduleid'], $tasks[$tn1]->getModuleId());
+		self::assertEquals($jobs[0]['propertya'], $tasks[$tn1]->getPropertyA());
+		self::assertEquals($jobs[1]['schedule'], $tasks[$tn2]->getSchedule());
+		self::assertEquals($jobs[1]['username'], $tasks[$tn2]->getUserName());
+		self::assertEquals($tn2, $tasks[$tn2]->getName());
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks[$tn2]);
+		self::assertEquals('CMT_UserManager3', $tasks[$tn2]->getModuleId());
+		self::assertEquals('method1', $tasks[$tn2]->getMethod());
+		self::assertEquals($jobs[2]['schedule'], $tasks[$tn3]->getSchedule());
+		self::assertEquals(null, $tasks[$tn3]->getUserName());
+		self::assertEquals($tn3, $tasks[$tn3]->getName());
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks[$tn3]);
+		self::assertEquals('CMT_UserManager3', $tasks[$tn3]->getModuleId());
+		self::assertEquals('method2(true)', $tasks[$tn3]->getMethod());
+		self::assertEquals($jobs[3]['schedule'], $tasks[$tn4]->getSchedule());
+		self::assertEquals(null, $tasks[$tn4]->getUserName());
+		self::assertEquals($tn4, $tasks[$tn4]->getName());
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks[$tn4]);
+		self::assertEquals('CMT_UserManager3', $tasks[$tn4]->getModuleId());
+		self::assertEquals('method3(86400)', $tasks[$tn4]->getMethod());
 		
 		$tasks = $this->obj->getRawTasks();
-		self::assertEquals(4, count($tasks));
-		self::assertInstanceOf('TTestCronModuleTask', $tasks['testTask1']);
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask2']);
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask3']);
-		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask4']);
+		self::assertEquals(count($jobs), count($tasks));
+		self::assertInstanceOf('TTestCronModuleTask', $tasks[$tn1]);
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks[$tn2]);
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks[$tn3]);
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks[$tn4]);
 		
-		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
-		self::assertTrue(abs($tasks['testTask1']->getLastExecTime() - time()) < 2);
-		self::assertEquals(0, $tasks['testTask2']->getProcessCount());
-		self::assertNull($tasks['testTask2']->getLastExecTime());
-		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
-		self::assertNull($tasks['testTask3']->getLastExecTime());
-		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
-		self::assertTrue(abs($tasks['testTask4']->getLastExecTime() - time()) < 2);
+		self::assertEquals(0, $tasks[$tn1]->getProcessCount());
+		self::assertTrue(abs($tasks[$tn1]->getLastExecTime() - time()) < 2);
+		self::assertEquals(0, $tasks[$tn2]->getProcessCount());
+		self::assertNull($tasks[$tn2]->getLastExecTime());
+		self::assertEquals(0, $tasks[$tn3]->getProcessCount());
+		self::assertNull($tasks[$tn3]->getLastExecTime());
+		self::assertEquals(0, $tasks[$tn4]->getProcessCount());
+		self::assertTrue(abs($tasks[$tn4]->getLastExecTime() - time()) < 2);
+		self::assertEquals(0, $tasks[$tn5]->getProcessCount());
+		self::assertNull($tasks[$tn5]->getLastExecTime());
+		self::assertEquals(0, $tasks[$tn6]->getProcessCount());
+		self::assertNull($tasks[$tn6]->getLastExecTime());
+		self::assertEquals(0, $tasks[$tn7]->getProcessCount());
+		self::assertNull($tasks[$tn7]->getLastExecTime());
 		
 		//check updateTaskInfo - test persistent data
-		self::assertEquals(1, $this->obj->processPendingTasks());
+		self::assertEquals(4, $this->obj->processPendingTasks());
 		
-		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask1']->getLastExecTime() < 2);
-		self::assertEquals(1, $tasks['testTask2']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask2']->getLastExecTime() < 2);
-		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
-		self::assertNull($tasks['testTask3']->getLastExecTime());
-		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask4']->getLastExecTime() < 2);
+		self::assertEquals(0, $tasks[$tn1]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn1]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn2]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn2]->getLastExecTime() < 2);
+		self::assertEquals(0, $tasks[$tn3]->getProcessCount());
+		self::assertNull($tasks[$tn3]->getLastExecTime());
+		self::assertEquals(0, $tasks[$tn4]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn4]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn5]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn5]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn6]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn6]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn7]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn7]->getLastExecTime() < 2);
 		
 		// check 
 		$this->checkPersistentData();
@@ -420,14 +452,20 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 		
 		$tasks = $this->obj->getTasks();
 		
-		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask1']->getLastExecTime() < 2);
-		self::assertEquals(1, $tasks['testTask2']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask2']->getLastExecTime() < 2);
-		self::assertEquals(0, $tasks['testTask3']->getProcessCount());
-		self::assertEquals(0, $tasks['testTask3']->getLastExecTime());
-		self::assertEquals(0, $tasks['testTask4']->getProcessCount());
-		self::assertTrue(microtime(true) - $tasks['testTask4']->getLastExecTime() < 2);
+		self::assertEquals(0, $tasks[$tn1]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn1]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn2]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn2]->getLastExecTime() < 2);
+		self::assertEquals(0, $tasks[$tn3]->getProcessCount());
+		self::assertEquals(0, $tasks[$tn3]->getLastExecTime());
+		self::assertEquals(0, $tasks[$tn4]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn4]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn5]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn5]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn6]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn6]->getLastExecTime() < 2);
+		self::assertEquals(1, $tasks[$tn7]->getProcessCount());
+		self::assertTrue(microtime(true) - $tasks[$tn7]->getLastExecTime() < 2);
 	}
 	
 	public function testGetTask()
@@ -504,22 +542,38 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			['name' => 'testTask3', 'schedule' => '0 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
 			['name' => 'testTask4', 'schedule' => '0 0 1 1 *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)'],
 			['name' => 'testTask5', 'schedule' => '0 0 1 1 * ' . TTimeScheduler::YEAR_MAX, 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)'],
-			['name' => 'testTask6', 'schedule' => '0 0 1 1 * 2000', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
+			['name' => 'testTask6', 'schedule' => '0 0 1 1 * 2000', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)'],
+			['name' => 'testTask7', 'schedule' => '@'.(time()-1000), 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		]);
 		$pendingTasks = $this->obj->getPendingTasks();
-		self::assertEquals(1, count($pendingTasks));
+		self::assertEquals(2, count($pendingTasks));
 		self::assertFalse(isset($pendingTasks['testTask1']));
 		self::assertFalse(isset($pendingTasks['testTask2']));
 		self::assertFalse(isset($pendingTasks['testTask3']));
 		self::assertFalse(isset($pendingTasks['testTask4']));
 		self::assertFalse(isset($pendingTasks['testTask5']));
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $pendingTasks['testTask6']);
+		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $pendingTasks['testTask7']);
 
-		self::assertEquals(1, $this->obj->processPendingTasks());
+		self::assertEquals(2, $this->obj->processPendingTasks());
 
 		$pendingTasks = $this->obj->getPendingTasks();
 		self::assertEquals(0, count($pendingTasks));
 		self::assertEquals(0, $this->obj->processPendingTasks());
+		
+		$this->obj = new $this->baseClass();
+		$this->obj->init([
+			['name' => 'A', 'schedule' => '@4200', 'task' => 'TTestCronModuleTask'],
+			['name' => 'B', 'schedule' => '@2050', 'task' => 'TTestCronModuleTask'],
+			['name' => 'C', 'schedule' => '@3100', 'task' => 'TTestCronModuleTask'],
+			['name' => 'CC', 'schedule' => '@3100', 'task' => 'TTestCronModuleTask'],
+			['name' => 'D', 'schedule' => '@1000', 'task' => 'TTestCronModuleTask'],
+			['name' => 'E', 'schedule' => '@5300', 'task' => 'TTestCronModuleTask'],
+			['name' => 'F', 'schedule' => '@3800', 'task' => 'TTestCronModuleTask'],
+		]);
+		$pendingTasks = $this->obj->getPendingTasks();
+		self::assertEquals(7, count($pendingTasks));
+		self::assertEquals(['A', 'B', 'C', 'CC', 'D', 'E', 'F'], array_keys($pendingTasks));
 	}
 	
 	public function testGetTasksByType_InstanceTask()

--- a/tests/unit/Util/Cron/TCronModuleTest.php
+++ b/tests/unit/Util/Cron/TCronModuleTest.php
@@ -844,6 +844,35 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			self::fail('failed to throw TInvalidOperationException when cannot set due to being initialized');
 		} catch(TInvalidOperationException $e) {}
 	}
+	
+	public function testInCronShell()
+	{
+		self::assertEquals(null, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell('');
+		self::assertEquals(true, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell(null);
+		self::assertEquals(null, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell(true);
+		self::assertEquals(true, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell(false);
+		self::assertEquals(false, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell(1);
+		self::assertEquals(true, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell(0);
+		self::assertEquals(false, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell('true');
+		self::assertEquals(true, $this->obj->getInCronShell());
+		
+		$this->obj->setInCronShell('false');
+		self::assertEquals(false, $this->obj->getInCronShell());
+	}
 
 	public function testAdditionalCronTasks()
 	{

--- a/tests/unit/Util/Cron/TCronTaskTest.php
+++ b/tests/unit/Util/Cron/TCronTaskTest.php
@@ -139,16 +139,32 @@ class TCronTaskTest extends PHPUnit\Framework\TestCase
 		$this->obj->setLastExecTime($value);
 		self::assertEquals(floor($value), $this->obj->getLastExecTime());
 		
+		// string of a numeric
+		$value = "9.999";
+		$this->obj->setLastExecTime($value);
+		self::assertEquals(floor($value), $this->obj->getLastExecTime());
+		
+		// null value
+		$value = null;
+		$this->obj->setLastExecTime($value);
+		self::assertEquals($value, $this->obj->getLastExecTime());
 	}
 	
 	public function testIsPending()
 	{
 		$this->obj->setSchedule("* * * * *");
-		$this->obj->setLastExecTime(time() - 60);
+		$this->obj->setLastExecTime(time() - 61);
+		self::assertTrue($this->obj->getIsPending());
+		
+		$this->obj->setLastExecTime(null);
 		self::assertTrue($this->obj->getIsPending());
 		
 		$this->obj->setLastExecTime(time());
 		self::assertFalse($this->obj->getIsPending());
 		
+		$this->obj->setSchedule("0 0 1 1 * 2000");
+		$this->obj->setLastExecTime(time());
+		self::assertEquals(null, $this->obj->getNextTriggerTime());
+		self::assertFalse($this->obj->getIsPending());
 	}
 }

--- a/tests/unit/Util/Cron/TDbCronModuleTest.php
+++ b/tests/unit/Util/Cron/TDbCronModuleTest.php
@@ -488,7 +488,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertFalse($this->obj->addTask($task));
 		
 		$count = rand();
-		$time = microtime(true);
+		$time = floor(microtime(true)) + 0.6;
 		
 		$task = new TTestCronModuleTask();
 		$task->setName('crudTask');

--- a/tests/unit/Util/Cron/TDbCronModuleTest.php
+++ b/tests/unit/Util/Cron/TDbCronModuleTest.php
@@ -387,6 +387,9 @@ class TDbCronModuleTest extends TCronModuleTest
 		$this->obj->clearRuntimeTasks();
 		self::assertEquals(0, count($app->onEndRequest));
 		self::assertNull($this->obj->getRuntimeTasks());
+		
+		//tell the object to filterStaleTasks.  This is for testing purposes only
+		$this->obj->processPendingTasks();
 	}
 	
 	public function testGetTask()

--- a/tests/unit/Util/Cron/TDbCronModuleTest.php
+++ b/tests/unit/Util/Cron/TDbCronModuleTest.php
@@ -91,16 +91,16 @@ class TDbCronModuleTest extends TCronModuleTest
 		$testTask2 = $this->obj->getTask('testTask2');
 		$testTask3 = $this->obj->getTask('testTask3');
 		$testTask4 = $this->obj->getTask('testTask4');
-		self::assertEquals(1, $tasksInfo['testTask1']['processcount']);
-		self::assertTrue(microtime(true) - $tasksInfo['testTask1']['lastexectime'] < 2);
+		self::assertEquals(0, $tasksInfo['testTask1']['processcount']);
+		self::assertTrue((microtime(true) - $tasksInfo['testTask1']['lastexectime']) < 2);
 		self::assertEquals(serialize($testTask1), $tasksInfo['testTask1']['options']);
 		self::assertEquals(1, $tasksInfo['testTask2']['processcount']);
 		self::assertTrue(microtime(true) - $tasksInfo['testTask2']['lastexectime'] < 2);
 		self::assertEquals(serialize($testTask2), $tasksInfo['testTask2']['options']);
-		self::assertEquals(1, $tasksInfo['testTask3']['processcount']);
-		self::assertTrue(microtime(true) - $tasksInfo['testTask3']['lastexectime'] < 2);
+		self::assertEquals(0, $tasksInfo['testTask3']['processcount']);
+		self::assertNull($tasksInfo['testTask3']['lastexectime']);
 		self::assertEquals(serialize($testTask3), $tasksInfo['testTask3']['options']);
-		self::assertEquals(1, $tasksInfo['testTask4']['processcount']);
+		self::assertEquals(0, $tasksInfo['testTask4']['processcount']);
 		self::assertTrue(microtime(true) - $tasksInfo['testTask4']['lastexectime'] < 2);
 		self::assertEquals(serialize($testTask4), $tasksInfo['testTask4']['options']);
 		
@@ -120,8 +120,8 @@ class TDbCronModuleTest extends TCronModuleTest
 		parent::testGetTasks();
 		
 		$jobs = [
-			['name' => 'testTask1', 'schedule' => '1 * * * *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
-			['name' => 'testTask2', 'schedule' => '2 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1', 'username' => 'admin1']
+			['name' => 'testTask1', 'schedule' => '1 * 1 1 *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
+			['name' => 'testTask2', 'schedule' => '2 * 1 1 *', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method1', 'username' => 'admin1']
 		];
 		
 		$this->obj = new $this->baseClass();
@@ -147,12 +147,12 @@ class TDbCronModuleTest extends TCronModuleTest
 		
 		$task = new TTestCronModuleTask();
 		$task->setName('testTask3');
-		$task->setSchedule('3 * * * * *'); // Testing out the 6 star pattern here too, normal is 5.
+		$task->setSchedule('3 * * * * 2020'); // Testing out the 6 star pattern here too, normal is 5.
 		$this->obj->addTask($task);
 		
 		$task = new TCronMethodTask('CMT_UserManager3', 'method3(86400)');
 		$task->setName('testTask4');
-		$task->setSchedule('4 * * * *');
+		$task->setSchedule('4 * * * * 2020');
 		$this->obj->addTask($task);
 		
 		$this->obj = new $this->baseClass();
@@ -164,22 +164,22 @@ class TDbCronModuleTest extends TCronModuleTest
 		
 		self::assertEquals(4, count($tasks));
 		self::assertInstanceOf('TTestCronModuleTask', $tasks['testTask1']);
-		self::assertEquals('1 * * * *', $tasks['testTask1']->getSchedule());
+		self::assertEquals('1 * 1 1 *', $tasks['testTask1']->getSchedule());
 		self::assertEquals('testTask1', $tasks['testTask1']->getName());
 		self::assertEquals('admin', $tasks['testTask1']->getUserName());
 		self::assertEquals('GT_module', $tasks['testTask1']->getModuleId());
 		self::assertEquals('value1', $tasks['testTask1']->getPropertyA());
-		self::assertEquals('2 * * * *', $tasks['testTask2']->getSchedule());
+		self::assertEquals('2 * 1 1 *', $tasks['testTask2']->getSchedule());
 		self::assertEquals('testTask2', $tasks['testTask2']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask2']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask2']->getModuleId());
 		self::assertEquals('method1', $tasks['testTask2']->getMethod());
 		
 		// GetTasks returns DB tasks
-		self::assertEquals('3 * * * * *', $tasks['testTask3']->getSchedule());
+		self::assertEquals('3 * * * * 2020', $tasks['testTask3']->getSchedule());
 		self::assertEquals('testTask3', $tasks['testTask3']->getName());
 		self::assertInstanceOf('TTestCronModuleTask', $tasks['testTask3']);
-		self::assertEquals('4 * * * *', $tasks['testTask4']->getSchedule());
+		self::assertEquals('4 * * * * 2020', $tasks['testTask4']->getSchedule());
 		self::assertEquals('testTask4', $tasks['testTask4']->getName());
 		self::assertInstanceOf('Prado\\Util\\Cron\\TCronMethodTask', $tasks['testTask4']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask4']->getModuleId());
@@ -191,7 +191,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertEquals(2, $this->obj->processPendingTasks());
 		
 		// check updateTaskInfo - test persistent data
-		self::assertEquals(1, $tasks['testTask1']->getProcessCount());
+		self::assertEquals(0, $tasks['testTask1']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask1']->getLastExecTime() < 2);
 		self::assertEquals(1, $tasks['testTask2']->getProcessCount());
 		self::assertTrue(microtime(true) - $tasks['testTask2']->getLastExecTime() < 2);
@@ -202,9 +202,9 @@ class TDbCronModuleTest extends TCronModuleTest
 		
 		$jobs2 = [
 			['name' => 'testTask1', 'schedule' => '1 * * * *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1', 'username' => 'admin', 'moduleid' => 'GT_module'],
-			['name' => 'testTask2', 'schedule' => '2 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1', 'username' => 'admin1'],
-			['name' => 'testTask3', 'schedule' => '3 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTask4', 'schedule' => '4 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTask2', 'schedule' => '2 * * * *', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method1', 'username' => 'admin1'],
+			['name' => 'testTask3', 'schedule' => '3 * * * *', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method2(true)'],
+			['name' => 'testTask4', 'schedule' => '4 * * * *', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		];
 		$this->obj = new $this->baseClass();
 		$this->obj->init($jobs2);
@@ -212,7 +212,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		try {
 			$this->obj->getTasks();
 			self::fail("failed to throw TConfigurationException when colliding configuration with DB tasks");
-		} catch(TConfigurationException $e) {
+		} catch (TConfigurationException $e) {
 		}
 		
 		$this->obj = new $this->baseClass();
@@ -225,11 +225,11 @@ class TDbCronModuleTest extends TCronModuleTest
 	{
 		$this->obj->init(null);
 		$jobs = [
-			['name' => 'testTaskAA', 'schedule' => '* * * * *', 'task' => 'TTestCronModuleTask'],
-			['name' => 'testTaskBB', 'schedule' => '* * * * *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1'],
-			['name' => 'testTaskCC', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1'],
-			['name' => 'testTaskDD', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTaskEE', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTaskAA', 'schedule' => '* * * * * 2020', 'task' => 'TTestCronModuleTask'],
+			['name' => 'testTaskBB', 'schedule' => '* * * * * 2020', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1'],
+			['name' => 'testTaskCC', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method1'],
+			['name' => 'testTaskDD', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method2(true)'],
+			['name' => 'testTaskEE', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		];
 		
 		$this->obj->setLogCronTasks(true);
@@ -275,11 +275,11 @@ class TDbCronModuleTest extends TCronModuleTest
 		
 		// Test when db logging is off
 		$jobs = [
-			['name' => 'testTask1', 'schedule' => '* * * * *', 'task' => 'TTestCronModuleTask'],
-			['name' => 'testTask2', 'schedule' => '* * * * *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1'],
-			['name' => 'testTask3', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1'],
-			['name' => 'testTask4', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTask5', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTask1', 'schedule' => '* * * * * 2020', 'task' => 'TTestCronModuleTask'],
+			['name' => 'testTask2', 'schedule' => '* * * * * 2020', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1'],
+			['name' => 'testTask3', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method1'],
+			['name' => 'testTask4', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method2(true)'],
+			['name' => 'testTask5', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		];
 		
 		$this->obj = new $this->baseClass();
@@ -288,7 +288,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		
 		self::assertEquals(5, $this->obj->getCronLogCount());
 		
-		$this->obj->processPendingTasks();
+		self::assertEquals(5, $this->obj->processPendingTasks());
 		
 		self::assertEquals(5, $this->obj->getCronLogCount());
 		$log = $this->obj->getCronLog(null, false, false, true);
@@ -411,25 +411,25 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertEquals('admin', $tasks['testTask1']['username']);
 		self::assertEquals('GT_module', $tasks['testTask1']['moduleid']);
 		self::assertEquals(0, $tasks['testTask1']['processcount']);
-		self::assertEquals(0, $tasks['testTask1']['lastexectime']);
+		self::assertTrue(abs(microtime(true) - $tasks['testTask1']['lastexectime']) < 2);
 		self::assertEquals('2 * * * ?', $tasks['testTask2']['schedule']);
 		self::assertEquals('testTask2', $tasks['testTask2']['name']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method1', $tasks['testTask2']['task']);
+		self::assertEquals('CMT_UserManager3' . self::SEPARATOR . 'method1', $tasks['testTask2']['task']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask2']['moduleid']);
 		self::assertEquals(0, $tasks['testTask2']['processcount']);
-		self::assertEquals(0, $tasks['testTask2']['lastexectime']);
+		self::assertTrue(abs(microtime(true) - $tasks['testTask2']['lastexectime']) < 2);
 		self::assertEquals('3 * * * ?', $tasks['testTask3']['schedule']);
 		self::assertEquals('testTask3', $tasks['testTask3']['name']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method2(true)', $tasks['testTask3']['task']);
+		self::assertEquals('CMT_UserManager3' . self::SEPARATOR . 'method2(true)', $tasks['testTask3']['task']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask3']['moduleid']);
 		self::assertEquals(0, $tasks['testTask3']['processcount']);
-		self::assertEquals(0, $tasks['testTask3']['lastexectime']);
+		self::assertTrue(abs(microtime(true) - $tasks['testTask3']['lastexectime']) < 2);
 		self::assertEquals('4 * * * ?', $tasks['testTask4']['schedule']);
 		self::assertEquals('testTask4', $tasks['testTask4']['name']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method3(86400)', $tasks['testTask4']['task']);
+		self::assertEquals('CMT_UserManager3' . self::SEPARATOR . 'method3(86400)', $tasks['testTask4']['task']);
 		self::assertEquals('CMT_UserManager3', $tasks['testTask4']['moduleid']);
 		self::assertEquals(0, $tasks['testTask4']['processcount']);
-		self::assertEquals(0, $tasks['testTask4']['lastexectime']);
+		self::assertTrue(abs(microtime(true) - $tasks['testTask4']['lastexectime']) < 2);
 		
 		self::assertNull($this->obj->getTask('non_testTask', false, false));
 		self::assertNull($this->obj->getTask('non_testTask', false, true));
@@ -437,7 +437,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertNull($this->obj->getTask('non_testTask', true, true));
 		
 		$jobs = [
-			['name' => 'testTaskAB', 'schedule' => '4 * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTaskAB', 'schedule' => '4 * * * *', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		];
 		
 		$this->obj = new $this->baseClass();
@@ -450,10 +450,10 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertTrue(is_numeric($task['tabuid']));
 		self::assertEquals('testTaskAB', $task['name']);
 		self::assertEquals('4 * * * *', $task['schedule']);
-		self::assertEquals('CMT_UserManager3'.self::SEPARATOR.'method3(86400)', $task['task']);
+		self::assertEquals('CMT_UserManager3' . self::SEPARATOR . 'method3(86400)', $task['task']);
 		self::assertNull($task['username']);
 		self::assertEquals(0, $task['processcount']);
-		self::assertNull($task['lastexectime']);
+		self::assertTrue(abs(microtime(true) - $task['lastexectime']) < 2);
 		self::assertInstanceOf('\\Prado\\Util\\Cron\\TCronMethodTask', $this->obj->getTask('testTaskAB', true, true));
 		
 		// Test DB task for GetTask
@@ -465,7 +465,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertEquals('TTestCronModuleTask', $task['task']);
 		self::assertNull($task['username']);
 		self::assertEquals(0, $task['processcount']);
-		self::assertNull($task['lastexectime']);
+		self::assertTrue(abs(microtime(true) - $task['lastexectime']) < 2);
 		
 		$task = $this->obj->getTask('testTask5', true, true);
 		self::assertInstanceOf('TTestCronModuleTask', $task);
@@ -474,7 +474,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertEquals('TTestCronModuleTask', $task->getTask());
 		self::assertNull($task->getUserName());
 		self::assertEquals(0, $task->getProcessCount());
-		self::assertNull($task->getLastExecTime());
+		self::assertTrue(abs(microtime(true) - $task->getLastExecTime()) < 2);
 		
 		$this->obj->removeTask($task);
 	}
@@ -555,7 +555,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertEquals('cronCrudUser', $taskInfo['username']);
 		self::assertEquals('1', $taskInfo['active']);
 		self::assertEquals($count, $taskInfo['processcount']);
-		self::assertEquals(floor($time), $taskInfo['lastexectime']);
+		self::assertTrue(abs($time - $taskInfo['lastexectime']) < 2);
 		
 		//were the tasks updated
 		self::assertTrue(isset($this->obj->getTasks()['crudTask']));
@@ -571,7 +571,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		self::assertEquals('cronCrudUser', $taskInfo['username']);
 		self::assertEquals('1', $taskInfo['active']);
 		self::assertEquals($count, $taskInfo['processcount']);
-		self::assertEquals(floor($time), $taskInfo['lastexectime']);
+		self::assertTrue(abs($time - $taskInfo['lastexectime']) < 2);
 		
 		$this->obj->removeTask($task);
 		self::assertFalse($this->obj->taskExists('crudTask'));
@@ -616,16 +616,17 @@ class TDbCronModuleTest extends TCronModuleTest
 		$cmd = $db->createCommand(
 			"INSERT INTO {$this->obj->getTableName()} " .
 				"(name, schedule, task, moduleid, username, processcount, lastexectime, active)" .
-				" VALUES ('testTask1', '* * * * *', 'TTestCronModuleTask', 'module1', 'cron', '3', " . ($time - 60) .  ", NULL)".
-				",('testTask2', '* * * * *', 'TTestCronModuleTask', 'module2', 'cron', '14', " . ($time - 60) .  ", NULL)".
-				",('testTask3', '* * * * *', 'CMT_UserManager3".self::SEPARATOR."method1', 'CMT_UserManager3', 'cron', '15', " . ($time - 60) .  ", NULL)".
-				",('testTask4', '* * * * *', 'CMT_UserManager3".self::SEPARATOR."method2(true)', 'CMT_UserManager3', 'cron', '16', " . ($time - 60) .  ", NULL)".
-				",('testTask5', '5 * * * *', 'CMT_UserManager3".self::SEPARATOR."method3(86400)', 'CMT_UserManager3', 'cron', '17', " . ($time - 60) .  ", NULL)".
-				", ('testTask1', '1 * * * *', 'TTestCronModuleTask', 'module1', 'cron', '18', " . ($time - 120) .  ", NULL)".
-				",('testTask2', '* * * * *', 'TTestCronModuleTask', 'module2', 'cron', '20', " . ($time - 120) .  ", NULL)".
-				",('testTask3', '* * * * *', 'CMT_UserManager3".self::SEPARATOR."method1', 'CMT_UserManager3', 'cron', '21', " . ($time - 120) .  ", NULL)".
-				",('testTask4', '* * * * *', 'CMT_UserManager3".self::SEPARATOR."method2(true)', 'CMT_UserManager3', 'cron', '23', " . ($time - 120) .  ", NULL)".
-				",('testTask5', '* * * * *', 'CMT_UserManager3".self::SEPARATOR."method3(86400)', 'CMT_UserManager3', 'cron', '24', " . ($time - 120) .  ", NULL)");
+				" VALUES ('testTask1', '* * * * *', 'TTestCronModuleTask', 'module1', 'cron', '3', " . ($time - 60) . ", NULL)" .
+				",('testTask2', '* * * * *', 'TTestCronModuleTask', 'module2', 'cron', '14', " . ($time - 60) . ", NULL)" .
+				",('testTask3', '* * * * *', 'CMT_UserManager3" . self::SEPARATOR . "method1', 'CMT_UserManager3', 'cron', '15', " . ($time - 60) . ", NULL)" .
+				",('testTask4', '* * * * *', 'CMT_UserManager3" . self::SEPARATOR . "method2(true)', 'CMT_UserManager3', 'cron', '16', " . ($time - 60) . ", NULL)" .
+				",('testTask5', '5 * * * *', 'CMT_UserManager3" . self::SEPARATOR . "method3(86400)', 'CMT_UserManager3', 'cron', '17', " . ($time - 60) . ", NULL)" .
+				", ('testTask1', '1 * * * *', 'TTestCronModuleTask', 'module1', 'cron', '18', " . ($time - 120) . ", NULL)" .
+				",('testTask2', '* * * * *', 'TTestCronModuleTask', 'module2', 'cron', '20', " . ($time - 120) . ", NULL)" .
+				",('testTask3', '* * * * *', 'CMT_UserManager3" . self::SEPARATOR . "method1', 'CMT_UserManager3', 'cron', '21', " . ($time - 120) . ", NULL)" .
+				",('testTask4', '* * * * *', 'CMT_UserManager3" . self::SEPARATOR . "method2(true)', 'CMT_UserManager3', 'cron', '23', " . ($time - 120) . ", NULL)" .
+				",('testTask5', '* * * * *', 'CMT_UserManager3" . self::SEPARATOR . "method3(86400)', 'CMT_UserManager3', 'cron', '24', " . ($time - 120) . ", NULL)"
+		);
 		
 		$cmd->execute();
 		
@@ -654,11 +655,11 @@ class TDbCronModuleTest extends TCronModuleTest
 	public function testGetCronLogCount()
 	{
 		$jobs = [
-			['name' => 'testTaskV', 'schedule' => '* * * * *', 'task' => 'TTestCronModuleTask'],
-			['name' => 'testTaskW', 'schedule' => '* * * * *', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1'],
-			['name' => 'testTaskX', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method1'],
-			['name' => 'testTaskY', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method2(true)'],
-			['name' => 'testTaskZ', 'schedule' => '* * * * *', 'task' => 'CMT_UserManager3'.self::SEPARATOR.'method3(86400)']
+			['name' => 'testTaskV', 'schedule' => '* * * * * 2020', 'task' => 'TTestCronModuleTask'],
+			['name' => 'testTaskW', 'schedule' => '* * * * * 2020', 'task' => 'TTestCronModuleTask', 'propertya' => 'value1'],
+			['name' => 'testTaskX', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method1'],
+			['name' => 'testTaskY', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method2(true)'],
+			['name' => 'testTaskZ', 'schedule' => '* * * * * 2020', 'task' => 'CMT_UserManager3' . self::SEPARATOR . 'method3(86400)']
 		];
 		
 		$this->obj->setLogCronTasks(true);

--- a/tests/unit/Util/Cron/TShellCronActionTest.php
+++ b/tests/unit/Util/Cron/TShellCronActionTest.php
@@ -53,7 +53,7 @@ class TShellCronActionTest extends PHPUnit\Framework\TestCase
 		self::assertTrue($this->obj->actionRun(['cron']));
 		self::assertEquals(1, preg_match("/TCronModule/", $text = $this->writer->flush()));
 		
-		$jobs = [['name' => 'testTaskA', 'schedule' => '1 2 3 4 ?', 'task' => 'TTestCronModuleTask', 'username' => 'admin123', 'moduleid' => 'cronmodule99', 'propertya' => 'value1']];
+		$jobs = [['name' => 'testTaskA', 'schedule' => '1 2 3 4 ? 2020', 'task' => 'TTestCronModuleTask', 'username' => 'admin123', 'moduleid' => 'cronmodule99', 'propertya' => 'value1']];
 		$cronClass = $this->getTestCronClass();
 		$cron = new $cronClass();
 		$cron->init($jobs);
@@ -65,6 +65,9 @@ class TShellCronActionTest extends PHPUnit\Framework\TestCase
 			self::assertTrue($this->obj->actionRun(['cron/run']));
 			$text = $this->writer->flush();
 			self::assertEquals(1, $task->getProcessCount());
+				
+			$ntask = $cron->getTask('testTaskA');
+			self::assertTrue($ntask === $task);
 		}
 		self::assertTrue(is_object($cron->asa(TCronModule::SHELL_LOG_BEHAVIOR)));
 		{	//cron tasks

--- a/tests/unit/Util/Cron/TShellCronLogBehaviorTest.php
+++ b/tests/unit/Util/Cron/TShellCronLogBehaviorTest.php
@@ -75,7 +75,7 @@ class TShellCronLogBehaviorTest extends PHPUnit\Framework\TestCase
 		//This is auto-flushed
 		
 		
-		$component->dyUpdateTaskInfo($task);
+		$component->dyLogCronTaskEnd($task);
 		self::assertEquals(1, preg_match("/Ending Task/i", $this->writer->flush()));
 	}
 	

--- a/tests/unit/Util/Cron/TShellDbCronActionTest.php
+++ b/tests/unit/Util/Cron/TShellDbCronActionTest.php
@@ -53,7 +53,7 @@ class TShellDbCronActionTest extends PHPUnit\Framework\TestCase
 		self::assertTrue($this->obj->actionRun(['cron']));
 		self::assertEquals(1, preg_match("/TDbCronModule/", $text = $this->writer->flush()));
 		
-		$jobs = [['name' => 'testTaskA', 'schedule' => '1 2 3 4 ?', 'task' => 'TTestCronModuleTask', 'username' => 'admin123', 'moduleid' => 'cronmodule99', 'propertya' => 'value1']];
+		$jobs = [['name' => 'testTaskA', 'schedule' => '1 2 3 4 ? 2020', 'task' => 'TTestCronModuleTask', 'username' => 'admin123', 'moduleid' => 'cronmodule99', 'propertya' => 'value1']];
 		$cronClass = $this->getTestCronClass();
 		$cron = new $cronClass();
 		$cron->setId('cronmodule88');
@@ -61,7 +61,7 @@ class TShellDbCronActionTest extends PHPUnit\Framework\TestCase
 		
 		$ttask = new TTestCronModuleTask();
 		$ttask->setName('testTaskB');
-		$ttask->setSchedule('2 2 2 2 *');
+		$ttask->setSchedule('2 2 2 2 * 2020');
 		$ttask->setModuleId('dbcronmodule100');
 		$ttask->setPropertyA('value2');
 		$ttask->setUserName('admin456');
@@ -73,6 +73,8 @@ class TShellDbCronActionTest extends PHPUnit\Framework\TestCase
 			self::assertEquals(0, $task->getProcessCount());
 			self::assertEquals(0, $ttask->getProcessCount());
 			self::assertTrue($this->obj->actionRun(['cron']));
+			$ntask = $cron->getTask('testTaskA');
+			self::assertTrue($ntask === $task);
 			self::assertEquals(1, $task->getProcessCount());
 			self::assertEquals(1, $ttask->getProcessCount());
 			$this->writer->flush();
@@ -166,7 +168,7 @@ class TShellDbCronActionTest extends PHPUnit\Framework\TestCase
 			self::assertEquals(1, preg_match("/Task Property 'PropertyB' is not found/i", $text));
 			
 			//add task with proper propertyA, with extra space
-			self::assertTrue($this->obj->actionAdd(['cron/add', 'testTaskC', 'cronclean', '5 0 * * ?', ' TimePeriod = 864000 ', 'username=cron007', 'moduleid=mycronModule']));
+			self::assertTrue($this->obj->actionAdd(['cron/add', 'testTaskC', 'cronclean', '5 0 * * ? 2000', ' TimePeriod = 864000 ', 'username=cron007', 'moduleid=mycronModule']));
 			$text = $this->writer->flush();
 			self::assertEquals(1, preg_match("/Task 'testTaskC' was added to the database/i", $text));
 			
@@ -175,7 +177,7 @@ class TShellDbCronActionTest extends PHPUnit\Framework\TestCase
 			self::assertTrue($cron->taskExists('testTaskC'));
 			
 			self::assertEquals('testTaskC', $task->getName());
-			self::assertEquals('5 0 * * ?', $task->getSchedule());
+			self::assertEquals('5 0 * * ? 2000', $task->getSchedule());
 			self::assertEquals('cron007', $task->getUserName());
 			self::assertEquals('mycronModule', $task->getModuleId());
 			self::assertEquals('864000', $task->getTimePeriod());

--- a/tests/unit/Util/Cron/TTimeSchedulerTest.php
+++ b/tests/unit/Util/Cron/TTimeSchedulerTest.php
@@ -146,6 +146,7 @@ class TTimeSchedulerTest extends PHPUnit\Framework\TestCase
 			'* * * * * 1969', '* * * * * 2100',
 			'* * ?-8 * *', '* * * * ?-4',
 			'* * ?/8 * *', '* * * * ?/4',
+			'@', '@test'
 		];
 		foreach ($schedules as $schedule) {
 			foreach ($yearAppend as $yap) {
@@ -165,6 +166,16 @@ class TTimeSchedulerTest extends PHPUnit\Framework\TestCase
 			$this->obj->setSchedule($schedule);
 			$this->assertEquals($schedule , $this->obj->getSchedule());
 		}
+		$this->obj->setSchedule($schedule = '@'.(time() - 120));
+		$this->assertEquals($schedule , $this->obj->getSchedule());
+	}
+	public function testGetNextTriggerTime_AtSecond()
+	{
+		$time = time();
+		$this->obj->setSchedule('@' . $time);
+		$this->assertNull($this->obj->getNextTriggerTime($time));
+		$this->assertNull($this->obj->getNextTriggerTime($time + 120));
+		$this->assertEquals($time, $this->obj->getNextTriggerTime($time - 120));
 	}
 	public function testGetNextTriggerTime_Minute_Hour()
 	{


### PR DESCRIPTION
This fixes the three issues identified in #815.

1) Initializes lastExecTime for cron when loading persistent data from the global state.
1) Initializes lastExecTime for DB Cron on adding and updating (when schedule is changed).
2) Better null nextTriggerTime handling stopped the recurring tasks without a next time.
3) Also removed the Timezone code from TTimeScheduler to correct the erroneous one hour offset.

Also adds better cron shell output when there is no lastexectime (or no runs)
Adds an "@1668165071" unix timestamp format to the TTimeScheduler to reduce computation time for validation, parsing, and next trigger time of one off tasks.
TTimeScheduler regex building is cached.
Corrects a bug in the shell tableWidget column and last column wrapping.
minor documentation update to cron.

Updates the Cron unit tests.
