### PR TITLE
#845 Adds TComponent::__clone, __wakeup, and callBehaviorsMethod

### DIFF
--- a/framework/Collections/TAttributeCollection.php
+++ b/framework/Collections/TAttributeCollection.php
@@ -137,7 +137,7 @@ class TAttributeCollection extends TMap
 	 * @param mixed $key the key
 	 * @return bool whether the map contains an item with the specified key
 	 */
-	public function contains($key)
+	public function contains($key): bool
 	{
 		return parent::contains($this->_caseSensitive ? $key : strtolower($key));
 	}

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -406,10 +406,8 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	protected function _getZappableSleepProps(&$exprops)
 	{
 		parent::_getZappableSleepProps($exprops);
-		if ($this->_d === []) {
-			$exprops[] = "\0*\0_d";
-		}
 		if ($this->_c === 0) {
+			$exprops[] = "\0*\0_d";
 			$exprops[] = "\0*\0_c";
 		}
 		if ($this->_r === false) {

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -44,7 +44,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * internal data storage
 	 * @var array
 	 */
-	protected array $_d = [];
+	protected $_d = [];
 	/**
 	 * number of items
 	 * @var int

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -44,16 +44,16 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * internal data storage
 	 * @var array
 	 */
-	private $_d = [];
+	protected array $_d = [];
 	/**
 	 * number of items
 	 * @var int
 	 */
-	private $_c = 0;
+	protected int $_c = 0;
 	/**
 	 * @var bool whether this list is read-only
 	 */
-	private $_r = false;
+	private bool $_r = false;
 
 	/**
 	 * Constructor.
@@ -74,7 +74,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @return bool whether this list is read-only or not. Defaults to false.
 	 */
-	public function getReadOnly()
+	public function getReadOnly(): bool
 	{
 		return $this->_r;
 	}
@@ -82,9 +82,9 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly($value)
+	protected function setReadOnly(bool $value)
 	{
-		$this->_r = TPropertyValue::ensureBoolean($value);
+		$this->_r = $value;
 	}
 
 	/**
@@ -93,7 +93,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * @return \Iterator an iterator for traversing the items in the list.
 	 */
 	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		return new \ArrayIterator($this->_d);
 	}
@@ -111,7 +111,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @return int the number of items in the list
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		return $this->_c;
 	}
@@ -223,7 +223,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * Removes all items in the list.
 	 * @throws TInvalidOperationException if the list is read-only
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		for ($i = $this->_c - 1; $i >= 0; --$i) {
 			$this->removeAt($i);
@@ -234,7 +234,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * @param mixed $item the item
 	 * @return bool whether the list contains the item
 	 */
-	public function contains($item)
+	public function contains($item): bool
 	{
 		return $this->indexOf($item) != -1;
 	}
@@ -303,7 +303,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @return array the list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return $this->_d;
 	}
@@ -393,5 +393,26 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	public function offsetUnset($offset): void
 	{
 		$this->removeAt($offset);
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if ($this->_d === []) {
+			$exprops[] = "\0*\0_d";
+		}
+		if ($this->_c === 0) {
+			$exprops[] = "\0*\0_c";
+		}
+		if ($this->_r === false) {
+			$exprops[] = "\0Prado\\Collections\\TList\0_r";
+		}
 	}
 }

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -401,6 +401,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
 	 * implementation first.
 	 * @param array $exprops by reference
+	 * @since 4.2.3
 	 */
 	protected function _getZappableSleepProps(&$exprops)
 	{

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -41,7 +41,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @var array<int|string, mixed> internal data storage
 	 */
-	protected array $_d = [];
+	protected $_d = [];
 	/**
 	 * @var bool whether this list is read-only
 	 */

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -284,7 +284,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	protected function _getZappableSleepProps(&$exprops)
 	{
 		parent::_getZappableSleepProps($exprops);
-		if ($this->_d === []) {
+		if (count($this->_d) === 0) {
 			$exprops[] = "\0*\0_d";
 		}
 		if ($this->_r === false) {

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -11,7 +11,6 @@ namespace Prado\Collections;
 
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
-use Prado\TPropertyValue;
 use Traversable;
 
 /**
@@ -42,29 +41,11 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @var array<int|string, mixed> internal data storage
 	 */
-	protected $_d = [];
+	protected array $_d = [];
 	/**
 	 * @var bool whether this list is read-only
 	 */
-	protected $_r = false;
-
-	/**
-	 * Returns an array with the names of all variables of this object that should NOT be serialized
-	 * because their value is the default one or useless to be cached for the next page loads.
-	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
-	 * implementation first.
-	 * @param array $exprops by reference
-	 */
-	protected function _getZappableSleepProps(&$exprops)
-	{
-		parent::_getZappableSleepProps($exprops);
-		if ($this->_d === []) {
-			$exprops[] = "\0*\0_d";
-		}
-		if ($this->_r === false) {
-			$exprops[] = "\0*\0_r";
-		}
-	}
+	private bool $_r = false;
 
 	/**
 	 * Constructor.
@@ -85,7 +66,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return bool whether this map is read-only or not. Defaults to false.
 	 */
-	public function getReadOnly()
+	public function getReadOnly(): bool
 	{
 		return $this->_r;
 	}
@@ -93,9 +74,9 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly($value)
+	protected function setReadOnly(bool $value)
 	{
-		$this->_r = TPropertyValue::ensureBoolean($value);
+		$this->_r = $value;
 	}
 
 	/**
@@ -104,7 +85,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @return \Iterator an iterator for traversing the items in the list.
 	 */
 	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		return new \ArrayIterator($this->_d);
 	}
@@ -122,7 +103,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return int the number of items in the map
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		return count($this->_d);
 	}
@@ -130,7 +111,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return array<int|string> the key list
 	 */
-	public function getKeys()
+	public function getKeys(): array
 	{
 		return array_keys($this->_d);
 	}
@@ -188,7 +169,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * Removes all items in the map.
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		foreach (array_keys($this->_d) as $key) {
 			$this->remove($key);
@@ -199,7 +180,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @param mixed $key the key
 	 * @return bool whether the map contains an item with the specified key
 	 */
-	public function contains($key)
+	public function contains($key): bool
 	{
 		return isset($this->_d[$key]) || array_key_exists($key, $this->_d);
 	}
@@ -207,7 +188,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return array<int|string, mixed> the list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return $this->_d;
 	}
@@ -291,5 +272,23 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	public function offsetUnset($offset): void
 	{
 		$this->remove($offset);
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if ($this->_d === []) {
+			$exprops[] = "\0*\0_d";
+		}
+		if ($this->_r === false) {
+			$exprops[] = "\0Prado\\Collections\\TMap\0_r";
+		}
 	}
 }

--- a/framework/Collections/TPagedList.php
+++ b/framework/Collections/TPagedList.php
@@ -273,7 +273,7 @@ class TPagedList extends TList
 	/**
 	 * @return int the number of items in current page
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		if ($this->_customPaging) {
 			return parent::getCount();
@@ -290,7 +290,7 @@ class TPagedList extends TList
 	 * @return \Iterator iterator
 	 */
 	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		if ($this->_customPaging) {
 			return parent::getIterator();
@@ -358,7 +358,7 @@ class TPagedList extends TList
 	/**
 	 * @return array the list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		$c = $this->getCount();
 		$array = [];

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -12,7 +12,6 @@ namespace Prado\Collections;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Exceptions\TInvalidOperationException;
-use Prado\TPropertyValue;
 
 /**
  * TPriorityList class
@@ -46,27 +45,19 @@ use Prado\TPropertyValue;
  * To extend TPriorityList for doing your own operations with each addition or removal,
  * override {@link insertAtIndexInPriority()} and {@link removeAtIndexInPriority()} and then call the parent.
  *
- * @author Brad Anderson <javalizard@gmail.com>
+ * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.2a
  */
 class TPriorityList extends TList
 {
 	/**
-	 * @var array internal data storage
-	 */
-	private $_d = [];
-	/**
 	 * @var bool indicates if the _d is currently ordered.
 	 */
-	private $_o = false;
+	private bool $_o = false;
 	/**
 	 * @var null|array cached flattened internal data storage
 	 */
-	private $_fd;
-	/**
-	 * @var int number of items contain within the list
-	 */
-	private $_c = 0;
+	private ?array $_fd = null;
 	/**
 	 * @var numeric the default priority of items without specified priorities
 	 */
@@ -74,7 +65,7 @@ class TPriorityList extends TList
 	/**
 	 * @var int the precision of the numeric priorities within this priority list.
 	 */
-	private $_p = 8;
+	private int $_p = 8;
 
 	/**
 	 * Constructor.
@@ -87,13 +78,9 @@ class TPriorityList extends TList
 	 */
 	public function __construct($data = null, $readOnly = false, $defaultPriority = 10, $precision = 8)
 	{
-		parent::__construct();
-		if ($data !== null) {
-			$this->copyFrom($data);
-		}
-		$this->setReadOnly($readOnly);
 		$this->setPrecision($precision);
 		$this->setDefaultPriority($defaultPriority);
+		parent::__construct($data, $readOnly);
 	}
 
 	/**
@@ -110,7 +97,7 @@ class TPriorityList extends TList
 	 * Returns the total number of items in the list
 	 * @return int the number of items in the list
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		return $this->_c;
 	}
@@ -143,13 +130,13 @@ class TPriorityList extends TList
 	 */
 	protected function setDefaultPriority($value)
 	{
-		$this->_dp = (string) round(TPropertyValue::ensureFloat($value), $this->_p);
+		$this->_dp = (string) round((float) $value, $this->_p);
 	}
 
 	/**
 	 * @return int The precision of numeric priorities, defaults to 8
 	 */
-	public function getPrecision()
+	public function getPrecision(): int
 	{
 		return $this->_p;
 	}
@@ -158,9 +145,9 @@ class TPriorityList extends TList
 	 * This must be called internally or when instantiated.
 	 * @param int $value The precision of numeric priorities.
 	 */
-	protected function setPrecision($value)
+	protected function setPrecision(int $value): void
 	{
-		$this->_p = TPropertyValue::ensureInteger($value);
+		$this->_p = $value;
 	}
 
 	/**
@@ -176,7 +163,7 @@ class TPriorityList extends TList
 		if ($priority === null || !is_numeric($priority)) {
 			$priority = $this->getDefaultPriority();
 		}
-		return (string) round(TPropertyValue::ensureFloat($priority), $this->_p);
+		return (string) round((float) $priority, $this->_p);
 	}
 
 	/**
@@ -185,7 +172,7 @@ class TPriorityList extends TList
 	 * @return \Iterator an iterator for traversing the items in the list.
 	 */
 	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		return new \ArrayIterator($this->flattenPriorities());
 	}
@@ -194,7 +181,7 @@ class TPriorityList extends TList
 	 * This returns a list of the priorities within this list, ordered lowest to highest.
 	 * @return array the array of priority numerics in decreasing priority order
 	 */
-	public function getPriorities()
+	public function getPriorities(): array
 	{
 		$this->sortPriorities();
 		return array_keys($this->_d);
@@ -204,7 +191,7 @@ class TPriorityList extends TList
 	/**
 	 * This orders the priority list internally.
 	 */
-	protected function sortPriorities()
+	protected function sortPriorities(): void
 	{
 		if (!$this->_o) {
 			ksort($this->_d, SORT_NUMERIC);
@@ -216,7 +203,7 @@ class TPriorityList extends TList
 	 * This flattens the priority list into a flat array [0,...,n-1]
 	 * @return array array of items in the list in priority and index order
 	 */
-	protected function flattenPriorities()
+	protected function flattenPriorities(): array
 	{
 		if (is_array($this->_fd)) {
 			return $this->_fd;
@@ -251,9 +238,9 @@ class TPriorityList extends TList
 	/**
 	 * Gets all the items at a specific priority.
 	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled in with the default priority, if left blank.
-	 * @return array all items at priority in index order, null if there are no items at that priority
+	 * @return ?array all items at priority in index order, null if there are no items at that priority
 	 */
-	public function itemsAtPriority($priority = null)
+	public function itemsAtPriority($priority = null): ?array
 	{
 		$priority = $this->ensurePriority($priority);
 		return $this->_d[$priority] ?? null;
@@ -469,7 +456,7 @@ class TPriorityList extends TList
 	/**
 	 * Removes all items in the priority list by calling removeAtIndexInPriority from the last item to the first.
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		if ($this->getReadOnly()) {
 			throw new TInvalidOperationException('list_readonly', get_class($this));
@@ -487,7 +474,7 @@ class TPriorityList extends TList
 	 * @param mixed $item item
 	 * @return bool whether the list contains the item
 	 */
-	public function contains($item)
+	public function contains($item): bool
 	{
 		return $this->indexOf($item) != -1;
 	}
@@ -609,7 +596,7 @@ class TPriorityList extends TList
 	/**
 	 * @return array the priority list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return $this->flattenPriorities();
 	}
@@ -617,7 +604,7 @@ class TPriorityList extends TList
 	/**
 	 * @return array the array of priorities keys with values of arrays of items.  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toPriorityArray()
+	public function toPriorityArray(): array
 	{
 		$this->sortPriorities();
 		return $this->_d;
@@ -630,7 +617,7 @@ class TPriorityList extends TList
 	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayBelowPriority($priority, $inclusive = false)
+	public function toArrayBelowPriority($priority, $inclusive = false): array
 	{
 		$this->sortPriorities();
 		$items = [];
@@ -650,7 +637,7 @@ class TPriorityList extends TList
 	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayAbovePriority($priority, $inclusive = true)
+	public function toArrayAbovePriority($priority, $inclusive = true): array
 	{
 		$this->sortPriorities();
 		$items = [];
@@ -777,5 +764,27 @@ class TPriorityList extends TList
 	public function offsetUnset($offset): void
 	{
 		$this->removeAt($offset);
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if ($this->_o === false) {
+			$exprops[] = "\0Prado\\Collections\\TPriorityList\0_o";
+		}
+		$exprops[] = "\0Prado\\Collections\\TPriorityList\0_fd";
+		if ($this->_dp == 10) {
+			$exprops[] = "\0Prado\\Collections\\TPriorityList\0_dp";
+		}
+		if ($this->_p === 8) {
+			$exprops[] = "\0Prado\\Collections\\TPriorityList\0_p";
+		}
 	}
 }

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -772,6 +772,7 @@ class TPriorityList extends TList
 	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
 	 * implementation first.
 	 * @param array $exprops by reference
+	 * @since 4.2.3
 	 */
 	protected function _getZappableSleepProps(&$exprops)
 	{

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -274,9 +274,9 @@ class TPriorityMap extends TMap
 	/**
 	 * Gets all the items at a specific priority.
 	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled in with the default priority, if left blank.
-	 * @return array all items at priority in index order, null if there are no items at that priority
+	 * @return ?array all items at priority in index order, null if there are no items at that priority
 	 */
-	public function itemsAtPriority($priority = null)
+	public function itemsAtPriority($priority = null): ?array
 	{
 		$priority = $this->ensurePriority($priority);
 		return $this->_d[$priority] ?? null;
@@ -458,7 +458,7 @@ class TPriorityMap extends TMap
 	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayBelowPriority($priority, $inclusive = false)
+	public function toArrayBelowPriority($priority, $inclusive = false): array
 	{
 		$this->sortPriorities();
 		$items = [];
@@ -478,7 +478,7 @@ class TPriorityMap extends TMap
 	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayAbovePriority($priority, $inclusive = true)
+	public function toArrayAbovePriority($priority, $inclusive = true): array
 	{
 		$this->sortPriorities();
 		$items = [];

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -550,6 +550,7 @@ class TPriorityMap extends TMap
 	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
 	 * implementation first.
 	 * @param array $exprops by reference
+	 * @since 4.2.3
 	 */
 	protected function _getZappableSleepProps(&$exprops)
 	{

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -30,7 +30,6 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	private static $_weak;
 
-
 	/**
 	 * Constructor.
 	 * Initializes the list with an array or an iterable object. Discovers the availability of the
@@ -66,6 +65,9 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	public static function getWeakReferenceEnabled()
 	{
+		if (self::$_weak === null) {
+			self::$_weak = class_exists('\WeakReference', false);
+		}
 		return self::$_weak;
 	}
 
@@ -146,7 +148,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * This flattens the priority list into a flat array [0,...,n-1]. This is needed to filter the output.
 	 * @return array array of items in the list in priority and index order
 	 */
-	protected function flattenPriorities()
+	protected function flattenPriorities(): array
 	{
 		return $this->filterItemsForOutput(parent::flattenPriorities());
 	}
@@ -159,7 +161,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array array of items in the list in priority and index order,
 	 *    where objects are WeakReference
 	 */
-	protected function flattenPrioritiesWeak()
+	protected function flattenPrioritiesWeak(): array
 	{
 		return parent::flattenPriorities();
 	}
@@ -186,9 +188,9 @@ class TWeakCallableCollection extends TPriorityList
 	 * Gets all the items at a specific priority. This is needed to filter the output.
 	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled
 	 * in with the default priority, if left blank.
-	 * @return array all items at priority in index order, null if there are no items at that priority
+	 * @return ?array all items at priority in index order, null if there are no items at that priority
 	 */
-	public function itemsAtPriority($priority = null)
+	public function itemsAtPriority($priority = null): ?array
 	{
 		return $this->filterItemsForOutput(parent::itemsAtPriority($priority));
 	}
@@ -272,7 +274,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array the array of priorities keys with values of arrays of callables.
 	 * The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toPriorityArray()
+	public function toPriorityArray(): array
 	{
 		$result = [];
 		foreach (parent::toPriorityArray() as $i => $v) {
@@ -299,7 +301,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayBelowPriority($priority, $inclusive = false)
+	public function toArrayBelowPriority($priority, $inclusive = false): array
 	{
 		return $this->filterItemsForOutput(parent::toArrayBelowPriority($priority, $inclusive));
 	}
@@ -311,7 +313,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayAbovePriority($priority, $inclusive = true)
+	public function toArrayAbovePriority($priority, $inclusive = true): array
 	{
 		return $this->filterItemsForOutput(parent::toArrayAbovePriority($priority, $inclusive));
 	}

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -19,6 +19,7 @@ component_tbehavior_cannot_attach_as_class_behavior	= IBehaviors cannot attach t
 component_no_class_provided_nor_late_binding = Adding or Removing Class Behaviors must have PHP feature Late Static Binding or a class provided as a parameter
 
 propertyvalue_enumvalue_invalid			= Value '{0}' is a not valid enumeration value ({1}).
+propertyvalue_invalid_hex_color			= Value '{0}' is a not valid hex color value.  eg. "#112233"
 
 list_index_invalid						= Index '{0}' is out of range.
 list_item_inexistent					= The item cannot be found in the list.

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -330,8 +330,8 @@ class TApplication extends \Prado\TComponent
 	protected function resolvePaths($basePath)
 	{
 		// determine configuration path and file
-		if (empty($basePath) || ($basePath = realpath($basePath)) === false) {
-			throw new TConfigurationException('application_basepath_invalid', $basePath);
+		if (empty($errValue = $basePath) || ($basePath = realpath($basePath)) === false) {
+			throw new TConfigurationException('application_basepath_invalid', $errValue);
 		}
 		if (is_dir($basePath) && is_file($basePath . DIRECTORY_SEPARATOR . $this->getConfigurationFileName())) {
 			$configFile = $basePath . DIRECTORY_SEPARATOR . $this->getConfigurationFileName();

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1570,7 +1570,7 @@ class TComponent
 	 * Returns the named behavior object.
 	 * The name 'asa' stands for 'as a'.
 	 * @param string $behaviorname the behavior name
-	 * @return IBehavior the behavior object, or null if the behavior does not exist
+	 * @return object the behavior object, or null if the behavior does not exist
 	 * @since 3.2.3
 	 */
 	public function asa($behaviorname)

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -533,22 +533,19 @@ class TComponent
 	 */
 	public function getClassHierarchy($lowercase = false)
 	{
-		static $_classhierarchy = [];
+		static $_classhierarchy = [[], []];
 		$class = get_class($this);
-		if (isset($_classhierarchy[$class]) && isset($_classhierarchy[$class][$lowercase ? 1 : 0])) {
+		if (isset($_classhierarchy[$class][$lowercase ? 1 : 0])) {
 			return $_classhierarchy[$class][$lowercase ? 1 : 0];
 		}
 		$classes = array_values(class_implements($class));
-		array_push($classes, $class);
-		while ($class = get_parent_class($class)) {
+		do {
 			array_push($classes, $class);
-		}
+		} while ($class = get_parent_class($class));
 		if ($lowercase) {
 			$classes = array_map('strtolower', $classes);
 		}
-		$_classhierarchy[$class] ??= [];
 		$_classhierarchy[$class][$lowercase ? 1 : 0] = $classes;
-
 		return $classes;
 	}
 

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -309,8 +309,10 @@ use Prado\Collections\TPriorityMap;
  * of when an global and/or undefined dynamic event is executed.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @author Brad Anderson <javalizard@mac.com>
+ * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.0
+ * @method void dyClone()
+ * @method void dyWakeUp()
  * @method void dyListen(array $globalEvents)
  * @method void dyUnlisten(array $globalEvents)
  * @method string dyPreRaiseEvent(string $name, mixed $sender, \Prado\TEventParameter $param, null|numeric $responsetype, null|function $postfunction)
@@ -388,6 +390,93 @@ class TComponent
 				$this->attachBehaviors(self::$_um[$class]);
 			}
 		}
+	}
+
+	/**
+	 * The common __clone magic method from PHP's "clone".
+	 * This reattaches the behaviors to the cloned object.
+	 * IBehavior objects are cloned, IClassBehaviors are not.
+	 * Clone object events are scrubbed of the old object behaviors' events.
+	 * To finalize the behaviors, dyClone is raised.
+	 * @since 4.2.3
+	 */
+	public function __clone()
+	{
+		foreach ($this->_e as $event => $handlers) {
+			$this->_e[$event] = clone $handlers;
+		}
+		$behaviorArray = array_values(($this->_m !== null) ? $this->_m->toArray() : []);
+		if (count($behaviorArray) && count($this->_e)) {
+			$behaviorArray = array_combine(array_map('spl_object_id', $behaviorArray), $behaviorArray);
+			foreach ($this->_e as $event => $handlers) {
+				foreach ($handlers->toArray() as $handler) {
+					$a = is_array($handler);
+					if ($a && array_key_exists(spl_object_id($handler[0]), $behaviorArray) || !$a && array_key_exists(spl_object_id($handler), $behaviorArray)) {
+						$handlers->remove($handler);
+					}
+				}
+			}
+		}
+		if ($this->_m !== null) {
+			$behaviors = $this->_m;
+			$this->_m = new TPriorityMap();
+			foreach ($behaviors->getPriorities() as $priority) {
+				foreach ($behaviors->itemsAtPriority($priority) as $name => $behavior) {
+					if (!($behavior instanceof \Prado\Util\IClassBehavior)) { //not a class behavior
+						$behavior = clone $behavior;
+					}
+					$this->attachBehavior($name, $behavior, $priority);
+				}
+			}
+		}
+		$this->callBehaviorsMethod('dyClone', $return);
+	}
+
+	/**
+	 * The common __wakeup magic method from PHP's "unserialize".
+	 * This reattaches the behaviors to the reconstructed object.
+	 * Any global class behaviors are used rather than their unserialized copy.
+	 * Any global behaviors not found in the object will be added.
+	 * To finalize the behaviors, dyWakeUp is raised.
+	 * If a TModule needs to add events to an object during unserialization,
+	 * the module can use a small IClassBehavior [implementing dyWakeUp]
+	 * (adding the event[s]) attached to the class with {@link
+	 * attachClassBehavior} prior to unserialization.
+	 * @since 4.2.3
+	 */
+	public function __wakeup()
+	{
+		$classes = $this->getClassHierarchy(true);
+		array_pop($classes);
+		$classBehaviors = [];
+		if ($this->_m !== null) {
+			$behaviors = $this->_m;
+			$this->_m = new TPriorityMap();
+			foreach ($behaviors->getPriorities() as $priority) {
+				foreach ($behaviors->itemsAtPriority($priority) as $name => $behavior) {
+					if ($behavior instanceof \Prado\Util\IClassBehavior) {
+						foreach ($classes as $class) {
+							if (isset(self::$_um[$class]) && array_key_exists($name, self::$_um[$class])) {
+								$behavior = self::$_um[$class][$name]->getBehavior();
+								break;
+							}
+						}
+					}
+					$classBehaviors[$name] = $name;
+					$this->attachBehavior($name, $behavior, $priority);
+				}
+			}
+		}
+		foreach ($classes as $class) {
+			if (isset(self::$_um[$class])) {
+				foreach (self::$_um[$class] as $name => $behavior) {
+					if (!array_key_exists($name, $classBehaviors)) {
+						$this->attachBehaviors([$behavior]);
+					}
+				}
+			}
+		}
+		$this->callBehaviorsMethod('dyWakeUp', $return);
 	}
 
 
@@ -600,49 +689,15 @@ class TComponent
 						$args[0] = new TJavaScriptString($args[0]);
 					}
 				}
-				return call_user_func_array([$this, $jsmethod], $args);
+				return $this->$jsmethod(...$args);
 			}
 
 			if (($getset == 'set') && method_exists($this, 'getjs' . $propname)) {
 				throw new TInvalidOperationException('component_property_readonly', get_class($this), $method);
 			}
 		}
-
-		if ($this->_m !== null && $this->_behaviorsenabled) {
-			if (strncasecmp($method, 'dy', 2) === 0) {
-				$callchain = null;
-				foreach ($this->_m->toArray() as $behavior) {
-					if ((!($behavior instanceof IBehavior) || $behavior->getEnabled()) && (method_exists($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
-						$behavior_args = $args;
-						if ($behavior instanceof IClassBehavior) {
-							array_unshift($behavior_args, $this);
-						}
-						if (!$callchain) {
-							$callchain = new TCallChain($method);
-						}
-						$callchain->addCall([$behavior, $method], $behavior_args);
-					}
-				}
-				if ($callchain) {
-					return call_user_func_array([$callchain, 'call'], $args);
-				}
-			} else {
-				foreach ($this->_m->toArray() as $behavior) {
-					if ((!($behavior instanceof IBehavior) || $behavior->getEnabled()) && method_exists($behavior, $method)) {
-						if ($behavior instanceof IClassBehavior) {
-							array_unshift($args, $this);
-						}
-						return call_user_func_array([$behavior, $method], $args);
-					}
-				}
-			}
-		}
-
-		if (strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
-			if ($this instanceof IDynamicMethods) {
-				return $this->__dycall($method, $args);
-			}
-			return $args[0] ?? null;
+		if($this->callBehaviorsMethod($method, $return, ...$args)) {
+			return $return;
 		}
 
 		// don't thrown an exception for __magicMethods() or any other weird methods natively implemented by php
@@ -937,6 +992,68 @@ class TComponent
 			$property = substr($path, $pos + 1);
 		}
 		$object->$property = $value;
+	}
+
+	/**
+	 * Calls a method on a component's behaviors.  When the method is a
+	 * dynamic event, it is raised with all the behaviors.  When a class implements
+	 * a dynamic event (eg. for patching), the class can customize raising the
+	 * dynamic event with the classes behaviors using this method.
+	 * Dynamic [dy] and global [fx] events call {@link __dycall} when $this
+	 * implements IDynamicMethods.  Finally, this catches all unexecuted
+	 * Dynamic [dy] and global [fx] events and returns the first $args parameter;
+	 * acting as a passthrough (filter) of the first $args parameter. In dy/fx methods,
+	 * there can be no $args parameters, the first parameter used as a pass through
+	 * filter, or act as a return variable with the first $args parameter being
+	 * the default return value.
+	 * @param string $method The method being called or dynamic/global event being raised.
+	 * @param mixed &$return The return value.
+	 * @param array $args The arguments to the method being called.
+	 * @return bool Was the method handled.
+	 * @since 4.2.3
+	 */
+	public function callBehaviorsMethod($method, &$return, ...$args): bool
+	{
+		if ($this->_m !== null && $this->_behaviorsenabled) {
+			if (strncasecmp($method, 'dy', 2) === 0) {
+				$classArgs = $callchain = null;
+				foreach ($this->_m->toArray() as $behavior) {
+					if ((!($behavior instanceof IBehavior) || $behavior->getEnabled()) && (method_exists($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
+						if ($classArgs === null) {
+							$classArgs = $args;
+							array_unshift($classArgs, $this);
+						}
+						if (!$callchain) {
+							$callchain = new TCallChain($method);
+						}
+						$callchain->addCall([$behavior, $method], ($behavior instanceof IClassBehavior) ? $classArgs : $args);
+					}
+				}
+				if ($callchain) {
+					$return = $callchain->call(...$args);
+					return true;
+				}
+			} else {
+				foreach ($this->_m->toArray() as $behavior) {
+					if ((!($behavior instanceof IBehavior) || $behavior->getEnabled()) && method_exists($behavior, $method)) {
+						if ($behavior instanceof IClassBehavior) {
+							array_unshift($args, $this);
+						}
+						$return = $behavior->$method(...$args);
+						return true;
+					}
+				}
+			}
+		}
+		if (strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
+			if ($this instanceof IDynamicMethods) {
+				$return = $this->__dycall($method, $args);
+				return true;
+			}
+			$return = $args[0] ?? null;
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -1494,7 +1611,7 @@ class TComponent
 	 */
 	public static function attachClassBehavior($name, $behavior, $class = null, $priority = null)
 	{
-		if (!$class && function_exists('get_called_class')) {
+		if (!$class) {
 			$class = get_called_class();
 		}
 		if (!$class) {
@@ -1543,7 +1660,7 @@ class TComponent
 	 */
 	public static function detachClassBehavior($name, $class = null, $priority = false)
 	{
-		if (!$class && function_exists('get_called_class')) {
+		if (!$class) {
 			$class = get_called_class();
 		}
 		if (!$class) {
@@ -1623,7 +1740,6 @@ class TComponent
 	/**
 	 * Returns all the behaviors attached to the TComponent.  IBehavior[s] may
 	 * be attached but not {@link \Prado\Util\IBehavior::getEnabled Enabled}.
-	 *
 	 * @return array all the behaviors attached to the TComponent
 	 * @since 4.2.2
 	 */
@@ -1886,9 +2002,7 @@ class TComponent
 		if ($this->_behaviorsenabled === true) {
 			$exprops[] = "\0*\0_behaviorsenabled";
 		}
-		if ($this->_e === []) {
-			$exprops[] = "\0*\0_e";
-		}
+		$exprops[] = "\0*\0_e";
 		if ($this->_m === null) {
 			$exprops[] = "\0*\0_m";
 		}

--- a/framework/Util/Behaviors/TNoUnserializeBehaviorTrait.php
+++ b/framework/Util/Behaviors/TNoUnserializeBehaviorTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * TNoUnserializeBehaviorTrait class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util\Behaviors;
+
+use Prado\Util\TCallChain;
+
+/**
+ * TNoUnserializeBehaviorTrait class.
+ *
+ * When this trait is used by an IBehavior, upon the owner being unserialized (via
+ * magic method __wakeup and dyWakeUp) this trait removes itself from its owner.
+ *
+ * This trait is used to deprecate serialized objects' IBehavior.  By re-serializing
+ * the object can be saved without the deprecated behavior.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+trait TNoUnserializeBehaviorTrait
+{
+	/**
+	 * This is raised when an owner is completed its unserialize() method call to
+	 * __wakeup.  This method removes it behavior from the owner.
+	 * @param TCallChain $chain The chain of dynamic event method handlers.
+	 */
+	public function dyWakeUp(TCallChain $chain)
+	{
+		$owner = $this->getOwner();
+		if ($index = array_search($this, $owner->getBehaviors())) {
+			$owner->detachBehavior($index);
+		}
+		return $chain->dyWakeUp();
+	}
+}

--- a/framework/Util/Behaviors/TNoUnserializeClassBehaviorTrait.php
+++ b/framework/Util/Behaviors/TNoUnserializeClassBehaviorTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * TNoUnserializeClassBehaviorTrait class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util\Behaviors;
+
+use Prado\Util\TCallChain;
+
+/**
+ * TNoUnserializeClassBehaviorTrait class.
+ *
+ * When this trait is used by an IClassBehavior, upon the owner being unserialized
+ * (via magic method __wakeup and dyWakeUp) this trait removes itself from its owner.
+ *
+ * This trait is used to deprecate serialized objects' IClassBehavior. By re-serializing
+ * the object can be saved without the deprecated behavior.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+trait TNoUnserializeClassBehaviorTrait
+{
+	/**
+	 * This is raised when an owner is completed its unserialize() method call to
+	 * __wakeup.  This method removes its behavior from the owner.
+	 * @param object $owner The owner of he behavior raising the dynamic event.
+	 * @param TCallChain $chain The chain of dynamic event method handlers.
+	 */
+	public function dyWakeUp(object $owner, TCallChain $chain)
+	{
+		if ($index = array_search($this, $owner->getBehaviors())) {
+			$owner->detachBehavior($index);
+		}
+		return $chain->dyWakeUp();
+	}
+}

--- a/framework/Util/TBehavior.php
+++ b/framework/Util/TBehavior.php
@@ -76,7 +76,7 @@ class TBehavior extends \Prado\TComponent implements IBehavior
 	}
 
 	/**
-	 * @return \Prado\TComponent the owner component that this behavior is attached to.
+	 * @return object the owner component that this behavior is attached to.
 	 */
 	public function getOwner()
 	{
@@ -97,5 +97,32 @@ class TBehavior extends \Prado\TComponent implements IBehavior
 	public function setEnabled($value)
 	{
 		$this->_enabled = TPropertyValue::ensureBoolean($value);
+	}
+
+	/**
+	 * This resets the Owner on cloning.
+	 * @since 4.2.3
+	 */
+	public function __clone()
+	{
+		$this->_owner = null;
+		parent::__clone();
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 * @since 4.2.3
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if ($this->_enabled === true) {
+			$exprops[] = "\0Prado\\Util\\TBehavior\0_enabled";
+		}
+		$exprops[] = "\0Prado\\Util\\TBehavior\0_owner";
 	}
 }

--- a/framework/Util/TCallChain.php
+++ b/framework/Util/TCallChain.php
@@ -91,10 +91,10 @@ class TCallChain extends TList implements IDynamicMethods
 	 * When there are no handlers or no handlers left, it returns the first parameter of the
 	 * argument list.
 	 *
+	 * @param array $args The parameters to send the function chain.
 	 */
-	public function call()
+	public function call(...$args)
 	{
-		$args = func_get_args();
 		if ($this->getCount() === 0) {
 			return $args[0] ?? null;
 		}

--- a/framework/Web/UI/TControlCollection.php
+++ b/framework/Web/UI/TControlCollection.php
@@ -86,7 +86,7 @@ class TControlCollection extends \Prado\Collections\TList
 	/**
 	 * Overrides the parent implementation by invoking {@link TControl::clearNamingContainer}
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		parent::clear();
 		if ($this->_o instanceof INamingContainer) {

--- a/framework/Web/UI/WebControls/TStyle.php
+++ b/framework/Web/UI/WebControls/TStyle.php
@@ -89,6 +89,7 @@ class TStyle extends \Prado\TComponent
 		if ($this->_font !== null) {
 			$this->_font = clone($this->_font);
 		}
+		parent::__clone();
 	}
 
 	/**

--- a/tests/unit/Util/Behaviors/TNoUnserializeBehaviorTraitTest.php
+++ b/tests/unit/Util/Behaviors/TNoUnserializeBehaviorTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Prado\TComponent;
+use Prado\Util\TBehavior;
+use Prado\Util\Behaviors\TNoUnserializeBehaviorTrait;
+
+class DeprecatedTestTComponent extends TComponent
+{
+}
+
+class TTestNonDeprecatedBehaviorClass extends TBehavior
+{
+}
+class TTestDeprecatedBehaviorClass extends TTestNonDeprecatedBehaviorClass
+{
+	use TNoUnserializeBehaviorTrait;
+}
+
+class TNoUnserializeBehaviorTraitTest extends PHPUnit\Framework\TestCase
+{
+	protected function setUp(): void
+	{
+	}
+
+	protected function tearDown(): void
+	{
+	}
+
+	public function testDyWakeUp()
+	{
+		$component = new DeprecatedTestTComponent();
+		$component->attachBehavior('b1', $b1 = new TTestNonDeprecatedBehaviorClass());
+		$component->attachBehavior('b2', $b2 = new TTestDeprecatedBehaviorClass());
+		
+		$data = serialize($component);
+		
+		$copy = unserialize($data);
+		self::assertNotNull($copy->asa('b1'));
+		self::assertNull($copy->asa('b2'));
+		self::assertNotNull($component->asa('b2'));
+		
+		$component->dyWakeUp();
+		self::assertNotNull($component->asa('b1'));
+		self::assertNull($component->asa('b2'));
+	}
+}

--- a/tests/unit/Util/Behaviors/TNoUnserializeClassBehaviorTraitTest.php
+++ b/tests/unit/Util/Behaviors/TNoUnserializeClassBehaviorTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Prado\TComponent;
+use Prado\Util\TClassBehavior;
+use Prado\Util\Behaviors\TNoUnserializeClassBehaviorTrait;
+
+class DeprecatedClassTestTComponent extends TComponent
+{
+}
+
+class TTestNonDeprecatedClassBehaviorClass extends TClassBehavior
+{
+}
+class TTestDeprecatedClassBehaviorClass extends TTestNonDeprecatedClassBehaviorClass
+{
+	use TNoUnserializeClassBehaviorTrait;
+}
+
+class TNoUnserializeClassBehaviorTraitTest extends PHPUnit\Framework\TestCase
+{
+	protected function setUp(): void
+	{
+	}
+
+	protected function tearDown(): void
+	{
+	}
+
+	public function testDyWakeUp()
+	{
+		$component = new DeprecatedClassTestTComponent();
+		$component->attachBehavior('b1', $b1 = new TTestNonDeprecatedClassBehaviorClass());
+		$component->attachBehavior('b2', $b2 = new TTestDeprecatedClassBehaviorClass());
+			
+		$data = serialize($component);
+		
+		$copy = unserialize($data);
+		self::assertNotNull($copy->asa('b1'));
+		self::assertNull($copy->asa('b2'));
+		self::assertNotNull($component->asa('b2'));
+		
+		$component->dyWakeUp();
+		self::assertNotNull($component->asa('b1'));
+		self::assertNull($component->asa('b2'));
+	}
+}


### PR DESCRIPTION
TComponent: adds __clone, __wakeup, and callBehaviorsMethod.
     * __clone removes former behaviors' event handlers and attaches the cloned behaviors to the new object.  At the end, dyClone is raised for attached behaviors to finalize themselves.
     * __wakeup attaches unserialized behaviors and uses global behaviors over old instances' unserialized copy, then attaches global behaviors when not found in the object. At the end, dyWakeUp is raised for attached behaviors to finalize themselves.
     * callBehaviorsMethod is to call a method or raise a dynamic event on a TComponent's behaviors.
-TBehavior: new __clone method resets the owner, adds _getZappableSleepProps to not save the owner.  Owners are set on unserialize when attaching.
- Adds parent::__clone to existing classes __clone method [TStyle].  It should typically be called after a class's own initialization

Updated unit tests unit tests, added tests for __clone and __wakeup.   callBehaviorsMethod are covered by the existing unit tests for __call.

There are a few updates the syntax of function calls.

Some TList and TMap have better Zapping sleep Props and are more strictly type cast with the upgrade to PHP 8.  The better serialization in TComponent uses the serialization of the list/map...  so the update kinda goes together.

A minor bug in error display in TApplication is corrected as well.
