### PR TITLE
Fixes #847 Adds IPriorityProperty & updates TPriority* to set priority on items

### DIFF
--- a/framework/Collections/IPriorityProperty.php
+++ b/framework/Collections/IPriorityProperty.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * IPriorityProperty interface file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Collections;
+
+/**
+ * IPriorityProperty interface
+ *
+ * IPriorityProperty specifies the interface for objects to have
+ * setter methods for the priority they receive in a TPriorityList
+ * or TPriorityMap.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.2
+ */
+interface IPriorityProperty extends IPriorityItem
+{
+	/**
+	 * @param numeric $value priority of the item
+	 */
+	public function setPriority($value);
+}

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -122,11 +122,7 @@ class TPriorityList extends TList
 	 */
 	public function getPriorityCount($priority = null)
 	{
-		if ($priority === null) {
-			$priority = $this->getDefaultPriority();
-		}
-		$priority = (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
-
+		$priority = $this->ensurePriority($priority);
 		if (!isset($this->_d[$priority]) || !is_array($this->_d[$priority])) {
 			return false;
 		}
@@ -165,6 +161,22 @@ class TPriorityList extends TList
 	protected function setPrecision($value)
 	{
 		$this->_p = TPropertyValue::ensureInteger($value);
+	}
+
+	/**
+	 * Taken an input Priority and ensures its value.
+	 * Sets the default $priority when none is set,
+	 * then rounds to the proper precision and makes
+	 * into a string.
+	 * @param mixed $priority
+	 * @return string the priority in string format
+	 */
+	protected function ensurePriority($priority): string
+	{
+		if ($priority === null || !is_numeric($priority)) {
+			$priority = $this->getDefaultPriority();
+		}
+		return (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
 	}
 
 	/**
@@ -243,11 +255,7 @@ class TPriorityList extends TList
 	 */
 	public function itemsAtPriority($priority = null)
 	{
-		if ($priority === null) {
-			$priority = $this->getDefaultPriority();
-		}
-		$priority = (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
-
+		$priority = $this->ensurePriority($priority);
 		return $this->_d[$priority] ?? null;
 	}
 
@@ -259,11 +267,7 @@ class TPriorityList extends TList
 	 */
 	public function itemAtIndexInPriority($index, $priority = null)
 	{
-		if ($priority === null) {
-			$priority = $this->getDefaultPriority();
-		}
-		$priority = (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
-
+		$priority = $this->ensurePriority($priority);
 		return !isset($this->_d[$priority]) ? false : (
 			$this->_d[$priority][$index] ?? false
 		);
@@ -323,13 +327,14 @@ class TPriorityList extends TList
 			throw new TInvalidOperationException('list_readonly', get_class($this));
 		}
 
-		if ($priority === null) {
-			if ($item instanceof IPriorityItem) {
-				$priority = $item->getPriority();
-			}
-			$priority = is_numeric($priority) ? $priority : $this->getDefaultPriority();
+		$itemPriority = null;
+		if (($priority === null || !is_numeric($priority)) && $item instanceof IPriorityItem) {
+			$itemPriority = $priority = $item->getPriority();
 		}
-		$priority = (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
+		$priority = $this->ensurePriority($priority);
+		if (($item instanceof IPriorityProperty) && $itemPriority != $priority) {
+			$item->setPriority($priority);
+		}
 
 		if ($preserveCache) {
 			if ($index === false && isset($this->_d[$priority])) {
@@ -398,11 +403,7 @@ class TPriorityList extends TList
 
 		if (($p = $this->priorityOf($item, true)) !== false) {
 			if ($priority !== false) {
-				if ($priority === null) {
-					$priority = $this->getDefaultPriority();
-				}
-				$priority = (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
-
+				$priority = $this->ensurePriority($priority);
 				if ($p[0] != $priority) {
 					throw new TInvalidDataValueException('list_item_inexistent');
 				}
@@ -447,11 +448,7 @@ class TPriorityList extends TList
 			throw new TInvalidOperationException('list_readonly', get_class($this));
 		}
 
-		if ($priority === null) {
-			$priority = $this->getDefaultPriority();
-		}
-		$priority = (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
-
+		$priority = $this->ensurePriority($priority);
 		if (!isset($this->_d[$priority]) || $index < 0 || $index >= count($this->_d[$priority])) {
 			throw new TInvalidDataValueException('list_item_inexistent');
 		}

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -215,11 +215,13 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	public function insertAtIndexInPriority($item, $index = false, $priority = null, $preserveCache = false)
 	{
-		if ($priority === null) {
-			if ($item instanceof IPriorityItem) {
-				$priority = $item->getPriority();
-				$priority = is_numeric($priority) ? $priority : null;
-			}
+		$itemPriority = null;
+		if (($priority === null || !is_numeric($priority)) && $item instanceof IPriorityItem) {
+			$itemPriority = $priority = $item->getPriority();
+		}
+		$priority = $this->ensurePriority($priority);
+		if ($item instanceof IPriorityProperty && $itemPriority != $priority) {
+			$item->setPriority($priority);
 		}
 		return parent::insertAtIndexInPriority($this->filterItemForInput($item, true), $index, $priority, $preserveCache);
 	}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -25,6 +25,7 @@ return [
 'TGlobalStateCacheDependency' => 'Prado\Caching\TGlobalStateCacheDependency',
 'TMemCache' => 'Prado\Caching\TMemCache',
 'IPriorityItem' => 'Prado\Collections\IPriorityItem',
+'IPriorityProperty' => 'Prado\Collections\IPriorityProperty',
 'TAttributeCollection' => 'Prado\Collections\TAttributeCollection',
 'TDummyDataSource' => 'Prado\Collections\TDummyDataSource',
 'TDummyDataSourceIterator' => 'Prado\Collections\TDummyDataSourceIterator',

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -29,6 +29,25 @@ class AutoPriorityListItem extends PriorityListItem implements IPriorityitem
 	}
 }
 
+class SetPriorityListItem extends PriorityListItem implements IPriorityProperty
+{
+	public $priority;
+	
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+
+	public function setPriority($value)
+	{
+		$this->priority = $value;
+	}
+
+	public function __invoke()
+	{
+	}
+}
+
 /**
  *	All Test cases for the TList are here.  The TPriorityList should act just like a TList when used exactly like a TList
  *
@@ -486,6 +505,14 @@ class TPriorityListTest extends TListTest
 		
 		$plist->remove($aplistitem);
 		$this->assertEquals([$this->pfirst], $plist->itemsAtPriority(10));
+		
+		
+		$aplistitem->priority = '7';
+		$plist->insertAtIndexInPriority($aplistitem, false, 'not_numeric');
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(7));
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(7));
 	}
 	
 
@@ -523,6 +550,68 @@ class TPriorityListTest extends TListTest
 		$plist = new $this->_baseClass($this->plist, true);
 		self::expectException('Prado\\Exceptions\\TInvalidOperationException');
 		$plist->removeAtIndexInPriority(0);
+	}
+	
+	public function testIPriorityProperty()
+	{
+		$plist = new $this->_baseClass();
+		$plist[] = $this->pfirst;
+		
+		$aplistitem = new SetPriorityListItem("my Data");
+		$plist->insertAtIndexInPriority($aplistitem, false, null);
+		$this->assertEquals([$this->pfirst, $aplistitem], $plist->itemsAtPriority(null));
+		$this->assertEquals($plist->getDefaultPriority(), $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals([$this->pfirst], $plist->itemsAtPriority(null));
+		$this->assertEquals($plist->getDefaultPriority(), $aplistitem->getPriority());
+		
+		$plist->insertAtIndexInPriority($aplistitem, false, 20);
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		$aplistitem->priority = 5;
+		$this->assertEquals(5, $aplistitem->getPriority());
+		$this->assertEquals(true, $aplistitem instanceof IPriorityItem);
+		$plist->insertAtIndexInPriority($aplistitem, false, null);
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(5));
+		$this->assertEquals(5, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(5));
+		$this->assertEquals(5, $aplistitem->getPriority());
+		
+		$plist->insertAtIndexInPriority($aplistitem, false, 20);
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		
+		$aplistitem->priority = 'string';
+		$plist->insertAtIndexInPriority($aplistitem, false, null);
+		$this->assertEquals([$this->pfirst, $aplistitem], $plist->itemsAtPriority(10));
+		$this->assertEquals(10, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals([$this->pfirst], $plist->itemsAtPriority(10));
+		$this->assertEquals(10, $aplistitem->getPriority());
+		
+		
+		$aplistitem->priority = '7';
+		$plist->insertAtIndexInPriority($aplistitem, false, 'not_numeric');
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(7));
+		$this->assertEquals(7, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(7));
+		$this->assertEquals(7, $aplistitem->getPriority());
 	}
 
 	public function testPriorityOfTPriorityList()


### PR DESCRIPTION
This is needed for bug fixes to Behaviors in #838

This also abstracts TPriority*::ensurePriority for setting default priority to null values, rounding to precision, and converting to string.

Updates TWeakCallableCollection for IPriorityProperty as well.

With unit tests. much better unit tests for TPriorityMap regarding priorities.