### PR TITLE
#845 Adds behavior support to TComponent on clone and wakeup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
 ## Version 4.2.3 - TBA
 
-ENH: Issue #845 - PHP Clone and Unserialize of TComponent objects supports behaviors.
-BUG: Issue #843 - Permissions Manager behaviors update getManager to getPermissionsManager for specificity.
-ENH: Issue #861 - TWebColors lists all the Web Colors in a TEnumerable and implements TPropertyValue::ensureHexColor
+ENH: Issue #845 - PHP Clone and Unserialize of TComponent objects supports behaviors. (belisoful)
+BUG: Issue #843 - Permissions Manager behaviors rename the method 'getManager' to 'getPermissionsManager' for specificity. (belisoful)
+ENH: Issue #861 - TWebColors lists all the Web Colors in a TEnumerable and implements TPropertyValue::ensureHexColor (belisoful)
 
 ## Version 4.2.2 - April 6, 2023
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ## Version 4.2.3 - TBA
 
+ENH: Issue #845 - PHP Clone and Unserialize of TComponent objects supports behaviors.
 BUG: Issue #843 - Permissions Manager behaviors update getManager to getPermissionsManager for specificity.
 ENH: Issue #861 - TWebColors lists all the Web Colors in a TEnumerable and implements TPropertyValue::ensureHexColor
 

--- a/framework/Data/ActiveRecord/TActiveRecord.php
+++ b/framework/Data/ActiveRecord/TActiveRecord.php
@@ -212,6 +212,7 @@ abstract class TActiveRecord extends \Prado\TComponent
 	{
 		$this->setupColumnMapping();
 		$this->setupRelations();
+		parent::__wakeup();
 	}
 
 	/**

--- a/framework/Data/SqlMap/Statements/TMappedStatement.php
+++ b/framework/Data/SqlMap/Statements/TMappedStatement.php
@@ -880,6 +880,7 @@ class TMappedStatement extends \Prado\TComponent implements IMappedStatement
 		if (null === $this->_selectQueue) {
 			$this->_selectQueue = [];
 		}
+		parent::__wakeup();
 	}
 
 	public function __sleep()

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -330,8 +330,8 @@ class TApplication extends \Prado\TComponent
 	protected function resolvePaths($basePath)
 	{
 		// determine configuration path and file
-		if (empty($basePath) || ($basePath = realpath($basePath)) === false) {
-			throw new TConfigurationException('application_basepath_invalid', $basePath);
+		if (empty($errValue = $basePath) || ($basePath = realpath($basePath)) === false) {
+			throw new TConfigurationException('application_basepath_invalid', $errValue);
 		}
 		if (is_dir($basePath) && is_file($basePath . DIRECTORY_SEPARATOR . $this->getConfigurationFileName())) {
 			$configFile = $basePath . DIRECTORY_SEPARATOR . $this->getConfigurationFileName();

--- a/framework/Util/Behaviors/TNoUnserializeBehaviorTrait.php
+++ b/framework/Util/Behaviors/TNoUnserializeBehaviorTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * TNoUnserializeBehaviorTrait class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util\Behaviors;
+
+use Prado\Util\TCallChain;
+
+/**
+ * TNoUnserializeBehaviorTrait class.
+ *
+ * When this trait is used by an IBehavior, upon the owner being unserialized (via
+ * magic method __wakeup and dyWakeUp) this trait removes itself from its owner.
+ *
+ * This trait is used to deprecate serialized objects' IBehavior.  By re-serializing
+ * the object can be saved without the deprecated behavior.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+trait TNoUnserializeBehaviorTrait
+{
+	/**
+	 * This is raised when an owner is completed its unserialize() method call to
+	 * __wakeup.  This method removes it behavior from the owner.
+	 * @param TCallChain $chain The chain of dynamic event method handlers.
+	 */
+	public function dyWakeUp(TCallChain $chain)
+	{
+		$owner = $this->getOwner();
+		if ($index = array_search($this, $owner->getBehaviors())) {
+			$owner->detachBehavior($index);
+		}
+		return $chain->dyWakeUp();
+	}
+}

--- a/framework/Util/Behaviors/TNoUnserializeClassBehaviorTrait.php
+++ b/framework/Util/Behaviors/TNoUnserializeClassBehaviorTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * TNoUnserializeClassBehaviorTrait class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util\Behaviors;
+
+use Prado\Util\TCallChain;
+
+/**
+ * TNoUnserializeClassBehaviorTrait class.
+ *
+ * When this trait is used by an IClassBehavior, upon the owner being unserialized
+ * (via magic method __wakeup and dyWakeUp) this trait removes itself from its owner.
+ *
+ * This trait is used to deprecate serialized objects' IClassBehavior. By re-serializing
+ * the object can be saved without the deprecated behavior.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+trait TNoUnserializeClassBehaviorTrait
+{
+	/**
+	 * This is raised when an owner is completed its unserialize() method call to
+	 * __wakeup.  This method removes its behavior from the owner.
+	 * @param object $owner The owner of he behavior raising the dynamic event.
+	 * @param TCallChain $chain The chain of dynamic event method handlers.
+	 */
+	public function dyWakeUp(object $owner, TCallChain $chain)
+	{
+		if ($index = array_search($this, $owner->getBehaviors())) {
+			$owner->detachBehavior($index);
+		}
+		return $chain->dyWakeUp();
+	}
+}

--- a/framework/Util/TBehavior.php
+++ b/framework/Util/TBehavior.php
@@ -76,7 +76,7 @@ class TBehavior extends \Prado\TComponent implements IBehavior
 	}
 
 	/**
-	 * @return \Prado\TComponent the owner component that this behavior is attached to.
+	 * @return object the owner component that this behavior is attached to.
 	 */
 	public function getOwner()
 	{
@@ -97,5 +97,32 @@ class TBehavior extends \Prado\TComponent implements IBehavior
 	public function setEnabled($value)
 	{
 		$this->_enabled = TPropertyValue::ensureBoolean($value);
+	}
+
+	/**
+	 * This resets the Owner on cloning.
+	 * @since 4.2.3
+	 */
+	public function __clone()
+	{
+		$this->_owner = null;
+		parent::__clone();
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 * @since 4.2.3
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if ($this->_enabled === true) {
+			$exprops[] = "\0Prado\\Util\\TBehavior\0_enabled";
+		}
+		$exprops[] = "\0Prado\\Util\\TBehavior\0_owner";
 	}
 }

--- a/framework/Util/TCallChain.php
+++ b/framework/Util/TCallChain.php
@@ -91,10 +91,10 @@ class TCallChain extends TList implements IDynamicMethods
 	 * When there are no handlers or no handlers left, it returns the first parameter of the
 	 * argument list.
 	 *
+	 * @param array $args The parameters to send the function chain.
 	 */
-	public function call()
+	public function call(...$args)
 	{
-		$args = func_get_args();
 		if ($this->getCount() === 0) {
 			return $args[0] ?? null;
 		}

--- a/framework/Web/UI/WebControls/TStyle.php
+++ b/framework/Web/UI/WebControls/TStyle.php
@@ -89,6 +89,7 @@ class TStyle extends \Prado\TComponent
 		if ($this->_font !== null) {
 			$this->_font = clone($this->_font);
 		}
+		parent::__clone();
 	}
 
 	/**

--- a/tests/unit/Util/Behaviors/TNoUnserializeBehaviorTraitTest.php
+++ b/tests/unit/Util/Behaviors/TNoUnserializeBehaviorTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Prado\TComponent;
+use Prado\Util\TBehavior;
+use Prado\Util\Behaviors\TNoUnserializeBehaviorTrait;
+
+class DeprecatedTestTComponent extends TComponent
+{
+}
+
+class TTestNonDeprecatedBehaviorClass extends TBehavior
+{
+}
+class TTestDeprecatedBehaviorClass extends TTestNonDeprecatedBehaviorClass
+{
+	use TNoUnserializeBehaviorTrait;
+}
+
+class TNoUnserializeBehaviorTraitTest extends PHPUnit\Framework\TestCase
+{
+	protected function setUp(): void
+	{
+	}
+
+	protected function tearDown(): void
+	{
+	}
+
+	public function testDyWakeUp()
+	{
+		$component = new DeprecatedTestTComponent();
+		$component->attachBehavior('b1', $b1 = new TTestNonDeprecatedBehaviorClass());
+		$component->attachBehavior('b2', $b2 = new TTestDeprecatedBehaviorClass());
+		
+		$data = serialize($component);
+		
+		$copy = unserialize($data);
+		self::assertNotNull($copy->asa('b1'));
+		self::assertNull($copy->asa('b2'));
+		self::assertNotNull($component->asa('b2'));
+		
+		$component->dyWakeUp();
+		self::assertNotNull($component->asa('b1'));
+		self::assertNull($component->asa('b2'));
+	}
+}

--- a/tests/unit/Util/Behaviors/TNoUnserializeClassBehaviorTraitTest.php
+++ b/tests/unit/Util/Behaviors/TNoUnserializeClassBehaviorTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Prado\TComponent;
+use Prado\Util\TClassBehavior;
+use Prado\Util\Behaviors\TNoUnserializeClassBehaviorTrait;
+
+class DeprecatedClassTestTComponent extends TComponent
+{
+}
+
+class TTestNonDeprecatedClassBehaviorClass extends TClassBehavior
+{
+}
+class TTestDeprecatedClassBehaviorClass extends TTestNonDeprecatedClassBehaviorClass
+{
+	use TNoUnserializeClassBehaviorTrait;
+}
+
+class TNoUnserializeClassBehaviorTraitTest extends PHPUnit\Framework\TestCase
+{
+	protected function setUp(): void
+	{
+	}
+
+	protected function tearDown(): void
+	{
+	}
+
+	public function testDyWakeUp()
+	{
+		$component = new DeprecatedClassTestTComponent();
+		$component->attachBehavior('b1', $b1 = new TTestNonDeprecatedClassBehaviorClass());
+		$component->attachBehavior('b2', $b2 = new TTestDeprecatedClassBehaviorClass());
+			
+		$data = serialize($component);
+		
+		$copy = unserialize($data);
+		self::assertNotNull($copy->asa('b1'));
+		self::assertNull($copy->asa('b2'));
+		self::assertNotNull($component->asa('b2'));
+		
+		$component->dyWakeUp();
+		self::assertNotNull($component->asa('b1'));
+		self::assertNull($component->asa('b2'));
+	}
+}


### PR DESCRIPTION
This corrects an error display bug in TApplication::resolvePaths where the path isn't displayed because it is overwritten by the bad value.

This adds TComponent::_clone and __wakeup.  It was necessary to create a function just for calling methods (functions, dynamic events, and global events) on behaviors.  The __clone and __wakeup add dynamic events dyClone and dyWakeUp but they cannot call the object; they must call only the behaviors or weird recursion will happen.

removed check for get_called_class because it was only needed for PHP versions before 7.

Less strict phpdoc type casting in asa.

The events of a TComponent are zapped because they are weak references and must be reconstructed during unserialize anyway.

TBehavior adds __clone to null the owner. it also adds zappable sleep props also so the owner isn't saved.  The behaviors are re-attached during unserialize so the owner shouldn't be saved.  There is also a phpdoc type that is too strict here as well.

TCallChain syntax is updated.

There are two new Traits added for serialized behaviors that are deprecated.  TNoUnserializeBehaviorTrait and TNoUnserializeClassBehaviorTrait, for IBehavior and IClassBehavior, are used to remove behaviors upon being unserialized via dyWakeUp.  For new versions of the app, this can be added so the behavior continues to unserialize but is then immediately removed.  With unit tests.
