### PR TITLE
#864 TUtfConverter takes language for national localization and TEscCharsetConversion for converting ESC charsets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
 		"bower-asset/clipboard": "^2",
 		"bower-asset/highlightjs-line-numbers.js": "^2",
 		"psy/psysh": "^0"
+		"bower-asset/highlightjs-line-numbers.js": "^2.8",
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "9.*",

--- a/framework/Util/TEscCharsetConverter.php
+++ b/framework/Util/TEscCharsetConverter.php
@@ -101,10 +101,11 @@ class TEscCharsetConverter
 	 * @return ?string The ESC character code representing the encoding
 	 *   or null if not found.
 	 */
-	public static function encodeEscapeCharset(string $charset): string
+	public static function encodeEscapeCharset(string $charset): ?string
 	{
-		if(($escEncoding = array_search($charset, self::ESC_CHAR_ENCODINGS_MAP) !== false)
-			return $charset;
+		if (($escEncoding = array_search($charset, self::ESC_CHAR_ENCODINGS_MAP)) !== false) {
+			return $escEncoding;
+		}
 		return null;
 	}
 }

--- a/framework/Util/TEscCharsetConverter.php
+++ b/framework/Util/TEscCharsetConverter.php
@@ -74,7 +74,7 @@ class TEscCharsetConverter
 			"\x1B\x24\x28\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x4F" => 'ISO-2022-JP-3',
 			"\x1B\x24\x28\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x50" => 'ISO-2022-JP-3',
 		];
-	
+
 	/**
 	 * Convert an Escape Character Code Encoding to the iconv character
 	 * encoding.

--- a/framework/Util/TEscCharsetConverter.php
+++ b/framework/Util/TEscCharsetConverter.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * TEscCharsetConverter class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util;
+
+/**
+ * TEscCharsetConverter class.
+ *
+ * TEscCharsetConverter is the ESC Charset Converter for converting between ESC
+ * character sets] encodings and their iConv character encodings.
+ *
+ * Each Esc charset Encoding has 4 versions for G0, G1, G2, and G3.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ * @see https://en.wikipedia.org/wiki/ISO/IEC_2022 General structure of character encodings.
+ * @see https://en.wikipedia.org/wiki/ISO/IEC_646 National standards for ASCII.
+ * @see https://www.sljfaq.org/afaq/encodings.html Japanese encodings and character sets.
+ *
+ * These are not yet in iconv (as of April, 2023):
+ * @todo missing ISO-5427. https://en.wikipedia.org/wiki/ISO_5427. (8 bit Cyrillic, 1979/1981)
+ * @todo missing ČSN (Czech technical standard) 369103. https://en.wikipedia.org/wiki/KOI_character_encodings (also Cyrillic)
+ */
+class TEscCharsetConverter
+{
+	public const ESC_CHAR_ENCODINGS_MAP = [
+			"\x1B\x25\x47" => 'UTF-8', // ESC-'%G'
+
+			"\x1B\x28\x40" => 'ASCII',		"\x1B\x29\x40" => 'ASCII',		"\x1B\x2A\x40" => 'ASCII',		"\x1B\x2B\x40" => 'ASCII',
+			"\x1B\x28\x41" => 'ASCII.en_GB', "\x1B\x29\x41" => 'ASCII.en_GB', "\x1B\x2A\x41" => 'ASCII.en_GB', "\x1B\x2B\x41" => 'ASCII.en_GB',
+			"\x1B\x28\x42" => 'ASCII.en_US', "\x1B\x29\x42" => 'ASCII.en_US', "\x1B\x2A\x42" => 'ASCII.en_US', "\x1B\x2B\x42" => 'ASCII.en_US',
+			"\x1B\x28\x43" => 'ASCII.fi',	"\x1B\x29\x43" => 'ASCII.fi',	"\x1B\x2A\x43" => 'ASCII.fi',	"\x1B\x2B\x43" => 'ASCII.fi',
+			"\x1B\x28\x44" => 'ASCII.sv',	"\x1B\x29\x44" => 'ASCII.sv',	"\x1B\x2A\x44" => 'ASCII.sv',	"\x1B\x2B\x44" => 'ASCII.sv',
+			"\x1B\x28\x45" => 'ASCII.no',	"\x1B\x29\x45" => 'ASCII.no',	"\x1B\x2A\x45" => 'ASCII.no',	"\x1B\x2B\x45" => 'ASCII.no',
+			"\x1B\x28\x46" => 'ASCII.no',	"\x1B\x29\x46" => 'ASCII.no',	"\x1B\x2A\x46" => 'ASCII.no',	"\x1B\x2B\x46" => 'ASCII.no',
+			"\x1B\x28\x47" => 'ASCII.se',	"\x1B\x29\x47" => 'ASCII.se',	"\x1B\x2A\x47" => 'ASCII.se',	"\x1B\x2B\x47" => 'ASCII.se',
+			"\x1B\x28\x49" => 'JIS_X0201',	"\x1B\x29\x49" => 'JIS_X0201',	"\x1B\x2A\x49" => 'JIS_X0201',	"\x1B\x2B\x49" => 'JIS_X0201',
+			"\x1B\x28\x4A" => 'JIS_X0201',	"\x1B\x29\x4A" => 'JIS_X0201',	"\x1B\x2A\x4A" => 'JIS_X0201',	"\x1B\x2B\x4A" => 'JIS_X0201',
+			"\x1B\x28\x4B" => 'ASCII.de',	"\x1B\x29\x4B" => 'ASCII.de',	"\x1B\x2A\x4B" => 'ASCII.de',	"\x1B\x2B\x4B" => 'ASCII.de',
+			"\x1B\x28\x4C" => 'ASCII.pt',	"\x1B\x29\x4C" => 'ASCII.pt',	"\x1B\x2A\x4C" => 'ASCII.pt',	"\x1B\x2B\x4C" => 'ASCII.pt',
+			"\x1B\x28\x4E" => 'ISO-5427',	"\x1B\x29\x4E" => 'ISO-5427',	"\x1B\x2A\x4E" => 'ISO-5427',	"\x1B\x2B\x4E" => 'ISO-5427',
+			"\x1B\x28\x54" => 'ISO646-CN',	"\x1B\x29\x54" => 'ISO646-CN',	"\x1B\x2A\x54" => 'ISO646-CN',	"\x1B\x2B\x54" => 'ISO646-CN',
+			"\x1B\x28\x59" => 'ASCII.it',	"\x1B\x29\x59" => 'ASCII.it',	"\x1B\x2A\x59" => 'ASCII.it',	"\x1B\x2B\x59" => 'ASCII.it',
+			"\x1B\x28\x5A" => 'ASCII.es',	"\x1B\x29\x5A" => 'ASCII.es',	"\x1B\x2A\x5A" => 'ASCII.es',	"\x1B\x2B\x5A" => 'ASCII.es',
+			"\x1B\x28\x5B" => 'ASCII.el',	"\x1B\x29\x5B" => 'ASCII.el',	"\x1B\x2A\x5B" => 'ASCII.el',	"\x1B\x2B\x5B" => 'ASCII.el',
+			"\x1B\x28\x60" => 'ASCII.no',	"\x1B\x29\x60" => 'ASCII.no',	"\x1B\x2A\x60" => 'ASCII.no',	"\x1B\x2B\x60" => 'ASCII.no',
+			"\x1B\x28\x66" => 'ASCII.fr',	"\x1B\x29\x66" => 'ASCII.fr',	"\x1B\x2A\x66" => 'ASCII.fr',	"\x1B\x2B\x66" => 'ASCII.fr',
+			"\x1B\x28\x67" => 'ASCII.pt',	"\x1B\x29\x67" => 'ASCII.pt',	"\x1B\x2A\x67" => 'ASCII.pt',	"\x1B\x2B\x67" => 'ASCII.pt',
+			"\x1B\x28\x68" => 'ASCII.es',	"\x1B\x29\x68" => 'ASCII.es',	"\x1B\x2A\x68" => 'ASCII.es',	"\x1B\x2B\x68" => 'ASCII.es',
+			"\x1B\x28\x69" => 'ASCII.hu',	"\x1B\x29\x69" => 'ASCII.hu',	"\x1B\x2A\x69" => 'ASCII.hu',	"\x1B\x2B\x69" => 'ASCII.hu',
+			"\x1B\x28\x77" => 'ASCII.fr_CA', "\x1B\x29\x77" => 'ASCII.fr_CA', "\x1B\x2A\x77" => 'ASCII.fr_CA', "\x1B\x2B\x77" => 'ASCII.fr_CA',
+			"\x1B\x28\x78" => 'ASCII.fr_CA', "\x1B\x29\x78" => 'ASCII.fr_CA', "\x1B\x2A\x78" => 'ASCII.fr_CA', "\x1B\x2B\x78" => 'ASCII.fr_CA',
+			"\x1B\x28\x7A" => 'ASCII.yu',	"\x1B\x29\x7A" => 'ASCII.yu',	"\x1B\x2A\x7A" => 'ASCII.yu',	"\x1B\x2B\x7A" => 'ASCII.yu',
+
+			"\x1B\x2C\x41" => 'ISO-8859-1',	"\x1B\x2D\x41" => 'ISO-8859-1',	"\x1B\x2E\x41" => 'ISO-8859-1',	"\x1B\x2F\x41" => 'ISO-8859-1',
+			"\x1B\x2C\x42" => 'ISO-8859-2',	"\x1B\x2D\x42" => 'ISO-8859-2',	"\x1B\x2E\x42" => 'ISO-8859-2',	"\x1B\x2F\x42" => 'ISO-8859-2',
+			"\x1B\x2C\x43" => 'ISO-8859-3',	"\x1B\x2D\x43" => 'ISO-8859-3',	"\x1B\x2E\x43" => 'ISO-8859-3',	"\x1B\x2F\x43" => 'ISO-8859-3',
+			"\x1B\x2C\x44" => 'ISO-8859-4',	"\x1B\x2D\x44" => 'ISO-8859-4',	"\x1B\x2E\x44" => 'ISO-8859-4',	"\x1B\x2F\x44" => 'ISO-8859-4',
+			"\x1B\x2C\x45" => 'ISO-8859-5',	"\x1B\x2D\x45" => 'ISO-8859-5',	"\x1B\x2E\x45" => 'ISO-8859-5',	"\x1B\x2F\x45" => 'ISO-8859-5',
+			"\x1B\x2C\x46" => 'ISO-8859-7',	"\x1B\x2D\x46" => 'ISO-8859-7',	"\x1B\x2E\x46" => 'ISO-8859-7',	"\x1B\x2F\x46" => 'ISO-8859-7',
+			"\x1B\x2C\x47" => 'ISO-8859-6',	"\x1B\x2D\x47" => 'ISO-8859-6',	"\x1B\x2E\x47" => 'ISO-8859-6',	"\x1B\x2F\x47" => 'ISO-8859-6',
+			"\x1B\x2C\x48" => 'ISO-8859-8',	"\x1B\x2D\x48" => 'ISO-8859-8',	"\x1B\x2E\x48" => 'ISO-8859-8',	"\x1B\x2F\x48" => 'ISO-8859-8',
+			"\x1B\x2C\x49" => 'CSN 369103',	"\x1B\x2D\x49" => 'CSN 369103',	"\x1B\x2E\x49" => 'CSN 369103',	"\x1B\x2F\x49" => 'CSN 369103',
+
+			"\x1B\x24\x28\x40" => 'JIS0208',	"\x1B\x24\x29\x40" => 'JIS0208',	"\x1B\x24\x2A\x40" => 'JIS0208',	"\x1B\x24\x2B\x40" => 'JIS0208',
+			"\x1B\x24\x28\x42" => 'JIS0208',	"\x1B\x24\x29\x42" => 'JIS0208',	"\x1B\x24\x2A\x42" => 'JIS0208',	"\x1B\x24\x2B\x42" => 'JIS0208',
+			"\x1B\x24\x28\x44" => 'JIS_X0212',	"\x1B\x24\x29\x44" => 'JIS_X0212',	"\x1B\x24\x2A\x44" => 'JIS_X0212',	"\x1B\x24\x2B\x44" => 'JIS_X0212',
+			"\x1B\x24\x28\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x4F" => 'ISO-2022-JP-3',
+			"\x1B\x24\x28\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x50" => 'ISO-2022-JP-3',
+		];
+	
+	/**
+	 * Convert an Escape Character Code Encoding to the iconv character
+	 * encoding.
+	 * @param string $charset The ESC character code for conversion.
+	 * @return ?string The decoded Character Encoding or null if not found.
+	 */
+	public static function decodeEscapeCharset(string $charset): ?string
+	{
+		$esc = "\x1B";
+		$codes = explode($esc, trim($charset, $esc));
+		foreach ($codes as $code) {
+			$code = $esc . $code;
+			if (array_key_exists($code, self::ESC_CHAR_ENCODINGS_MAP)) {
+				return self::ESC_CHAR_ENCODINGS_MAP[$code];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Convert an Escape Character Code Encoding to the iconv character
+	 * encoding.
+	 * @param string $charset The iconv charset encoding to be encoded
+	 * @return ?string The ESC character code representing the encoding
+	 *   or null if not found.
+	 */
+	public static function encodeEscapeCharset(string $charset): string
+	{
+		if(($escEncoding = array_search($charset, self::ESC_CHAR_ENCODINGS_MAP) !== false)
+			return $charset;
+		return null;
+	}
+}

--- a/framework/Util/TUtf8Converter.php
+++ b/framework/Util/TUtf8Converter.php
@@ -17,61 +17,9 @@ namespace Prado\Util;
  *
  * @author Fabio Bas <fbio.bas@gmail.com>
  * @since 4.0.2
- * @see https://en.wikipedia.org/wiki/ISO/IEC_2022 General structure of character encodings.
- * @see https://en.wikipedia.org/wiki/ISO/IEC_646 National standards for ASCII.
- * @see https://www.sljfaq.org/afaq/encodings.html Japanese encodings and character sets.
- *
- * These are not yet in iconv (as of April, 2023):
- * @todo missing ISO-5427. https://en.wikipedia.org/wiki/ISO_5427. (8 bit Cyrillic, 1979/1981)
- * @todo missing ČSN (Czech technical standard) 369103. https://en.wikipedia.org/wiki/KOI_character_encodings (also Cyrillic)
  */
 class TUtf8Converter
 {
-	public const ESC_CHARENCODINGS_MAP = [
-			"\x1B\x25\x47" => 'UTF-8', // ESC-'%G'
-
-			"\x1B\x28\x40" => 'ASCII',	"\x1B\x29\x40" => 'ASCII',	"\x1B\x2A\x40" => 'ASCII',	"\x1B\x2B\x40" => 'ASCII',
-			"\x1B\x28\x41" => 'ASCII.en_GB', "\x1B\x29\x41" => 'ASCII.en_GB', "\x1B\x2A\x41" => 'ASCII.en_GB', "\x1B\x2B\x41" => 'ASCII.en_GB',
-			"\x1B\x28\x42" => 'ASCII.en_US', "\x1B\x29\x42" => 'ASCII.en_US', "\x1B\x2A\x42" => 'ASCII.en_US', "\x1B\x2B\x42" => 'ASCII.en_US',
-			"\x1B\x28\x43" => 'ASCII.fi',	"\x1B\x29\x43" => 'ASCII.fi',	"\x1B\x2A\x43" => 'ASCII.fi',	"\x1B\x2B\x43" => 'ASCII.fi',
-			"\x1B\x28\x44" => 'ASCII.sv',	"\x1B\x29\x44" => 'ASCII.sv',	"\x1B\x2A\x44" => 'ASCII.sv',	"\x1B\x2B\x44" => 'ASCII.sv',
-			"\x1B\x28\x45" => 'ASCII.no',	"\x1B\x29\x45" => 'ASCII.no',	"\x1B\x2A\x45" => 'ASCII.no',	"\x1B\x2B\x45" => 'ASCII.no',
-			"\x1B\x28\x46" => 'ASCII.no',	"\x1B\x29\x46" => 'ASCII.no',	"\x1B\x2A\x46" => 'ASCII.no',	"\x1B\x2B\x46" => 'ASCII.no',
-			"\x1B\x28\x47" => 'ASCII.se',	"\x1B\x29\x47" => 'ASCII.se',	"\x1B\x2A\x47" => 'ASCII.se',	"\x1B\x2B\x47" => 'ASCII.se',
-			"\x1B\x28\x49" => 'JIS_X0201',	"\x1B\x29\x49" => 'JIS_X0201',	"\x1B\x2A\x49" => 'JIS_X0201',	"\x1B\x2B\x49" => 'JIS_X0201',
-			"\x1B\x28\x4A" => 'JIS_X0201',	"\x1B\x29\x4A" => 'JIS_X0201',	"\x1B\x2A\x4A" => 'JIS_X0201',	"\x1B\x2B\x4A" => 'JIS_X0201',
-			"\x1B\x28\x4B" => 'ASCII.de',	"\x1B\x29\x4B" => 'ASCII.de',	"\x1B\x2A\x4B" => 'ASCII.de',	"\x1B\x2B\x4B" => 'ASCII.de',
-			"\x1B\x28\x4C" => 'ASCII.pt',	"\x1B\x29\x4C" => 'ASCII.pt',	"\x1B\x2A\x4C" => 'ASCII.pt',	"\x1B\x2B\x4C" => 'ASCII.pt',
-			"\x1B\x28\x4E" => 'ISO-5427',	"\x1B\x29\x4E" => 'ISO-5427',	"\x1B\x2A\x4E" => 'ISO-5427',	"\x1B\x2B\x4E" => 'ISO-5427',
-			"\x1B\x28\x54" => 'ISO646-CN',	"\x1B\x29\x54" => 'ISO646-CN',	"\x1B\x2A\x54" => 'ISO646-CN',	"\x1B\x2B\x54" => 'ISO646-CN',
-			"\x1B\x28\x59" => 'ASCII.it',	"\x1B\x29\x59" => 'ASCII.it',	"\x1B\x2A\x59" => 'ASCII.it',	"\x1B\x2B\x59" => 'ASCII.it',
-			"\x1B\x28\x5A" => 'ASCII.es',	"\x1B\x29\x5A" => 'ASCII.es',	"\x1B\x2A\x5A" => 'ASCII.es',	"\x1B\x2B\x5A" => 'ASCII.es',
-			"\x1B\x28\x5B" => 'ASCII.el',	"\x1B\x29\x5B" => 'ASCII.el',	"\x1B\x2A\x5B" => 'ASCII.el',	"\x1B\x2B\x5B" => 'ASCII.el',
-			"\x1B\x28\x60" => 'ASCII.no',	"\x1B\x29\x60" => 'ASCII.no',	"\x1B\x2A\x60" => 'ASCII.no',	"\x1B\x2B\x60" => 'ASCII.no',
-			"\x1B\x28\x66" => 'ASCII.fr',	"\x1B\x29\x66" => 'ASCII.fr',	"\x1B\x2A\x66" => 'ASCII.fr',	"\x1B\x2B\x66" => 'ASCII.fr',
-			"\x1B\x28\x67" => 'ASCII.pt',	"\x1B\x29\x67" => 'ASCII.pt',	"\x1B\x2A\x67" => 'ASCII.pt',	"\x1B\x2B\x67" => 'ASCII.pt',
-			"\x1B\x28\x68" => 'ASCII.es',	"\x1B\x29\x68" => 'ASCII.es',	"\x1B\x2A\x68" => 'ASCII.es',	"\x1B\x2B\x68" => 'ASCII.es',
-			"\x1B\x28\x69" => 'ASCII.hu',	"\x1B\x29\x69" => 'ASCII.hu',	"\x1B\x2A\x69" => 'ASCII.hu',	"\x1B\x2B\x69" => 'ASCII.hu',
-			"\x1B\x28\x77" => 'ASCII.fr_CA', "\x1B\x29\x77" => 'ASCII.fr_CA', "\x1B\x2A\x77" => 'ASCII.fr_CA', "\x1B\x2B\x77" => 'ASCII.fr_CA',
-			"\x1B\x28\x78" => 'ASCII.fr_CA', "\x1B\x29\x78" => 'ASCII.fr_CA', "\x1B\x2A\x78" => 'ASCII.fr_CA', "\x1B\x2B\x78" => 'ASCII.fr_CA',
-			"\x1B\x28\x7A" => 'ASCII.yu',	"\x1B\x29\x7A" => 'ASCII.yu',	"\x1B\x2A\x7A" => 'ASCII.yu',	"\x1B\x2B\x7A" => 'ASCII.yu',
-
-			"\x1B\x2C\x41" => 'ISO-8859-1',	"\x1B\x2D\x41" => 'ISO-8859-1',	"\x1B\x2E\x41" => 'ISO-8859-1',	"\x1B\x2F\x41" => 'ISO-8859-1',
-			"\x1B\x2C\x42" => 'ISO-8859-2',	"\x1B\x2D\x42" => 'ISO-8859-2',	"\x1B\x2E\x42" => 'ISO-8859-2',	"\x1B\x2F\x42" => 'ISO-8859-2',
-			"\x1B\x2C\x43" => 'ISO-8859-3',	"\x1B\x2D\x43" => 'ISO-8859-3',	"\x1B\x2E\x43" => 'ISO-8859-3',	"\x1B\x2F\x43" => 'ISO-8859-3',
-			"\x1B\x2C\x44" => 'ISO-8859-4',	"\x1B\x2D\x44" => 'ISO-8859-4',	"\x1B\x2E\x44" => 'ISO-8859-4',	"\x1B\x2F\x44" => 'ISO-8859-4',
-			"\x1B\x2C\x45" => 'ISO-8859-5',	"\x1B\x2D\x45" => 'ISO-8859-5',	"\x1B\x2E\x45" => 'ISO-8859-5',	"\x1B\x2F\x45" => 'ISO-8859-5',
-			"\x1B\x2C\x46" => 'ISO-8859-7',	"\x1B\x2D\x46" => 'ISO-8859-7',	"\x1B\x2E\x46" => 'ISO-8859-7',	"\x1B\x2F\x46" => 'ISO-8859-7',
-			"\x1B\x2C\x47" => 'ISO-8859-6',	"\x1B\x2D\x47" => 'ISO-8859-6',	"\x1B\x2E\x47" => 'ISO-8859-6',	"\x1B\x2F\x47" => 'ISO-8859-6',
-			"\x1B\x2C\x48" => 'ISO-8859-8',	"\x1B\x2D\x48" => 'ISO-8859-8',	"\x1B\x2E\x48" => 'ISO-8859-8',	"\x1B\x2F\x48" => 'ISO-8859-8',
-			"\x1B\x2C\x49" => 'CSN 369103',	"\x1B\x2D\x49" => 'CSN 369103',	"\x1B\x2E\x49" => 'CSN 369103',	"\x1B\x2F\x49" => 'CSN 369103',
-
-			"\x1B\x24\x28\x40" => 'JIS0208',	"\x1B\x24\x29\x40" => 'JIS0208',	"\x1B\x24\x2A\x40" => 'JIS0208',	"\x1B\x24\x2B\x40" => 'JIS0208',
-			"\x1B\x24\x28\x42" => 'JIS0208',	"\x1B\x24\x29\x42" => 'JIS0208',	"\x1B\x24\x2A\x42" => 'JIS0208',	"\x1B\x24\x2B\x42" => 'JIS0208',
-			"\x1B\x24\x28\x44" => 'JIS_X0212',	"\x1B\x24\x29\x44" => 'JIS_X0212',	"\x1B\x24\x2A\x44" => 'JIS_X0212',	"\x1B\x24\x2B\x44" => 'JIS_X0212',
-			"\x1B\x24\x28\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x4F" => 'ISO-2022-JP-3',
-			"\x1B\x24\x28\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x50" => 'ISO-2022-JP-3',
-		];
 	/**
 	 * Convert strings to UTF-8 via iconv. NB, the result may not by UTF-8
 	 * if the conversion failed.
@@ -79,11 +27,16 @@ class TUtf8Converter
 	 * @param string $from source encoding
 	 * @param ?string $lang Language of the encoding as accepted by PHP setLocale
 	 * @return string UTF-8 encoded string, original string if iconv failed.
+	 * @see https://www.php.net/manual/en/function.setlocale.php
+	 *   The $lang locale information is maintained per process, not per thread.
 	 */
 	public static function toUTF8($string, $from, $lang = null)
 	{
 		if ($from != 'UTF-8') {
 			$locale = null;
+			if ($lang === null) {
+				self::parseEncodingLanguage($from, $lang);
+			}
 			if ($lang !== null) {
 				$locale = setLocale(LC_CTYPE, '0');
 				setLocale(LC_CTYPE, $lang);
@@ -104,11 +57,16 @@ class TUtf8Converter
 	 * @param string $to destination encoding
 	 * @param ?string $lang Language of the encoding as accepted by PHP setLocale
 	 * @return string encoded string.
+	 * @see https://www.php.net/manual/en/function.setlocale.php
+	 *   The $lang locale information is maintained per process, not per thread.
 	 */
 	public static function fromUTF8($string, $to, $lang = null)
 	{
 		if ($to != 'UTF-8') {
 			$locale = null;
+			if ($lang === null) {
+				self::parseEncodingLanguage($to, $lang);
+			}
 			if ($lang !== null) {
 				$locale = setLocale(LC_CTYPE, '0');
 				setLocale(LC_CTYPE, $lang);
@@ -123,32 +81,20 @@ class TUtf8Converter
 	}
 
 	/**
-	 * Convert an Escape Character Code Encoding to the iconv character
-	 * encoding.
-	 * @param string $charset The ESC character code for conversion.
-	 * @return string The decoded Character Encoding.
+	 * This parses a Character Set Encoding for an appended/embedded language.
+	 * eg "ASCII" can also be "ASCII.de" to designate German ASCII layout.
+	 * In this example, at input $encoding is "ASCII.de" and on output $encoding
+	 * is 'ASCII' with $lang is "de".
+	 * @param string $encoding The character set encoding with optional period and
+	 *   language appended.
+	 * @param ?string &$lang The output language of the encoding.
 	 */
-	public static function decodeEscapeCharset(string $charset): string
+	public static function parseEncodingLanguage(string &$encoding, &$lang)
 	{
-		$esc = "\x1B";
-		$codes = explode($esc, trim($charset, $esc));
-		foreach ($codes as $code) {
-			$code = $esc . $code;
-			if (array_key_exists($code, self::ESC_CHARENCODINGS_MAP)) {
-				return self::ESC_CHARENCODINGS_MAP[$code];
-			}
+		if(strpos($encoding, '.') !== false) {
+			$parts = explode($encoding, '.', 1);
+			$encoding = $parts[0];
+			$lang = $parts[1];
 		}
-		return null;
-	}
-
-	/**
-	 * Convert an Escape Character Code Encoding to the iconv character
-	 * encoding.
-	 * @param string $charset The iconv charset encoding to be encoded
-	 * @return string The ESC character code representing the encoding.
-	 */
-	public static function encodeEscapeCharset(string $charset): string
-	{
-		return array_search($charset, self::ESC_CHARENCODINGS_MAP);
 	}
 }

--- a/framework/Util/TUtf8Converter.php
+++ b/framework/Util/TUtf8Converter.php
@@ -17,10 +17,15 @@ namespace Prado\Util;
  *
  * @author Fabio Bas <fbio.bas@gmail.com>
  * @since 4.0.2
+ * @see https://en.wikipedia.org/wiki/ISO/IEC_2022 General structure of character encodings.
+ * @see https://en.wikipedia.org/wiki/ISO/IEC_646 National standards for ASCII.
+ * @see https://www.sljfaq.org/afaq/encodings.html Japanese encodings.
+ * @todo missing ISO-5427. https://en.wikipedia.org/wiki/ISO_5427. (8 bit Cyrillic, 1979/1981)
+ * @todo missing ČSN (Czech technical standard) 369103. https://en.wikipedia.org/wiki/KOI_character_encodings (also Cyrillic)
  */
 class TUtf8Converter
 {
-	public const ESC_CHARSET_MAP = [
+	public const ESC_CHARENCODINGS_MAP = [
 			"\x1B\x25\x47" => 'UTF-8', // ESC-'%G'
 
 			"\x1B\x28\x40" => 'ASCII',	"\x1B\x29\x40" => 'ASCII',	"\x1B\x2A\x40" => 'ASCII',	"\x1B\x2B\x40" => 'ASCII',
@@ -95,7 +100,7 @@ class TUtf8Converter
 	 * may not have been encoded if iconv fails.
 	 * @param string $string the UTF-8 string for conversion
 	 * @param string $to destination encoding
-	 * @param ?string $lang Language of the encoding.
+	 * @param ?string $lang Language of the encoding as accepted by PHP setLocale
 	 * @return string encoded string.
 	 */
 	public static function fromUTF8($string, $to, $lang = null)
@@ -127,8 +132,8 @@ class TUtf8Converter
 		$codes = explode($esc, trim($charset, $esc));
 		foreach ($codes as $code) {
 			$code = $esc . $code;
-			if (array_key_exists($code, self::ESC_CHARSET_MAP)) {
-				return self::ESC_CHARSET_MAP[$code];
+			if (array_key_exists($code, self::ESC_CHARENCODINGS_MAP)) {
+				return self::ESC_CHARENCODINGS_MAP[$code];
 			}
 		}
 		return null;
@@ -142,6 +147,6 @@ class TUtf8Converter
 	 */
 	public static function encodeEscapeCharset(string $charset): string
 	{
-		return array_search($charset, self::ESC_CHARSET_MAP);
+		return array_search($charset, self::ESC_CHARENCODINGS_MAP);
 	}
 }

--- a/framework/Util/TUtf8Converter.php
+++ b/framework/Util/TUtf8Converter.php
@@ -19,7 +19,9 @@ namespace Prado\Util;
  * @since 4.0.2
  * @see https://en.wikipedia.org/wiki/ISO/IEC_2022 General structure of character encodings.
  * @see https://en.wikipedia.org/wiki/ISO/IEC_646 National standards for ASCII.
- * @see https://www.sljfaq.org/afaq/encodings.html Japanese encodings.
+ * @see https://www.sljfaq.org/afaq/encodings.html Japanese encodings and character sets.
+ *
+ * These are not yet in iconv (as of April, 2023):
  * @todo missing ISO-5427. https://en.wikipedia.org/wiki/ISO_5427. (8 bit Cyrillic, 1979/1981)
  * @todo missing ČSN (Czech technical standard) 369103. https://en.wikipedia.org/wiki/KOI_character_encodings (also Cyrillic)
  */

--- a/framework/Util/TUtf8Converter.php
+++ b/framework/Util/TUtf8Converter.php
@@ -20,17 +20,71 @@ namespace Prado\Util;
  */
 class TUtf8Converter
 {
+	public const ESC_CHARSET_MAP = [
+			"\x1B\x25\x47" => 'UTF-8', // ESC-'%G'
+
+			"\x1B\x28\x40" => 'ASCII',	"\x1B\x29\x40" => 'ASCII',	"\x1B\x2A\x40" => 'ASCII',	"\x1B\x2B\x40" => 'ASCII',
+			"\x1B\x28\x41" => 'ASCII.en_GB', "\x1B\x29\x41" => 'ASCII.en_GB', "\x1B\x2A\x41" => 'ASCII.en_GB', "\x1B\x2B\x41" => 'ASCII.en_GB',
+			"\x1B\x28\x42" => 'ASCII.en_US', "\x1B\x29\x42" => 'ASCII.en_US', "\x1B\x2A\x42" => 'ASCII.en_US', "\x1B\x2B\x42" => 'ASCII.en_US',
+			"\x1B\x28\x43" => 'ASCII.fi',	"\x1B\x29\x43" => 'ASCII.fi',	"\x1B\x2A\x43" => 'ASCII.fi',	"\x1B\x2B\x43" => 'ASCII.fi',
+			"\x1B\x28\x44" => 'ASCII.sv',	"\x1B\x29\x44" => 'ASCII.sv',	"\x1B\x2A\x44" => 'ASCII.sv',	"\x1B\x2B\x44" => 'ASCII.sv',
+			"\x1B\x28\x45" => 'ASCII.no',	"\x1B\x29\x45" => 'ASCII.no',	"\x1B\x2A\x45" => 'ASCII.no',	"\x1B\x2B\x45" => 'ASCII.no',
+			"\x1B\x28\x46" => 'ASCII.no',	"\x1B\x29\x46" => 'ASCII.no',	"\x1B\x2A\x46" => 'ASCII.no',	"\x1B\x2B\x46" => 'ASCII.no',
+			"\x1B\x28\x47" => 'ASCII.se',	"\x1B\x29\x47" => 'ASCII.se',	"\x1B\x2A\x47" => 'ASCII.se',	"\x1B\x2B\x47" => 'ASCII.se',
+			"\x1B\x28\x49" => 'JIS_X0201',	"\x1B\x29\x49" => 'JIS_X0201',	"\x1B\x2A\x49" => 'JIS_X0201',	"\x1B\x2B\x49" => 'JIS_X0201',
+			"\x1B\x28\x4A" => 'JIS_X0201',	"\x1B\x29\x4A" => 'JIS_X0201',	"\x1B\x2A\x4A" => 'JIS_X0201',	"\x1B\x2B\x4A" => 'JIS_X0201',
+			"\x1B\x28\x4B" => 'ASCII.de',	"\x1B\x29\x4B" => 'ASCII.de',	"\x1B\x2A\x4B" => 'ASCII.de',	"\x1B\x2B\x4B" => 'ASCII.de',
+			"\x1B\x28\x4C" => 'ASCII.pt',	"\x1B\x29\x4C" => 'ASCII.pt',	"\x1B\x2A\x4C" => 'ASCII.pt',	"\x1B\x2B\x4C" => 'ASCII.pt',
+			"\x1B\x28\x4E" => 'ISO-5427',	"\x1B\x29\x4E" => 'ISO-5427',	"\x1B\x2A\x4E" => 'ISO-5427',	"\x1B\x2B\x4E" => 'ISO-5427',
+			"\x1B\x28\x54" => 'ISO646-CN',	"\x1B\x29\x54" => 'ISO646-CN',	"\x1B\x2A\x54" => 'ISO646-CN',	"\x1B\x2B\x54" => 'ISO646-CN',
+			"\x1B\x28\x59" => 'ASCII.it',	"\x1B\x29\x59" => 'ASCII.it',	"\x1B\x2A\x59" => 'ASCII.it',	"\x1B\x2B\x59" => 'ASCII.it',
+			"\x1B\x28\x5A" => 'ASCII.es',	"\x1B\x29\x5A" => 'ASCII.es',	"\x1B\x2A\x5A" => 'ASCII.es',	"\x1B\x2B\x5A" => 'ASCII.es',
+			"\x1B\x28\x5B" => 'ASCII.el',	"\x1B\x29\x5B" => 'ASCII.el',	"\x1B\x2A\x5B" => 'ASCII.el',	"\x1B\x2B\x5B" => 'ASCII.el',
+			"\x1B\x28\x60" => 'ASCII.no',	"\x1B\x29\x60" => 'ASCII.no',	"\x1B\x2A\x60" => 'ASCII.no',	"\x1B\x2B\x60" => 'ASCII.no',
+			"\x1B\x28\x66" => 'ASCII.fr',	"\x1B\x29\x66" => 'ASCII.fr',	"\x1B\x2A\x66" => 'ASCII.fr',	"\x1B\x2B\x66" => 'ASCII.fr',
+			"\x1B\x28\x67" => 'ASCII.pt',	"\x1B\x29\x67" => 'ASCII.pt',	"\x1B\x2A\x67" => 'ASCII.pt',	"\x1B\x2B\x67" => 'ASCII.pt',
+			"\x1B\x28\x68" => 'ASCII.es',	"\x1B\x29\x68" => 'ASCII.es',	"\x1B\x2A\x68" => 'ASCII.es',	"\x1B\x2B\x68" => 'ASCII.es',
+			"\x1B\x28\x69" => 'ASCII.hu',	"\x1B\x29\x69" => 'ASCII.hu',	"\x1B\x2A\x69" => 'ASCII.hu',	"\x1B\x2B\x69" => 'ASCII.hu',
+			"\x1B\x28\x77" => 'ASCII.fr_CA', "\x1B\x29\x77" => 'ASCII.fr_CA', "\x1B\x2A\x77" => 'ASCII.fr_CA', "\x1B\x2B\x77" => 'ASCII.fr_CA',
+			"\x1B\x28\x78" => 'ASCII.fr_CA', "\x1B\x29\x78" => 'ASCII.fr_CA', "\x1B\x2A\x78" => 'ASCII.fr_CA', "\x1B\x2B\x78" => 'ASCII.fr_CA',
+			"\x1B\x28\x7A" => 'ASCII.yu',	"\x1B\x29\x7A" => 'ASCII.yu',	"\x1B\x2A\x7A" => 'ASCII.yu',	"\x1B\x2B\x7A" => 'ASCII.yu',
+
+			"\x1B\x2C\x41" => 'ISO-8859-1',	"\x1B\x2D\x41" => 'ISO-8859-1',	"\x1B\x2E\x41" => 'ISO-8859-1',	"\x1B\x2F\x41" => 'ISO-8859-1',
+			"\x1B\x2C\x42" => 'ISO-8859-2',	"\x1B\x2D\x42" => 'ISO-8859-2',	"\x1B\x2E\x42" => 'ISO-8859-2',	"\x1B\x2F\x42" => 'ISO-8859-2',
+			"\x1B\x2C\x43" => 'ISO-8859-3',	"\x1B\x2D\x43" => 'ISO-8859-3',	"\x1B\x2E\x43" => 'ISO-8859-3',	"\x1B\x2F\x43" => 'ISO-8859-3',
+			"\x1B\x2C\x44" => 'ISO-8859-4',	"\x1B\x2D\x44" => 'ISO-8859-4',	"\x1B\x2E\x44" => 'ISO-8859-4',	"\x1B\x2F\x44" => 'ISO-8859-4',
+			"\x1B\x2C\x45" => 'ISO-8859-5',	"\x1B\x2D\x45" => 'ISO-8859-5',	"\x1B\x2E\x45" => 'ISO-8859-5',	"\x1B\x2F\x45" => 'ISO-8859-5',
+			"\x1B\x2C\x46" => 'ISO-8859-7',	"\x1B\x2D\x46" => 'ISO-8859-7',	"\x1B\x2E\x46" => 'ISO-8859-7',	"\x1B\x2F\x46" => 'ISO-8859-7',
+			"\x1B\x2C\x47" => 'ISO-8859-6',	"\x1B\x2D\x47" => 'ISO-8859-6',	"\x1B\x2E\x47" => 'ISO-8859-6',	"\x1B\x2F\x47" => 'ISO-8859-6',
+			"\x1B\x2C\x48" => 'ISO-8859-8',	"\x1B\x2D\x48" => 'ISO-8859-8',	"\x1B\x2E\x48" => 'ISO-8859-8',	"\x1B\x2F\x48" => 'ISO-8859-8',
+			"\x1B\x2C\x49" => 'CSN 369103',	"\x1B\x2D\x49" => 'CSN 369103',	"\x1B\x2E\x49" => 'CSN 369103',	"\x1B\x2F\x49" => 'CSN 369103',
+
+			"\x1B\x24\x28\x40" => 'JIS0208',	"\x1B\x24\x29\x40" => 'JIS0208',	"\x1B\x24\x2A\x40" => 'JIS0208',	"\x1B\x24\x2B\x40" => 'JIS0208',
+			"\x1B\x24\x28\x42" => 'JIS0208',	"\x1B\x24\x29\x42" => 'JIS0208',	"\x1B\x24\x2A\x42" => 'JIS0208',	"\x1B\x24\x2B\x42" => 'JIS0208',
+			"\x1B\x24\x28\x44" => 'JIS_X0212',	"\x1B\x24\x29\x44" => 'JIS_X0212',	"\x1B\x24\x2A\x44" => 'JIS_X0212',	"\x1B\x24\x2B\x44" => 'JIS_X0212',
+			"\x1B\x24\x28\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x4F" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x4F" => 'ISO-2022-JP-3',
+			"\x1B\x24\x28\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x29\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2A\x50" => 'ISO-2022-JP-3',	"\x1B\x24\x2B\x50" => 'ISO-2022-JP-3',
+		];
 	/**
 	 * Convert strings to UTF-8 via iconv. NB, the result may not by UTF-8
 	 * if the conversion failed.
 	 * @param string $string string to convert to UTF-8
 	 * @param string $from source encoding
+	 * @param ?string $lang Language of the encoding as accepted by PHP setLocale
 	 * @return string UTF-8 encoded string, original string if iconv failed.
 	 */
-	public static function toUTF8($string, $from)
+	public static function toUTF8($string, $from, $lang = null)
 	{
 		if ($from != 'UTF-8') {
+			$locale = null;
+			if ($lang !== null) {
+				$locale = setLocale(LC_CTYPE, '0');
+				setLocale(LC_CTYPE, $lang);
+			}
 			$s = iconv($from, 'UTF-8', $string); //to UTF-8
+			if ($lang !== null) {
+				setLocale(LC_CTYPE, $locale);
+			}
 			return $s !== false ? $s : $string; //it could return false
 		}
 		return $string;
@@ -41,14 +95,53 @@ class TUtf8Converter
 	 * may not have been encoded if iconv fails.
 	 * @param string $string the UTF-8 string for conversion
 	 * @param string $to destination encoding
+	 * @param ?string $lang Language of the encoding.
 	 * @return string encoded string.
 	 */
-	public static function fromUTF8($string, $to)
+	public static function fromUTF8($string, $to, $lang = null)
 	{
 		if ($to != 'UTF-8') {
+			$locale = null;
+			if ($lang !== null) {
+				$locale = setLocale(LC_CTYPE, '0');
+				setLocale(LC_CTYPE, $lang);
+			}
 			$s = iconv('UTF-8', $to, $string);
+			if ($lang !== null) {
+				setLocale(LC_CTYPE, $locale);
+			}
 			return $s !== false ? $s : $string;
 		}
 		return $string;
+	}
+
+	/**
+	 * Convert an Escape Character Code Encoding to the iconv character
+	 * encoding.
+	 * @param string $charset The ESC character code for conversion.
+	 * @return string The decoded Character Encoding.
+	 */
+	public static function decodeEscapeCharset(string $charset): string
+	{
+		$esc = "\x1B";
+		$codes = explode($esc, trim($charset, $esc));
+		foreach ($codes as $code) {
+			$code = $esc . $code;
+			if (array_key_exists($code, self::ESC_CHARSET_MAP)) {
+				return self::ESC_CHARSET_MAP[$code];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Convert an Escape Character Code Encoding to the iconv character
+	 * encoding.
+	 * @param string $charset The iconv charset encoding to be encoded
+	 * @return string The ESC character code representing the encoding.
+	 */
+	public static function encodeEscapeCharset(string $charset): string
+	{
+		return array_search($charset, self::ESC_CHARSET_MAP);
 	}
 }

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -294,6 +294,7 @@ return [
 'TDbParameterModule' => 'Prado\Util\TDbParameterModule',
 'TDbPluginModule' => 'Prado\Util\TDbPluginModule',
 'TEmailLogRoute' => 'Prado\Util\TEmailLogRoute',
+'TEscCharsetConverter' => 'Prado\Util\TEscCharsetConverter',
 'TFileLogRoute' => 'Prado\Util\TFileLogRoute',
 'TFirebugLogRoute' => 'Prado\Util\TFirebugLogRoute',
 'TFirePhpLogRoute' => 'Prado\Util\TFirePhpLogRoute',


### PR DESCRIPTION
```
toUTF8($string, $from, $lang = null)
fromUTF8($string, $to, $lang = null)
```
these functions add the $lang parameter for setting the PHP setLocale(LC_CTYPE, $lang) because various countries/languages have slightly different character sets despite being the same encoding.  eg ASCII has different national standards.

This is the most comprehensive list of ESC character set encodings i was able to find in reasonable time.