### PR TITLE
Implement THttpRequest::ResolveMethod

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 ## Version 4.2.2 - ____
 
 ENH: Issue #828 - TApplication::onSetUser raised when setting user. (belisoful)
+ENH: Issue #866 - HTMLPurifier_Config and cache path (majuca)
+ENH: Issue #868 - RFC: Service detection is fragile (ctrlaltca)
 BUG: Issue #815 - Cron tasks delay until their proper time on first entry. Long running cron tasks no longer repeat further pending tasks. (belisoful)
 
 ## Version 4.2.1 - May 9, 2022

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,4 @@
-# Upgrading Instructions for PRADO Framework v4.2.1
+# Upgrading Instructions for PRADO Framework v4.2.2
 
 ### !!!IMPORTANT!!!
 
@@ -6,6 +6,10 @@ The following upgrading instructions are cumulative. That is,
 if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
+
+Upgrading from v4.2.1
+---------------------
+- The way PRADO determines what service to instanciate when receiving a request has been changed. If you experience problems, the old behavior can be restored setting the "request" module to use the "ServiceOrder" ResolveMethod in application configuration.
 
 Upgrading from v4.1.2
 ---------------------

--- a/framework/Web/THttpRequestResolveMethod.php
+++ b/framework/Web/THttpRequestResolveMethod.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * THttpRequestResolveMethod class file
+ *
+ * @author Fabio Bas <ctrlaltca[at]gmail[dot]com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Web;
+
+/**
+ * THttpRequestResolveMethod class.
+ * THttpRequestResolveMethod defines the method used to determine the
+ * service that needs to be instanciated to handle the user request.
+ *
+ * The following enumerable values are defined:
+ * - ServiceOrder: use the first service defined in the application
+ *   configuration matching one of the request parameters
+ * - ParameterOrder: use the first request parameter matching one of
+ *   the services defined in application configuration.
+ *
+ * PRADO versions before 4.2.2 used the ServiceOrder method.
+ * Since 4.2.2 the new default is ParameterOrder, that leads to a
+ * better identification of the correct service when using the Path
+ * and HiddenPath url formats.
+ *
+ * @author Fabio Bas <ctrlaltca[at]gmail[dot]com>
+ * @since 4.2.2
+ */
+class THttpRequestResolveMethod extends \Prado\TEnumerable
+{
+	public const ServiceOrder = 'ServiceOrder';
+	public const ParameterOrder = 'ParameterOrder';
+}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -332,6 +332,7 @@ return [
 'THttpCookie' => 'Prado\Web\THttpCookie',
 'THttpCookieCollection' => 'Prado\Web\THttpCookieCollection',
 'THttpRequest' => 'Prado\Web\THttpRequest',
+'THttpRequestResolveMethod' => 'Prado\Web\THttpRequestResolveMethod',
 'THttpRequestUrlFormat' => 'Prado\Web\THttpRequestUrlFormat',
 'THttpResponse' => 'Prado\Web\THttpResponse',
 'THttpResponseAdapter' => 'Prado\Web\THttpResponseAdapter',


### PR DESCRIPTION
This new parameter instructs THttpRequest on the behavior used to determine the correct service to be used to handle the request
Fix #868 