### PR TITLE
#827 TTemplateManager no need to check class against an interface

### DIFF
--- a/framework/Web/UI/TTemplateManager.php
+++ b/framework/Web/UI/TTemplateManager.php
@@ -84,7 +84,7 @@ class TTemplateManager extends \Prado\TModule
 		if ($tplClass === null) {
 			$tplClass = $this->_defaultTemplateClass;
 		}
-		if ($tplClass != ITemplate::class && !is_subclass_of($tplClass, ITemplate::class)) {
+		if (!is_subclass_of($tplClass, ITemplate::class)) {
 			return null;
 		}
 		if (($fileName = $this->getLocalizedTemplate($fileName, $culture)) !== null) {


### PR DESCRIPTION
remove remnant code from when checking against TTemplate rather than ITemplate.