### PR TITLE
#889 TList/TMap variable types and minor updates

### DIFF
--- a/framework/Collections/TAttributeCollection.php
+++ b/framework/Collections/TAttributeCollection.php
@@ -137,7 +137,7 @@ class TAttributeCollection extends TMap
 	 * @param mixed $key the key
 	 * @return bool whether the map contains an item with the specified key
 	 */
-	public function contains($key)
+	public function contains($key): bool
 	{
 		return parent::contains($this->_caseSensitive ? $key : strtolower($key));
 	}

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -12,7 +12,6 @@ namespace Prado\Collections;
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
-use Prado\TPropertyValue;
 
 /**
  * TList class
@@ -44,16 +43,16 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * internal data storage
 	 * @var array
 	 */
-	private $_d = [];
+	protected array $_d = [];
 	/**
 	 * number of items
 	 * @var int
 	 */
-	private $_c = 0;
+	protected int $_c = 0;
 	/**
 	 * @var bool whether this list is read-only
 	 */
-	private $_r = false;
+	private bool $_r = false;
 
 	/**
 	 * Constructor.
@@ -64,17 +63,17 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 */
 	public function __construct($data = null, $readOnly = false)
 	{
+		parent::__construct();
 		if ($data !== null) {
 			$this->copyFrom($data);
 		}
 		$this->setReadOnly($readOnly);
-		parent::__construct();
 	}
 
 	/**
 	 * @return bool whether this list is read-only or not. Defaults to false.
 	 */
-	public function getReadOnly()
+	public function getReadOnly(): bool
 	{
 		return $this->_r;
 	}
@@ -82,9 +81,9 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly($value)
+	protected function setReadOnly(bool $value)
 	{
-		$this->_r = TPropertyValue::ensureBoolean($value);
+		$this->_r = $value;
 	}
 
 	/**
@@ -92,8 +91,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * This method is required by the interface \IteratorAggregate.
 	 * @return \Iterator an iterator for traversing the items in the list.
 	 */
-	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		return new \ArrayIterator($this->_d);
 	}
@@ -111,7 +109,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @return int the number of items in the list
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		return $this->_c;
 	}
@@ -223,7 +221,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * Removes all items in the list.
 	 * @throws TInvalidOperationException if the list is read-only
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		for ($i = $this->_c - 1; $i >= 0; --$i) {
 			$this->removeAt($i);
@@ -234,9 +232,9 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * @param mixed $item the item
 	 * @return bool whether the list contains the item
 	 */
-	public function contains($item)
+	public function contains($item): bool
 	{
-		return $this->indexOf($item) != -1;
+		return $this->indexOf($item) !== -1;
 	}
 
 	/**
@@ -303,7 +301,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @return array the list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return $this->_d;
 	}
@@ -314,7 +312,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * @param mixed $data the data to be copied from, must be an array or object implementing Traversable
 	 * @throws TInvalidDataTypeException If data is neither an array nor a Traversable.
 	 */
-	public function copyFrom($data)
+	public function copyFrom($data): void
 	{
 		if (is_array($data) || ($data instanceof \Traversable)) {
 			if ($this->_c > 0) {
@@ -334,7 +332,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * @param mixed $data the data to be merged with, must be an array or object implementing Traversable
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */
-	public function mergeWith($data)
+	public function mergeWith($data): void
 	{
 		if (is_array($data) || ($data instanceof \Traversable)) {
 			foreach ($data as $item) {
@@ -363,8 +361,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 * @throws TInvalidDataValueException if the offset is invalid
 	 * @return mixed the item at the offset
 	 */
-	#[\ReturnTypeWillChange]
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		return $this->itemAt($offset);
 	}
@@ -393,5 +390,24 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	public function offsetUnset($offset): void
 	{
 		$this->removeAt($offset);
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * When there are no items in the list, _d and _c are not stored
+	 * @param array $exprops by reference
+	 * @since 4.2.3
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if ($this->_c === 0) {
+			$exprops[] = "\0*\0_d";
+			$exprops[] = "\0*\0_c";
+		}
+		if ($this->_r === false) {
+			$exprops[] = "\0" . __CLASS__ . "\0_r";
+		}
 	}
 }

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -82,7 +82,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	public function setReadOnly($value)
+	protected function setReadOnly($value)
 	{
 		$this->_r = TPropertyValue::ensureBoolean($value);
 	}

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -12,6 +12,7 @@ namespace Prado\Collections;
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
+use Prado\TPropertyValue;
 
 /**
  * TList class
@@ -81,9 +82,9 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly(bool $value)
+	protected function setReadOnly($value)
 	{
-		$this->_r = $value;
+		$this->_r = TPropertyValue::ensureBoolean($value);
 	}
 
 	/**

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -82,7 +82,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly($value)
+	public function setReadOnly($value)
 	{
 		$this->_r = TPropertyValue::ensureBoolean($value);
 	}

--- a/framework/Collections/TListItemCollection.php
+++ b/framework/Collections/TListItemCollection.php
@@ -63,7 +63,7 @@ class TListItemCollection extends TList
 	 * @param TListItem $item the item to be inserted.
 	 * @throws TInvalidDataTypeException if the item being inserted is neither a string nor TListItem
 	 */
-	public function insertAt($index, $item)
+	public function insertAt($index, $item): void
 	{
 		if (is_string($item)) {
 			$item = $this->createNewListItem($item);

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -77,7 +77,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 */
 	protected function setReadOnly($value)
 	{
-		$this->_r = TPropertyValue::ensureBoolean($value);;
+		$this->_r = TPropertyValue::ensureBoolean($value);
 	}
 
 	/**

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -11,7 +11,6 @@ namespace Prado\Collections;
 
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
-use Prado\TPropertyValue;
 use Traversable;
 
 /**
@@ -42,29 +41,11 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @var array<int|string, mixed> internal data storage
 	 */
-	protected $_d = [];
+	protected array $_d = [];
 	/**
 	 * @var bool whether this list is read-only
 	 */
-	protected $_r = false;
-
-	/**
-	 * Returns an array with the names of all variables of this object that should NOT be serialized
-	 * because their value is the default one or useless to be cached for the next page loads.
-	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
-	 * implementation first.
-	 * @param array $exprops by reference
-	 */
-	protected function _getZappableSleepProps(&$exprops)
-	{
-		parent::_getZappableSleepProps($exprops);
-		if ($this->_d === []) {
-			$exprops[] = "\0*\0_d";
-		}
-		if ($this->_r === false) {
-			$exprops[] = "\0*\0_r";
-		}
-	}
+	private bool $_r = false;
 
 	/**
 	 * Constructor.
@@ -75,17 +56,17 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 */
 	public function __construct($data = null, $readOnly = false)
 	{
+		parent::__construct();
 		if ($data !== null) {
 			$this->copyFrom($data);
 		}
 		$this->setReadOnly($readOnly);
-		parent::__construct();
 	}
 
 	/**
 	 * @return bool whether this map is read-only or not. Defaults to false.
 	 */
-	public function getReadOnly()
+	public function getReadOnly(): bool
 	{
 		return $this->_r;
 	}
@@ -93,9 +74,9 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly($value)
+	protected function setReadOnly(bool $value)
 	{
-		$this->_r = TPropertyValue::ensureBoolean($value);
+		$this->_r = $value;
 	}
 
 	/**
@@ -103,8 +84,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * This method is required by the interface \IteratorAggregate.
 	 * @return \Iterator an iterator for traversing the items in the list.
 	 */
-	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		return new \ArrayIterator($this->_d);
 	}
@@ -122,7 +102,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return int the number of items in the map
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		return count($this->_d);
 	}
@@ -130,7 +110,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return array<int|string> the key list
 	 */
-	public function getKeys()
+	public function getKeys(): array
 	{
 		return array_keys($this->_d);
 	}
@@ -188,7 +168,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * Removes all items in the map.
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		foreach (array_keys($this->_d) as $key) {
 			$this->remove($key);
@@ -199,7 +179,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @param mixed $key the key
 	 * @return bool whether the map contains an item with the specified key
 	 */
-	public function contains($key)
+	public function contains($key): bool
 	{
 		return isset($this->_d[$key]) || array_key_exists($key, $this->_d);
 	}
@@ -207,7 +187,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @return array<int|string, mixed> the list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return $this->_d;
 	}
@@ -218,7 +198,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @param mixed $data the data to be copied from, must be an array or object implementing Traversable
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */
-	public function copyFrom($data)
+	public function copyFrom($data): void
 	{
 		if (is_array($data) || $data instanceof Traversable) {
 			if ($this->getCount() > 0) {
@@ -238,7 +218,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @param mixed $data the data to be merged with, must be an array or object implementing Traversable
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */
-	public function mergeWith($data)
+	public function mergeWith($data): void
 	{
 		if (is_array($data) || $data instanceof Traversable) {
 			foreach ($data as $key => $value) {
@@ -266,8 +246,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @param mixed $offset the offset to retrieve element.
 	 * @return mixed the element at the offset, null if no element is found at the offset
 	 */
-	#[\ReturnTypeWillChange]
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		return $this->itemAt($offset);
 	}
@@ -291,5 +270,23 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	public function offsetUnset($offset): void
 	{
 		$this->remove($offset);
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		if (count($this->_d) === 0) {
+			$exprops[] = "\0*\0_d";
+		}
+		if ($this->_r === false) {
+			$exprops[] = "\0" . __CLASS__ . "\0_r";
+		}
 	}
 }

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -11,6 +11,7 @@ namespace Prado\Collections;
 
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\TPropertyValue;
 use Traversable;
 
 /**
@@ -74,9 +75,9 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * @param bool $value whether this list is read-only or not
 	 */
-	protected function setReadOnly(bool $value)
+	protected function setReadOnly($value)
 	{
-		$this->_r = $value;
+		$this->_r = TPropertyValue::ensureBoolean($value);;
 	}
 
 	/**

--- a/framework/Collections/TPagedList.php
+++ b/framework/Collections/TPagedList.php
@@ -273,7 +273,7 @@ class TPagedList extends TList
 	/**
 	 * @return int the number of items in current page
 	 */
-	public function getCount()
+	public function getCount(): int
 	{
 		if ($this->_customPaging) {
 			return parent::getCount();
@@ -289,8 +289,7 @@ class TPagedList extends TList
 	/**
 	 * @return \Iterator iterator
 	 */
-	#[\ReturnTypeWillChange]
-	public function getIterator()
+	public function getIterator(): \Iterator
 	{
 		if ($this->_customPaging) {
 			return parent::getIterator();
@@ -349,8 +348,7 @@ class TPagedList extends TList
 	 * @throws TInvalidDataValueException if the offset is invalid
 	 * @return mixed the item at the offset
 	 */
-	#[\ReturnTypeWillChange]
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		return $this->itemAt($offset);
 	}
@@ -358,7 +356,7 @@ class TPagedList extends TList
 	/**
 	 * @return array the list of items in array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		$c = $this->getCount();
 		$array = [];

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -12,6 +12,7 @@ namespace Prado\Collections;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\TPropertyValue;
 
 /**
  * TPriorityList class
@@ -97,7 +98,7 @@ class TPriorityList extends TList
 	 */
 	protected function setDefaultPriority($value)
 	{
-		$this->_dp = (string) round((float) $value, $this->_p);
+		$this->_dp = (string) round(TPropertyValue::ensureFloat($value), $this->_p);
 	}
 
 	/**
@@ -112,9 +113,9 @@ class TPriorityList extends TList
 	 * This must be called internally or when instantiated.
 	 * @param int $value The precision of numeric priorities.
 	 */
-	protected function setPrecision(int $value): void
+	protected function setPrecision($value): void
 	{
-		$this->_p = $value;
+		$this->_p = TPropertyValue::ensureInteger($value);
 	}
 
 	/**
@@ -469,7 +470,7 @@ class TPriorityList extends TList
 			if (($index = array_search($item, $items, true)) !== false) {
 				$absindex += $index;
 				return $withindex ? [$priority, $index, $absindex,
-						'priority' => $priority, 'index' => $index, 'absindex' => $absindex] : $priority;
+						'priority' => $priority, 'index' => $index, 'absindex' => $absindex, ] : $priority;
 			} else {
 				$absindex += count($items);
 			}
@@ -500,7 +501,7 @@ class TPriorityList extends TList
 				$index -= $c;
 			} else {
 				return $withindex ? [$priority, $index, $absindex,
-						'priority' => $priority, 'index' => $index, 'absindex' => $absindex] : $priority;
+						'priority' => $priority, 'index' => $index, 'absindex' => $absindex, ] : $priority;
 			}
 		}
 		return false;

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -406,14 +406,17 @@ class TPriorityList extends TList
 		}
 
 		$priority = $this->ensurePriority($priority);
-		if (!isset($this->_d[$priority]) || $index < 0 || $index >= count($this->_d[$priority])) {
+		if (!isset($this->_d[$priority]) || $index < 0 || $index >= ($c = count($this->_d[$priority]))) {
 			throw new TInvalidDataValueException('list_item_inexistent');
 		}
 
 		// $value is an array of elements removed, only one
-		$value = array_splice($this->_d[$priority], $index, 1);
-		$value = $value[0];
-
+		if ($index === $c - 1) {
+			$value = array_pop($this->_d[$priority]);
+		} else {
+			$value = array_splice($this->_d[$priority], $index, 1);
+			$value = $value[0];
+		}
 		if (!count($this->_d[$priority])) {
 			unset($this->_d[$priority]);
 		}

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -129,7 +129,7 @@ class TPriorityMap extends TMap
 	 */
 	protected function setPrecision($value): void
 	{
-		$this->_p = TPropertyValue::ensureInt($value);
+		$this->_p = TPropertyValue::ensureInteger($value);
 	}
 
 	/**

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -11,6 +11,7 @@ namespace Prado\Collections;
 
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\TPropertyValue;
 
 /**
  * TPriorityMap class
@@ -111,7 +112,7 @@ class TPriorityMap extends TMap
 	 */
 	protected function setDefaultPriority($value)
 	{
-		$this->_dp = (string) round((float) $value, $this->_p);
+		$this->_dp = (string) round(TPropertyValue::ensureFloat($value), $this->_p);
 	}
 
 	/**
@@ -126,9 +127,9 @@ class TPriorityMap extends TMap
 	 * This must be called internally or when instantiated.
 	 * @param int $value The precision of numeric priorities.
 	 */
-	protected function setPrecision(int $value): void
+	protected function setPrecision($value): void
 	{
-		$this->_p = $value;
+		$this->_p = TPropertyValue::ensureInt($value);
 	}
 
 	/**

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -141,16 +141,14 @@ class TWeakCallableCollection extends TPriorityList
 		return $handler;
 	}
 
-
 	/**
 	 * This flattens the priority list into a flat array [0,...,n-1]. This is needed to filter the output.
 	 * @return array array of items in the list in priority and index order
 	 */
-	protected function flattenPriorities()
+	protected function flattenPriorities(): array
 	{
 		return $this->filterItemsForOutput(parent::flattenPriorities());
 	}
-
 
 	/**
 	 * This flattens the priority list into a flat array [0,...,n-1], but
@@ -159,7 +157,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array array of items in the list in priority and index order,
 	 *    where objects are WeakReference
 	 */
-	protected function flattenPrioritiesWeak()
+	protected function flattenPrioritiesWeak(): array
 	{
 		return parent::flattenPriorities();
 	}
@@ -186,9 +184,9 @@ class TWeakCallableCollection extends TPriorityList
 	 * Gets all the items at a specific priority. This is needed to filter the output.
 	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled
 	 * in with the default priority, if left blank.
-	 * @return array all items at priority in index order, null if there are no items at that priority
+	 * @return ?array all items at priority in index order, null if there are no items at that priority
 	 */
-	public function itemsAtPriority($priority = null)
+	public function itemsAtPriority($priority = null): ?array
 	{
 		return $this->filterItemsForOutput(parent::itemsAtPriority($priority));
 	}
@@ -266,13 +264,12 @@ class TWeakCallableCollection extends TPriorityList
 		return parent::priorityOf($this->filterItemForInput($item), $withindex);
 	}
 
-
 	/**
 	 *  This is needed to filter the output.
 	 * @return array the array of priorities keys with values of arrays of callables.
 	 * The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toPriorityArray()
+	public function toPriorityArray(): array
 	{
 		$result = [];
 		foreach (parent::toPriorityArray() as $i => $v) {
@@ -280,7 +277,6 @@ class TWeakCallableCollection extends TPriorityList
 		}
 		return $result;
 	}
-
 
 	/**
 	 * @return array the array of priorities keys with values of arrays of callables with
@@ -299,7 +295,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayBelowPriority($priority, $inclusive = false)
+	public function toArrayBelowPriority($priority, $inclusive = false): array
 	{
 		return $this->filterItemsForOutput(parent::toArrayBelowPriority($priority, $inclusive));
 	}
@@ -311,8 +307,24 @@ class TWeakCallableCollection extends TPriorityList
 	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
 	 *  The priorities are sorted so important priorities, lower numerics, are first.
 	 */
-	public function toArrayAbovePriority($priority, $inclusive = true)
+	public function toArrayAbovePriority($priority, $inclusive = true): array
 	{
 		return $this->filterItemsForOutput(parent::toArrayAbovePriority($priority, $inclusive));
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 * @since 4.2.3
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		$c = $this->_c;
+		$this->_c = 0;
+		parent::_getZappableSleepProps($exprops);
+		$this->_c = $c;
 	}
 }

--- a/framework/Web/UI/TControlCollection.php
+++ b/framework/Web/UI/TControlCollection.php
@@ -86,7 +86,7 @@ class TControlCollection extends \Prado\Collections\TList
 	/**
 	 * Overrides the parent implementation by invoking {@link TControl::clearNamingContainer}
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		parent::clear();
 		if ($this->_o instanceof INamingContainer) {

--- a/tests/unit/Collections/TListTest.php
+++ b/tests/unit/Collections/TListTest.php
@@ -76,6 +76,10 @@ class TListTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(true, $list->getReadOnly(), 'List is not read-only');
 		$list = new $this->_baseClass(null, false);
 		self::assertEquals(false, $list->getReadOnly(), 'List is read-only');
+		$list = new $this->_baseClass(null, "true");
+		self::assertEquals(true, $list->getReadOnly(), 'List is not read-only');
+		$list = new $this->_baseClass(null, "false");
+		self::assertEquals(false, $list->getReadOnly(), 'List is read-only');
 	}
 
 	public function testGetCountTList()

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -138,12 +138,13 @@ class TPriorityListTest extends TListTest
 		$this->item4 = null;
 
 		// ****  start the setup for non-TList things
-		$this->list = null;
-		$this->item1 = null;
-		$this->item2 = null;
-		$this->item3 = null;
-		$this->item4 = null;
-		$this->item5 = null;
+		$this->plist = null;
+		$this->pfirst = null;
+		$this->pitem1 = null;
+		$this->pitem2 = null;
+		$this->pitem3 = null;
+		$this->pitem4 = null;
+		$this->pitem5 = null;
 	}
 
 	//*****************************************************************


### PR DESCRIPTION
TList and TMap variables and some methods are typed.  subclass methods that could override an input or output are not typed.

The storage is made protected rather than private because some subclasses may need direct access to the storage _d.  TWeakList needs to scrub _d in place without accessor functions.

A few functions were move around to make the files and method locations more symmetric to each other.

_getZappableSleepProps is added to TList, TPriorityList, TPriorityMap, and TWeakCallableCollections

TPriorityList uses its parent _d.  Smaller code can be made for insertAtIndexInPriority as well.  offsetGet is redundant

Regression on existing TList and TMap subclasses are updated

TPriorityListTest unit tests are corrected (not that it did something erroneous)