### PR TITLE
Add support for OFFSET parameter without LIMIT clause in SQL query for TActiveRecord; fix #819

### DIFF
--- a/framework/Data/DataGateway/TSqlCriteria.php
+++ b/framework/Data/DataGateway/TSqlCriteria.php
@@ -142,7 +142,7 @@ class TSqlCriteria extends \Prado\TComponent
 		//    [LIMIT {[offset,] row_count | row_count OFFSET offset}]
 		// See: http://dev.mysql.com/doc/refman/5.0/en/select.html
 
-		if (preg_match('/ORDER\s+BY\s+(.*?)(?=LIMIT)|ORDER\s+BY\s+(.*?)$/i', $value, $matches) > 0) {
+		if (preg_match('/ORDER\s+BY\s+(.*?)(?=\s+(?:LIMIT|OFFSET))|ORDER\s+BY\s+(.*?)$/i', $value, $matches) > 0) {
 			// condition contains ORDER BY
 			$value = str_replace($matches[0], '', $value);
 			if (strlen($matches[1]) > 0) {


### PR DESCRIPTION
Hello The PRADO Group,

According to issue #819 I would like to add to the framework support for OFFSET parameter without LIMIT clause. In MySQL OFFSET has to be used together with LIMIT clause, but in PostgreSQL syntax OFFSET can be used without LIMIT.

Thank you in advance for accepting this change.

Best regards,
Marcin Haba (gani)