### PR TITLE
TPriorityList and TPriorityMap updates for less variable copying and better organization

### DIFF
--- a/framework/Collections/TPriorityCollectionTrait.php
+++ b/framework/Collections/TPriorityCollectionTrait.php
@@ -146,15 +146,14 @@ trait TPriorityCollectionTrait
 
 	/**
 	 * This flattens the priority list into a flat array [0,...,n-1]
-	 * @return array array of items in the list in priority and index order
 	 */
-	protected function flattenPriorities(): array
+	protected function flattenPriorities(): void
 	{
 		if (is_array($this->_fd)) {
-			return $this->_fd;
+			return;
 		}
 		$this->sortPriorities();
-		return $this->_fd = array_merge(...$this->_d);
+		$this->_fd = array_merge(...$this->_d);
 	}
 
 	/**
@@ -188,7 +187,8 @@ trait TPriorityCollectionTrait
 	 */
 	public function getIterator(): \Iterator
 	{
-		return new \ArrayIterator($this->flattenPriorities());
+		$this->flattenPriorities();
+		return new \ArrayIterator($this->_fd);
 	}
 
 	/**
@@ -207,7 +207,8 @@ trait TPriorityCollectionTrait
 	 */
 	public function toArray(): array
 	{
-		return $this->flattenPriorities();
+		$this->flattenPriorities();
+		return $this->_fd;
 	}
 
 	/**

--- a/framework/Collections/TPriorityCollectionTrait.php
+++ b/framework/Collections/TPriorityCollectionTrait.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * TPriorityCollectionTrait class
+ *
+ * @author Brad Anderson <javalizard@gmail.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Collections;
+
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\TPropertyValue;
+
+/**
+ * TPriorityCollectionTrait class
+ *
+ * This trait implements the common properties and methods of Priority Collection
+ * classes.
+ *
+ * The trait adds a boolean for whether or not _d is ordered, a cached flattened
+ * array _fd, a default priority (by default, 10) _dp, and precision of priorities (by 
+ * default, 8 [decimal places]) _p.
+ *
+ * The trait adds methods:
+ *	- {@link getDefaultPriority} returns the default priority of items without priority.
+ *	- {@link setDefaultPriority} sets the default priority. (protected)
+ *	- {@link getPrecision} returns the precision of priorities.
+ *	- {@link setPrecision} sets the precision of priorities. (protected)
+ *	- {@link ensurePriority} standardize and round priorities. (protected)
+ *	- {@link sortPriorities} sorts _d and flags as sorted. (protected)
+ *	- {@link flattenPriorities} flattens the priority items, in order into cache.. (protected)
+ *	- {@link getPriorities} gets the priorities of the collection.
+ *	- {@link getPriorityCount} gets the number of items at a priority.
+ *	- {@link itemsAtPriority} gets the items at a given priority.
+ *	- {@link getIterator} overrides subclasses for an iterator of the flattened array.
+ *	- {@link toArray} the flattened collection in order.
+ *	- {@link toPriorityArray} the array of priorities (keys) and array of items (value).
+ *	- {@link toArrayBelowPriority} the items below a Priority, default is not inclusive
+ *	- {@link toArrayAbovePriority} the items above a priority, default is inclusive.
+ *	- {@link _priorityZappableSleepProps} to add the excluded trait properties on sleep.
+ *
+ * The priorities are implemented as numeric strings
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+trait TPriorityCollectionTrait
+{
+	/**
+	 * @var bool indicates if the _d is currently ordered.
+	 */
+	protected bool $_o = false;
+	
+	/**
+	 * @var null|array cached flattened internal data storage
+	 */
+	protected ?array $_fd = null;
+	
+	/**
+	 * @var string the default priority of items without specified priorities
+	 */
+	private string $_dp = '10';
+	
+	/**
+	 * @var int the precision of the numeric priorities within this priority list.
+	 */
+	private int $_p = 8;
+
+	/**
+	 * @return numeric gets the default priority of inserted items without a specified priority
+	 */
+	public function getDefaultPriority()
+	{
+		return $this->_dp;
+	}
+
+	/**
+	 * This must be called internally or when instantiated.
+	 * @param numeric $value sets the default priority of inserted items without a specified priority
+	 */
+	protected function setDefaultPriority($value)
+	{
+		$this->_dp = (string) round(TPropertyValue::ensureFloat($value), $this->_p);
+	}
+
+	/**
+	 * @return int The precision of numeric priorities, defaults to 8
+	 */
+	public function getPrecision(): int
+	{
+		return $this->_p;
+	}
+
+	/**
+	 * This must be called internally or when instantiated.
+	 * This resets the array priorities to the new precision and adjusts
+	 * the DefaultPriority to the new precision as well.
+	 * @param int $value The precision of numeric priorities.
+	 */
+	protected function setPrecision($value): void
+	{
+		$this->_p = TPropertyValue::ensureInteger($value);
+		$this->setDefaultPriority($this->_dp);
+		$_d = [];
+		foreach(array_keys($this->_d) as $priority) {
+			$newPriority = $this->ensurePriority($priority);
+			if (array_key_exists($newPriority, $_d))
+				$_d[$newPriority] = array_merge($_d[$newPriority], $this->_d[$priority]);
+			else
+				$_d[$newPriority] = $this->_d[$priority];
+		}
+		$this->_d = $_d;
+		$this->_fd = null;
+	}
+
+	/**
+	 * Taken an input Priority and ensures its value.
+	 * Sets the default $priority when none is set,
+	 * then rounds to the proper precision and makes
+	 * into a string.
+	 * @param mixed $priority
+	 * @return string the priority in string format
+	 */
+	protected function ensurePriority($priority): string
+	{
+		if ($priority === null || !is_numeric($priority)) {
+			$priority = $this->getDefaultPriority();
+		}
+		return (string) round((float) $priority, $this->_p);
+	}
+
+
+	/**
+	 * This orders the priority list internally.
+	 */
+	protected function sortPriorities(): void
+	{
+		if (!$this->_o) {
+			ksort($this->_d, SORT_NUMERIC);
+			$this->_o = true;
+		}
+	}
+
+	/**
+	 * This flattens the priority list into a flat array [0,...,n-1]
+	 * @return array array of items in the list in priority and index order
+	 */
+	protected function flattenPriorities(): array
+	{
+		if (is_array($this->_fd)) {
+			return $this->_fd;
+		}
+		$this->sortPriorities();
+		return $this->_fd = array_merge(...$this->_d);
+	}
+
+	/**
+	 * This returns a list of the priorities within this list, ordered lowest to highest.
+	 * @return array the array of priority numerics in decreasing priority order
+	 */
+	public function getPriorities(): array
+	{
+		$this->sortPriorities();
+		return array_keys($this->_d);
+	}
+
+	/**
+	 * Gets the number of items at a priority within the list
+	 * @param null|numeric $priority optional priority at which to count items.  if no parameter, it will be set to the default {@link getDefaultPriority}
+	 * @return false|int the number of items in the list at the specified priority
+	 */
+	public function getPriorityCount($priority = null)
+	{
+		$priority = $this->ensurePriority($priority);
+		if (!isset($this->_d[$priority]) || !is_array($this->_d[$priority])) {
+			return false;
+		}
+		return count($this->_d[$priority]);
+	}
+
+	/**
+	 * Returns an iterator for traversing the items in the list.
+	 * This method is required by the interface \IteratorAggregate.
+	 * @return \Iterator an iterator for traversing the items in the list.
+	 */
+	public function getIterator(): \Iterator
+	{
+		return new \ArrayIterator($this->flattenPriorities());
+	}
+
+	/**
+	 * Gets all the items at a specific priority.
+	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled in with the default priority, if left blank.
+	 * @return ?array all items at priority in index order, null if there are no items at that priority
+	 */
+	public function itemsAtPriority($priority = null): ?array
+	{
+		$priority = $this->ensurePriority($priority);
+		return $this->_d[$priority] ?? null;
+	}
+
+	/**
+	 * @return array the priority list of items in array
+	 */
+	public function toArray(): array
+	{
+		return $this->flattenPriorities();
+	}
+
+	/**
+	 * @return array the array of priorities keys with values of arrays of items.  The priorities are sorted so important priorities, lower numerics, are first.
+	 */
+	public function toPriorityArray(): array
+	{
+		$this->sortPriorities();
+		return $this->_d;
+	}
+
+	/**
+	 * Combines the map elements which have a priority below the parameter value
+	 * @param numeric $priority the cut-off priority.  All items of priority less than this are returned.
+	 * @param bool $inclusive whether or not the input cut-off priority is inclusive.  Default: false, not inclusive.
+	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
+	 *  The priorities are sorted so important priorities, lower numerics, are first.
+	 */
+	public function toArrayBelowPriority($priority, $inclusive = false): array
+	{
+		$this->sortPriorities();
+		$items = [];
+		foreach ($this->_d as $itemspriority => $itemsatpriority) {
+			if ((!$inclusive && $itemspriority >= $priority) || $itemspriority > $priority) {
+				break;
+			}
+			$items = array_merge($items, $itemsatpriority);
+		}
+		return $items;
+	}
+
+	/**
+	 * Combines the map elements which have a priority above the parameter value
+	 * @param numeric $priority the cut-off priority.  All items of priority greater than this are returned.
+	 * @param bool $inclusive whether or not the input cut-off priority is inclusive.  Default: true, inclusive.
+	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
+	 *  The priorities are sorted so important priorities, lower numerics, are first.
+	 */
+	public function toArrayAbovePriority($priority, $inclusive = true): array
+	{
+		$this->sortPriorities();
+		$items = [];
+		foreach ($this->_d as $itemspriority => $itemsatpriority) {
+			if ((!$inclusive && $itemspriority <= $priority) || $itemspriority < $priority) {
+				continue;
+			}
+			$items = array_merge($items, $itemsatpriority);
+		}
+		return $items;
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 */
+	protected function _priorityZappableSleepProps(&$exprops)
+	{
+		if ($this->_o === false) {
+			$exprops[] = "\0*\0_o";
+		}
+		$exprops[] = "\0*\0_fd";
+		if ($this->_dp == 10) {
+			$exprops[] = "\0" . __CLASS__ . "\0_dp";
+		}
+		if ($this->_p === 8) {
+			$exprops[] = "\0" . __CLASS__ . "\0_p";
+		}
+	}
+}

--- a/framework/Collections/TPriorityCollectionTrait.php
+++ b/framework/Collections/TPriorityCollectionTrait.php
@@ -235,9 +235,9 @@ trait TPriorityCollectionTrait
 			if ((!$inclusive && $itemspriority >= $priority) || $itemspriority > $priority) {
 				break;
 			}
-			$items = array_merge($items, $itemsatpriority);
+			$items[] = $itemsatpriority;
 		}
-		return $items;
+		return array_merge(...$items);
 	}
 
 	/**
@@ -255,9 +255,9 @@ trait TPriorityCollectionTrait
 			if ((!$inclusive && $itemspriority <= $priority) || $itemspriority < $priority) {
 				continue;
 			}
-			$items = array_merge($items, $itemsatpriority);
+			$items[] = $itemsatpriority;
 		}
-		return $items;
+		return array_merge(...$items);
 	}
 
 	/**

--- a/framework/Collections/TPriorityCollectionTrait.php
+++ b/framework/Collections/TPriorityCollectionTrait.php
@@ -21,7 +21,7 @@ use Prado\TPropertyValue;
  * classes.
  *
  * The trait adds a boolean for whether or not _d is ordered, a cached flattened
- * array _fd, a default priority (by default, 10) _dp, and precision of priorities (by 
+ * array _fd, a default priority (by default, 10) _dp, and precision of priorities (by
  * default, 8 [decimal places]) _p.
  *
  * The trait adds methods:
@@ -53,17 +53,17 @@ trait TPriorityCollectionTrait
 	 * @var bool indicates if the _d is currently ordered.
 	 */
 	protected bool $_o = false;
-	
+
 	/**
 	 * @var null|array cached flattened internal data storage
 	 */
 	protected ?array $_fd = null;
-	
+
 	/**
 	 * @var string the default priority of items without specified priorities
 	 */
 	private string $_dp = '10';
-	
+
 	/**
 	 * @var int the precision of the numeric priorities within this priority list.
 	 */
@@ -107,10 +107,11 @@ trait TPriorityCollectionTrait
 		$_d = [];
 		foreach(array_keys($this->_d) as $priority) {
 			$newPriority = $this->ensurePriority($priority);
-			if (array_key_exists($newPriority, $_d))
+			if (array_key_exists($newPriority, $_d)) {
 				$_d[$newPriority] = array_merge($_d[$newPriority], $this->_d[$priority]);
-			else
+			} else {
 				$_d[$newPriority] = $this->_d[$priority];
+			}
 		}
 		$this->_d = $_d;
 		$this->_fd = null;

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -89,13 +89,20 @@ class TPriorityList extends TList
 	/**
 	 * Returns the item at an index within a priority
 	 * @param int $index the index into the list of items at priority
-	 * @param numeric $priority the priority which to index.  no parameter or null will result in the default priority
+	 * @param null|numeric $priority the priority which to index.  no parameter or null 
+	 *   will result in the default priority
+	 * @throws TInvalidDataValueException if the index is out of the range at the 
+	 *   priority or no items at the priority.
 	 * @return mixed the element at the offset, false if no element is found at the offset
 	 */
 	public function itemAtIndexInPriority($index, $priority = null)
 	{
 		$priority = $this->ensurePriority($priority);
-		return isset($this->_d[$priority]) ? 0 <= $index && $index < count($this->_d[$priority]) ? $this->_d[$priority][$index] : false : false;
+		if (isset($this->_d[$priority]) && 0 <= $index && $index < count($this->_d[$priority])) {
+			return $this->_d[$priority][$index];
+		} else {
+			throw new TInvalidDataValueException('prioritylist_index_invalid', $index, $priority);
+		}
 	}
 
 	/**

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -358,7 +358,7 @@ class TPriorityList extends TList
 	 */
 	public function priorityAt($index, $withindex = false)
 	{
-		if ($index < 0 || $index >= max(1, $this->getCount())) {
+		if ($index < 0 || $index > $this->getCount()) {
 			throw new TInvalidDataValueException('list_index_invalid', $index);
 		}
 

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -101,7 +101,7 @@ class TPriorityList extends TList
 		if (isset($this->_d[$priority]) && 0 <= $index && $index < count($this->_d[$priority])) {
 			return $this->_d[$priority][$index];
 		} else {
-			throw new TInvalidDataValueException('prioritylist_index_invalid', $index, $priority);
+			throw new TInvalidDataValueException('prioritylist_index_invalid', $index, count($this->_d[$priority] ?? []), $priority);
 		}
 	}
 

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -139,7 +139,7 @@ class TPriorityList extends TList
 		if (($priority = $this->priorityAt($index, true)) !== false) {
 			$this->insertAtIndexInPriority($item, $priority[1], $priority[0]);
 		} else {
-			throw new TInvalidDataValueException('list_index_invalid', $index);
+			$this->insertAtIndexInPriority($item);
 		}
 	}
 
@@ -358,7 +358,7 @@ class TPriorityList extends TList
 	 */
 	public function priorityAt($index, $withindex = false)
 	{
-		if ($index < 0 || $index >= $this->getCount()) {
+		if ($index < 0 || $index >= max(1, $this->getCount())) {
 			throw new TInvalidDataValueException('list_index_invalid', $index);
 		}
 

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -138,8 +138,10 @@ class TPriorityList extends TList
 
 		if (($priority = $this->priorityAt($index, true)) !== false) {
 			$this->insertAtIndexInPriority($item, $priority[1], $priority[0]);
-		} else {
+		} elseif($index === $this->_c) {
 			$this->insertAtIndexInPriority($item);
+		} else {
+			throw new TInvalidDataValueException('list_index_invalid', $index);
 		}
 	}
 
@@ -358,19 +360,20 @@ class TPriorityList extends TList
 	 */
 	public function priorityAt($index, $withindex = false)
 	{
-		if ($index < 0 || $index > $this->getCount()) {
-			throw new TInvalidDataValueException('list_index_invalid', $index);
-		}
-
-		$absindex = $index;
-		$this->sortPriorities();
-		foreach (array_keys($this->_d) as $priority) {
-			if ($index >= ($c = count($this->_d[$priority]))) {
-				$index -= $c;
-			} else {
-				return $withindex ? [$priority, $index, $absindex,
-						'priority' => $priority, 'index' => $index, 'absindex' => $absindex, ] : $priority;
+		if (0 <= $index && $index <= $this->getCount()) {
+			$c = $absindex = $index;
+			$priority = null;
+			$this->sortPriorities();
+			foreach (array_keys($this->_d) as $priority) {
+				if ($index >= ($c = count($this->_d[$priority]))) {
+					$index -= $c;
+				} else {
+					return $withindex ? [$priority, $index, $absindex,
+							'priority' => $priority, 'index' => $index, 'absindex' => $absindex, ] : $priority;
+				}
 			}
+			return $withindex ? [$priority, $c, $absindex,
+					'priority' => $priority, 'index' => $c, 'absindex' => $absindex, ] : $priority;
 		}
 		return false;
 	}

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -138,8 +138,6 @@ class TPriorityList extends TList
 
 		if (($priority = $this->priorityAt($index, true)) !== false) {
 			$this->insertAtIndexInPriority($item, $priority[1], $priority[0]);
-		} elseif($index === $this->_c) {
-			$this->insertAtIndexInPriority($item);
 		} else {
 			throw new TInvalidDataValueException('list_index_invalid', $index);
 		}
@@ -170,12 +168,16 @@ class TPriorityList extends TList
 			$item->setPriority($priority);
 		}
 
-		if ($index === false && isset($this->_d[$priority])) {
-			$c = count($this->_d[$priority]);
-			$this->_d[$priority][] = $item;
-		} elseif (isset($this->_d[$priority])) {
-			$c = $index;
-			array_splice($this->_d[$priority], $index, 0, [$item]);
+		if (isset($this->_d[$priority])) {
+			if ($index === false) {
+				$c = count($this->_d[$priority]);
+				$this->_d[$priority][] = $item;
+			} elseif (0 <= $index && $index <= count($this->_d[$priority])) {
+				$c = $index;
+				array_splice($this->_d[$priority], $index, 0, [$item]);
+			} else {
+				throw new TInvalidDataValueException('prioritylist_index_invalid', $index, count($this->_d[$priority] ?? []), $priority);
+			}
 		} else {
 			$c = 0;
 			$this->_o = false;
@@ -194,7 +196,7 @@ class TPriorityList extends TList
 				}
 				array_splice($this->_fd, $c, 0, [$item]);
 			}
-		} elseif (!$preserveCache) {
+		} else {
 			if ($this->_fd !== null && count($this->_d) == 1) {
 				array_splice($this->_fd, $c, 0, [$item]);
 			} else {

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -334,13 +334,13 @@ class TPriorityList extends TList
 		$this->sortPriorities();
 
 		$absindex = 0;
-		foreach ($this->_d as $priority => $items) {
-			if (($index = array_search($item, $items, true)) !== false) {
+		foreach (array_keys($this->_d) as $priority) {
+			if (($index = array_search($item, $this->_d[$priority], true)) !== false) {
 				$absindex += $index;
 				return $withindex ? [$priority, $index, $absindex,
 						'priority' => $priority, 'index' => $index, 'absindex' => $absindex, ] : $priority;
 			} else {
-				$absindex += count($items);
+				$absindex += count($this->_d[$priority]);
 			}
 		}
 
@@ -364,8 +364,8 @@ class TPriorityList extends TList
 
 		$absindex = $index;
 		$this->sortPriorities();
-		foreach ($this->_d as $priority => $items) {
-			if ($index >= ($c = count($items))) {
+		foreach (array_keys($this->_d) as $priority) {
+			if ($index >= ($c = count($this->_d[$priority]))) {
 				$index -= $c;
 			} else {
 				return $withindex ? [$priority, $index, $absindex,

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -79,8 +79,8 @@ class TPriorityList extends TList
 	public function itemAt($index)
 	{
 		if ($index >= 0 && $index < $this->getCount()) {
-			$arr = $this->flattenPriorities();
-			return $arr[$index];
+			$this->flattenPriorities();
+			return $this->_fd[$index];
 		} else {
 			throw new TInvalidDataValueException('list_index_invalid', $index);
 		}
@@ -305,7 +305,8 @@ class TPriorityList extends TList
 	 */
 	public function indexOf($item)
 	{
-		if (($index = array_search($item, $this->flattenPriorities(), true)) === false) {
+		$this->flattenPriorities();
+		if (($index = array_search($item, $this->_fd, true)) === false) {
 			return -1;
 		} else {
 			return $index;

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -178,10 +178,12 @@ class TPriorityList extends TList
 			} else {
 				throw new TInvalidDataValueException('prioritylist_index_invalid', $index, count($this->_d[$priority] ?? []), $priority);
 			}
-		} else {
+		} elseif ($index === 0 || $index === false) {
 			$c = 0;
 			$this->_o = false;
 			$this->_d[$priority] = [$item];
+		} else {
+			throw new TInvalidDataValueException('prioritylist_index_invalid', $index, 0, $priority);
 		}
 
 		if ($preserveCache) {
@@ -278,7 +280,6 @@ class TPriorityList extends TList
 			throw new TInvalidDataValueException('list_item_inexistent');
 		}
 
-		// $value is an array of elements removed, only one
 		if ($index === $c - 1) {
 			$value = array_pop($this->_d[$priority]);
 		} else {
@@ -352,7 +353,9 @@ class TPriorityList extends TList
 	}
 
 	/**
-	 * Returns the priority of an item at a particular flattened index.
+	 * Returns the priority of an item at a particular flattened index.  The index after 
+	 * the last item does not exist but receives a priority from the last item so that
+	 * priority information about any new items being appended is available.
 	 * @param int $index index of the item within the list
 	 * @param bool $withindex this specifies if the full positional data of the item within the list is returned.
 	 * 		This defaults to false, if no parameter is provided, so only provides the priority number of the item by default.

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -365,7 +365,7 @@ class TPriorityList extends TList
 	 */
 	public function priorityAt($index, $withindex = false)
 	{
-		if (0 <= $index && $index <= $this->getCount()) {
+		if (0 <= $index && $index <= $this->_c) {
 			$c = $absindex = $index;
 			$priority = null;
 			$this->sortPriorities();
@@ -532,8 +532,7 @@ class TPriorityList extends TList
 			return;
 		}
 		if ($offset === $this->getCount()) {
-			$priority = $this->priorityAt($offset - 1, true);
-			$priority[1]++;
+			$priority = $this->priorityAt($offset, true);
 		} else {
 			$priority = $this->priorityAt($offset, true);
 			$this->removeAtIndexInPriority($priority[1], $priority[0]);

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -89,9 +89,9 @@ class TPriorityList extends TList
 	/**
 	 * Returns the item at an index within a priority
 	 * @param int $index the index into the list of items at priority
-	 * @param null|numeric $priority the priority which to index.  no parameter or null 
+	 * @param null|numeric $priority the priority which to index.  no parameter or null
 	 *   will result in the default priority
-	 * @throws TInvalidDataValueException if the index is out of the range at the 
+	 * @throws TInvalidDataValueException if the index is out of the range at the
 	 *   priority or no items at the priority.
 	 * @return mixed the element at the offset, false if no element is found at the offset
 	 */
@@ -353,7 +353,7 @@ class TPriorityList extends TList
 	}
 
 	/**
-	 * Returns the priority of an item at a particular flattened index.  The index after 
+	 * Returns the priority of an item at a particular flattened index.  The index after
 	 * the last item does not exist but receives a priority from the last item so that
 	 * priority information about any new items being appended is available.
 	 * @param int $index index of the item within the list

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -51,22 +51,7 @@ use Prado\TPropertyValue;
  */
 class TPriorityList extends TList
 {
-	/**
-	 * @var bool indicates if the _d is currently ordered.
-	 */
-	protected bool $_o = false;
-	/**
-	 * @var null|array cached flattened internal data storage
-	 */
-	protected ?array $_fd = null;
-	/**
-	 * @var numeric the default priority of items without specified priorities
-	 */
-	private $_dp = 10;
-	/**
-	 * @var int the precision of the numeric priorities within this priority list.
-	 */
-	private int $_p = 8;
+	use TPriorityCollectionTrait;
 
 	/**
 	 * Constructor.
@@ -83,121 +68,6 @@ class TPriorityList extends TList
 		$this->setDefaultPriority($defaultPriority);
 		parent::__construct($data, $readOnly);
 	}
-
-	/**
-	 * @return numeric gets the default priority of inserted items without a specified priority
-	 */
-	public function getDefaultPriority()
-	{
-		return $this->_dp;
-	}
-
-	/**
-	 * This must be called internally or when instantiated.
-	 * @param numeric $value sets the default priority of inserted items without a specified priority
-	 */
-	protected function setDefaultPriority($value)
-	{
-		$this->_dp = (string) round(TPropertyValue::ensureFloat($value), $this->_p);
-	}
-
-	/**
-	 * @return int The precision of numeric priorities, defaults to 8
-	 */
-	public function getPrecision(): int
-	{
-		return $this->_p;
-	}
-
-	/**
-	 * This must be called internally or when instantiated.
-	 * @param int $value The precision of numeric priorities.
-	 */
-	protected function setPrecision($value): void
-	{
-		$this->_p = TPropertyValue::ensureInteger($value);
-	}
-
-	/**
-	 * Taken an input Priority and ensures its value.
-	 * Sets the default $priority when none is set,
-	 * then rounds to the proper precision and makes
-	 * into a string.
-	 * @param mixed $priority
-	 * @return string the priority in string format
-	 */
-	protected function ensurePriority($priority): string
-	{
-		if ($priority === null || !is_numeric($priority)) {
-			$priority = $this->getDefaultPriority();
-		}
-		return (string) round((float) $priority, $this->_p);
-	}
-
-
-	/**
-	 * This orders the priority list internally.
-	 */
-	protected function sortPriorities(): void
-	{
-		if (!$this->_o) {
-			ksort($this->_d, SORT_NUMERIC);
-			$this->_o = true;
-		}
-	}
-
-	/**
-	 * This flattens the priority list into a flat array [0,...,n-1]
-	 * @return array array of items in the list in priority and index order
-	 */
-	protected function flattenPriorities(): array
-	{
-		if (is_array($this->_fd)) {
-			return $this->_fd;
-		}
-
-		$this->sortPriorities();
-		$this->_fd = [];
-		foreach ($this->_d as $priority => $itemsatpriority) {
-			$this->_fd = array_merge($this->_fd, $itemsatpriority);
-		}
-		return $this->_fd;
-	}
-
-	/**
-	 * This returns a list of the priorities within this list, ordered lowest to highest.
-	 * @return array the array of priority numerics in decreasing priority order
-	 */
-	public function getPriorities(): array
-	{
-		$this->sortPriorities();
-		return array_keys($this->_d);
-	}
-
-	/**
-	 * Gets the number of items at a priority within the list
-	 * @param null|numeric $priority optional priority at which to count items.  if no parameter, it will be set to the default {@link getDefaultPriority}
-	 * @return false|int the number of items in the list at the specified priority
-	 */
-	public function getPriorityCount($priority = null)
-	{
-		$priority = $this->ensurePriority($priority);
-		if (!isset($this->_d[$priority]) || !is_array($this->_d[$priority])) {
-			return false;
-		}
-		return count($this->_d[$priority]);
-	}
-
-	/**
-	 * Returns an iterator for traversing the items in the list.
-	 * This method is required by the interface \IteratorAggregate.
-	 * @return \Iterator an iterator for traversing the items in the list.
-	 */
-	public function getIterator(): \Iterator
-	{
-		return new \ArrayIterator($this->flattenPriorities());
-	}
-
 
 	/**
 	 * Returns the item at the index of a flattened priority list.
@@ -217,17 +87,6 @@ class TPriorityList extends TList
 	}
 
 	/**
-	 * Gets all the items at a specific priority.
-	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled in with the default priority, if left blank.
-	 * @return ?array all items at priority in index order, null if there are no items at that priority
-	 */
-	public function itemsAtPriority($priority = null): ?array
-	{
-		$priority = $this->ensurePriority($priority);
-		return $this->_d[$priority] ?? null;
-	}
-
-	/**
 	 * Returns the item at an index within a priority
 	 * @param int $index the index into the list of items at priority
 	 * @param numeric $priority the priority which to index.  no parameter or null will result in the default priority
@@ -236,9 +95,7 @@ class TPriorityList extends TList
 	public function itemAtIndexInPriority($index, $priority = null)
 	{
 		$priority = $this->ensurePriority($priority);
-		return !isset($this->_d[$priority]) ? false : (
-			$this->_d[$priority][$index] ?? false
-		);
+		return isset($this->_d[$priority]) ? 0 <= $index && $index < count($this->_d[$priority]) ? $this->_d[$priority][$index] : false : false;
 	}
 
 	/**
@@ -435,8 +292,8 @@ class TPriorityList extends TList
 			throw new TInvalidOperationException('list_readonly', $this::class);
 		}
 
-		foreach ($this->_d as $priority => $items) {
-			for ($index = count($items) - 1; $index >= 0; $index--) {
+		foreach (array_keys($this->_d) as $priority) {
+			for ($index = count($this->_d[$priority]) - 1; $index >= 0; $index--) {
 				$this->removeAtIndexInPriority($index, $priority);
 			}
 		}
@@ -461,7 +318,7 @@ class TPriorityList extends TList
 	 * @param bool $withindex this specifies if the full positional data of the item within the list is returned.
 	 * 		This defaults to false, if no parameter is provided, so only provides the priority number of the item by default.
 	 * @return array|false|numeric the priority of the item in the list, false if not found.
-	 *   if withindex is true, an array is returned of [0 => $priority, 1 => $priorityIndex, 2 => flattenedIndex,
+	 *   if $withindex is true, an array is returned of [0 => $priority, 1 => $priorityIndex, 2 => flattenedIndex,
 	 * 'priority' => $priority, 'index' => $priorityIndex, 'absindex' => flattenedIndex]
 	 */
 	public function priorityOf($item, $withindex = false)
@@ -483,12 +340,12 @@ class TPriorityList extends TList
 	}
 
 	/**
-	 * Retutrns the priority of an item at a particular flattened index.
+	 * Returns the priority of an item at a particular flattened index.
 	 * @param int $index index of the item within the list
 	 * @param bool $withindex this specifies if the full positional data of the item within the list is returned.
 	 * 		This defaults to false, if no parameter is provided, so only provides the priority number of the item by default.
 	 * @return array|false|numeric the priority of the item in the list, false if not found.
-	 *   if withindex is true, an array is returned of [0 => $priority, 1 => $priorityIndex, 2 => flattenedIndex,
+	 *   if $withindex is true, an array is returned of [0 => $priority, 1 => $priorityIndex, 2 => flattenedIndex,
 	 * 'priority' => $priority, 'index' => $priorityIndex, 'absindex' => flattenedIndex]
 	 */
 	public function priorityAt($index, $withindex = false)
@@ -557,64 +414,6 @@ class TPriorityList extends TList
 	}
 
 	/**
-	 * @return array the priority list of items in array
-	 */
-	public function toArray(): array
-	{
-		return $this->flattenPriorities();
-	}
-
-	/**
-	 * @return array the array of priorities keys with values of arrays of items.  The priorities are sorted so important priorities, lower numerics, are first.
-	 */
-	public function toPriorityArray(): array
-	{
-		$this->sortPriorities();
-		return $this->_d;
-	}
-
-	/**
-	 * Combines the map elements which have a priority below the parameter value
-	 * @param numeric $priority the cut-off priority.  All items of priority less than this are returned.
-	 * @param bool $inclusive whether or not the input cut-off priority is inclusive.  Default: false, not inclusive.
-	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
-	 *  The priorities are sorted so important priorities, lower numerics, are first.
-	 */
-	public function toArrayBelowPriority($priority, $inclusive = false): array
-	{
-		$this->sortPriorities();
-		$items = [];
-		foreach ($this->_d as $itemspriority => $itemsatpriority) {
-			if ((!$inclusive && $itemspriority >= $priority) || $itemspriority > $priority) {
-				break;
-			}
-			$items = array_merge($items, $itemsatpriority);
-		}
-		return $items;
-	}
-
-	/**
-	 * Combines the map elements which have a priority above the parameter value
-	 * @param numeric $priority the cut-off priority.  All items of priority greater than this are returned.
-	 * @param bool $inclusive whether or not the input cut-off priority is inclusive.  Default: true, inclusive.
-	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
-	 *  The priorities are sorted so important priorities, lower numerics, are first.
-	 */
-	public function toArrayAbovePriority($priority, $inclusive = true): array
-	{
-		$this->sortPriorities();
-		$items = [];
-		foreach ($this->_d as $itemspriority => $itemsatpriority) {
-			if ((!$inclusive && $itemspriority <= $priority) || $itemspriority < $priority) {
-				continue;
-			}
-			$items = array_merge($items, $itemsatpriority);
-		}
-		return $items;
-	}
-
-
-	/**
 	 * Copies iterable data into the priority list.
 	 * Note, existing data in the map will be cleared first.
 	 * @param mixed $data the data to be copied from, must be an array or object implementing Traversable
@@ -626,17 +425,28 @@ class TPriorityList extends TList
 			if ($this->getCount() > 0) {
 				$this->clear();
 			}
-			foreach ($data->getPriorities() as $priority) {
-				foreach ($data->itemsAtPriority($priority) as $index => $item) {
-					$this->insertAtIndexInPriority($item, $index, $priority);
+			$array = $data->toPriorityArray();
+			foreach (array_keys($array) as $priority) {
+				for ($i = 0, $c = count($array[$priority]); $i < $c; $i++) {
+					$this->insertAtIndexInPriority($array[$priority][$i], false, $priority);
+				}
+			}
+		} elseif ($data instanceof TPriorityMap) {
+			if ($this->getCount() > 0) {
+				$this->clear();
+			}
+			$array = $data->toPriorityArray();
+			foreach (array_keys($array) as $priority) {
+				foreach ($array[$priority] as $item) {
+					$this->insertAtIndexInPriority($item, false, $priority);
 				}
 			}
 		} elseif (is_array($data) || $data instanceof \Traversable) {
 			if ($this->getCount() > 0) {
 				$this->clear();
 			}
-			foreach ($data as $key => $item) {
-				$this->add($item);
+			foreach ($data as $item) {
+				$this->insertAtIndexInPriority($item);
 			}
 		} elseif ($data !== null) {
 			throw new TInvalidDataTypeException('map_data_not_iterable');
@@ -654,14 +464,22 @@ class TPriorityList extends TList
 	public function mergeWith($data): void
 	{
 		if ($data instanceof TPriorityList) {
-			foreach ($data->getPriorities() as $priority) {
-				foreach ($data->itemsAtPriority($priority) as $index => $item) {
+			$array = $data->toPriorityArray();
+			foreach (array_keys($array) as $priority) {
+				for ($i = 0, $c = count($array[$priority]); $i < $c; $i++) {
+					$this->insertAtIndexInPriority($array[$priority][$i], false, $priority);
+				}
+			}
+		} elseif ($data instanceof TPriorityMap) {
+			$array = $data->toPriorityArray();
+			foreach (array_keys($array) as $priority) {
+				foreach ($array[$priority] as $item) {
 					$this->insertAtIndexInPriority($item, false, $priority);
 				}
 			}
 		} elseif (is_array($data) || $data instanceof \Traversable) {
-			foreach ($data as $priority => $item) {
-				$this->add($item);
+			foreach ($data as $item) {
+				$this->insertAtIndexInPriority($item);
 			}
 		} elseif ($data !== null) {
 			throw new TInvalidDataTypeException('map_data_not_iterable');
@@ -728,15 +546,6 @@ class TPriorityList extends TList
 	protected function _getZappableSleepProps(&$exprops)
 	{
 		parent::_getZappableSleepProps($exprops);
-		if ($this->_o === false) {
-			$exprops[] = "\0*\0_o";
-		}
-		$exprops[] = "\0*\0_fd";
-		if ($this->_dp == 10) {
-			$exprops[] = "\0" . __CLASS__ . "\0_dp";
-		}
-		if ($this->_p === 8) {
-			$exprops[] = "\0" . __CLASS__ . "\0_p";
-		}
+		$this->_priorityZappableSleepProps($exprops);
 	}
 }

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -113,8 +113,8 @@ class TPriorityMap extends TMap
 	public function itemAt($key, $priority = false)
 	{
 		if ($priority === false) {
-			$map = $this->flattenPriorities();
-			return array_key_exists($key, $map) ? $map[$key] : $this->dyNoItem(null, $key);
+			$this->flattenPriorities();
+			return array_key_exists($key, $this->_fd) ? $this->_fd[$key] : $this->dyNoItem(null, $key);
 		} else {
 			$priority = $this->ensurePriority($priority);
 			return (isset($this->_d[$priority]) && array_key_exists($key, $this->_d[$priority])) ? $this->_d[$priority][$key] : $this->dyNoItem(null, $key);
@@ -293,8 +293,8 @@ class TPriorityMap extends TMap
 	 */
 	public function contains($key): bool
 	{
-		$map = $this->flattenPriorities();
-		return isset($map[$key]) || array_key_exists($key, $map);
+		$this->flattenPriorities();
+		return isset($this->_fd[$key]) || array_key_exists($key, $this->_fd);
 	}
 
 	/**

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -62,7 +62,7 @@ use Prado\TPropertyValue;
 class TPriorityMap extends TMap
 {
 	use TPriorityCollectionTrait;
-	
+
 	/**
 	 * @var int number of items contain within the map
 	 */
@@ -71,7 +71,7 @@ class TPriorityMap extends TMap
 	/**
 	 * Constructor.
 	 * Initializes the array with an array or an iterable object.
-	 * @param null|array|TPriorityMap|TPriorityList|\Traversable $data the initial data. Default is null, meaning no initialization.
+	 * @param null|array|TPriorityList|TPriorityMap|\Traversable $data the initial data. Default is null, meaning no initialization.
 	 * @param bool $readOnly whether the list is read-only
 	 * @param numeric $defaultPriority the default priority of items without specified priorities.
 	 * @param int $precision the precision of the numeric priorities
@@ -106,7 +106,7 @@ class TPriorityMap extends TMap
 	 * Returns the item with the specified key.  If a priority is specified, only items
 	 * within that specific priority will be selected.
 	 * @param mixed $key the key
-	 * @param false|null|numeric $priority the priority.  null is the default priority, false is any priority,
+	 * @param null|false|numeric $priority the priority.  null is the default priority, false is any priority,
 	 *    and numeric is a specific priority.  default: false, any priority.
 	 * @return mixed the element at the offset, null if no element is found at the offset
 	 */
@@ -300,7 +300,7 @@ class TPriorityMap extends TMap
 	/**
 	 * Copies iterable data into the map.
 	 * Note, existing data in the map will be cleared first.
-	 * @param array|TPriorityMap|TPriorityList|\Traversable $data the data to be copied from, must be an array, object implementing
+	 * @param array|TPriorityList|TPriorityMap|\Traversable $data the data to be copied from, must be an array, object implementing
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */
 	public function copyFrom($data): void
@@ -340,7 +340,7 @@ class TPriorityMap extends TMap
 	/**
 	 * Merges iterable data into the map.
 	 * Existing data in the map will be kept and overwritten if the keys are the same.
-	 * @param array|TPriorityMap|TPriorityList|\Traversable $data the data to be merged with, must be an array,
+	 * @param array|TPriorityList|TPriorityMap|\Traversable $data the data to be merged with, must be an array,
 	 * object implementing Traversable, or a TPriorityMap
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -61,31 +61,17 @@ use Prado\TPropertyValue;
  */
 class TPriorityMap extends TMap
 {
-	/**
-	 * @var bool indicates if the _d is currently ordered.
-	 */
-	protected bool $_o = false;
-	/**
-	 * @var null|array cached flattened internal data storage
-	 */
-	protected ?array $_fd = null;
+	use TPriorityCollectionTrait;
+	
 	/**
 	 * @var int number of items contain within the map
 	 */
 	protected int $_c = 0;
-	/**
-	 * @var numeric the default priority of items without specified priorities
-	 */
-	private $_dp = 10;
-	/**
-	 * @var int the precision of the numeric priorities within this priority list.
-	 */
-	private int $_p = 8;
 
 	/**
 	 * Constructor.
 	 * Initializes the array with an array or an iterable object.
-	 * @param null|array|TPriorityMap|\Traversable $data the intial data. Default is null, meaning no initialization.
+	 * @param null|array|TPriorityMap|TPriorityList|\Traversable $data the initial data. Default is null, meaning no initialization.
 	 * @param bool $readOnly whether the list is read-only
 	 * @param numeric $defaultPriority the default priority of items without specified priorities.
 	 * @param int $precision the precision of the numeric priorities
@@ -99,86 +85,6 @@ class TPriorityMap extends TMap
 	}
 
 	/**
-	 * @return numeric gets the default priority of inserted items without a specified priority
-	 */
-	public function getDefaultPriority()
-	{
-		return $this->_dp;
-	}
-
-	/**
-	 * This must be called internally or when instantiated.
-	 * @param numeric $value sets the default priority of inserted items without a specified priority
-	 */
-	protected function setDefaultPriority($value)
-	{
-		$this->_dp = (string) round(TPropertyValue::ensureFloat($value), $this->_p);
-	}
-
-	/**
-	 * @return int The precision of numeric priorities, defaults to 8
-	 */
-	public function getPrecision(): int
-	{
-		return $this->_p;
-	}
-
-	/**
-	 * This must be called internally or when instantiated.
-	 * @param int $value The precision of numeric priorities.
-	 */
-	protected function setPrecision($value): void
-	{
-		$this->_p = TPropertyValue::ensureInteger($value);
-	}
-
-	/**
-	 * Takes an input Priority and ensures its value.
-	 * Sets the default $priority when none is set,
-	 * then rounds to the proper precision and makes
-	 * into a string.
-	 * @param null|numeric $priority the priority to ensure
-	 * @return string the priority in string format
-	 */
-	protected function ensurePriority($priority): string
-	{
-		if ($priority === null || !is_numeric($priority)) {
-			$priority = $this->getDefaultPriority();
-		}
-		return (string) round((float) $priority, $this->_p);
-	}
-
-
-	/**
-	 * Orders the priority list internally.
-	 */
-	protected function sortPriorities()
-	{
-		if (!$this->_o) {
-			ksort($this->_d, SORT_NUMERIC);
-			$this->_o = true;
-		}
-	}
-
-	/**
-	 * This flattens the priority map into a flat array [0,...,n-1]
-	 * @return array array of items in the list in priority and index order
-	 */
-	protected function flattenPriorities(): array
-	{
-		if (is_array($this->_fd)) {
-			return $this->_fd;
-		}
-
-		$this->sortPriorities();
-		$this->_fd = [];
-		foreach ($this->_d as $priority => $itemsatpriority) {
-			$this->_fd = array_merge($this->_fd, $itemsatpriority);
-		}
-		return $this->_fd;
-	}
-
-	/**
 	 * @return int the number of items in the map
 	 */
 	public function getCount(): int
@@ -187,55 +93,21 @@ class TPriorityMap extends TMap
 	}
 
 	/**
-	 * This returns a list of the priorities within this map, ordered lowest to highest.
-	 * @return array the array of priority numerics in decreasing priority order
-	 */
-	public function getPriorities(): array
-	{
-		$this->sortPriorities();
-		return array_keys($this->_d);
-	}
-
-	/**
-	 * Gets the number of items at a priority within the map.
-	 * @param null|numeric $priority optional priority at which to count items.  if no parameter,
-	 * it will be set to the default {@link getDefaultPriority}
-	 * @return false|int the number of items in the map at the specified priority
-	 */
-	public function getPriorityCount($priority = null)
-	{
-		$priority = $this->ensurePriority($priority);
-		if (!isset($this->_d[$priority]) || !is_array($this->_d[$priority])) {
-			return false;
-		}
-		return count($this->_d[$priority]);
-	}
-
-	/**
-	 * Returns an iterator for traversing the items in the map.
-	 * This method is required by the interface \IteratorAggregate.
-	 * @return \Iterator an iterator for traversing the items in the map.
-	 */
-	public function getIterator(): \Iterator
-	{
-		return new \ArrayIterator($this->flattenPriorities());
-	}
-
-	/**
 	 * Returns the keys within the map ordered through the priority of each key-value pair
 	 * @return array the key list
 	 */
 	public function getKeys(): array
 	{
-		return array_keys($this->flattenPriorities());
+		$this->sortPriorities();
+		return array_merge(...array_map('array_keys', $this->_d));
 	}
 
 	/**
 	 * Returns the item with the specified key.  If a priority is specified, only items
-	 * within that specific priority will be selected
+	 * within that specific priority will be selected.
 	 * @param mixed $key the key
-	 * @param mixed $priority the priority.  null is the default priority, false is any priority,
-	 * and numeric is a specific priority.  default: false, any priority.
+	 * @param false|null|numeric $priority the priority.  null is the default priority, false is any priority,
+	 *    and numeric is a specific priority.  default: false, any priority.
 	 * @return mixed the element at the offset, null if no element is found at the offset
 	 */
 	public function itemAt($key, $priority = false)
@@ -268,26 +140,15 @@ class TPriorityMap extends TMap
 	}
 
 	/**
-	 * Gets all the items at a specific priority.
-	 * @param null|numeric $priority priority of the items to get.  Defaults to null, filled in with the default priority, if left blank.
-	 * @return ?array all items at priority in index order, null if there are no items at that priority
-	 */
-	public function itemsAtPriority($priority = null): ?array
-	{
-		$priority = $this->ensurePriority($priority);
-		return $this->_d[$priority] ?? null;
-	}
-
-	/**
 	 * Returns the priority of a particular item within the map.  This searches the map for the item.
 	 * @param mixed $item item to look for within the map
-	 * @return false|numeric priority of the item in the map
+	 * @return false|numeric priority of the item in the map.  False if not found.
 	 */
 	public function priorityOf($item)
 	{
 		$this->sortPriorities();
-		foreach ($this->_d as $priority => $items) {
-			if (($index = array_search($item, $items, true)) !== false) {
+		foreach (array_keys($this->_d) as $priority) {
+			if (($index = array_search($item, $this->_d[$priority], true)) !== false) {
 				return $priority;
 			}
 		}
@@ -295,15 +156,15 @@ class TPriorityMap extends TMap
 	}
 
 	/**
-	 * Retutrns the priority of an item at a particular flattened index.
-	 * @param int $key index of the item within the map
-	 * @return false|numeric priority of the item in the map
+	 * Returns the priority of an item at a particular key.  This searches the map for the item.
+	 * @param mixed $key index of the item within the map
+	 * @return false|numeric priority of the item in the map. False if not found.
 	 */
 	public function priorityAt($key)
 	{
 		$this->sortPriorities();
-		foreach ($this->_d as $priority => $items) {
-			if (array_key_exists($key, $items)) {
+		foreach (array_keys($this->_d) as $priority) {
+			if (array_key_exists($key, $this->_d[$priority])) {
 				return $priority;
 			}
 		}
@@ -321,7 +182,7 @@ class TPriorityMap extends TMap
 	 * @param mixed $value
 	 * @param null|numeric $priority default: null, filled in with default priority
 	 * @throws TInvalidOperationException if the map is read-only
-	 * @return numeric priority at which the pair was added
+	 * @return numeric priority at which the key-value pair was added
 	 */
 	public function add($key, $value, $priority = null)
 	{
@@ -335,8 +196,8 @@ class TPriorityMap extends TMap
 		}
 
 		if (!$this->getReadOnly()) {
-			foreach ($this->_d as $innerpriority => $items) {
-				if (array_key_exists($key, $items)) {
+			foreach (array_keys($this->_d) as $innerpriority) {
+				if (array_key_exists($key, $this->_d[$innerpriority])) {
 					unset($this->_d[$innerpriority][$key]);
 					$this->_c--;
 					if (count($this->_d[$innerpriority]) === 0) {
@@ -377,8 +238,8 @@ class TPriorityMap extends TMap
 		if (!$this->getReadOnly()) {
 			if ($priority === false) {
 				$this->sortPriorities();
-				foreach ($this->_d as $priority => $items) {
-					if (array_key_exists($key, $items)) {
+				foreach (array_keys($this->_d) as $priority) {
+					if (array_key_exists($key, $this->_d[$priority])) {
 						$value = $this->_d[$priority][$key];
 						unset($this->_d[$priority][$key]);
 						$this->_c--;
@@ -419,8 +280,8 @@ class TPriorityMap extends TMap
 	 */
 	public function clear(): void
 	{
-		foreach ($this->_d as $priority => $items) {
-			foreach (array_keys($items) as $key) {
+		foreach (array_keys($this->_d) as $priority) {
+			foreach (array_keys($this->_d[$priority]) as $key) {
 				$this->remove($key);
 			}
 		}
@@ -437,60 +298,9 @@ class TPriorityMap extends TMap
 	}
 
 	/**
-	 * When the map is flattened into an array, the priorities are taken into
-	 * account and elements of the map are ordered in the array according to
-	 * their priority.
-	 * @return array the list of items in array
-	 */
-	public function toArray(): array
-	{
-		return $this->flattenPriorities();
-	}
-
-	/**
-	 * Combines the map elements which have a priority below the parameter value
-	 * @param numeric $priority the cut-off priority.  All items of priority less than this are returned.
-	 * @param bool $inclusive whether or not the input cut-off priority is inclusive.  Default: false, not inclusive.
-	 * @return array the array of priorities keys with values of arrays of items that are below a specified priority.
-	 *  The priorities are sorted so important priorities, lower numerics, are first.
-	 */
-	public function toArrayBelowPriority($priority, $inclusive = false): array
-	{
-		$this->sortPriorities();
-		$items = [];
-		foreach ($this->_d as $itemspriority => $itemsatpriority) {
-			if ((!$inclusive && $itemspriority >= $priority) || $itemspriority > $priority) {
-				break;
-			}
-			$items = array_merge($items, $itemsatpriority);
-		}
-		return $items;
-	}
-
-	/**
-	 * Combines the map elements which have a priority above the parameter value
-	 * @param numeric $priority the cut-off priority.  All items of priority greater than this are returned.
-	 * @param bool $inclusive whether or not the input cut-off priority is inclusive.  Default: true, inclusive.
-	 * @return array the array of priorities keys with values of arrays of items that are above a specified priority.
-	 *  The priorities are sorted so important priorities, lower numerics, are first.
-	 */
-	public function toArrayAbovePriority($priority, $inclusive = true): array
-	{
-		$this->sortPriorities();
-		$items = [];
-		foreach ($this->_d as $itemspriority => $itemsatpriority) {
-			if ((!$inclusive && $itemspriority <= $priority) || $itemspriority < $priority) {
-				continue;
-			}
-			$items = array_merge($items, $itemsatpriority);
-		}
-		return $items;
-	}
-
-	/**
 	 * Copies iterable data into the map.
 	 * Note, existing data in the map will be cleared first.
-	 * @param array|TPriorityMap|\Traversable $data the data to be copied from, must be an array, object implementing
+	 * @param array|TPriorityMap|TPriorityList|\Traversable $data the data to be copied from, must be an array, object implementing
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */
 	public function copyFrom($data): void
@@ -502,6 +312,17 @@ class TPriorityMap extends TMap
 			foreach ($data->getPriorities() as $priority) {
 				foreach ($data->itemsAtPriority($priority) as $key => $value) {
 					$this->add($key, $value, $priority);
+				}
+			}
+		} elseif ($data instanceof TPriorityList) {
+			if ($this->getCount() > 0) {
+				$this->clear();
+			}
+			$index = 0;
+			$array = $data->toPriorityArray();
+			foreach (array_keys($array) as $priority) {
+				for ($i = 0, $c = count($array[$priority]); $i < $c; $i++) {
+					$this->add($index++, $array[$priority][$i], $priority);
 				}
 			}
 		} elseif (is_array($data) || $data instanceof \Traversable) {
@@ -519,7 +340,7 @@ class TPriorityMap extends TMap
 	/**
 	 * Merges iterable data into the map.
 	 * Existing data in the map will be kept and overwritten if the keys are the same.
-	 * @param array|TPriorityMap|\Traversable $data the data to be merged with, must be an array,
+	 * @param array|TPriorityMap|TPriorityList|\Traversable $data the data to be merged with, must be an array,
 	 * object implementing Traversable, or a TPriorityMap
 	 * @throws TInvalidDataTypeException If data is neither an array nor an iterator.
 	 */
@@ -529,6 +350,14 @@ class TPriorityMap extends TMap
 			foreach ($data->getPriorities() as $priority) {
 				foreach ($data->itemsAtPriority($priority) as $key => $value) {
 					$this->add($key, $value, $priority);
+				}
+			}
+		} elseif ($data instanceof TPriorityList) {
+			$index = 0;
+			$array = $data->toPriorityArray();
+			foreach (array_keys($array) as $priority) {
+				for ($i = 0, $c = count($array[$priority]); $i < $c; $i++) {
+					$this->add($index++, $array[$priority][$i], $priority);
 				}
 			}
 		} elseif (is_array($data) || $data instanceof \Traversable) {
@@ -551,18 +380,6 @@ class TPriorityMap extends TMap
 	protected function _getZappableSleepProps(&$exprops)
 	{
 		parent::_getZappableSleepProps($exprops);
-		if ($this->_o === false) {
-			$exprops[] = "\0*\0_o";
-		}
-		$exprops[] = "\0*\0_fd";
-		if ($this->_c === 0) {
-			$exprops[] = "\0*\0_c";
-		}
-		if ($this->_dp == 10) {
-			$exprops[] = "\0" . __CLASS__ . "\0_dp";
-		}
-		if ($this->_p === 8) {
-			$exprops[] = "\0" . __CLASS__ . "\0_p";
-		}
+		$this->_priorityZappableSleepProps($exprops);
 	}
 }

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -127,22 +127,21 @@ class TWeakCallableCollection extends TPriorityList
 	/**
 	 * This flattens the priority list into a flat array [0,...,n-1]. This is needed to filter the output.
 	 * @return array array of items in the list in priority and index order
-	 */
+	 *
 	protected function flattenPriorities(): array
 	{
 		return $this->filterItemsForOutput(parent::flattenPriorities());
 	}
-
+	
 	/**
-	 * This flattens the priority list into a flat array [0,...,n-1], but
-	 * leaves the objects in the array as WeakReference rather than standard
-	 * callable.
-	 * @return array array of items in the list in priority and index order,
-	 *    where objects are WeakReference
+	 * Returns an iterator for traversing the items in the list.
+	 * This method is required by the interface \IteratorAggregate.
+	 * @return \Iterator an iterator for traversing the items in the list.
 	 */
-	protected function flattenPrioritiesWeak(): array
+	public function getIterator(): \Iterator
 	{
-		return parent::flattenPriorities();
+		$this->flattenPriorities();
+		return new \ArrayIterator($this->filterItemsForOutput($this->_fd));
 	}
 
 
@@ -156,8 +155,8 @@ class TWeakCallableCollection extends TPriorityList
 	public function itemAt($index)
 	{
 		if ($index >= 0 && $index < $this->getCount()) {
-			$arr = $this->flattenPrioritiesWeak();
-			return $this->filterItemForOutput($arr[$index]);
+			parent::flattenPriorities();
+			return $this->filterItemForOutput($this->_fd[$index]);
 		} else {
 			throw new TInvalidDataValueException('list_index_invalid', $index);
 		}
@@ -226,7 +225,8 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	public function indexOf($item)
 	{
-		if (($index = array_search($this->filterItemForInput($item), $this->flattenPrioritiesWeak(), true)) === false) {
+		parent::flattenPriorities();
+		if (($index = array_search($this->filterItemForInput($item), $this->_fd, true)) === false) {
 			return -1;
 		} else {
 			return $index;
@@ -245,6 +245,15 @@ class TWeakCallableCollection extends TPriorityList
 	public function priorityOf($item, $withindex = false)
 	{
 		return parent::priorityOf($this->filterItemForInput($item), $withindex);
+	}
+	
+	/**
+	 * @return array the priority list of items in array
+	 */
+	public function toArray(): array
+	{
+		$this->flattenPriorities();
+		return $this->filterItemsForOutput($this->_fd);
 	}
 
 	/**

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -125,18 +125,10 @@ class TWeakCallableCollection extends TPriorityList
 	}
 
 	/**
-	 * This flattens the priority list into a flat array [0,...,n-1]. This is needed to filter the output.
-	 * @return array array of items in the list in priority and index order
-	 *
-	protected function flattenPriorities(): array
-	{
-		return $this->filterItemsForOutput(parent::flattenPriorities());
-	}
-	
-	/**
 	 * Returns an iterator for traversing the items in the list.
 	 * This method is required by the interface \IteratorAggregate.
 	 * @return \Iterator an iterator for traversing the items in the list.
+	 * since 4.2.3
 	 */
 	public function getIterator(): \Iterator
 	{
@@ -246,9 +238,10 @@ class TWeakCallableCollection extends TPriorityList
 	{
 		return parent::priorityOf($this->filterItemForInput($item), $withindex);
 	}
-	
+
 	/**
 	 * @return array the priority list of items in array
+	 * @since 4.2.3
 	 */
 	public function toArray(): array
 	{

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -25,7 +25,7 @@ list_index_invalid						= Index '{0}' is out of range.
 list_item_inexistent					= The item cannot be found in the list.
 list_data_not_iterable					= Data must be either an array or an object implementing Traversable interface.
 list_readonly							= {0} is read-only.
-prioritylist_index_invalid				= Index '{0}' at Priority '{1}' is out of range.
+prioritylist_index_invalid				= Index '{0}' of '{1}' at Priority '{2}' is out of range.
 
 map_addition_disallowed					= The new item cannot be added to the map.
 map_item_unremovable					= The item cannot be removed from the map.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -25,6 +25,7 @@ list_index_invalid						= Index '{0}' is out of range.
 list_item_inexistent					= The item cannot be found in the list.
 list_data_not_iterable					= Data must be either an array or an object implementing Traversable interface.
 list_readonly							= {0} is read-only.
+prioritylist_index_invalid				= Index '{0}' at Priority '{1}' is out of range.
 
 map_addition_disallowed					= The new item cannot be added to the map.
 map_item_unremovable					= The item cannot be removed from the map.

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -45,6 +45,8 @@ return [
 'TQueueIterator' => 'Prado\Collections\TQueueIterator',
 'TStack' => 'Prado\Collections\TStack',
 'TWeakCallableCollection' => 'Prado\Collections\TWeakCallableCollection',
+'TWeakCollectionTrait' => 'Prado\Collections\TWeakCollectionTrait',
+'TWeakList' => 'Prado\Collections\TWeakList',
 'TActiveRecordConfigurationException' => 'Prado\Data\ActiveRecord\Exceptions\TActiveRecordConfigurationException',
 'TActiveRecordException' => 'Prado\Data\ActiveRecord\Exceptions\TActiveRecordException',
 'TActiveRecordBelongsTo' => 'Prado\Data\ActiveRecord\Relations\TActiveRecordBelongsTo',

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -39,6 +39,7 @@ return [
 'TPagedListIterator' => 'Prado\Collections\TPagedListIterator',
 'TPagedListPageChangedEventParameter' => 'Prado\Collections\TPagedListPageChangedEventParameter',
 'TPagedMapIterator' => 'Prado\Collections\TPagedMapIterator',
+'TPriorityCollectionTrait' => 'Prado\Collections\TPriorityCollectionTrait',
 'TPriorityList' => 'Prado\Collections\TPriorityList',
 'TPriorityMap' => 'Prado\Collections\TPriorityMap',
 'TQueue' => 'Prado\Collections\TQueue',

--- a/tests/unit/Collections/TListTest.php
+++ b/tests/unit/Collections/TListTest.php
@@ -22,6 +22,9 @@ class TListTest extends PHPUnit\Framework\TestCase
 	protected $item3;
 	protected $item4;
 	
+	protected $_baseClass;
+	protected $_baseItemClass;
+	
 	protected function newList()
 	{
 		return  'TList';
@@ -34,8 +37,6 @@ class TListTest extends PHPUnit\Framework\TestCase
 	{
 		return true;
 	}
-	protected $_baseClass;
-	protected $_baseItemClass;
 
 	protected function setUp(): void
 	{

--- a/tests/unit/Collections/TMapTest.php
+++ b/tests/unit/Collections/TMapTest.php
@@ -10,6 +10,12 @@ use Prado\Util\TBehavior;
 class TMapTest_MapItem
 {
 	public $data = 'data';
+	
+	public function __construct($d = null)
+	{
+		if($d !== null)
+			$this->data = $d;
+	}
 }
 
 class TMapTestBehavior extends TBehavior implements IDynamicMethods
@@ -41,13 +47,28 @@ class TMapTest extends PHPUnit\Framework\TestCase
 	protected $item1;
 	protected $item2;
 	protected $item3;
+	
+	protected $_baseClass;
+	protected $_baseItemClass;
 
+	protected function newList()
+	{
+		return  TMap::class;
+	}
+	protected function newListItem()
+	{
+		return TMapTest_MapItem::class;
+	}
+	
 	protected function setUp(): void
 	{
-		$this->map = new TMap;
-		$this->item1 = new TMapTest_MapItem;
-		$this->item2 = new TMapTest_MapItem;
-		$this->item3 = new TMapTest_MapItem;
+		$this->_baseClass = $this->newList();
+		$this->_baseItemClass = $this->newListItem();
+		
+		$this->map = new $this->_baseClass();
+		$this->item1 = new $this->_baseItemClass(1);
+		$this->item2 = new $this->_baseItemClass(2);
+		$this->item3 = new $this->_baseItemClass(3);
 		$this->map->add('key1', $this->item1);
 		$this->map->add('key2', $this->item2);
 	}

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -1031,7 +1031,8 @@ class TPriorityListTest extends TListTest
 				$found++;
 			}
 		}
-		$this->assertTrue($n == 4 && $found == 4);
+		$this->assertTrue($n == 4, "Not 4 items in the list.");
+		$this->assertTrue($found == 4, "$found of 4 items were in the list.");
 	}
 
 	public function testArrayMiscTPriorityList()

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -328,6 +328,9 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals($this->pitem1, $this->plist->itemAtIndexInPriority(0, $this->plist->getDefaultPriority()));
 		$this->assertEquals($this->pfirst, $this->plist->itemAtIndexInPriority(0, -10000000));
 		$this->assertEquals($this->pitem3, $this->plist->itemAtIndexInPriority(0, 100));
+		
+		self::expectException(TInvalidDataValueException::class);
+		$this->plist->itemAtIndexInPriority(2);
 	}
 
 

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -254,8 +254,11 @@ class TPriorityListTest extends TListTest
 		$plist = new $this->_baseClass($this->plist);
 		$this->assertNull($plist->insertAt(0, $this->pitem3));
 		$this->assertEquals(-10000000, $plist->priorityAt(0));
-
 		$this->assertEquals(100, $plist->priorityAt(4));
+		
+		$plist = new $this->_baseClass();
+		$this->assertNull($plist->insertAt(0, $this->pitem3));
+		$this->assertEquals($this->pitem3, $plist->itemAt(0));
 
 		self::expectException(TInvalidDataValueException::class);
 		$plist->insertAt(5, $this->pitem3);

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -2,6 +2,7 @@
 
 use Prado\Collections\IPriorityItem;
 use Prado\Collections\TPriorityList;
+use Prado\Collections\TPriorityMap;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Exceptions\TInvalidOperationException;
@@ -777,39 +778,128 @@ class TPriorityListTest extends TListTest
 
 	public function testCopyFromTPriorityList()
 	{
-		$plist = new $this->_baseClass();
-		$plist->copyFrom($this->plist);
-		$this->assertEquals(0, $plist->indexOf($this->pfirst));
-		$this->assertEquals(1, $plist->indexOf($this->pitem1));
-		$this->assertEquals(2, $plist->indexOf($this->pitem2));
-		$this->assertEquals(3, $plist->indexOf($this->pitem3));
-		$this->assertEquals(-10000000, $plist->priorityOf($this->pfirst));
-		$this->assertEquals(10, $plist->priorityOf($this->pitem1));
-		$this->assertEquals(10, $plist->priorityOf($this->pitem2));
-		$this->assertEquals(100, $plist->priorityOf($this->pitem3));
-		$this->assertEquals(-1, $plist->indexOf($this->pitem4));
+		// Copy from TPriorityList
+		$pfirst = new $this->_baseItemClass(-10000);
+		$pitem1 = new $this->_baseItemClass(-1);
+		$pitem2 = new $this->_baseItemClass(-2);
+		$pitem3 = new $this->_baseItemClass(-3);
+		
+		$plist = new TPriorityList();
+		$plist->add($pitem3, 100);
+		$plist->add($pitem1);
+		$plist->add($pfirst, -10000000);
+		$plist->add($pitem2);
+		
+		$this->plist->copyFrom($plist);
+		$this->assertEquals($plist->getCount(), $this->plist->getCount());
+		$this->assertEquals(0, $this->plist->indexOf($pfirst));
+		$this->assertEquals(1, $this->plist->indexOf($pitem1));
+		$this->assertEquals(2, $this->plist->indexOf($pitem2));
+		$this->assertEquals(3, $this->plist->indexOf($pitem3));
+		$this->assertEquals(-10000000, $this->plist->priorityOf($pfirst));
+		$this->assertEquals(10, $this->plist->priorityOf($pitem1));
+		$this->assertEquals(10, $this->plist->priorityOf($pitem2));
+		$this->assertEquals(100, $this->plist->priorityOf($pitem3));
+		$this->assertEquals(-1, $this->plist->indexOf($this->pitem1));
+		
+		// Copy from TPriorityMap
+		$map = new TPriorityMap();
+		$map->add('key3', $this->pitem3, 100);
+		$map->add('key1', $this->pitem1);
+		$map->add('key0', $this->pfirst, -10000000);
+		$map->add('key2', $this->pitem2);
+		$this->plist->copyFrom($map);
+		$this->assertEquals($map->getCount(), $this->plist->getCount());
+		$this->assertEquals(0, $this->plist->indexOf($this->pfirst));
+		$this->assertEquals(1, $this->plist->indexOf($this->pitem1));
+		$this->assertEquals(2, $this->plist->indexOf($this->pitem2));
+		$this->assertEquals(3, $this->plist->indexOf($this->pitem3));
+		$this->assertEquals(-10000000, $this->plist->priorityOf($this->pfirst));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem1));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem2));
+		$this->assertEquals(100, $this->plist->priorityOf($this->pitem3));
+		$this->assertEquals(-1, $this->plist->indexOf($pitem1));
+		
+		// copy from Traversable
+		$this->plist->copyFrom(['a' => $this->pitem1, 10 => $this->pitem2]);
+		$this->assertEquals(2, $this->plist->getCount());
+		$this->assertEquals(0, $this->plist->indexOf($this->pitem1));
+		$this->assertEquals(1, $this->plist->indexOf($this->pitem2));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem1));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem2));
+		
+		self::expectException(TInvalidDataTypeException::class);
+		$this->plist->copyFrom($this);
 	}
 
 	public function testMergeWithTPriorityList()
 	{
-		$plist = new $this->_baseClass([
-			$this->item3, $this->item1
-		]);
-		$plist->mergeWith($this->plist);
-		$this->assertEquals(6, $plist->getCount());
-		$this->assertEquals(0, $plist->indexOf($this->pfirst));
-		$this->assertEquals(1, $plist->indexOf($this->item3));
-		$this->assertEquals(2, $plist->indexOf($this->item1));
-		$this->assertEquals(3, $plist->indexOf($this->pitem1));
-		$this->assertEquals(4, $plist->indexOf($this->pitem2));
-		$this->assertEquals(5, $plist->indexOf($this->pitem3));
-		$this->assertEquals(-10000000, $plist->priorityOf($this->pfirst));
-		$this->assertEquals(10, $plist->priorityOf($this->item3));
-		$this->assertEquals(10, $plist->priorityOf($this->item1));
+		// Merge TPriorityList
+		$plist = new TPriorityList();
+		$plist->add($this->item3, 5);
+		$plist->add($this->item1, 15);
+		$this->plist->mergeWith($plist);
+		$this->assertEquals(6, $this->plist->getCount());
+		$this->assertEquals(0, $this->plist->indexOf($this->pfirst));
+		$this->assertEquals(1, $this->plist->indexOf($this->item3));
+		$this->assertEquals(2, $this->plist->indexOf($this->pitem1));
+		$this->assertEquals(3, $this->plist->indexOf($this->pitem2));
+		$this->assertEquals(4, $this->plist->indexOf($this->item1));
+		$this->assertEquals(5, $this->plist->indexOf($this->pitem3));
+		$this->assertEquals(-10000000, $this->plist->priorityOf($this->pfirst));
+		$this->assertEquals(5, $this->plist->priorityOf($this->item3));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem1));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem2));
+		$this->assertEquals(15, $this->plist->priorityOf($this->item1));
+		$this->assertEquals(100, $this->plist->priorityOf($this->pitem3));
+		$this->assertEquals(-1, $this->plist->indexOf($this->pitem4));
+		
+		// Merge Traversable
+		$plist->mergeWith([100 => $this->pitem1, 10 => $this->pitem2]);
+		$this->assertEquals(4, $plist->getCount());
+		$this->assertEquals(0, $plist->indexOf($this->item3));
+		$this->assertEquals(1, $plist->indexOf($this->pitem1));
+		$this->assertEquals(2, $plist->indexOf($this->pitem2));
+		$this->assertEquals(3, $plist->indexOf($this->item1));
+		$this->assertEquals(5, $plist->priorityOf($this->item3));
 		$this->assertEquals(10, $plist->priorityOf($this->pitem1));
 		$this->assertEquals(10, $plist->priorityOf($this->pitem2));
-		$this->assertEquals(100, $plist->priorityOf($this->pitem3));
-		$this->assertEquals(-1, $plist->indexOf($this->pitem4));
+		$this->assertEquals(15, $plist->priorityOf($this->item1));
+		
+		// Merge TPriorityMap, drops keys and keeps priority
+		$item1 = new $this->_baseItemClass(-1);
+		$item2 = new $this->_baseItemClass(-2);
+		$item3 = new $this->_baseItemClass(-3);
+		$map = new TPriorityMap();
+		$map->add('key3', $item3, 15);
+		$map->add('key1', $item1, 5);
+		$map->add('key2', $item2, 10);
+		$this->plist->mergeWith($map);
+		$this->assertEquals(9, $this->plist->getCount());
+		$this->assertEquals(-10000000, $this->plist->priorityOf($this->pfirst));
+		$this->assertEquals(5, $this->plist->priorityOf($this->item3));
+		$this->assertEquals(5, $this->plist->priorityOf($item1));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem1));
+		$this->assertEquals(10, $this->plist->priorityOf($this->pitem2));
+		$this->assertEquals(10, $this->plist->priorityOf($item2));
+		$this->assertEquals(15, $this->plist->priorityOf($this->item1));
+		$this->assertEquals(15, $this->plist->priorityOf($item3));
+		$this->assertEquals(100, $this->plist->priorityOf($this->pitem3));
+		
+		$this->assertEquals(0, $this->plist->indexOf($this->pfirst));
+		$this->assertEquals(1, $this->plist->indexOf($this->item3));
+		$this->assertEquals(2, $this->plist->indexOf($item1));
+		$this->assertEquals(3, $this->plist->indexOf($this->pitem1));
+		$this->assertEquals(4, $this->plist->indexOf($this->pitem2));
+		$this->assertEquals(5, $this->plist->indexOf($item2));
+		$this->assertEquals(6, $this->plist->indexOf($this->item1));
+		$this->assertEquals(7, $this->plist->indexOf($item3));
+		$this->assertEquals(8, $this->plist->indexOf($this->pitem3));
+		
+		$this->assertEquals(-1, $this->plist->indexOf($this->pitem4));
+		
+		self::expectException(TInvalidDataTypeException::class);
+		$this->plist->mergeWith($this);
 	}
 
 	public function testToArrayTPriorityList()

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -257,10 +257,17 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals(100, $plist->priorityAt(4));
 		
 		$plist = new $this->_baseClass();
-		$this->assertNull($plist->insertAt(0, $this->pitem3));
-		$this->assertEquals($this->pitem3, $plist->itemAt(0));
-		$this->assertNull($plist->insertAt(1, $this->pitem4));
-		$this->assertEquals($this->pitem3, $plist->itemAt(0));
+		$this->assertNull($plist->insertAt(0, $this->pitem1));
+		$this->assertEquals($this->pitem1, $plist->itemAt(0));
+		$this->assertEquals(10, $plist->priorityOf($this->pitem1));
+		$plist->add($this->pitem4, 20);
+		$this->assertNull($plist->insertAt(1, $this->pitem2));
+		$this->assertEquals($this->pitem1, $plist->itemAt(0));
+		$this->assertEquals($this->pitem2, $plist->itemAt(1));
+		$this->assertEquals(20, $plist->priorityOf($this->pitem2));
+		$this->assertNull($plist->insertAt(3, $this->pitem3));
+		$this->assertEquals(20, $plist->priorityOf($this->pitem3));
+		$this->assertEquals(20, $plist->priorityAt(3));
 
 		self::expectException(TInvalidDataValueException::class);
 		$plist->insertAt(5, $this->pitem3);
@@ -361,7 +368,13 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3
 		], $plist->toArray());
-		$plist->insertAtIndexInPriority($this->pitem4, 5, null);
+		
+		try {	// Out of range index/priority
+			$plist->insertAtIndexInPriority($this->pitem4, 5, null);
+			$this->fail("failed to assert TInvalidDataValueException when inserting at index out of range for priority.");
+		} catch(TInvalidDataValueException $e){
+		}
+		$plist->insertAtIndexInPriority($this->pitem4, 4, null);
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4
 		], $plist->toArray());
@@ -370,7 +383,7 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5
 		], $plist->toArray());
-		$plist->insertAtIndexInPriority($this->item1, 7, 10);
+		$plist->insertAtIndexInPriority($this->item1, 6, 10);
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5, $this->item1
 		], $plist->toArray());
@@ -406,7 +419,7 @@ class TPriorityListTest extends TListTest
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3
 		], $plist->toArray());
 
-		$plist->insertAtIndexInPriority($this->pitem4, 5, null, true);
+		$plist->insertAtIndexInPriority($this->pitem4, 4, null, true);
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4
 		], $plist->toArray());
@@ -416,7 +429,7 @@ class TPriorityListTest extends TListTest
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5
 		], $plist->toArray());
 
-		$plist->insertAtIndexInPriority($this->item1, 7, 10, true);
+		$plist->insertAtIndexInPriority($this->item1, 6, 10, true);
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5, $this->item1
 		], $plist->toArray());
@@ -430,8 +443,9 @@ class TPriorityListTest extends TListTest
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5, $this->item1, $this->item2, $this->item3
 		], $plist->toArray());
 
-		$plist = new $this->_baseClass();
 
+
+		$plist = new $this->_baseClass();
 		$plist->insertAtIndexInPriority($this->pfirst, false, null, false);
 		$this->assertEquals([
 			$this->pfirst
@@ -450,7 +464,7 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3
 		], $plist->toArray());
-		$plist->insertAtIndexInPriority($this->pitem4, 5, null, false);
+		$plist->insertAtIndexInPriority($this->pitem4, 4, null, false);
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4
 		], $plist->toArray());
@@ -459,7 +473,7 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5
 		], $plist->toArray());
-		$plist->insertAtIndexInPriority($this->item1, 7, 10, false);
+		$plist->insertAtIndexInPriority($this->item1, 6, 10, false);
 		$this->assertEquals([
 			$this->pfirst, $this->pitem1, $this->pitem2, $this->pitem3, $this->pitem4, $this->pitem5, $this->item1
 		], $plist->toArray());

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -259,6 +259,8 @@ class TPriorityListTest extends TListTest
 		$plist = new $this->_baseClass();
 		$this->assertNull($plist->insertAt(0, $this->pitem3));
 		$this->assertEquals($this->pitem3, $plist->itemAt(0));
+		$this->assertNull($plist->insertAt(1, $this->pitem4));
+		$this->assertEquals($this->pitem3, $plist->itemAt(0));
 
 		self::expectException(TInvalidDataValueException::class);
 		$plist->insertAt(5, $this->pitem3);

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -80,12 +80,6 @@ class PriorityPropertyListItem extends PriorityListItem implements IPriorityProp
  */
 class TPriorityListTest extends TListTest
 {
-	protected $list;
-	protected $item1;
-	protected $item2;
-	protected $item3;
-	protected $item4;
-
 	protected $plist;
 	protected $pfirst;
 	protected $pitem1;
@@ -132,11 +126,7 @@ class TPriorityListTest extends TListTest
 
 	protected function tearDown(): void
 	{
-		$this->list = null;
-		$this->item1 = null;
-		$this->item2 = null;
-		$this->item3 = null;
-		$this->item4 = null;
+		parent::tearDown();
 
 		// ****  start the setup for non-TList things
 		$this->plist = null;
@@ -321,9 +311,11 @@ class TPriorityListTest extends TListTest
 	{
 		$plist = new $this->_baseClass($this->plist);
 
+		$this->assertEquals(4, $plist->getCount());
 		$this->assertEquals($this->pitem1, $plist->removeAt(1));
+		$this->assertEquals(3, $plist->getCount());
 		$this->assertEquals(-1, $plist->indexOf($this->pitem1));
-		$this->assertEquals(1, $plist->indexOf($this->pitem2));
+		$this->assertEquals(1, $plist->indexOf($this->pitem2), 'Item 2 was not in the list.');
 		$this->assertEquals(0, $plist->indexOf($this->pfirst));
 
 		self::expectException(TInvalidDataValueException::class);

--- a/tests/unit/Collections/TWeakCallableCollectionTest.php
+++ b/tests/unit/Collections/TWeakCallableCollectionTest.php
@@ -9,9 +9,10 @@ use Prado\Exceptions\TPhpErrorException;
 class CallableListItem
 {
 	public $data = 'data';
-	public function __construct($d)
+	public function __construct($d = null)
 	{
-		$this->data = $d;
+		if ($d !== null)
+			$this->data = $d;
 	}
 	public function eventHandler($sender, $param)
 	{

--- a/tests/unit/Collections/TWeakListTest.php
+++ b/tests/unit/Collections/TWeakListTest.php
@@ -91,6 +91,10 @@ class TWeakListTest extends TListTest
 	-		offsetUnset (calls $this->removeAt)
 	-*	 #	_getZappableSleepProps
 	
+		 #	Test Closures are not made WeakReference (they are not lost if the only anonymous function).
+		 #	Test arrays as items have their objects made WeakReference and back.
+		 #	Test changing [set]DiscardInvalid by children, adding objects to WeakMap and scrubbing.
+	
 	*/
 	
 	public function testConstructTWeakList()


### PR DESCRIPTION
This adds the TPriorityCollectionTrait to simply the TPriorityList/Map classes.

TPriorityList is made more efficient in reducing variable/array copying and has better error checking.  This also adds support for copyFrom and MergeWith of TPriorityMap; where the keys are dropped and put in the order given.

TPriorityMap is made more efficient in reducing variable/array copying and add support for copyFrom and MergeWith a TPriorityList where the list index is treated as the key in the map.  List index numbers are the new keys at the specified priority.

TWeakCallableCollection gets two new functions getIterator and toArray to account for changes in the TPriorityList code.

The new traits and classes are added the classes.php list.

Unit tests for the new code.