### PR TITLE
#855 TCallChain throws exception when incorrect dynamic event

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -138,6 +138,8 @@ pageserviceconf_parameter_invalid		= <parameter> element must have an "id" attri
 pageserviceconf_page_invalid			= <page> element must have an "id" attribute in page directory configuration file '{0}'.
 pageserviceconf_includefile_required	= Page configuration <include> element must have a "file" attribute.
 
+callchain_bad_dynamic_event				= TCallChain.{0} was raised but {1} was expected..
+
 behaviormodule_behavior_as_array_required = php <behavior> must be an array.
 behaviormodule_behaviorname_required	= <behavior> must contain a 'name' attribute for attaching the behavior.
 behaviormodule_behaviorclass_required	= <behavior> must contain a 'class' attribute defining the behavior class.

--- a/framework/Util/TCallChain.php
+++ b/framework/Util/TCallChain.php
@@ -9,6 +9,7 @@
 
 namespace Prado\Util;
 
+use Prado\Exceptions\TApplicationException;
 use Prado\Collections\TList;
 
 /**
@@ -145,6 +146,8 @@ class TCallChain extends TList implements IDynamicMethods
 	{
 		if ($this->_method == $method) {
 			return call_user_func_array([$this, 'call'], $args);
+		} else {
+			throw new TApplicationException('callchain_bad_dynamic_event', $method, $this->_method);
 		}
 		return null;
 	}

--- a/tests/unit/Util/TCallChainTest.php
+++ b/tests/unit/Util/TCallChainTest.php
@@ -1,6 +1,7 @@
 <?php
 
 
+use Prado\Exceptions\TApplicationException;
 use Prado\Util\TCallChain;
 
 class TCallChainTest extends PHPUnit\Framework\TestCase
@@ -11,6 +12,20 @@ class TCallChainTest extends PHPUnit\Framework\TestCase
 
 	protected function tearDown(): void
 	{
+	}
+	
+	public function testException()
+	{
+		$chain = new TCallChain('dySimpleMethod');
+		
+		$chain->dySimpleMethod();
+		
+		self::assertTrue(true);
+		try {
+			$chain->dyNoMethod();
+			self::fail('Expected TApplicationException not thrown when invalid dynamic event raised.');
+		} catch (TApplicationException $e) {
+		}
 	}
 
 	protected $_order = [];


### PR DESCRIPTION
TCallChain is a different animal regarding dynamic events than other classes.  As a small utility class, I can't imagine it having its own behaviors for modifying its function.  Those could be identified and accounted for if/when the time comes.