### PR TITLE
#843 changed PermissionsBehaviors::getManager to getPermissionsManager for specificity

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ## Version 4.2.3 - TBA
 
+BUG: Issue #843 - Permissions Manager behaviors update getManager to getPermissionsManager for specificity.
 ENH: Issue #861 - TWebColors lists all the Web Colors in a TEnumerable and implements TPropertyValue::ensureHexColor
 
 ## Version 4.2.2 - April 6, 2023

--- a/framework/Security/Permissions/TPermissionsBehavior.php
+++ b/framework/Security/Permissions/TPermissionsBehavior.php
@@ -87,7 +87,7 @@ class TPermissionsBehavior extends TBehavior implements IDynamicMethods
 	public function __construct($manager = null)
 	{
 		if ($manager) {
-			$this->setManager($manager);
+			$this->setPermissionsManager($manager);
 		}
 		parent::__construct();
 	}
@@ -99,14 +99,15 @@ class TPermissionsBehavior extends TBehavior implements IDynamicMethods
 	{
 		parent::attach($owner);
 		if (method_exists($owner, 'getPermissions')) {
+			$manager = $this->getPermissionsManager();
 			$this->_permissionEvents = [];
-			$this->_events = $owner->getPermissions($this->getManager()) ?? [];
+			$this->_events = $owner->getPermissions($manager) ?? [];
 			foreach ($this->_events as $permEvent) {
 				$perm = $permEvent->getName();
 				foreach ($permEvent->getEvents() as $event) {
 					$this->_permissionEvents[$event][] = $perm;
 				}
-				$this->getManager()->registerPermission($perm, $permEvent->getDescription(), $permEvent->getRules());
+				$manager->registerPermission($perm, $permEvent->getDescription(), $permEvent->getRules());
 			}
 		}
 	}
@@ -157,7 +158,7 @@ class TPermissionsBehavior extends TBehavior implements IDynamicMethods
 	 * Gets the TPermissionsManager for the behavior
 	 * @return \Prado\Security\Permissions\TPermissionsManager manages application permissions
 	 */
-	public function getManager()
+	public function getPermissionsManager()
 	{
 		return $this->_manager;
 	}
@@ -166,7 +167,7 @@ class TPermissionsBehavior extends TBehavior implements IDynamicMethods
 	 * Sets the TPermissionsManager for the behavior
 	 * @param \Prado\Security\Permissions\TPermissionsManager|\WeakReference $manager manages application permissions
 	 */
-	public function setManager($manager)
+	public function setPermissionsManager($manager)
 	{
 		if (class_exists('\WeakReference', false) && $manager instanceof \WeakReference) {
 			$manager = $manager->get();

--- a/framework/Security/Permissions/TPermissionsConfigurationBehavior.php
+++ b/framework/Security/Permissions/TPermissionsConfigurationBehavior.php
@@ -44,7 +44,7 @@ class TPermissionsConfigurationBehavior extends TBehavior
 	public function __construct($manager = null)
 	{
 		if ($manager) {
-			$this->setManager($manager);
+			$this->setPermissionsManager($manager);
 		}
 		parent::__construct();
 	}
@@ -89,7 +89,7 @@ class TPermissionsConfigurationBehavior extends TBehavior
 	 */
 	public function dyApplyConfiguration($callchain)
 	{
-		$manager = $this->getManager();
+		$manager = $this->getPermissionsManager();
 		foreach ($this->_permissions as $permission) {
 			$manager->loadPermissionsData($permission);
 		}
@@ -99,7 +99,7 @@ class TPermissionsConfigurationBehavior extends TBehavior
 	/**
 	 * @return \Prado\Security\Permissions\TPermissionsManager manages application permissions
 	 */
-	public function getManager()
+	public function getPermissionsManager()
 	{
 		return $this->_manager;
 	}
@@ -107,7 +107,7 @@ class TPermissionsConfigurationBehavior extends TBehavior
 	/**
 	 * @param \Prado\Security\Permissions\TPermissionsManager|\WeakReference $manager manages application permissions
 	 */
-	public function setManager($manager)
+	public function setPermissionsManager($manager)
 	{
 		if (class_exists('\WeakReference', false) && $manager instanceof \WeakReference) {
 			$manager = $manager->get();

--- a/framework/Security/Permissions/TPermissionsManager.php
+++ b/framework/Security/Permissions/TPermissionsManager.php
@@ -253,9 +253,9 @@ class TPermissionsManager extends \Prado\TModule implements IPermissions
 		$this->_initialized = true;
 
 		$manager = class_exists('\WeakReference', false) ? \WeakReference::create($this) : $this;
-		TComponent::attachClassBehavior(static::PERMISSIONS_BEHAVIOR, ['class' => 'Prado\\Security\\Permissions\\TPermissionsBehavior', 'manager' => $manager], 'Prado\\Security\\Permissions\\IPermissions', -10);
-		TComponent::attachClassBehavior(static::USER_PERMISSIONS_BEHAVIOR, ['class' => 'Prado\\Security\\Permissions\\TUserPermissionsBehavior', 'manager' => $manager], 'Prado\\Security\\IUser', -10);
-		TComponent::attachClassBehavior(static::PERMISSIONS_CONFIG_BEHAVIOR, ['class' => 'Prado\\Security\\Permissions\\TPermissionsConfigurationBehavior', 'manager' => $manager], 'Prado\\Web\\Services\\TPageConfiguration', -10);
+		TComponent::attachClassBehavior(static::PERMISSIONS_BEHAVIOR, ['class' => 'Prado\\Security\\Permissions\\TPermissionsBehavior', 'permissionsmanager' => $manager], 'Prado\\Security\\Permissions\\IPermissions', -10);
+		TComponent::attachClassBehavior(static::USER_PERMISSIONS_BEHAVIOR, ['class' => 'Prado\\Security\\Permissions\\TUserPermissionsBehavior', 'permissionsmanager' => $manager], 'Prado\\Security\\IUser', -10);
+		TComponent::attachClassBehavior(static::PERMISSIONS_CONFIG_BEHAVIOR, ['class' => 'Prado\\Security\\Permissions\\TPermissionsConfigurationBehavior', 'permissionsmanager' => $manager], 'Prado\\Web\\Services\\TPageConfiguration', -10);
 
 		$this->loadPermissionsData($config);
 		if ($this->_permissionFile !== null) {

--- a/framework/Security/Permissions/TUserPermissionsBehavior.php
+++ b/framework/Security/Permissions/TUserPermissionsBehavior.php
@@ -36,7 +36,7 @@ class TUserPermissionsBehavior extends TBehavior
 	public function __construct($manager = null)
 	{
 		if ($manager) {
-			$this->setManager($manager);
+			$this->setPermissionsManager($manager);
 		}
 		parent::__construct();
 	}
@@ -48,7 +48,7 @@ class TUserPermissionsBehavior extends TBehavior
 	 */
 	public function can($permission, $extraData = null)
 	{
-		$rules = $this->getManager()->getPermissionRules($permission);
+		$rules = $this->getPermissionsManager()->getPermissionRules($permission);
 		if (!$rules) {
 			return true; //Default from TAuthorizationRuleCollection::isUserAllowed
 		}
@@ -63,7 +63,7 @@ class TUserPermissionsBehavior extends TBehavior
 	 */
 	public function dyDefaultRoles($roles, $callchain)
 	{
-		$roles = array_merge($roles, $this->getManager()->getDefaultRoles() ?? []);
+		$roles = array_merge($roles, $this->getPermissionsManager()->getDefaultRoles() ?? []);
 		return $callchain->dyDefaultRoles($roles);
 	}
 
@@ -76,14 +76,14 @@ class TUserPermissionsBehavior extends TBehavior
 	 */
 	public function dyIsInRole($return, $role, $callchain)
 	{
-		$inRole = $this->getManager()->isInHierarchy($this->getOwner()->getRoles(), $role);
+		$inRole = $this->getPermissionsManager()->isInHierarchy($this->getOwner()->getRoles(), $role);
 		return $callchain->dyIsInRole($return, $role) || $inRole;
 	}
 
 	/**
 	 * @return \Prado\Security\Permissions\TPermissionsManager application permissions manager
 	 */
-	public function getManager()
+	public function getPermissionsManager()
 	{
 		return $this->_manager;
 	}
@@ -91,7 +91,7 @@ class TUserPermissionsBehavior extends TBehavior
 	/**
 	 * @param \Prado\Security\Permissions\TPermissionsManager|\WeakReference $manager manages application permissions
 	 */
-	public function setManager($manager)
+	public function setPermissionsManager($manager)
 	{
 		if (class_exists('\WeakReference', false) && $manager instanceof \WeakReference) {
 			$manager = $manager->get();

--- a/tests/unit/Security/Permissions/TPermissionsBehaviorTest.php
+++ b/tests/unit/Security/Permissions/TPermissionsBehaviorTest.php
@@ -45,18 +45,18 @@ class TPermissionsBehaviorTest extends PHPUnit\Framework\TestCase
 	public function testConstruct()
 	{
 		self::assertInstanceOf('Prado\\Security\\Permissions\\TPermissionsBehavior', $this->behavior);
-		self::assertNull($this->behavior->getManager());
+		self::assertNull($this->behavior->getPermissionsManager());
 		
 		$this->behavior = new TPermissionsBehavior($v = new stdClass());
-		self::assertEquals($v, $this->behavior->getManager());
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
 	}
 	
 	public function testManager()
 	{
-		$this->behavior->setManager($v = new stdClass());
-		self::assertEquals($v, $this->behavior->getManager());
-		$this->behavior->setManager(\WeakReference::create($v));
-		self::assertEquals($v, $this->behavior->getManager());
+		$this->behavior->setPermissionsManager($v = new stdClass());
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
+		$this->behavior->setPermissionsManager(\WeakReference::create($v));
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
 	}
 	
 	public function testAttachAndEvent()
@@ -64,7 +64,7 @@ class TPermissionsBehaviorTest extends PHPUnit\Framework\TestCase
 		$permission = TPermissionsManager::PERM_PERMISSIONS_MANAGE_ROLES;
 		$this->manager = $manager = new TPermissionsManager();
 		$manager->setId('perms');
-		$this->behavior->setManager($manager);
+		$this->behavior->setPermissionsManager($manager);
 		
 		self::assertEquals([], $this->behavior->getPermissionEvents());
 		self::assertNull($manager->getPermissionRules($permission));
@@ -83,7 +83,7 @@ class TPermissionsBehaviorTest extends PHPUnit\Framework\TestCase
 		$this->user = $user = new TUser($userManager);
 		$user->setName($userName);
 		Prado::getApplication()->setUser($user);
-		$user->attachBehavior('can', ['class' => 'Prado\Security\Permissions\TUserPermissionsBehavior', 'manager' => $manager]);
+		$user->attachBehavior('can', ['class' => 'Prado\Security\Permissions\TUserPermissionsBehavior', 'permissionsmanager' => $manager]);
 		
 		//Test dynamic event permission
 		$user->setRoles($permission);

--- a/tests/unit/Security/Permissions/TPermissionsConfigurationBehaviorTest.php
+++ b/tests/unit/Security/Permissions/TPermissionsConfigurationBehaviorTest.php
@@ -30,18 +30,18 @@ class TPermissionsConfigurationBehaviorTest extends PHPUnit\Framework\TestCase
 	public function testConstruct()
 	{
 		self::assertInstanceOf('Prado\\Security\\Permissions\\TPermissionsConfigurationBehavior', $this->behavior);
-		self::assertNull($this->behavior->getManager());
+		self::assertNull($this->behavior->getPermissionsManager());
 		
 		$this->behavior = new TPermissionsBehavior($v = new stdClass());
-		self::assertEquals($v, $this->behavior->getManager());
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
 	}
 	
 	public function testManager()
 	{
-		$this->behavior->setManager($v = new stdClass());
-		self::assertEquals($v, $this->behavior->getManager());
-		$this->behavior->setManager(\WeakReference::create($v));
-		self::assertEquals($v, $this->behavior->getManager());
+		$this->behavior->setPermissionsManager($v = new stdClass());
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
+		$this->behavior->setPermissionsManager(\WeakReference::create($v));
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
 	}
 	
 	public function testAttachAndEvents()
@@ -50,7 +50,7 @@ class TPermissionsConfigurationBehaviorTest extends PHPUnit\Framework\TestCase
 		$manager = new TPermissionsManager();
 		$manager->setId('perms');
 		$manager->setAutoAllowWithPermission(false);
-		$this->behavior->setManager($manager);
+		$this->behavior->setPermissionsManager($manager);
 		
 		self::assertNull($manager->getPermissionRules($permission));
 		

--- a/tests/unit/Security/Permissions/TUserPermissionsBehaviorTest.php
+++ b/tests/unit/Security/Permissions/TUserPermissionsBehaviorTest.php
@@ -25,15 +25,15 @@ class TUserPermissionsBehaviorTest extends PHPUnit\Framework\TestCase
 		self::assertInstanceOf('Prado\\Security\\Permissions\\TUserPermissionsBehavior', $this->behavior);
 		
 		$this->behavior = new TUserPermissionsBehavior($v = new stdClass());
-		self::assertEquals($v, $this->behavior->getManager());
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
 	}
 	
 	public function testManager()
 	{
-		$this->behavior->setManager($v = new stdClass());
-		self::assertEquals($v, $this->behavior->getManager());
-		$this->behavior->setManager(\WeakReference::create($v));
-		self::assertEquals($v, $this->behavior->getManager());
+		$this->behavior->setPermissionsManager($v = new stdClass());
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
+		$this->behavior->setPermissionsManager(\WeakReference::create($v));
+		self::assertEquals($v, $this->behavior->getPermissionsManager());
 	}
 	
 	public function testBehavior()
@@ -43,7 +43,7 @@ class TUserPermissionsBehaviorTest extends PHPUnit\Framework\TestCase
 		
 		$manager = new TPermissionsManager();
 		//$manager->init(null);
-		$this->behavior->setManager($manager);
+		$this->behavior->setPermissionsManager($manager);
 		
 		//$manager->addPermissionRule('*', new TAuthorizationRule('deny', '*', '*', '*', '*', 999999));
 		


### PR DESCRIPTION
basically, as behaviors, these shouldn't hog the "getManager" name from other behaviors, and it needed to be more specific on its own.