### PR TITLE
#824 TBehaviorParameterLoader needs config on Behavior::init, dyInit fed its parameter configuration object

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ## Version 4.2.3 - TBA
 
+BUG: Issue #824 - All system initialized behaviors call the behavior "init($config)"" similar to TModule. (belisoful)
+BUG: Issue #848 - TComponent events support Closures [anonymous functions]. (belisoful)
 ENH: Issue #886 - Lists the 1st level traits of the class and its parents in TComponent::getClassHierarchy.  Class-wide behaviors support attaching to Traits as well as interfaces, classes, and their parents. (belisoful)
 ENH: Issue #845 - PHP Clone and Unserialize of TComponent objects supports behaviors. (belisoful)
 BUG: Issue #843 - Permissions Manager behaviors rename the method 'getManager' to 'getPermissionsManager' for specificity. (belisoful)
@@ -18,7 +20,6 @@ ENH: Issues #840, #847 - TPriority updates (belisoful)
 ENH: Issues #818, #846 - TCallChain updates (belisoful)
 ENH: Issue #866 - HTMLPurifier_Config and cache path (majuca)
 ENH: Issue #868 - RFC: Service detection is fragile (ctrlaltca)
-BUG: Issue #815 - Cron tasks delay until their proper time on first entry. Long running cron tasks no longer repeat further pending tasks. (belisoful)
 ENH: Issue #865 - File and dir permissions were too permissive 0777, now the file permissions are 0644 and 0755 for directory by default. (majuca)
 ENH: Issue #869 - Remove execute permission on all files excepted on php-cli (majuca)
 ENH: Issue #875 - Make Prado::using able to autoload traits defined as prado3 namespaces (ctrlaltca)

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -1080,7 +1080,7 @@ class TApplication extends \Prado\TComponent
 				foreach ($parameter[1] as $name => $value) {
 					$component->setSubProperty($name, $value);
 				}
-				$component->dyInit(null);
+				$component->dyInit($parameter[2]);
 				$this->_parameters->add($id, $component);
 			} else {
 				$this->_parameters->add($id, $parameter);

--- a/framework/TApplicationConfiguration.php
+++ b/framework/TApplicationConfiguration.php
@@ -425,7 +425,7 @@ class TApplicationConfiguration extends \Prado\TComponent
 					unset($parameter['class']);
 					$properties = $parameter['properties'] ?? [];
 					$properties['id'] = $id;
-					$this->_parameters[$id] = [$type, $properties];
+					$this->_parameters[$id] = [$type, $properties, $parameter];
 				}
 			} else {
 				$this->_parameters[$id] = $parameter;
@@ -453,7 +453,7 @@ class TApplicationConfiguration extends \Prado\TComponent
 						$this->_parameters[$id] = $value;
 					}
 				} else {
-					$this->_parameters[$id] = [$type, $properties->toArray()];
+					$this->_parameters[$id] = [$type, $properties->toArray(), $element];
 				}
 				$this->_empty = false;
 			} else {

--- a/framework/Util/Behaviors/TBehaviorParameterLoader.php
+++ b/framework/Util/Behaviors/TBehaviorParameterLoader.php
@@ -14,6 +14,7 @@ use Prado\Exceptions\TConfigurationException;
 use Prado\Prado;
 use Prado\TComponent;
 use Prado\TPropertyValue;
+use Prado\Util\IBaseBehavior;
 
 /**
  * TBehaviorParameterLoader class.
@@ -82,6 +83,7 @@ class TBehaviorParameterLoader extends TComponent
 			throw new TConfigurationException('behaviorparameterloader_attachto_and_class_only_one');
 		}
 		$this->_properties['class'] = $this->_behaviorClass;
+		$this->_properties[IBaseBehavior::CONFIG_KEY] = $config;
 		if ($this->_attachtoclass) {
 			TComponent::attachClassBehavior($this->_behaviorName, $this->_properties, $this->_attachtoclass, $this->_priority);
 		} else {

--- a/framework/Util/TParameterModule.php
+++ b/framework/Util/TParameterModule.php
@@ -101,8 +101,7 @@ class TParameterModule extends \Prado\TModule
 		if (is_array($config)) {
 			foreach ($config as $id => $parameter) {
 				if (is_array($parameter) && isset($parameter['class'])) {
-					$properties = $parameter['properties'] ?? [];
-					$parameters[$id] = [$parameter['class'], $properties];
+					$parameters[$id] = [$parameter['class'], $parameter['properties'] ?? [], $parameter];
 				} else {
 					$parameters[$id] = $parameter;
 				}
@@ -120,7 +119,7 @@ class TParameterModule extends \Prado\TModule
 						$parameters[$id] = $value;
 					}
 				} else {
-					$parameters[$id] = [$type, $properties->toArray()];
+					$parameters[$id] = [$type, $properties->toArray(), $node];
 				}
 			}
 		}
@@ -132,7 +131,7 @@ class TParameterModule extends \Prado\TModule
 				foreach ($parameter[1] as $name => $value) {
 					$component->setSubProperty($name, $value);
 				}
-				$component->dyInit(null);
+				$component->dyInit($parameter[2]);
 				$appParams->add($id, $component);
 			} else {
 				$appParams->add($id, $parameter);

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -196,7 +196,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	}
 	
 	
-	public function testEnsureColor()
+	public function testEnsureHexColor()
 	{
 		// Integer Color in format 0x00RRGGBB
 		self::assertEquals('#000000', TPropertyValue::ensureHexColor(0));

--- a/tests/unit/Util/Behaviors/TBehaviorParameterLoaderTest.php
+++ b/tests/unit/Util/Behaviors/TBehaviorParameterLoaderTest.php
@@ -7,6 +7,17 @@ use Prado\Web\UI\TPage;
 class TestModuleBehaviorLoader1 extends TBehavior
 {
 	private $_propertyA = 'default';
+	public $config = null;
+	
+	public const NULL_CONFIG = "null-config";
+	
+	public function init($config)
+	{
+		if ($config === null)
+			$config = self::NULL_CONFIG;
+		$this->config = $config;
+	}
+	
 	public function getPropertyA()
 	{
 		return $this->_propertyA;
@@ -116,11 +127,12 @@ class TBehaviorParameterLoaderTest extends PHPUnit\Framework\TestCase
 			$this->obj->BehaviorClass = 'TestModuleBehaviorLoader1';
 			$this->obj->AttachTo = 'Application';
 			$this->obj->propertya = 'value1';
-			$this->obj->dyInit(null);
+			$this->obj->dyInit(['data123']);
 			
 			//Check was App behavior installed
 			$this->assertInstanceOf('TestModuleBehaviorLoader1', $app->asa('testBehavior1'));
 			$this->assertEquals('value1', $app->asa('testBehavior1')->propertyA);
+			$this->assertEquals(['data123'], $app->asa('testBehavior1')->config);
 			$app->detachBehavior('testBehavior1');
 		}
 	}


### PR DESCRIPTION
This updates two parts

- TBehaviorParameterLoader needed to stash the $config into the behavior initialization array so it would init with the data properly.
- dyInit is fed its xml parameter node or php array in case it has more complex configuration than just one node or properties.