### PR TITLE
#872 Corrections for PHP 8.2: erroneous missing properties in unit tests, type conversion, flagging Password parameters as sensitive

### DIFF
--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -403,7 +403,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	/**
 	 * @param string $value the password for establishing DB connection
 	 */
-	public function setPassword($value)
+	public function setPassword(#[\SensitiveParameter] $value)
 	{
 		$this->_password = $value;
 	}

--- a/framework/Data/TDbConnection.php
+++ b/framework/Data/TDbConnection.php
@@ -123,7 +123,7 @@ class TDbConnection extends \Prado\TComponent
 	 * @param string $charset Charset used for DB Connection (MySql & pgsql only). If not set, will use the default charset of your database server
 	 * @see http://www.php.net/manual/en/function.PDO-construct.php
 	 */
-	public function __construct($dsn = '', $username = '', $password = '', $charset = '')
+	public function __construct($dsn = '', $username = '', #[\SensitiveParameter] $password = '', $charset = '')
 	{
 		$this->_dsn = $dsn;
 		$this->_username = $username;
@@ -287,7 +287,7 @@ class TDbConnection extends \Prado\TComponent
 	/**
 	 * @param string $value the password for establishing DB connection
 	 */
-	public function setPassword($value)
+	public function setPassword(#[\SensitiveParameter] $value)
 	{
 		$this->_password = $value;
 	}

--- a/framework/Security/IUserManager.php
+++ b/framework/Security/IUserManager.php
@@ -50,5 +50,5 @@ interface IUserManager
 	 * @param string $password password
 	 * @return bool true if validation is successful, false otherwise.
 	 */
-	public function validateUser($username, $password);
+	public function validateUser($username, #[\SensitiveParameter] $password);
 }

--- a/framework/Security/TAuthManager.php
+++ b/framework/Security/TAuthManager.php
@@ -426,7 +426,7 @@ class TAuthManager extends \Prado\TModule
 	 * @param int $expire number of seconds that automatic login will remain effective. If 0, it means user logs out when session ends. This parameter is added since 3.1.1.
 	 * @return bool if login is successful
 	 */
-	public function login($username, $password, $expire = 0)
+	public function login($username, #[\SensitiveParameter] $password, $expire = 0)
 	{
 		if ($this->_userManager->validateUser($username, $password)) {
 			if (($user = $this->_userManager->getUser($username)) === null) {

--- a/framework/Security/TDbUser.php
+++ b/framework/Security/TDbUser.php
@@ -59,7 +59,7 @@ abstract class TDbUser extends TUser
 	 * @param string $password password
 	 * @return bool whether the validation succeeds
 	 */
-	abstract public function validateUser($username, $password);
+	abstract public function validateUser($username, #[\SensitiveParameter] $password);
 
 	/**
 	 * Creates a new user instance given the username.

--- a/framework/Security/TDbUserManager.php
+++ b/framework/Security/TDbUserManager.php
@@ -106,7 +106,7 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	 * @param string $password password
 	 * @return bool true if validation is successful, false otherwise.
 	 */
-	public function validateUser($username, $password)
+	public function validateUser($username, #[\SensitiveParameter] $password)
 	{
 		return $this->_userFactory->validateUser($username, $password);
 	}

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -277,7 +277,7 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	 * @param string $password password
 	 * @return bool true if validation is successful, false otherwise.
 	 */
-	public function validateUser($username, $password)
+	public function validateUser($username, #[\SensitiveParameter] $password)
 	{
 		if ($this->_passwordMode === TUserManagerPasswordMode::MD5) {
 			$password = md5($password);

--- a/framework/Shell/TShellLoginBehavior.php
+++ b/framework/Shell/TShellLoginBehavior.php
@@ -136,7 +136,7 @@ class TShellLoginBehavior extends \Prado\Util\TBehavior
 	/**
 	 * @param string $password password of the login from the command line
 	 */
-	public function setPassword($password)
+	public function setPassword(#[\SensitiveParameter] $password)
 	{
 		$this->_password = $password;
 	}

--- a/framework/Util/Cron/TShellCronAction.php
+++ b/framework/Util/Cron/TShellCronAction.php
@@ -92,7 +92,7 @@ class TShellCronAction extends TShellAction
 			return true;
 		}
 		$time = $module->getLastCronTime();
-		$this->_outWriter->writeLine("\n Last cron run time was " . ($time == 0 ? 'never' : date('Y-m-d H:i:s TP', $time)) . '');
+		$this->_outWriter->writeLine("\n Last cron run time was " . ($time == 0 ? 'never' : date('Y-m-d H:i:s TP', (int) $time)) . '');
 		$module->processPendingTasks();
 		return true;
 	}

--- a/tests/unit/Collections/TWeakCallableCollectionTest.php
+++ b/tests/unit/Collections/TWeakCallableCollectionTest.php
@@ -72,7 +72,6 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 		$item2 = $list[] = ['CallableListItem', 'staticHandler'];
 		$item3 = $list[] = [$this->item1, 'eventHandler'];
 		$item4 = $list[] = 'CallableListItem::staticHandler';
-		$item5 = $list[] = ['CallableListItemChild','parent::staticHandler'];
 		$item6 = $list[] = $this->item2;
 		
 		// Check that callables that have proper syntax but do not exist
@@ -118,8 +117,7 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 		$this->assertEquals($p[$priority][2][0]->get(), $this->item1);
 		$this->assertEquals($p[$priority][2][1], 'eventHandler');
 		$this->assertEquals($p[$priority][3], 'CallableListItem::staticHandler');
-		$this->assertEquals($p[$priority][4], ['CallableListItemChild','parent::staticHandler']);
-		$this->assertEquals($p[$priority][5]->get(), $this->item2);
+		$this->assertEquals($p[$priority][4]->get(), $this->item2);
 		
 	}
 	

--- a/tests/unit/Collections/TWeakCallableCollectionTest.php
+++ b/tests/unit/Collections/TWeakCallableCollectionTest.php
@@ -4,6 +4,7 @@ use Prado\Collections\TWeakCallableCollection;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\Exceptions\TPhpErrorException;
 
 class CallableListItem
 {
@@ -72,6 +73,11 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 		$item2 = $list[] = ['CallableListItem', 'staticHandler'];
 		$item3 = $list[] = [$this->item1, 'eventHandler'];
 		$item4 = $list[] = 'CallableListItem::staticHandler';
+		try {
+			$item5 = $list[] = ['CallableListItemChild','parent::staticHandler'];
+		} catch (TPhpErrorException $e) {
+			$item5 = $list[] = ['CallableListItemChild','staticHandler'];
+		}
 		$item6 = $list[] = $this->item2;
 		
 		// Check that callables that have proper syntax but do not exist
@@ -95,7 +101,8 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 		try {
 			$list[] = ['CallableListItemChild','parent::noMethod'];
 			$this->fail('TInvalidDataValueException string of [valid static object, \'parent::nostaticmethod\'] that is not a method did not throw error');
-		} catch(TInvalidDataValueException $e){}
+		} catch(TInvalidDataValueException $e) {// Catch PHP 8.1
+		} catch(TPhpErrorException $e) {} // Catch PHP 8.2+
 		try {
 			$list[] = $component;
 			$this->fail('TInvalidDataValueException object without  __invocke did not throw error');
@@ -117,7 +124,7 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 		$this->assertEquals($p[$priority][2][0]->get(), $this->item1);
 		$this->assertEquals($p[$priority][2][1], 'eventHandler');
 		$this->assertEquals($p[$priority][3], 'CallableListItem::staticHandler');
-		$this->assertEquals($p[$priority][4]->get(), $this->item2);
+		$this->assertEquals($p[$priority][5]->get(), $this->item2);
 		
 	}
 	

--- a/tests/unit/Data/SqlMap/DataMapper/TPropertyAccessTest.php
+++ b/tests/unit/Data/SqlMap/DataMapper/TPropertyAccessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-
+use Prado\Exceptions\TPhpErrorException;
 use Prado\Data\SqlMap\DataMapper\TPropertyAccess;
 
 class TPropertyAccessTest extends PHPUnit\Framework\TestCase
@@ -38,8 +38,11 @@ class TPropertyAccessTest extends PHPUnit\Framework\TestCase
 		TPropertyAccess::set($testobj, 'b', 20);
 		self::assertEquals(20, TPropertyAccess::get($testobj, 'b'));
 
-		TPropertyAccess::set($testobj, 'c', 30);
-		self::assertEquals(30, TPropertyAccess::get($testobj, 'c'));
+		try { // PHP 8.2 throws an error on undefined properties.
+			TPropertyAccess::set($testobj, 'c', 30);
+			self::assertEquals(30, TPropertyAccess::get($testobj, 'c'));
+		} catch(TPhpErrorException $e) {
+		}
 	}
 
 
@@ -89,9 +92,12 @@ class TPropertyAccessTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(100, TPropertyAccess::get($testobj, 'b'));
 		self::assertEquals(100, TPropertyAccess::get($testobj, 'B'));
 
-		TPropertyAccess::set($testobj, 'c', 30);
-		self::assertEquals(30, TPropertyAccess::get($testobj, 'c'));
-
+		try {
+			TPropertyAccess::set($testobj, 'c', 30);
+			self::assertEquals(30, TPropertyAccess::get($testobj, 'c'));
+		} catch(TPhpErrorException $e) {
+		}
+			
 		self::expectException(Prado\Data\SqlMap\DataMapper\TInvalidPropertyException::class);
 		TPropertyAccess::get($testobj, 'C');
 	}
@@ -175,8 +181,15 @@ class TPropertyAccessTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(10, TPropertyAccess::get($testobj, 'a.d.a'));
 		self::assertEquals(10, TPropertyAccess::get($testobj, 'a.e.a'));
 
-		TPropertyAccess::set($testobj, 'a.c.c', 30);
-		TPropertyAccess::set($testobj, 'a.d.c', 30);
+		try { // no public variable $c, error in PHP 8.2
+			TPropertyAccess::set($testobj, 'a.c.c', 30);
+		} catch (TPhpErrorException $e) {
+		}
+		try { // no getter methods for $c, error in PHP 8.2
+			TPropertyAccess::set($testobj, 'a.d.c', 30);
+		} catch (TPhpErrorException $e) {
+		}
+		// But dynamic magic methods accept $c without error as no error is coded into the test class.
 		TPropertyAccess::set($testobj, 'a.e.c', 30);
 
 		self::assertEquals(30, TPropertyAccess::get($testobj, 'a.c.c'));

--- a/tests/unit/Util/Cron/TShellCronLogBehaviorTest.php
+++ b/tests/unit/Util/Cron/TShellCronLogBehaviorTest.php
@@ -9,7 +9,7 @@ use Prado\Util\Cron\TShellCronLogBehavior;
 class TShellCronLogBehaviorTest extends PHPUnit\Framework\TestCase
 {
 	protected $obj;
-	
+	protected $writer;
 
 	protected function setUp(): void
 	{

--- a/tests/unit/Util/Cron/TShellDbCronActionTest.php
+++ b/tests/unit/Util/Cron/TShellDbCronActionTest.php
@@ -11,6 +11,7 @@ use Prado\Util\Cron\TDbCronModule;
 class TShellDbCronActionTest extends PHPUnit\Framework\TestCase
 {
 	protected $obj;
+	protected $writer;
 	
 	protected function getTestClass()
 	{

--- a/tests/unit/Web/TUriTest.php
+++ b/tests/unit/Web/TUriTest.php
@@ -7,6 +7,8 @@ class TUriTest extends PHPUnit\Framework\TestCase
 {
 	const URISTR = 'http://login:p@ssw0rd:compl3x@www.pradoframework.net:80/demos/quickstart/index.php?page=test&param1=test2#anchor';
 
+	protected $uri;
+
 	protected function setUp(): void
 	{
 		$this->uri = new TUri(self::URISTR);


### PR DESCRIPTION
Due to the upgrade of PRADO to PHP 8.1 and 8.2, today became upgrade day from PHP 8.0.  so then move to 8.1 or 8.2?   how about 8.2...

PHP-CS-Fixer is saying it doesn't support PHP 8.2.  This just may be my install being out of date and needing a `composer update` command.
And there were a few errors that needed fixing:
- removed deprecated callable styles from TWeakCallableCollection unit tests that were failing.
- Some test units failed to declare some variables.
- TPropertyAccess unit test tests for undeclared variables that is deprecated in 8.2; requiring an update.  PHP 8.1 runs the tests, PHP 8.2 fails gracefully without error.
- There was a minor conversion (float => int) error in TShellCronAction regarding display of time.
- Added SensitiveParameter flag to Password parameters in functions so they do not display in stack traces.  Not exactly important for simple setters, but a must for Setting Database passwords, Auth Manager user login, and User Manager validation.

With these edits, PRADO in PHP 8.2 is passing all the checks.