### PR TITLE
#827 TTemplateManager accepts template class and culture

### DIFF
--- a/framework/Web/UI/ITemplate.php
+++ b/framework/Web/UI/ITemplate.php
@@ -27,10 +27,10 @@ interface ITemplate
 	 * @param \Prado\Web\UI\TControl $parent the parent control
 	 */
 	public function instantiateIn($parent);
-    
-    /**
-     * TTemplateManager calls this method for caching the included file modification times.
-     * @return array list of included external template files
-     */
-    public function getIncludedFiles();
+
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles();
 }

--- a/framework/Web/UI/ITemplate.php
+++ b/framework/Web/UI/ITemplate.php
@@ -27,4 +27,10 @@ interface ITemplate
 	 * @param \Prado\Web\UI\TControl $parent the parent control
 	 */
 	public function instantiateIn($parent);
+    
+    /**
+     * TTemplateManager calls this method for caching the included file modification times.
+     * @return array list of included external template files
+     */
+    public function getIncludedFiles();
 }

--- a/framework/Web/UI/JuiControls/TJuiAutoCompleteTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiAutoCompleteTemplate.php
@@ -38,7 +38,7 @@ class TJuiAutoCompleteTemplate extends \Prado\TComponent implements ITemplate
 	{
 		$parent->getControls()->add($this->_template);
 	}
-	
+
 	/**
 	 * TTemplateManager calls this method for caching the included file modification times.
 	 * @return array list of included external template files

--- a/framework/Web/UI/JuiControls/TJuiAutoCompleteTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiAutoCompleteTemplate.php
@@ -38,4 +38,13 @@ class TJuiAutoCompleteTemplate extends \Prado\TComponent implements ITemplate
 	{
 		$parent->getControls()->add($this->_template);
 	}
+	
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles()
+	{
+		return [];
+	}
 }

--- a/framework/Web/UI/JuiControls/TJuiSelectableTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiSelectableTemplate.php
@@ -38,4 +38,13 @@ class TJuiSelectableTemplate extends \Prado\TComponent implements ITemplate
 	{
 		$parent->getControls()->add($this->_template);
 	}
+	
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles()
+	{
+		return [];
+	}
 }

--- a/framework/Web/UI/JuiControls/TJuiSelectableTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiSelectableTemplate.php
@@ -38,7 +38,7 @@ class TJuiSelectableTemplate extends \Prado\TComponent implements ITemplate
 	{
 		$parent->getControls()->add($this->_template);
 	}
-	
+
 	/**
 	 * TTemplateManager calls this method for caching the included file modification times.
 	 * @return array list of included external template files

--- a/framework/Web/UI/JuiControls/TJuiSortableTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiSortableTemplate.php
@@ -38,4 +38,13 @@ class TJuiSortableTemplate extends \Prado\TComponent implements ITemplate
 	{
 		$parent->getControls()->add($this->_template);
 	}
+	
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles()
+	{
+		return [];
+	}
 }

--- a/framework/Web/UI/JuiControls/TJuiSortableTemplate.php
+++ b/framework/Web/UI/JuiControls/TJuiSortableTemplate.php
@@ -38,7 +38,7 @@ class TJuiSortableTemplate extends \Prado\TComponent implements ITemplate
 	{
 		$parent->getControls()->add($this->_template);
 	}
-	
+
 	/**
 	 * TTemplateManager calls this method for caching the included file modification times.
 	 * @return array list of included external template files

--- a/framework/Web/UI/TTemplateManager.php
+++ b/framework/Web/UI/TTemplateManager.php
@@ -11,6 +11,7 @@ namespace Prado\Web\UI;
 
 use Prado\Prado;
 use Prado\TApplicationMode;
+use Prado\TPropertyValue;
 
 /**
  * TTemplateManager class
@@ -42,6 +43,10 @@ class TTemplateManager extends \Prado\TModule
 	 * Prefix of the cache variable name for storing parsed templates
 	 */
 	public const TEMPLATE_CACHE_PREFIX = 'prado:template:';
+	/**
+	 * @var string Default template class, default '\Prado\Web\UI\TTemplate'
+	 */
+	private string $_defaultTemplateClass = TTemplate::class;
 
 	/**
 	 * Initializes the module.
@@ -69,17 +74,25 @@ class TTemplateManager extends \Prado\TModule
 
 	/**
 	 * Loads the template from the specified file.
-	 * @param mixed $fileName
-	 * @return \Prado\Web\UI\TTemplate template parsed from the specified file, null if the file doesn't exist.
+	 * @param string $fileName The file path and name of the template.
+	 * @param string $tplClass, default null for the Default Template Class
+	 * @param string $culture culture string, null to use current application culture
+	 * @return \Prado\Web\UI\TTemplate or subclass template parsed from the specified file, null if the file doesn't exist.
 	 */
-	public function getTemplateByFileName($fileName)
+	public function getTemplateByFileName($fileName, $tplClass = null, $culture = null)
 	{
-		if (($fileName = $this->getLocalizedTemplate($fileName)) !== null) {
+		if ($tplClass === null) {
+			$tplClass = $this->_defaultTemplateClass;
+		}
+		if ($tplClass != TTemplate::class && !is_subclass_of($tplClass, TTemplate::class)) {
+			return null;
+		}
+		if (($fileName = $this->getLocalizedTemplate($fileName, $culture)) !== null) {
 			Prado::trace("Loading template $fileName", TTemplateManager::class);
 			if (($cache = $this->getApplication()->getCache()) === null) {
-				return new TTemplate(file_get_contents($fileName), dirname($fileName), $fileName);
+				return new $tplClass(file_get_contents($fileName), dirname($fileName), $fileName);
 			} else {
-				$array = $cache->get(self::TEMPLATE_CACHE_PREFIX . $fileName);
+				$array = $cache->get(self::TEMPLATE_CACHE_PREFIX . $fileName . ':' . $tplClass);
 				if (is_array($array)) {
 					[$template, $timestamps] = $array;
 					if ($this->getApplication()->getMode() === TApplicationMode::Performance) {
@@ -96,14 +109,14 @@ class TTemplateManager extends \Prado\TModule
 						return $template;
 					}
 				}
-				$template = new TTemplate(file_get_contents($fileName), dirname($fileName), $fileName);
+				$template = new $tplClass(file_get_contents($fileName), dirname($fileName), $fileName);
 				$includedFiles = $template->getIncludedFiles();
 				$timestamps = [];
 				$timestamps[$fileName] = filemtime($fileName);
 				foreach ($includedFiles as $includedFile) {
 					$timestamps[$includedFile] = filemtime($includedFile);
 				}
-				$cache->set(self::TEMPLATE_CACHE_PREFIX . $fileName, [$template, $timestamps]);
+				$cache->set(self::TEMPLATE_CACHE_PREFIX . $fileName . ':' . $tplClass, [$template, $timestamps]);
 				return $template;
 			}
 		} else {
@@ -114,18 +127,35 @@ class TTemplateManager extends \Prado\TModule
 	/**
 	 * Finds a localized template file.
 	 * @param string $filename template file.
+	 * @param string $culture culture string, null to use current culture
 	 * @return null|string a localized template file if found, null otherwise.
 	 */
-	protected function getLocalizedTemplate($filename)
+	protected function getLocalizedTemplate($filename, $culture = null)
 	{
 		if (($app = $this->getApplication()->getGlobalization(false)) === null) {
 			return is_file($filename) ? $filename : null;
 		}
-		foreach ($app->getLocalizedResource($filename) as $file) {
+		foreach ($app->getLocalizedResource($filename, $culture) as $file) {
 			if (($file = realpath($file)) !== false && is_file($file)) {
 				return $file;
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * @return string the default template class.
+	 */
+	public function getDefaultTemplateClass(): string
+	{
+		return $this->_defaultTemplateClass;
+	}
+
+	/**
+	 * @param string $tplClass the default template class.
+	 */
+	public function setDefaultTemplateClass($tplClass)
+	{
+		$this->_defaultTemplateClass = TPropertyValue::ensureString($tplClass);
 	}
 }

--- a/framework/Web/UI/TTemplateManager.php
+++ b/framework/Web/UI/TTemplateManager.php
@@ -84,7 +84,7 @@ class TTemplateManager extends \Prado\TModule
 		if ($tplClass === null) {
 			$tplClass = $this->_defaultTemplateClass;
 		}
-		if ($tplClass != TTemplate::class && !is_subclass_of($tplClass, TTemplate::class)) {
+		if ($tplClass != ITemplate::class && !is_subclass_of($tplClass, ITemplate::class)) {
 			return null;
 		}
 		if (($fileName = $this->getLocalizedTemplate($fileName, $culture)) !== null) {

--- a/framework/Web/UI/WebControls/TWizardNavigationTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardNavigationTemplate.php
@@ -48,7 +48,7 @@ class TWizardNavigationTemplate extends \Prado\TComponent implements ITemplate
 	public function instantiateIn($parent)
 	{
 	}
-	
+
 	/**
 	 * TTemplateManager calls this method for caching the included file modification times.
 	 * @return array list of included external template files

--- a/framework/Web/UI/WebControls/TWizardNavigationTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardNavigationTemplate.php
@@ -48,6 +48,15 @@ class TWizardNavigationTemplate extends \Prado\TComponent implements ITemplate
 	public function instantiateIn($parent)
 	{
 	}
+	
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles()
+	{
+		return [];
+	}
 
 	/**
 	 * Creates a navigation button.

--- a/framework/Web/UI/WebControls/TWizardSideBarListItemTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardSideBarListItemTemplate.php
@@ -30,7 +30,7 @@ class TWizardSideBarListItemTemplate extends \Prado\TComponent implements ITempl
 		$button->setID(TWizard::ID_SIDEBAR_BUTTON);
 		$parent->getControls()->add($button);
 	}
-	
+
 	/**
 	 * TTemplateManager calls this method for caching the included file modification times.
 	 * @return array list of included external template files

--- a/framework/Web/UI/WebControls/TWizardSideBarListItemTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardSideBarListItemTemplate.php
@@ -30,4 +30,13 @@ class TWizardSideBarListItemTemplate extends \Prado\TComponent implements ITempl
 		$button->setID(TWizard::ID_SIDEBAR_BUTTON);
 		$parent->getControls()->add($button);
 	}
+	
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles()
+	{
+		return [];
+	}
 }

--- a/framework/Web/UI/WebControls/TWizardSideBarTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardSideBarTemplate.php
@@ -32,4 +32,13 @@ class TWizardSideBarTemplate extends \Prado\TComponent implements ITemplate
 		$dataList->setItemTemplate(new TWizardSideBarListItemTemplate());
 		$parent->getControls()->add($dataList);
 	}
+	
+	/**
+	 * TTemplateManager calls this method for caching the included file modification times.
+	 * @return array list of included external template files
+	 */
+	public function getIncludedFiles()
+	{
+		return [];
+	}
 }

--- a/framework/Web/UI/WebControls/TWizardSideBarTemplate.php
+++ b/framework/Web/UI/WebControls/TWizardSideBarTemplate.php
@@ -32,7 +32,7 @@ class TWizardSideBarTemplate extends \Prado\TComponent implements ITemplate
 		$dataList->setItemTemplate(new TWizardSideBarListItemTemplate());
 		$parent->getControls()->add($dataList);
 	}
-	
+
 	/**
 	 * TTemplateManager calls this method for caching the included file modification times.
 	 * @return array list of included external template files


### PR DESCRIPTION
With the option of setting a new default template class upon instancing of TTemplateManager.

This change allows a template to be formed upon a designated culture rather than just the web user's culture settings.  this is important for when sending emails to someone with different culture settings.  The template must be formed around the email receiver and not the web user.