### PR TITLE
#840 Update TMap, TList, and TPriorityList

### DIFF
--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -225,7 +225,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 */
 	public function clear()
 	{
-		for ($i = $this->_c - 1;$i >= 0;--$i) {
+		for ($i = $this->_c - 1; $i >= 0; --$i) {
 			$this->removeAt($i);
 		}
 	}
@@ -236,7 +236,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 */
 	public function contains($item)
 	{
-		return $this->indexOf($item) >= 0;
+		return $this->indexOf($item) != -1;
 	}
 
 	/**

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -143,7 +143,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 */
 	public function itemAt($key)
 	{
-		return $this->_d[$key] ?? $this->dyNoItem(null, $key);
+		return array_key_exists($key, $this->_d) ? $this->_d[$key] : $this->dyNoItem(null, $key);
 	}
 
 	/**

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -489,7 +489,7 @@ class TPriorityList extends TList
 	 */
 	public function contains($item)
 	{
-		return $this->indexOf($item) >= 0;
+		return $this->indexOf($item) != -1;
 	}
 
 	/**


### PR DESCRIPTION
The TList and TPriorityList is updated to check contains against -1 rather than being greater than or equal to 0.  This subtle change allows subclasses to override indexOf to work with contains when returning, eg, a string rather than just an index.   This allows implementations to access more contained data than just the primary list.

The TMap needed to be corrected from ?? to array_key_exists as well.