### PR TITLE
#885 TWeakList and TWeakCollectionTrait for WeakMap Management

### DIFF
--- a/framework/Collections/TWeakCollectionTrait.php
+++ b/framework/Collections/TWeakCollectionTrait.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * TWeakCollectionTrait class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Collections;
+
+/**
+ * TWeakCollectionTrait trait
+ *
+ * This is the common WeakMap caching implementation for Weak Collections. It constructs
+ * a WeakMap, where available, and tracks the number of times an object is {@link
+ * weakAdd added} to and {@link weakRemove removed} from the Collection.
+ *
+ * When the PHP environment invalidates a WeakReference, it is no longer linked in
+ * the WeakMap.  The number of known objects is tracked and upon deviations in the
+ * WeakMap count then {@link weakChanged} becomes true.  When weakChanged is true
+ * the implementing class can scrub the list of invalidated WeakReference.
+ *
+ * There are utility functions for managing the WeakMap to {@link weakStart start},
+ * {@link weakRestart restart}, {@link weakClone clone}, and {@link weakStop stop}
+ * the WeakMap.  The total number of objects in the WeakMap can be retrieved with
+ * {@link weakCount} and the count of each object with {@link weakObjectCount}.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ * @see https://www.php.net/manual/en/class.weakmap.php
+ */
+trait TWeakCollectionTrait
+{
+	/**
+	 * @var null|\WeakMap Maintains the cache of list objects.  Any invalid weak references
+	 *  change the WeakMap count automatically.  This also tracks the number of times
+	 *  on object has been inserted in the collection.
+	 */
+	private ?object $_weakMap = null;
+
+	/** @var int Number of known objects in the collection. */
+	private int $_weakCount = 0;
+
+	private static ?bool $_hasWeakMap = null;
+	/**
+	 * Initializes a new WeakMap in PHP 8.0+.
+	 */
+	protected function weakStart(): void
+	{
+		if (self::$_hasWeakMap === null) { // PHP 8.0+
+			self::$_hasWeakMap = class_exists('\WeakMap', false);
+		}
+		if (self::$_hasWeakMap) {
+			$this->_weakMap = new \WeakMap();
+		}
+	}
+
+	/**
+	 * Restarts the WeakMap cache if it exists.
+	 */
+	protected function weakRestart(): void
+	{
+		if ($this->_weakMap) {
+			$this->_weakMap = new \WeakMap();
+		}
+	}
+
+	/**
+	 * Stops the WeakMap cache.
+	 */
+	protected function weakClone(): void
+	{
+		if ($this->_weakMap) {
+			$this->_weakMap = clone $this->_weakMap;
+		}
+	}
+
+	/**
+	 * Checks if the WeakMap has changed.  Prior to PHP 8.0, this will always return
+	 * true.
+	 * @return bool Are there any changes to the WeakMap.
+	 */
+	protected function weakChanged(): bool
+	{
+		return $this->_weakMap && $this->_weakMap->count() !== $this->_weakCount || !self::$_hasWeakMap;
+	}
+
+	/**
+	 * Resets the new number of known objects in the list to the current WeakMap count.
+	 */
+	protected function weakResetCount(): void
+	{
+		if ($this->_weakMap) {
+			$this->_weakCount = $this->_weakMap->count();
+		}
+	}
+
+	/**
+	 * @return ?int The number of items being tracked in the WeakMap. null if there is
+	 *   no WeakMap.
+	 */
+	protected function weakCount(): ?int
+	{
+		if ($this->_weakMap) {
+			return $this->_weakMap->count();
+		}
+		return null;
+	}
+
+	/**
+	 * Adds or updates an object to track with the WeakMap.
+	 * @param object $object The object being tracked for existence.
+	 * @return int The number of times the object has been added.
+	 */
+	protected function weakAdd(object $object): int
+	{
+		if ($this->_weakMap) {
+			if (!$this->_weakMap->offsetExists($object)) {
+				$count = 1;
+				$this->_weakCount++;
+			} else {
+				$count = $this->_weakMap->offsetGet($object) + 1;
+			}
+			$this->_weakMap->offsetSet($object, $count);
+			return $count;
+		}
+		return 0;
+	}
+
+	/**
+	 * @param object $object The object being tracked.
+	 * @return ?int The number of instances of the object in the Collection.
+	 */
+	protected function weakObjectCount(object $object): ?int
+	{
+		if ($this->_weakMap && $this->_weakMap->offsetExists($object)) {
+			return $this->_weakMap->offsetGet($object);
+		}
+		return null;
+	}
+
+	/**
+	 * Removes or updates an object from WeakMap tracking.
+	 * @param object $object The object being tracked for existence.
+	 * @return int The number of remaining instances of the object in the Collection.
+	 */
+	protected function weakRemove(object $object): int
+	{
+		if ($this->_weakMap) {
+			$count = $this->_weakMap->offsetGet($object) - 1;
+			if ($count) {
+				$this->_weakMap->offsetSet($object, $count);
+			} else {
+				$this->_weakMap->offsetUnset($object);
+				$this->_weakCount--;
+			}
+			return $count;
+		}
+		return 0;
+	}
+
+	/**
+	 * Stops the WeakMap cache.
+	 */
+	protected function weakStop(): void
+	{
+		$this->_weakMap = null;
+	}
+
+	/**
+	 * @param array &$exprops Properties to remove from serialize.
+	 */
+	protected function _weakZappableSleepProps(array &$exprops): void
+	{
+		$exprops[] = "\0" . __CLASS__ . "\0_weakMap";
+		$exprops[] = "\0" . __CLASS__ . "\0_weakCount";
+	}
+}

--- a/framework/Collections/TWeakList.php
+++ b/framework/Collections/TWeakList.php
@@ -1,0 +1,530 @@
+<?php
+/**
+ * TWeakList class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Collections;
+
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\TPropertyValue;
+
+use ArrayAccess;
+use Closure;
+use Traversable;
+use WeakReference;
+
+/**
+ * TWeakList class
+ *
+ * TWeakList implements an integer-indexed collection class with objects kept as
+ * WeakReference.  Closure are treated as function PHP types rather than as objects.
+ *
+ * Objects in the TWeakList are encoded into WeakReference when saved, and the objects
+ * restored on retrieval.  When an object becomes unset in the application/system
+ * and its WeakReference invalidated, it can be removed from the TWeakList or have
+ * a null in place of the object, depending on the mode.  The mode can be set during
+ * {@link __construct Construct}.  The default mode of the TWeakList is to maintain
+ * a list of only valid objects -where the count and item locations can change when
+ * an item is invalidated-.  The other mode is to retain the place of invalidated
+ * objects and replace the object with null -maintaining the count and item locations-.
+ *
+ * List items do not need to be objects.  TWeakList is similar to TList except list
+ * items that are objects (except Closure) are stored as WeakReference.  List items
+ * that are arrays are recursively traversed for replacement of objects with WeakReference
+ * before storing.  In this way, TWeakList will not retain objects (incrementing
+ * their use/reference counter) that it contains.  Only primary list items are tracked
+ * with the WeakMap, and objects in arrays has no effect on the whole.   If an object
+ * in an array is invalidated, it well be replaced by "null".  Arrays in the TWeakList
+ * are kept regardless of the use/reference count of contained objects.
+ *
+ * {@link TWeakCollectionTrait} implements a PHP 8 WeakMap used to track any changes
+ * in WeakReference objects in the TWeakList and optionally scrubs the list of invalid
+ * objects on any changes to the WeakMap.
+ *
+ * Note that any objects or objects in arrays will be lost if they are not otherwise
+ * retained in other parts of the application.  The only exception is a PHP Closure.
+ * Closures are stored without WeakReference so anonymous functions can be stored
+ * without risk of deletion if it is the only reference.  Closures act similarly to
+ * a PHP data type rather than an object.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+class TWeakList extends TList
+{
+	use TWeakCollectionTrait;
+
+	/** @var bool Should invalid WeakReference automatically be deleted from the list.
+	 *    Default True.
+	 */
+	private bool $_discardInvalid = true;
+
+	/**
+	 * Constructor.
+	 * Initializes the weak list with an array or an iterable object.
+	 * @param null|array|\Iterator $data The initial data. Default is null, meaning no initialization.
+	 * @param bool $readOnly Whether the list is read-only. Default is false.
+	 * @param bool $discardInvalid Whether the list is scrubbed of invalid WeakReferences.
+	 *   Default is true.
+	 * @throws TInvalidDataTypeException If data is not null and neither an array nor an iterator.
+	 */
+	public function __construct($data = null, $readOnly = false, $discardInvalid = true)
+	{
+		$this->_discardInvalid = $discardInvalid;
+		if ($discardInvalid) {
+			$this->weakStart();
+		}
+		parent::__construct($data, $readOnly);
+	}
+
+	/**
+	 * Cloning a TWeakList requires cloning the WeakMap
+	 */
+	public function __clone()
+	{
+		$this->weakClone();
+		parent::__clone();
+	}
+
+	/**
+	 * Waking up a TWeakList requires creating the WeakMap.  No items are saved in
+	 * TWeakList so only initialization of the WeakMap is required.
+	 */
+	public function __wakeup()
+	{
+		if ($this->_discardInvalid) {
+			$this->weakStart();
+		}
+		parent::__wakeup();
+	}
+
+	/**
+	 * Converts the $item callable that has WeakReference rather than the actual object
+	 * back into a regular callable.
+	 * @param mixed &$item
+	 */
+	protected function filterItemForOutput(&$item): void
+	{
+		if (is_array($item) || ($item instanceof Traversable && $item instanceof ArrayAccess)) {
+			foreach (array_keys($item) as $key) {
+				$this->filterItemForOutput($item[$key]);
+			}
+		} elseif (is_object($item) && ($item instanceof WeakReference)) {
+			$item = $item->get();
+		}
+	}
+
+	/**
+	 * Converts the $item object and objects in an array into their WeakReference version
+	 * for storage.  Closure[s] are not converted into WeakReference and so act like a
+	 * basic PHP type.  Closures are added to the the WeakMap cache but has no weak
+	 * effect because the TWeakList maintains references to Closure[s] preventing their
+	 * invalidation.
+	 * @param mixed &$item object to convert into a WeakReference where needed.
+	 */
+	protected function filterItemForInput(&$item): void
+	{
+		if (is_array($item) || ($item instanceof Traversable && $item instanceof ArrayAccess)) {
+			foreach (array_keys($item) as $key) {
+				$this->filterItemForInput($item[$key]);
+			}
+		} elseif (is_object($item) && !($item instanceof Closure)) {
+			$item = WeakReference::create($item);
+		}
+	}
+
+	/**
+	 * When a change in the WeakMap is detected, scrub the list of invalid WeakReference.
+	 */
+	protected function scrubWeakReferences(): void
+	{
+		if (!$this->_discardInvalid || !$this->weakChanged()) {
+			return;
+		}
+		for ($i = $this->_c - 1; $i >= 0; $i--) {
+			if (is_object($this->_d[$i]) && ($this->_d[$i] instanceof WeakReference) && $this->_d[$i]->get() === null) {
+				$this->_c--;
+				if ($i === $this->_c) {
+					array_pop($this->_d);
+				} else {
+					array_splice($this->_d, $i, 1);
+				}
+			}
+		}
+		$this->weakResetCount();
+	}
+
+	/**
+	 * @return bool Does the TWeakList scrub invalid WeakReference.
+	 */
+	public function getDiscardInvalid(): bool
+	{
+		return $this->_discardInvalid;
+	}
+
+	/**
+	 * @param bool $value Sets the TWeakList scrubbing of invalid WeakReference.
+	 */
+	protected function setDiscardInvalid($value): void
+	{
+		$value = TPropertyValue::ensureBoolean($value);
+		if ($value && !$this->_discardInvalid) {
+			$this->weakStart();
+			for ($i = $this->_c - 1; $i >= 0; $i--) {
+				$object = false;
+				if (is_object($this->_d[$i]) && ($this->_d[$i] instanceof WeakReference) && ($object = $this->_d[$i]->get()) !== null) {
+					$this->weakAdd($object);
+				}
+				if ($object === null) {
+					$this->_c--;	//on read only, parent::removeAt won't remove for scrub.
+					if ($i === $this->_c) {
+						array_pop($this->_d);
+					} else {
+						array_splice($this->_d, $i, 1);
+					}
+				}
+			}
+		} elseif (!$value && $this->_discardInvalid) {
+			$this->weakStop();
+		}
+		$this->_discardInvalid = $value;
+	}
+
+	/**
+	 * Returns an iterator for traversing the items in the list.
+	 * This method is required by the interface \IteratorAggregate.
+	 * All invalid WeakReference[s] are optionally removed from the iterated list.
+	 * @return \Iterator an iterator for traversing the items in the list.
+	 */
+	public function getIterator(): \Iterator
+	{
+		return new \ArrayIterator($this->toArray());
+	}
+
+	/**
+	 * All invalid WeakReference[s] are optionally removed from the list before counting.
+	 * @return int the number of items in the list
+	 */
+	public function getCount(): int
+	{
+		$this->scrubWeakReferences();
+		return parent::getCount();
+	}
+
+	/**
+	 * Returns the item at the specified offset.
+	 * This method is exactly the same as {@link offsetGet}.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param int $index the index of the item
+	 * @throws TInvalidDataValueException if the index is out of the range
+	 * @return mixed the item at the index
+	 */
+	public function itemAt($index)
+	{
+		$this->scrubWeakReferences();
+		$item = parent::itemAt($index);
+		$this->filterItemForOutput($item);
+		return $item;
+	}
+
+	/**
+	 * Appends an item at the end of the list.
+	 * All invalid WeakReference[s] are optionally removed from the list before adding
+	 * for proper indexing.
+	 * @param mixed $item new item
+	 * @throws TInvalidOperationException if the list is read-only
+	 * @return int the zero-based index at which the item is added
+	 */
+	public function add($item)
+	{
+		$this->scrubWeakReferences();
+		if (is_object($item)) {
+			$this->weakAdd($item);
+		}
+		$this->filterItemForInput($item);
+		parent::insertAt($this->_c, $item);
+		return $this->_c - 1;
+	}
+
+	/**
+	 * Inserts an item at the specified position.
+	 * Original item at the position and the next items
+	 * will be moved one step towards the end.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param int $index the specified position.
+	 * @param mixed $item new item
+	 * @throws TInvalidDataValueException If the index specified exceeds the bound
+	 * @throws TInvalidOperationException if the list is read-only
+	 */
+	public function insertAt($index, $item)
+	{
+		$this->scrubWeakReferences();
+		if (is_object($item)) {
+			$this->weakAdd($item);
+		}
+		$this->filterItemForInput($item);
+		parent::insertAt($index, $item);
+	}
+
+	/**
+	 * Removes an item from the list.
+	 * The list will first search for the item.
+	 * The first item found will be removed from the list.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param mixed $item the item to be removed.
+	 * @throws TInvalidDataValueException If the item does not exist
+	 * @throws TInvalidOperationException if the list is read-only
+	 * @return int the index at which the item is being removed
+	 */
+	public function remove($item)
+	{
+		if (!$this->getReadOnly()) {
+			if (($index = $this->indexOf($item)) !== -1) {
+				if (is_object($item)) {
+					$this->weakRemove($item);
+				}
+				parent::removeAt($index);
+				return $index;
+			} else {
+				throw new TInvalidDataValueException('list_item_inexistent');
+			}
+		} else {
+			throw new TInvalidOperationException('list_readonly', get_class($this));
+		}
+	}
+
+	/**
+	 * Removes an item at the specified position.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param int $index the index of the item to be removed.
+	 * @throws TInvalidDataValueException If the index specified exceeds the bound
+	 * @throws TInvalidOperationException if the list is read-only
+	 * @return mixed the removed item.
+	 */
+	public function removeAt($index)
+	{
+		$this->scrubWeakReferences();
+		$item = parent::removeAt($index);
+		$this->filterItemForOutput($item);
+		if (is_object($item)) {
+			$this->weakRemove($item);
+		}
+		return $item;
+	}
+
+	/**
+	 * Removes all items in the list and resets the Weak Cache.
+	 * @throws TInvalidOperationException if the list is read-only
+	 */
+	public function clear(): void
+	{
+		$c = $this->_c;
+		for ($i = $this->_c - 1; $i >= 0; --$i) {
+			parent::removeAt($i);
+		}
+		if ($c) {
+			$this->weakRestart();
+		}
+	}
+
+	/**
+	 * @param mixed $item the item
+	 * @return bool whether the list contains the item
+	 */
+	public function contains($item): bool
+	{
+		$this->filterItemForInput($item);
+		return parent::indexOf($item) !== -1;
+	}
+
+	/**
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param mixed $item the item
+	 * @return int the index of the item in the list (0 based), -1 if not found.
+	 */
+	public function indexOf($item)
+	{
+		$this->scrubWeakReferences();
+		$this->filterItemForInput($item);
+		return parent::indexOf($item);
+	}
+
+	/**
+	 * Finds the base item.  If found, the item is inserted before it.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param mixed $baseitem the base item which will be pushed back by the second parameter
+	 * @param mixed $item the item
+	 * @throws TInvalidDataValueException if the base item is not within this list
+	 * @throws TInvalidOperationException if the list is read-only
+	 * @return int the index where the item is inserted
+	 */
+	public function insertBefore($baseitem, $item)
+	{
+		if (!$this->getReadOnly()) {
+			if (($index = $this->indexOf($baseitem)) === -1) {
+				throw new TInvalidDataValueException('list_item_inexistent');
+			}
+			if (is_object($item)) {
+				$this->weakAdd($item);
+			}
+			$this->filterItemForInput($item);
+			parent::insertAt($index, $item);
+			return $index;
+		} else {
+			throw new TInvalidOperationException('list_readonly', get_class($this));
+		}
+	}
+
+	/**
+	 * Finds the base item.  If found, the item is inserted after it.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param mixed $baseitem the base item which comes before the second parameter when added to the list
+	 * @param mixed $item the item
+	 * @throws TInvalidDataValueException if the base item is not within this list
+	 * @throws TInvalidOperationException if the list is read-only
+	 * @return int the index where the item is inserted
+	 */
+	public function insertAfter($baseitem, $item)
+	{
+		if (!$this->getReadOnly()) {
+			if (($index = $this->indexOf($baseitem)) === -1) {
+				throw new TInvalidDataValueException('list_item_inexistent');
+			}
+			if (is_object($item)) {
+				$this->weakAdd($item);
+			}
+			$this->filterItemForInput($item);
+			parent::insertAt($index + 1, $item);
+			return $index + 1;
+		} else {
+			throw new TInvalidOperationException('list_readonly', get_class($this));
+		}
+	}
+
+	/**
+	 * All invalid WeakReference[s] are optionally removed from the list.
+	 * @return array the list of items in array
+	 */
+	public function toArray(): array
+	{
+		$this->scrubWeakReferences();
+		$items = $this->_d;
+		$this->filterItemForOutput($items);
+		return $items;
+	}
+
+	/**
+	 * Copies iterable data into the list.
+	 * Note, existing data in the list will be cleared first.
+	 * @param mixed $data the data to be copied from, must be an array or object implementing Traversable
+	 * @throws TInvalidDataTypeException If data is neither an array nor a Traversable.
+	 */
+	public function copyFrom($data): void
+	{
+		if (is_array($data) || ($data instanceof Traversable)) {
+			if ($this->_c > 0) {
+				$this->clear();
+			}
+			foreach ($data as $item) {
+				if (is_object($item)) {
+					$this->weakAdd($item);
+				}
+				$this->filterItemForInput($item);
+				parent::insertAt($this->_c, $item);
+			}
+		} elseif ($data !== null) {
+			throw new TInvalidDataTypeException('list_data_not_iterable');
+		}
+	}
+
+	/**
+	 * Merges iterable data into the map.
+	 * New data will be appended to the end of the existing data.
+	 * @param mixed $data the data to be merged with, must be an array or object implementing Traversable
+	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
+	 */
+	public function mergeWith($data): void
+	{
+		if (is_array($data) || ($data instanceof Traversable)) {
+			foreach ($data as $item) {
+				if (is_object($item)) {
+					$this->weakAdd($item);
+				}
+				$this->filterItemForInput($item);
+				parent::insertAt($this->_c, $item);
+			}
+		} elseif ($data !== null) {
+			throw new TInvalidDataTypeException('list_data_not_iterable');
+		}
+	}
+
+	/**
+	 * Returns whether there is an item at the specified offset.
+	 * This method is required by the interface \ArrayAccess.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param int $offset the offset to check on
+	 * @return bool
+	 */
+	public function offsetExists($offset): bool
+	{
+		return ($offset >= 0 && $offset < $this->getCount());
+	}
+
+	/**
+	 * Sets the item at the specified offset.
+	 * This method is required by the interface \ArrayAccess.
+	 * All invalid WeakReference[s] are optionally removed from the list before indexing.
+	 * @param int $offset the offset to set item
+	 * @param mixed $item the item value
+	 */
+	public function offsetSet($offset, $item): void
+	{
+		$this->scrubWeakReferences();
+		if ($offset === null || $offset === $this->_c) {
+			if (is_object($item)) {
+				$this->weakAdd($item);
+			}
+			$this->filterItemForInput($item);
+			parent::insertAt($this->_c, $item);
+		} else {
+			$removed = parent::removeAt($offset);
+			$this->filterItemForOutput($removed);
+			if (is_object($removed)) {
+				$this->weakRemove($removed);
+			}
+			if (is_object($item)) {
+				$this->weakAdd($item);
+			}
+			$this->filterItemForInput($item);
+			parent::insertAt($offset, $item);
+		}
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should
+	 * NOT be serialized because their value is the default one or useless to be cached
+	 * for the next page loads.  Reimplement in derived classes to add new variables,
+	 * but remember to  also to call the parent implementation first.
+	 * Due to being weak, the TWeakList is not serialized.  The count is artificially
+	 * made zero so the parent has no values to save.
+	 * @param array $exprops by reference
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		$c = $this->_c;
+		$this->_c = 0;
+		parent::_getZappableSleepProps($exprops);
+		$this->_c = $c;
+
+		$this->_weakZappableSleepProps($exprops);
+		if ($this->_discardInvalid === true) {
+			$exprops[] = "\0" . __CLASS__ . "\0_discardInvalid";
+		}
+	}
+}

--- a/tests/unit/Collections/TWeakListTest.php
+++ b/tests/unit/Collections/TWeakListTest.php
@@ -1,0 +1,412 @@
+<?php
+
+use Prado\Collections\TWeakList;
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Exceptions\TInvalidOperationException;
+
+class TWeakListUnit extends TWeakList
+{
+	public function getWeakCount(): ?int
+	{
+		return $this->weakCount();
+	}
+	
+	public function getWeakObjectCount($obj): ?int
+	{
+		return $this->weakObjectCount($obj);
+	}
+	
+	public function _setDiscardInvalid(bool $value): void
+	{
+		$this->setDiscardInvalid($value);
+	}
+}
+
+/**
+ *	All Test cases for the TList are here.  The TPriorityList should act just like a TList when used exactly like a TList
+ *
+ * The TPriority List should start behaving differently when using the class outside of the standard TList Function calls
+ */
+class TWeakListTest extends TListTest
+{
+	protected $list;
+	protected $item1;
+	protected $item2;
+	protected $item3;
+	protected $item4;
+
+	protected function newList()
+	{
+		return  TWeakListUnit::class;
+	}
+	protected function newListItem()
+	{
+		return 'PriorityListItem';
+	}
+	protected function getCanAddNull()
+	{
+		return true;
+	}
+
+	//*****************************************************************
+	//*******  start test cases for TList operations
+	//*******		TWeakList should act exactly like a TList if objects are all retained.
+	
+	// These tests are inherited from TListTest
+
+	//*******  end test cases for TList operations
+	//*****************************************************************
+
+	/*
+	Methodical Method Unit Tests for TWeakList
+	
+	Key:	- is TList, 
+			* is TWeakList [TWL], (main functionality is from parent)
+			& is full custom implementation in TWL 
+			~ is scrub the list for invalid weak references, 
+			= is IO filtering
+			# is a unit test
+	
+	methods:
+	-*		__Construct
+	-*& 	getIterator (calls $this->toArray to scrub)
+	-* ~ #	getCount [scrub WeakRef]
+	-* ~=#	itemAt [scrub WeakRef]
+	-* ~=#	add, return index  [scrub WeakRef, check add/incr WeakMpa]
+	-* ~=#	insertAt [scrub WeakRef, check add/incr WeakMap]
+	-*& =#	remove (calls $this->indexOf to scrub), return index  [scrub WeakRef, check rm/deincr WeakMap]
+	-* ~=#	removeAt [scrub WeakRef, check rm/deincr WeakMap]
+	-*&  #	clear [scrub WeakRef, check for WeakMap count = 0]
+	-*& =	contains, return bool
+	-* ~=#	indexOf, return index  [scrub WeakRef]
+	-*& =#	insertBefore, return index (calls $this->indexOf to scrub)[scrub WeakRef, check add/incr WeakMap]
+	-*& =#	insertAfter, return index (calls $this->indexOf to scrub)[scrub WeakRef, check add/incr WeakMap]
+	-*&~=#	toArray, return array [scrub WeakRef]
+	-*& =#	copyFrom [parent::insertAt, objects are add/incr WeakMap]
+	-*& =#	mergeWith [parent::insertAt, objects are add/incr WeakMap]
+	-*& 	offsetExists (calls $this->getCount to scrub)
+	-		offsetGet (calls $this->itemAt)
+	-*&~=#	offsetSet [scrub WeakRef, object add/incr WeakMap, old object deincr]
+	-		offsetUnset (calls $this->removeAt)
+	-*	 #	_getZappableSleepProps
+	
+	*/
+	
+	public function testGetIteratorTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		unset($this->item2);
+		unset($this->item3);
+		
+		$iter = $this->list->getIterator();
+		self::assertEquals(2, $this->list->getWeakCount());
+		self::assertEquals($this->item1, $iter->current());
+		self::assertEquals(0, $iter->key());
+		$iter->next();
+		self::assertEquals($this->item4, $iter->current());
+		self::assertEquals(1, $iter->key());
+		$iter->next();
+		self::assertFalse($iter->valid());
+	}
+	
+	public function testGetCountTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		unset($this->item2);
+		unset($this->item3);
+		
+		self::assertEquals(2, $this->list->getCount());
+		self::assertEquals(2, $this->list->getWeakCount());
+		
+		// Test the read only and not discard invalid aspect of scrubWeakReferences
+		
+		// Read only with scrubbing.
+		$this->item2 = new $this->_baseItemClass(2);
+		$this->item3 = new $this->_baseItemClass(3);
+		$this->list = new $this->_baseClass([$this->item1, $this->item2, $this->item3, $this->item4], true, true);
+		self::assertTrue($this->list->getDiscardInvalid());
+		unset($this->item2);
+		unset($this->item3);
+		self::assertEquals([$this->item1, $this->item4], $this->list->toArray());
+			
+		// Read only without scrubbing.
+		$this->item2 = new $this->_baseItemClass(2);
+		$this->item3 = new $this->_baseItemClass(3);
+		$this->list = new $this->_baseClass([$this->item1, $this->item2, $this->item3, $this->item4], true, false);
+		self::assertFalse($this->list->getDiscardInvalid());
+		unset($this->item2);
+		unset($this->item3);
+		self::assertEquals([$this->item1, null, null, $this->item4], $this->list->toArray());
+		
+		// mutable without scrubbing
+		$this->item2 = new $this->_baseItemClass(2);
+		$this->item3 = new $this->_baseItemClass(3);
+		$this->list = new $this->_baseClass(null, false, false);
+		self::assertFalse($this->list->getDiscardInvalid());
+		$this->list->add($this->item1);
+		$this->list->add($this->item2);
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		unset($this->item2);
+		unset($this->item3);
+		
+		self::assertEquals(4, $this->list->getCount());
+		self::assertNull($this->list->itemAt(1));
+		self::assertNull($this->list->itemAt(2));
+	}
+	
+	public function testItemAtTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		unset($this->item2);
+		unset($this->item3);
+		
+		try {
+			self::assertEquals($this->item1, $this->list->itemAt(2));
+		} catch(TInvalidDataValueException $e) {
+		}
+		self::assertEquals($this->item4, $this->list->itemAt(1));
+		self::assertEquals($this->item1, $this->list->itemAt(0));
+		self::assertEquals(2, $this->list->getWeakCount());
+	}
+	
+	public function testAddTWeakList()
+	{
+		self::assertEquals(2, $this->list->add($this->item3));
+		
+		unset($this->item2);
+		unset($this->item3);
+		
+		self::assertEquals(1, $this->list->add($this->item4));
+		self::assertEquals(2, $this->list->add($this->item4));
+		
+		self::assertEquals(2, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(2, $this->list->getWeakObjectCount($this->item4));
+	}
+	
+	public function testInsertAtTWeakList()
+	{
+		$this->list->insertAt(0, $this->item3);
+		
+		unset($this->item2);
+		unset($this->item3);
+		
+		$this->list->insertAt(0, $this->item4);
+		$this->list->insertAt(2, $this->item4);
+		
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(2, $this->list->getWeakObjectCount($this->item4));
+		self::assertEquals(2, $this->list->getWeakCount());
+	}
+	
+	
+	public function testRemoveTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		$this->list->add($this->item1);
+		$this->list->add($this->item4);
+		
+		self::assertEquals(2, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item2));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(2, $this->list->getWeakObjectCount($this->item4));
+		self::assertEquals(4, $this->list->getWeakCount());
+		
+		unset($this->item1);
+		unset($this->item2);
+		
+		self::assertEquals(2, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->remove($this->item4));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+		self::assertEquals(1, $this->list->remove($this->item4));
+		self::assertNull($this->list->getWeakObjectCount($this->item4));
+		
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakCount());
+	}
+	
+	
+	public function testRemoveAtTWeakList()
+	{
+		$item5 = new $this->_baseItemClass(5);
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		$this->list->add($this->item1);
+		$this->list->add($item5);
+		$this->list->add($this->item4);
+		self::assertEquals(5, $this->list->getWeakCount());
+		
+		unset($this->item1);
+		unset($this->item2);
+		
+		self::assertEquals(3, $this->list->getWeakCount());
+		self::assertEquals($this->item4, $this->list->removeAt(1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+		self::assertEquals($this->item4, $this->list->removeAt(2));
+		self::assertNull($this->list->getWeakObjectCount($this->item4));
+		self::assertEquals(2, $this->list->getWeakCount());
+		
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakObjectCount($item5));
+		self::assertEquals(2, $this->list->getWeakCount());
+	}
+	
+	
+	public function testClearTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		$this->list->add($this->item1);
+		$this->list->add($this->item4);
+		
+		unset($this->item1);
+		unset($this->item2);
+		self::assertEquals(2, $this->list->getWeakCount());
+		
+		$this->list->clear();
+		self::assertEquals(0, $this->list->getWeakCount());
+	}
+	
+	
+	public function testIndexOfTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		
+		unset($this->item2);
+		unset($this->item3);
+		
+		self::assertEquals(1, $this->list->indexOf($this->item4));
+		self::assertEquals(0, $this->list->indexOf($this->item1));
+	}
+	
+	
+	public function testInsertBeforeTWeakList()
+	{
+		unset($this->item1);
+		
+		self::assertEquals(0, $this->list->insertBefore($this->item2, $this->item3));
+	}
+	
+	
+	public function testInsertAfterTWeakList()
+	{
+		unset($this->item1);
+		
+		self::assertEquals(1, $this->list->insertAfter($this->item2, $this->item3));
+	}
+	
+	
+	public function testToArrayTWeakList()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		
+		unset($this->item2);
+		unset($this->item3);
+		
+		self::assertEquals([$this->item1, $this->item4], $this->list->toArray($this->item4));
+		self::assertEquals(2, $this->list->getWeakCount());
+	}
+	
+	
+	public function testCopyFromTWeakList()
+	{
+		self::assertEquals(2, $this->list->getWeakCount());
+		unset($this->item2);
+		self::assertEquals(1, $this->list->getWeakCount());
+		$this->list->copyFrom([$this->item3, $this->item4]);
+		
+		self::assertEquals(2, $this->list->getWeakCount());
+		self::assertNull($this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+	}
+	
+	
+	public function testMergeWithTWeakList()
+	{
+		$this->list->mergeWith([$this->item3, $this->item4]);
+		
+		self::assertEquals(4, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item2));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+	}
+	
+	
+	public function testOffsetSetTWeakList()
+	{
+		unset($this->item2);
+		$this->list[1] = $this->item3;
+		$this->list[] = $this->item4;
+		self::assertEquals(3, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+		
+		$item5 = new $this->_baseItemClass(5);
+		$this->list[1] = $item5;
+		self::assertEquals(3, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertNull($this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakObjectCount($item5));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+	}
+	
+	public function testClosureTWeakList()
+	{
+		$this->list->add(function ($param1) {
+			return $param1 + $param1;
+		});
+		unset($this->item2);
+		try {
+			$closure = $this->list->itemAt(1);
+		} catch (Exception $e) {
+			self::fail("Closure was put under WeakReference when it shouldn't have been, resulting in:\n" . $e->getMessage());
+		}
+		self::assertInstanceOf(Closure::class, $closure);
+	}
+	
+	public function testArrayAsItemTWeakList()
+	{
+		$this->list->add([$this->item3, $this->item4]);
+		self::assertEquals([$this->item1, $this->item2, [$this->item3, $this->item4]], $this->list->toArray());
+		unset($this->item2);
+		unset($this->item3);
+		self::assertEquals([$this->item1, [null, $this->item4]], $this->list->toArray());
+	}
+	
+	public function testDiscardInvalid()
+	{
+		$this->list->add($this->item3);
+		$this->list->add($this->item4);
+		self::assertTrue($this->list->getDiscardInvalid());
+		
+		self::assertEquals(4, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item2));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item3));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+		
+		$this->list->_setDiscardInvalid(false);
+		self::assertNull($this->list->weakCount());
+		self::assertFalse($this->list->getDiscardInvalid());
+		
+		unset($this->item2);
+		unset($this->item3);
+		
+		$this->list->_setDiscardInvalid(true);
+		self::assertTrue($this->list->getDiscardInvalid());
+		self::assertEquals(2, $this->list->getWeakCount());
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item1));
+		self::assertEquals(1, $this->list->getWeakObjectCount($this->item4));
+	}
+}


### PR DESCRIPTION
We aren't using TWeakList yet, but I'm planning on using it to track Owners attached TClassBehaviors.  This will be used to remove events, and re-add the events on Enable/disable of the TClassBehavior to all owners.  Owners should be tracked in TClassBehavior via TWeakList.

TWeakCollectionTrait is going to be used by TWeakCallableCollection being worked on now.  It's the common code for WeakMap tracking of WeakReferences.