### PR TITLE
#829 Moved TThemeManager and TTemplateManager from TPageService to TApplication

### DIFF
--- a/framework/Exceptions/messages/messages-fr.txt
+++ b/framework/Exceptions/messages/messages-fr.txt
@@ -161,7 +161,6 @@ authmanager_usermanager_invalid			= TAuthManager.UserManager '{0}' does not refe
 authmanager_usermanager_unchangeable	= TAuthManager.UserManager cannot be modified after the module is initialized.
 authmanager_session_required			= TAuthManager requires a session application module.
 
-thememanager_service_unavailable		= TThemeManager requires TPageService to be available. This error often occurs when you configure TThemeManager outside of the page service configuration.
 thememanager_basepath_invalid			= TThemeManager.BasePath '{0}' is not a valid path alias. Make sure you have defined this alias in configuration and it points to a valid directory.
 thememanager_basepath_invalid2			= TThemeManager.BasePath '{0}' is not a valid directory.
 thememanager_basepath_unchangeable		= TThemeManager.BasePath cannot be modified after the module is initialized.

--- a/framework/Exceptions/messages/messages-id.txt
+++ b/framework/Exceptions/messages/messages-id.txt
@@ -161,7 +161,6 @@ authmanager_usermanager_invalid		= TAuthManager.UserManager '{0}' tidak merujuk 
 authmanager_usermanager_unchangeable	= TAuthManager.UserManager tidak bisa diubah setelah modul diinisialisasi.
 authmanager_session_required		= TAuthManager memerlukan modul aplikasi sesi.
 
-thememanager_service_unavailable	= TThemeManager memerlukan ketersediaan TPageService. Kesalahan ini sering terjadi saat anda mengkonfigurasi TThemeManager di luar konfigurasi layanan halaman.
 thememanager_basepath_invalid		= TThemeManager.BasePath '{0}' bukan alias path yang benar. Pastikan anda telah mendefinisikan alias ini dalam konfigurasi dan mengarahkan ke direktori yang benar.
 thememanager_basepath_invalid2		= TThemeManager.BasePath '{0}' bukan direktori yang benar.
 thememanager_basepath_unchangeable	= TThemeManager.BasePath tidak bisa diubah setelah modul diinisialisasi.

--- a/framework/Exceptions/messages/messages-zh.txt
+++ b/framework/Exceptions/messages/messages-zh.txt
@@ -166,7 +166,6 @@ authmanager_usermanager_invalid			= TAuthManager.UserManager '{0}' does not refe
 authmanager_usermanager_unchangeable	= TAuthManager.UserManager cannot be modified after the module is initialized.
 authmanager_session_required			= TAuthManager requires a session application module.
 
-thememanager_service_unavailable		= TThemeManager requires TPageService to be available. This error often occurs when you configure TThemeManager outside of the page service configuration.
 thememanager_basepath_invalid			= TThemeManager.BasePath '{0}' is not a valid path alias. Make sure you have defined this alias in configuration and it points to a valid directory.
 thememanager_basepath_invalid2			= TThemeManager.BasePath '{0}' is not a valid directory.
 thememanager_basepath_unchangeable		= TThemeManager.BasePath cannot be modified after the module is initialized.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -224,7 +224,6 @@ permissions_children_invalid			= TPermissionsManager.*RoleChildren children must
 permissions_property_unchangeable		= TPermissionsManager.{0} cannot be set because it is already initialized.
 permissions_permissionfile_invalid		= TPermissionsManager.PermissionFile '{0}' is not a valid file.
 
-thememanager_service_unavailable		= TThemeManager requires TPageService to be available. This error often occurs when you configure TThemeManager outside of the page service configuration.
 thememanager_basepath_invalid			= TThemeManager.BasePath '{0}' is not a valid path alias. Make sure you have defined this alias in configuration and it points to a valid directory.
 thememanager_basepath_invalid2			= TThemeManager.BasePath '{0}' is not a valid directory.
 thememanager_basepath_unchangeable		= TThemeManager.BasePath cannot be modified after the module is initialized.

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -18,9 +18,9 @@ use Prado\Web\TAssetManager;
 use Prado\Web\THttpRequest;
 use Prado\Web\THttpResponse;
 use Prado\Web\THttpSession;
+use Prado\Util\TLogger;
 use Prado\Web\UI\TTemplateManager;
 use Prado\Web\UI\TThemeManager;
-use Prado\Util\TLogger;
 
 /**
  * TApplication class.

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -18,6 +18,8 @@ use Prado\Web\TAssetManager;
 use Prado\Web\THttpRequest;
 use Prado\Web\THttpResponse;
 use Prado\Web\THttpSession;
+use Prado\Web\UI\TTemplateManager;
+use Prado\Web\UI\TThemeManager;
 use Prado\Util\TLogger;
 
 /**
@@ -264,6 +266,14 @@ class TApplication extends \Prado\TComponent
 	 * @var TAssetManager asset manager module
 	 */
 	private $_assetManager;
+	/**
+	 * @var \Prado\Web\UI\TTemplateManager template manager module
+	 */
+	private $_templateManager;
+	/**
+	 * @var \Prado\Web\UI\TThemeManager theme manager module
+	 */
+	private $_themeManager;
 	/**
 	 * @var \Prado\Security\TAuthorizationRuleCollection collection of authorization rules
 	 */
@@ -861,6 +871,46 @@ class TApplication extends \Prado\TComponent
 	public function setAssetManager(TAssetManager $value)
 	{
 		$this->_assetManager = $value;
+	}
+
+	/**
+	 * @return TTemplateManager template manager
+	 */
+	public function getTemplateManager()
+	{
+		if (!$this->_templateManager) {
+			$this->_templateManager = new TTemplateManager();
+			$this->_templateManager->init(null);
+		}
+		return $this->_templateManager;
+	}
+
+	/**
+	 * @param TTemplateManager $value template manager
+	 */
+	public function setTemplateManager(TTemplateManager $value)
+	{
+		$this->_templateManager = $value;
+	}
+
+	/**
+	 * @return TThemeManager theme manager
+	 */
+	public function getThemeManager()
+	{
+		if (!$this->_themeManager) {
+			$this->_themeManager = new TThemeManager();
+			$this->_themeManager->init(null);
+		}
+		return $this->_themeManager;
+	}
+
+	/**
+	 * @param TThemeManager $value theme manager
+	 */
+	public function setThemeManager(TThemeManager $value)
+	{
+		$this->_themeManager = $value;
 	}
 
 	/**

--- a/framework/Web/Services/TPageService.php
+++ b/framework/Web/Services/TPageService.php
@@ -137,14 +137,6 @@ class TPageService extends \Prado\TService
 	 * @var bool whether service is initialized
 	 */
 	private $_initialized = false;
-	/**
-	 * @var TThemeManager theme manager
-	 */
-	private $_themeManager;
-	/**
-	 * @var TTemplateManager template manager
-	 */
-	private $_templateManager;
 
 	/**
 	 * Initializes the service.
@@ -295,42 +287,38 @@ class TPageService extends \Prado\TService
 
 	/**
 	 * @return TTemplateManager template manager
+	 * @deprecated 4.2.3, removal in 4.3
 	 */
 	public function getTemplateManager()
 	{
-		if (!$this->_templateManager) {
-			$this->_templateManager = new TTemplateManager();
-			$this->_templateManager->init(null);
-		}
-		return $this->_templateManager;
+		return Prado::getApplication()->getTemplateManager();
 	}
 
 	/**
 	 * @param TTemplateManager $value template manager
+	 * @deprecated 4.2.3, removal in 4.3
 	 */
 	public function setTemplateManager(TTemplateManager $value)
 	{
-		$this->_templateManager = $value;
+		Prado::getApplication()->setTemplateManager($value);
 	}
 
 	/**
 	 * @return TThemeManager theme manager
+	 * @deprecated 4.2.3, removal in 4.3
 	 */
 	public function getThemeManager()
 	{
-		if (!$this->_themeManager) {
-			$this->_themeManager = new TThemeManager();
-			$this->_themeManager->init(null);
-		}
-		return $this->_themeManager;
+		return Prado::getApplication()->getThemeManager();
 	}
 
 	/**
 	 * @param TThemeManager $value theme manager
+	 * @deprecated 4.2.3, removal in 4.3
 	 */
 	public function setThemeManager(TThemeManager $value)
 	{
-		$this->_themeManager = $value;
+		Prado::getApplication() > setThemeManager($value);
 	}
 
 	/**

--- a/framework/Web/Services/TPageService.php
+++ b/framework/Web/Services/TPageService.php
@@ -318,7 +318,7 @@ class TPageService extends \Prado\TService
 	 */
 	public function setThemeManager(TThemeManager $value)
 	{
-		Prado::getApplication() > setThemeManager($value);
+		Prado::getApplication()->setThemeManager($value);
 	}
 
 	/**

--- a/framework/Web/UI/TTemplateManager.php
+++ b/framework/Web/UI/TTemplateManager.php
@@ -51,7 +51,7 @@ class TTemplateManager extends \Prado\TModule
 	 */
 	public function init($config)
 	{
-		$this->getService()->setTemplateManager($this);
+		Prado::getApplication()->setTemplateManager($this);
 		parent::init($config);
 	}
 

--- a/framework/Web/UI/TThemeManager.php
+++ b/framework/Web/UI/TThemeManager.php
@@ -77,12 +77,7 @@ class TThemeManager extends \Prado\TModule
 	public function init($config)
 	{
 		$this->_initialized = true;
-		$service = $this->getService();
-		if ($service instanceof TPageService) {
-			$service->setThemeManager($this);
-		} else {
-			throw new TConfigurationException('thememanager_service_unavailable');
-		}
+		Prado::getApplication()->setThemeManager($this);
 		parent::init($config);
 	}
 


### PR DESCRIPTION
the old methods in TPageService were marked deprecated and marked for removal in PRADO 4.3.

one error message wasn't needed any more.  It was deleted.