### PR TITLE
#847 just IPriorityCapture changes

### DIFF
--- a/framework/Collections/IPriorityCapture.php
+++ b/framework/Collections/IPriorityCapture.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * IPriorityCapture interface file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Collections;
+
+/**
+ * IPriorityCapture interface
+ *
+ * IPriorityCapture specifies the interface for capturing the priority of
+ * added objects in a TPriorityList or TPriorityMap
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.2
+ */
+interface IPriorityCapture
+{
+	/**
+	 * @param numeric $value priority of the item
+	 */
+	public function setPriority($value);
+}

--- a/framework/Collections/IPriorityProperty.php
+++ b/framework/Collections/IPriorityProperty.php
@@ -19,10 +19,6 @@ namespace Prado\Collections;
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 4.2.2
  */
-interface IPriorityProperty extends IPriorityItem
+interface IPriorityProperty extends IPriorityItem, IPriorityCapture
 {
-	/**
-	 * @param numeric $value priority of the item
-	 */
-	public function setPriority($value);
 }

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -328,11 +328,11 @@ class TPriorityList extends TList
 		}
 
 		$itemPriority = null;
-		if (($priority === null || !is_numeric($priority)) && $item instanceof IPriorityItem) {
+		if (($isPriorityItem = ($item instanceof IPriorityItem)) && ($priority === null || !is_numeric($priority))) {
 			$itemPriority = $priority = $item->getPriority();
 		}
 		$priority = $this->ensurePriority($priority);
-		if (($item instanceof IPriorityProperty) && $itemPriority != $priority) {
+		if (($item instanceof IPriorityCapture) && (!$isPriorityItem || $itemPriority !== $priority)) {
 			$item->setPriority($priority);
 		}
 

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -331,11 +331,11 @@ class TPriorityMap extends TMap
 	public function add($key, $value, $priority = null)
 	{
 		$itemPriority = null;
-		if (($priority === null || !is_numeric($priority)) && $value instanceof IPriorityItem) {
+		if (($isPriorityItem = ($value instanceof IPriorityItem)) && ($priority === null || !is_numeric($priority))) {
 			$itemPriority = $priority = $value->getPriority();
 		}
 		$priority = $this->ensurePriority($priority);
-		if (($value instanceof IPriorityProperty) && $itemPriority != $priority) {
+		if (($value instanceof IPriorityCapture) && (!$isPriorityItem || $itemPriority !== $priority)) {
 			$value->setPriority($priority);
 		}
 

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -216,11 +216,11 @@ class TWeakCallableCollection extends TPriorityList
 	public function insertAtIndexInPriority($item, $index = false, $priority = null, $preserveCache = false)
 	{
 		$itemPriority = null;
-		if (($priority === null || !is_numeric($priority)) && $item instanceof IPriorityItem) {
+		if (($isPriorityItem = ($item instanceof IPriorityItem)) && ($priority === null || !is_numeric($priority))) {
 			$itemPriority = $priority = $item->getPriority();
 		}
 		$priority = $this->ensurePriority($priority);
-		if ($item instanceof IPriorityProperty && $itemPriority != $priority) {
+		if (($item instanceof IPriorityCapture) && (!$isPriorityItem || $itemPriority !== $priority)) {
 			$item->setPriority($priority);
 		}
 		return parent::insertAtIndexInPriority($this->filterItemForInput($item, true), $index, $priority, $preserveCache);

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -24,6 +24,7 @@ return [
 'TFileCacheDependency' => 'Prado\Caching\TFileCacheDependency',
 'TGlobalStateCacheDependency' => 'Prado\Caching\TGlobalStateCacheDependency',
 'TMemCache' => 'Prado\Caching\TMemCache',
+'IPriorityCapture' => 'Prado\Collections\IPriorityCapture',
 'IPriorityItem' => 'Prado\Collections\IPriorityItem',
 'IPriorityProperty' => 'Prado\Collections\IPriorityProperty',
 'TAttributeCollection' => 'Prado\Collections\TAttributeCollection',

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -15,7 +15,7 @@ class PriorityListItem
 	}
 }
 
-class AutoPriorityListItem extends PriorityListItem implements IPriorityitem
+class AutoPriorityListItem extends PriorityListItem implements IPriorityItem
 {
 	public $priority;
 	
@@ -24,12 +24,36 @@ class AutoPriorityListItem extends PriorityListItem implements IPriorityitem
 		return $this->priority;
 	}
 	
+	public function setPriority($value)
+	{
+		$this->priority = $value;
+	}
+	
 	public function __invoke()
 	{
 	}
 }
 
-class SetPriorityListItem extends PriorityListItem implements IPriorityProperty
+class CapturePriorityListItem extends PriorityListItem implements IPriorityCapture
+{
+	public $priority;
+	
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+	
+	public function setPriority($value)
+	{
+		$this->priority = $value;
+	}
+	
+	public function __invoke()
+	{
+	}
+}
+
+class PriorityPropertyListItem extends PriorityListItem implements IPriorityProperty
 {
 	public $priority;
 	
@@ -479,6 +503,7 @@ class TPriorityListTest extends TListTest
 		
 		$plist->insertAtIndexInPriority($aplistitem, false, 20);
 		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(20));
+		$this->assertEquals(null, $aplistitem->getPriority());
 		
 		$plist->remove($aplistitem);
 		$this->assertEquals(null, $plist->itemsAtPriority(20));
@@ -552,12 +577,57 @@ class TPriorityListTest extends TListTest
 		$plist->removeAtIndexInPriority(0);
 	}
 	
+	public function testIPriorityCapture()
+	{
+		$plist = new $this->_baseClass();
+		$plist[] = $this->pfirst;
+		
+		$aplistitem = new CapturePriorityListItem("my Data");
+		$this->assertEquals(null, $aplistitem->getPriority());
+		$plist->insertAtIndexInPriority($aplistitem, false, null);
+		$this->assertEquals([$this->pfirst, $aplistitem], $plist->itemsAtPriority(null));
+		$this->assertEquals($plist->getDefaultPriority(), $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals([$this->pfirst], $plist->itemsAtPriority(null));
+		$this->assertEquals($plist->getDefaultPriority(), $aplistitem->getPriority());
+		
+		$plist->insertAtIndexInPriority($aplistitem, false, 20);
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		$aplistitem->priority = 5;
+		$this->assertEquals(5, $aplistitem->getPriority());
+		$this->assertEquals(true, $aplistitem instanceof IPriorityCapture);
+		$this->assertEquals(false, $aplistitem instanceof IPriorityItem);
+		$plist->insertAtIndexInPriority($aplistitem, false, null);
+		$this->assertEquals([$this->pfirst, $aplistitem], $plist->itemsAtPriority($aplistitem->getPriority()));
+		$this->assertEquals($aplistitem->getPriority(), $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals([$this->pfirst], $plist->itemsAtPriority($aplistitem->getPriority()));
+		$this->assertEquals($aplistitem->getPriority(), $aplistitem->getPriority());
+		
+		$aplistitem->priority = 5;
+		$plist->insertAtIndexInPriority($aplistitem, false, 20);
+		$this->assertEquals([$aplistitem], $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+		
+		$plist->remove($aplistitem);
+		$this->assertEquals(null, $plist->itemsAtPriority(20));
+		$this->assertEquals(20, $aplistitem->getPriority());
+	}
+	
 	public function testIPriorityProperty()
 	{
 		$plist = new $this->_baseClass();
 		$plist[] = $this->pfirst;
 		
-		$aplistitem = new SetPriorityListItem("my Data");
+		$aplistitem = new PriorityPropertyListItem("my Data");
 		$plist->insertAtIndexInPriority($aplistitem, false, null);
 		$this->assertEquals([$this->pfirst, $aplistitem], $plist->itemsAtPriority(null));
 		$this->assertEquals($plist->getDefaultPriority(), $aplistitem->getPriority());

--- a/tests/unit/Collections/TPriorityMapTest.php
+++ b/tests/unit/Collections/TPriorityMapTest.php
@@ -22,7 +22,22 @@ class AutoPriorityMapItem extends TPriorityMapTest_MapItem implements IPriorityI
 	}
 }
 
-class SetPriorityMapItem extends TPriorityMapTest_MapItem implements IPriorityProperty
+class CapturePropertyMapItem extends TPriorityMapTest_MapItem implements IPriorityCapture
+{
+	public $priority;
+	
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+	
+	public function setPriority($value)
+	{
+		$this->priority = $value;
+	}
+}
+
+class PriorityPropertyMapItem extends TPriorityMapTest_MapItem implements IPriorityProperty
 {
 	public $priority;
 	
@@ -381,9 +396,9 @@ class TPriorityMapTest extends PHPUnit\Framework\TestCase
 		
 		$this->assertEquals(5, $this->map->getCount());
 		
-		$this->map = new TPriorityMap();
 		// Test IPriorityProperty
-		$autoItem = new SetPriorityMapItem();
+		$this->map = new TPriorityMap();
+		$autoItem = new PriorityPropertyMapItem();
 		
 		$this->map->add('keyA', $autoItem);
 		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityAt('keyA'));
@@ -402,6 +417,45 @@ class TPriorityMapTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals(4, $this->map->priorityAt('keyC'));
 		$this->assertEquals(4, $this->map->priorityOf($autoItem));
 		$this->assertEquals(4, $autoItem->getPriority());
+		$this->map->remove('keyC');
+		
+		$autoItem->priority = 3;
+		$this->map->add('keyD', $autoItem, 5);
+		$this->assertEquals(5, $this->map->priorityAt('keyD'));
+		$this->assertEquals(5, $this->map->priorityOf($autoItem));
+		$this->assertEquals(5, $autoItem->getPriority());
+		$this->map->remove('keyD');
+		
+		$autoItem->priority = 'not_a_numeric';
+		$this->map->add('keyE', $autoItem, 'not_numeric');
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityAt('keyE'));
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityOf($autoItem));
+		$this->assertEquals($this->map->getDefaultPriority(), $autoItem->getPriority());
+		$this->map->remove('keyE');
+		
+		$this->assertEquals(0, $this->map->getCount());
+		
+		// Test IPriorityCapture
+		$this->map = new TPriorityMap();
+		$autoItem = new CapturePropertyMapItem();
+		
+		$this->map->add('keyA', $autoItem);
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityAt('keyA'));
+		$this->assertEquals($this->map->getDefaultPriority(), $autoItem->getPriority());
+		$this->map->remove('keyA');
+		
+		$autoItem->priority = 4;
+		$this->map->add('keyB', $autoItem);
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityAt('keyB'));
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityOf($autoItem));
+		$this->assertEquals($this->map->getDefaultPriority(), $autoItem->getPriority());
+		$this->map->remove('keyB');
+		
+		$autoItem->priority = 4;
+		$this->map->add('keyC', $autoItem, 'not_numeric');
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityAt('keyC'));
+		$this->assertEquals($this->map->getDefaultPriority(), $this->map->priorityOf($autoItem));
+		$this->assertEquals($this->map->getDefaultPriority(), $autoItem->getPriority());
 		$this->map->remove('keyC');
 		
 		$autoItem->priority = 3;


### PR DESCRIPTION
Added IPriorityCapture to capture changes to priority but not set them.  IPriorityProperties is the interface for extending both giving and receive priority.