### PR TITLE
4.2.3 General Behaviors Update... 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 ## Version 4.2.3 - TBA
 
-BUG: Issue #824 - All system initialized behaviors call the behavior "init($config)"" similar to TModule. (belisoful)
-BUG: Issue #848 - TComponent events support Closures [anonymous functions]. (belisoful)
+ENH: Issues #824, #838, #851, #891 - General Behaviors Update: IBaseBehavior has init($config) method. TClassBehavior tracks their owners.  Behaviors attach their registered event handlers at the behavior priority.  Registered Behavior event can optionally attached and detached automatically when the behavior is enabled or disabled (default).  Behavior events() support Closures and multiple handlers per event. IBehaviors are attachable class-wide by cloning. Behaviors for behaviors has better support. (belisoful)
+ENH: ISSUE #848 - TComponent events support Closure (anonymous functions) as handlers. (belisoful)
 ENH: Issue #886 - Lists the 1st level traits of the class and its parents in TComponent::getClassHierarchy.  Class-wide behaviors support attaching to Traits as well as interfaces, classes, and their parents. (belisoful)
 ENH: Issue #845 - PHP Clone and Unserialize of TComponent objects supports behaviors. (belisoful)
 BUG: Issue #843 - Permissions Manager behaviors rename the method 'getManager' to 'getPermissionsManager' for specificity. (belisoful)

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -140,7 +140,19 @@ pageserviceconf_parameter_invalid		= <parameter> element must have an "id" attri
 pageserviceconf_page_invalid			= <page> element must have an "id" attribute in page directory configuration file '{0}'.
 pageserviceconf_includefile_required	= Page configuration <include> element must have a "file" attribute.
 
-callchain_bad_dynamic_event				= TCallChain.{0} was raised but {1} was expected..
+basebehavior_cannot_setname_with_owner	= The TBaseBehavior.Name "{0}" cannot be changed (to "{1}") after the behavior is attached.
+basebehavior_sync_no_owner				= The TBaseBehavior "{0}" has no owner and cannot synchronize event handlers on a component without owners.
+basebehavior_sync_not_owner				= The TBaseBehavior "{0}" cannot synchronize event handlers on an object that is not the owner.
+behavior_has_owner						= The TBehavior "{0}" can only attach to one owner.
+behavior_bad_attach_component			= The TBehavior "{0}" can only attach to a TComponent.
+behavior_detach_without_owner			= The TBehavior "{0}" cannot be detached without an owner.
+behavior_detach_wrong_owner				= The TBehavior "{0}" cannot detach from an object that is not its owner.
+classbehavior_owner_attach_once			= The TClassBehavior "{0}" can only be attached to an owner once.  The handlers would not be unique.
+classbehavior_bad_attach_component		= The TClassBehavior "{0}" can only attach to a TComponent.
+classbehavior_detach_without_owner		= The TClassBehavior "{0}" cannot be detached without an owner.
+classbehavior_detach_wrong_owner		= The TClassBehavior "{0}" cannot detach from an object that is not its owner.
+
+callchain_bad_dynamic_event				= TCallChain.{0} was raised but {1} was expected.
 
 behaviormodule_behavior_as_array_required = php <behavior> must be an array.
 behaviormodule_behaviorname_required	= <behavior> must contain a 'name' attribute for attaching the behavior.

--- a/framework/Util/Behaviors/TBehaviorParameterLoader.php
+++ b/framework/Util/Behaviors/TBehaviorParameterLoader.php
@@ -10,6 +10,7 @@
 
 namespace Prado\Util\Behaviors;
 
+use Prado\Collections\TPriorityItemTrait;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Prado;
 use Prado\TComponent;
@@ -39,14 +40,13 @@ use Prado\Util\IBaseBehavior;
  */
 class TBehaviorParameterLoader extends TComponent
 {
+	use TPriorityItemTrait;
+
 	/** @var string name of the behavior attaching to the owner */
 	private $_behaviorName;
 
 	/** @var string class of the behavior attaching to the owner */
 	private $_behaviorClass;
-
-	/** @var numeric priority of the behavior attaching to the owner */
-	private $_priority;
 
 	/** @var string what object to attach the behavior */
 	private $_attachto;
@@ -224,24 +224,6 @@ class TBehaviorParameterLoader extends TComponent
 	public function setBehaviorClass($className)
 	{
 		$this->_behaviorClass = TPropertyValue::ensureString($className);
-	}
-
-	/**
-	 * gets the priority of the attaching behavior.
-	 * @return numeric the priority of the attaching behavior.
-	 */
-	public function getPriority()
-	{
-		return $this->_priority;
-	}
-
-	/**
-	 * sets the priority of the attaching behavior.
-	 * @param numeric $priority the priority of the attaching behavior.
-	 */
-	public function setPriority($priority)
-	{
-		$this->_priority = TPropertyValue::ensureFloat($priority);
 	}
 
 	/**

--- a/framework/Util/IBaseBehavior.php
+++ b/framework/Util/IBaseBehavior.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * TComponent, TPropertyValue classes
+ * IBaseBehavior class
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  *
- * Global Events, intra-object events, Class behaviors, expanded behaviors
- * @author Brad Anderson <javalizard@mac.com>
+ * Dynamic events, Class-wide behaviors, expanded behaviors
+ * @author Brad Anderson <belisoful@icloud.com>
  *
  * @link https://github.com/pradosoft/prado
  * @license https://github.com/pradosoft/prado/blob/master/LICENSE
@@ -13,33 +13,117 @@
 
 namespace Prado\Util;
 
+use Prado\Collections\IPriorityProperty;
+
 /**
- * IBaseBehavior interface is the base behavior class from which all other
- * behaviors types are derived
+ * IBaseBehavior interface is the base behavior interface from which the two PRADO
+ * behaviors interface types are derived.  All behaviors are attached to an owner
+ * TComponent, essentially extending it with run time traits; implementing new methods,
+ * properties, and fine internal process control for the owner component at run time.
  *
- * @author Brad Anderson <javalizard@mac.com>
+ * There are two specific types of behaviors in PRADO:
+ * -{@link IClassBehavior} is stateless and one instance attaches to multiple owners.
+ *    The owner is injected as the first parameter argument in behavior implemented
+ *    methods called on the owner.
+ * -{@link IBehavior} is stateful and each one instance attaches to one owner.
+ *
+ * All public methods and properties in the behavior are inherited by the owners
+ * and so IBaseBehavior act like run-time traits.
+ *
+ * IBaseBehavior handler "dy" dynamic events their from owners as well.  "dy" dynamic
+ * events are an optional event system between owners and behaviors.  When an owner
+ * calls a method starting with "dy", all attached enabled behaviors implementing
+ * the dynamic event are raised. For example:
+ * <code>
+ *		$filteredData = $componentObject->dyFilterData($data);
+ * </code>
+ * would automatically call all enabled behaviors attached to $componentObject implementing
+ * dyFilterData(..., ?TCallchain $chain = null).  The first parameter in "dy" dynamic
+ * events is passed through as the return value and so acts like a filter or default
+ * return value.  When there are no handlers for a dynamic event, the returned value
+ * will always be the value of the first method parameter.
+ *
+ * "dy" dynamic event methods append a "TCallChain" to the argument lists and the
+ * event must be called on with the dynamic event to continue the call chain. Dynamic
+ * events work slightly differently between IClassBehavior and IBehavior where the
+ * IClassBehavior has the owner object injected as the first method argument and
+ * the IBehavior does not.  The call chain may be optional to make the dynamic event
+ * method callable without the $chain but will always be present in owner called
+ * behavior dynamic event methods.
+ *
+ * See {@link IBehavior} and {@link IClassBehavior} for examples of their respective
+ * dynamic event implementations.
+ *
+ * @author Brad Anderson <belisoful@icloud.ocm>
  * @since 3.2.3
  */
-interface IBaseBehavior
+interface IBaseBehavior extends IPriorityProperty
 {
 	/**
 	 * The array key for the $config data in instancing behaviors with init($config),
 	 */
-	public const CONFIG_KEY = "=config";
+	public const CONFIG_KEY = '=config=';
+
 	/**
-	 * Handles behavior configurations from TBehaviorsModule
-	 * @param mixed $config
+	 * Handles behavior configurations from TBehaviorsModule and TBehaviorParameterLoader.
+	 * @param mixed $config The configuration data.
 	 * @since 4.2.2
 	 */
 	public function init($config);
+
 	/**
 	 * Attaches the behavior object to the component.
-	 * @param \Prado\TComponent $component the component that this behavior is to be attached to.
+	 * @param TComponent $component The component that this behavior is being attached to.
 	 */
 	public function attach($component);
+
 	/**
 	 * Detaches the behavior object from the component.
-	 * @param \Prado\TComponent $component the component that this behavior is to be detached from.
+	 * @param TComponent $component The component that this behavior is being detached from.
 	 */
 	public function detach($component);
+
+	/**
+	 * @return bool Whether this behavior is enabled.  See implementation for default.
+	 * @since 4.2.3
+	 */
+	public function getEnabled(): bool;
+
+	/**
+	 * @param bool $value Whether this behavior is enabled.
+	 * @since 4.2.3
+	 */
+	public function setEnabled($value);
+
+	/**
+	 * @return array The owner component(s) that this behavior is attached to. [] when none.
+	 * @since 4.2.3
+	 */
+	public function getOwners(): array;
+
+	/**
+	 * @return bool Is the behavior attached to an owner.
+	 * @since 4.2.3
+	 */
+	public function hasOwner(): bool;
+
+	/**
+	 * @param object $component The component to check if its an owner.
+	 * @return bool Is the object an owner of the behavior.
+	 * @since 4.2.3
+	 */
+	public function isOwner(object $component): bool;
+
+	/**
+	 * Synchronize the $component or all owners' events of the behavior event handlers
+	 * by attaching or detaching handlers where needed.
+	 * @param ?object $component The component to manage the behaviors handlers on. Default
+	 *   is null for synchronizing all owners.
+	 * @param null|bool|int $attachOverride Overrides the default attachment logic or whether
+	 *   to install and forcibly attach or detach the handlers when true or null.  Default
+	 *   is 0 for standard attachment logic.  false resets the overrides to default attachment
+	 *   logic.
+	 * @since 4.2.3
+	 */
+	public function syncEventHandlers(?object $component = null, $attachOverride = 0);
 }

--- a/framework/Util/IBaseBehavior.php
+++ b/framework/Util/IBaseBehavior.php
@@ -73,15 +73,27 @@ interface IBaseBehavior extends IPriorityProperty
 
 	/**
 	 * Attaches the behavior object to the component.
-	 * @param TComponent $component The component that this behavior is being attached to.
+	 * @param Prado\TComponent $component The component that this behavior is being attached to.
 	 */
 	public function attach($component);
 
 	/**
 	 * Detaches the behavior object from the component.
-	 * @param TComponent $component The component that this behavior is being detached from.
+	 * @param Prado\TComponent $component The component that this behavior is being detached from.
 	 */
 	public function detach($component);
+
+	/**
+	 * @return ?string The name of the behavior in the owner[s].
+	 */
+	public function getName(): ?string;
+
+	/**
+	 * @param ?string $value The name of the behavior in the owner[s].
+	 * @throws TInvalidOperationException When there is an owner and the new name is
+	 *   not the same as the given name.
+	 */
+	public function setName($value);
 
 	/**
 	 * @return bool Whether this behavior is enabled.  See implementation for default.

--- a/framework/Util/IBaseBehavior.php
+++ b/framework/Util/IBaseBehavior.php
@@ -73,25 +73,25 @@ interface IBaseBehavior extends IPriorityProperty
 
 	/**
 	 * Attaches the behavior object to the component.
-	 * @param Prado\TComponent $component The component that this behavior is being attached to.
+	 * @param \Prado\TComponent $component The component that this behavior is being attached to.
 	 */
 	public function attach($component);
 
 	/**
 	 * Detaches the behavior object from the component.
-	 * @param Prado\TComponent $component The component that this behavior is being detached from.
+	 * @param \Prado\TComponent $component The component that this behavior is being detached from.
 	 */
 	public function detach($component);
 
 	/**
 	 * @return ?string The name of the behavior in the owner[s].
+	 * @since 4.2.3
 	 */
 	public function getName(): ?string;
 
 	/**
 	 * @param ?string $value The name of the behavior in the owner[s].
-	 * @throws TInvalidOperationException When there is an owner and the new name is
-	 *   not the same as the given name.
+	 * @since 4.2.3
 	 */
 	public function setName($value);
 

--- a/framework/Util/IBehavior.php
+++ b/framework/Util/IBehavior.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * TComponent, TPropertyValue classes
+ * IBehavior class
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  *
- * Global Events, intra-object events, Class behaviors, expanded behaviors
- * @author Brad Anderson <javalizard@mac.com>
+ * Dynamic events, Class-wide behaviors, expanded behaviors
+ * @author Brad Anderson <belisoful@icloud.com>
  *
  * @link https://github.com/pradosoft/prado
  * @license https://github.com/pradosoft/prado/blob/master/LICENSE
@@ -14,11 +14,74 @@
 namespace Prado\Util;
 
 /**
- * IBehavior interfaces is implemented by instance behavior classes.
+ * IBehavior is the base interface for behaviors that extend an owner component with
+ * new state information, properties, run time methods, and fine process modification.
+ * This is a stateful behavior class and retains per object information.  Each instance
+ * of IBehavior may only be attached to a single owner.  When attached at the class
+ * level, IBehaviors are cloned from the given IBehavior object or instanced individually
+ * from its class/property array configuration (or string).
  *
- * A behavior is a way to enhance a component with additional methods and
- * events that are defined in the behavior class and not available in the
- * class.  Objects may signal behaviors through dynamic events.
+ * IBehavior is one of two types of behavior interfaces.  The other type of behavior
+ * interface is the {@link IClassBehavior} that handles stateless behaviors and
+ * where each behavior is attached to multiple different owners.
+ *
+ * All public methods and properties in the behavior are inherited by the owners
+ * and so IBehavior act like run-time traits.
+ *
+ * When a method is called on the owner that is implemented by the behavior, there is
+ * no change in the parameters.  For example:
+ * <code>
+ *  $result = $objWithBehavior->MethodOfBehavior(1, 20);
+ *  $filteredText = $objWithBehavior->dyFilteringBehavior('filter text', 10);
+ * </code>
+ * will be implemented within an IBehavior like this:
+ * <code>
+ *  public function MethodOfBehavior($firstParam, $secondParam)
+ *  {
+ *      // $firstParam === 1, $secondParam === 20
+ *      return $firstParam + $secondParam + $this->getOwner()->getNumber();
+ *  }
+ * </code>
+ *
+ * When an IBehaviors implements a "dy" dynamic event, the {@link TCallChain} is
+ * appended to the end of the method argument list.  For example, a dynamic event method
+ * implementations might look like:
+ * <code>
+ *  public function dyFilteringBehavior($defaultReturnData, $secondParam, TCallChain $chain)
+ *  {
+ *      // $defaultReturnData === 'filter text', $secondParam === 10
+ *      $defaultReturnData = $this->getOwner()->processText($defaultReturnData, $secondParam);
+ *
+ *      // TCallChain dynamic method will return $defaultReturnData after other behaviors are run
+ *      return $chain->dyFilteringBehavior($defaultReturnData, $secondParam);
+ *  }
+ * </code>
+ * In dynamic events, the TCallChain must be called with the dynamic event method
+ * to continue the chain but without the last (TCallChain) argument parameter.  The
+ * $chain will return the first parameter value so as to act like a filtering mechanism
+ * or default return value.
+ *
+ * The call chain may be optional to make the dynamic event method callable without
+ * the $chain but will always be present in owner called behavior dynamic event
+ * methods.  For example:
+ * <code>
+ *  public function dyFilteringBehavior($defaultReturnData, $secondParam, ?TCallChain $chain = null)
+ *  {
+ *      // $defaultReturnData === 'filter text', $secondParam === 10
+ *      $defaultReturnData = $this->getOwner()->processText($defaultReturnData, $secondParam);
+ *
+ *      // TCallChain dynamic method will return $defaultReturnData after other behaviors are run
+ *      if ($chain)
+ *          return $chain->dyFilteringBehavior($defaultReturnData, $secondParam);
+ *      else
+ *          return $defaultReturnData;
+ *  }
+ * </code>
+ *
+ * All dynamic event logic should be before the $chain dynamic event continuation
+ * unless specifically designated, in very rare instances.  Placing your behavior
+ * logic after the $chain continuation will reverse the order of the processing
+ * from behavior priority.
  *
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.2.3
@@ -26,11 +89,8 @@ namespace Prado\Util;
 interface IBehavior extends IBaseBehavior
 {
 	/**
-	 * @return bool whether this behavior is enabled
+	 * @return ?object The owner component that this behavior is attached to.
+	 *   Default null when not attached.
 	 */
-	public function getEnabled();
-	/**
-	 * @param bool $value whether this behavior is enabled
-	 */
-	public function setEnabled($value);
+	public function getOwner(): ?object;
 }

--- a/framework/Util/TBaseBehavior.php
+++ b/framework/Util/TBaseBehavior.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * TBaseBehavior class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util;
+
+use Prado\Collections\TPriorityItemTrait;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\TComponent;
+use Prado\TPropertyValue;
+
+/**
+ * TBaseBehavior is the base implementing class for both PRADO behaviors types
+ * {@link TClassBehavior} and {@link @TBehavior}.
+ *
+ * This provides an {@link init} stub, {@link events} for attaching the behaviors'
+ * handlers (value) to events (keys), an {@link getEnabled Enabled} flag, the {@link
+ * getName Name} of the behavior, a {@link getRetainDisabledHandlers RetainDisabledHandlers}
+ * flag to retain event handlers on the behavior being disabled, and {@link attach}ing
+ * and {@link detach}ing from an owner.  Attaching and detaching call methods {@link
+ * syncEventHandlers} and {@link detachEventHandlers}, respectively, to manage the
+ * behaviors' handlers in the owner[s] events.
+ *
+ * Behaviors use the {@link TPriorityItemTrait} to receive priority information
+ * from insertion into the owner's {@link TPriorityMap} of behaviors.  When attaching
+ * events to an owner, the event handlers receive the same priority as the behavior
+ * in the owner.
+ *
+ * Changing the {@link setEnabled Enabled} flag can automatically attach or detach
+ * events from the owner. If the behavior events should be preserved in the owner
+ * when disabled, set {@link setRetainDisabledHandlers RetainDisabledHandlers} to
+ * true.  To force detach event handlers, give this property the value null.  When
+ * false, the default attachment logic applies where the behavior event handlers
+ * are attached where the owner has behaviors enabled and the behavior is enabled.
+ *
+ * Event Handlers from {@link events} are cached and available by the method {@link
+ * eventsLog}.  The eventsLog retains Closures across event handler management
+ * and multiple TClassBehavior owners.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+abstract class TBaseBehavior extends TComponent implements IBaseBehavior
+{
+	use TPriorityItemTrait;
+
+	/** @var ?string The name of the behavior in the owner[s] */
+	protected ?string $_name = null;
+
+	/** @var bool Is the behavior enabled or not. Default true */
+	private bool $_enabled = true;
+
+	/** @var null|bool Indicates how to maintain the event handlers. Default: false
+	 *   for default installation logic. True for always attached and null for always
+	 *   detached.
+	 */
+	private $_retainDisabledHandlers = false;
+
+	/** @var null|array|false The cached events of the behavior, for Closures. */
+	private $_eventsLog = false;
+
+	/**
+	 * Cloning a new instance clears the behavior name.
+	 */
+	public function __clone()
+	{
+		$this->_name = null;
+		parent::__clone();
+	}
+
+	/**
+	 * This processes behavior configuration elements.  This is usually called before
+	 * attach. This is only needed for complex behavior configurations.
+	 * @param array|\Prado\Xml\TXmlElement $config The innards to the behavior
+	 *   configuration.
+	 */
+	public function init($config)
+	{
+	}
+
+	/**
+	 * Declares events and the corresponding event handler methods.
+	 * The events are defined by the {@link owner} component, while the handler
+	 * methods defined in the behavior class.  These events will be attached to the
+	 * owner depending on the enable status and {@link getRetainDisabledHandlers}.
+	 * The format of events is as follows:
+	 * e.g. return ["onEvent" => function($sender, $param) {...}, "onInit" => "myInitHandler",
+	 * 'onAnEvent' => [$this, 'methodHandler'], 'onOtherEvent' => [[$this, 'handlerMethod'],
+	 * "behaviorMethod", function($sender, $param) {...}];
+	 *
+	 * Subclasses should use {@link mergeHandlers} to combine event handlers with the
+	 * parent's event handlers.  For example:
+	 * <code>
+	 *	return self::mergeHandlers(parent::events(), ['onEvent' => 'myHandler', ...]]);
+	 * </code>
+	 *
+	 * Acceptable array values are string name of behavior method, callable, or
+	 * an array of string behavior method names or callables.
+	 * @return array events (array keys) and the corresponding event handler methods
+	 *   (array values).
+	 */
+	public function events()
+	{
+		return [];
+	}
+
+	/**
+	 * Returns the cached events of the behavior where Closures are retained.  TClassBehavior
+	 * owners will all have the same Closure instances.
+	 * @return array events (keys) and the array of corresponding event handler methods (values).
+	 *   e.g. return results look like: ['onMyEvent' => ['objectMethod', $callable, $closure],
+	 *   'onEvent' => ['behaviorMethod', $callable2, $closure2]]
+	 */
+	public function eventsLog()
+	{
+		if ($this->_eventsLog === false) {
+			$this->_eventsLog = self::mergeHandlers($this->events());
+		}
+		return $this->_eventsLog;
+	}
+
+	/**
+	 * By default, all events with handlers in {@link eventsLog} are attached or there
+	 * will be an error.  When this is false, attaching behavior event handlers will
+	 * not fail if the owner is missing events and handlers are not attached.  Put
+	 * another way, when false, behavior event handlers are optional rather than made
+	 * mandatory.
+	 * @return bool Strictly enforce attaching behavior event handlers. Default true.
+	 */
+	public function getStrictEvents(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * Merges the handlers of an event into an array of keys (as event names) and values
+	 * as an array of behavior method names (strings) and callable.
+	 * @param array $args The array of events (keys) and values of either behavior method
+	 *   names (strings), callable, or an array of the former.  Multiple handlers can be
+	 *   set on a single event to allow subclasses to have their own handlers.
+	 * @return array The array of combined events (keys) and an array (values) of handlers
+	 *   for each.
+	 */
+	public static function mergeHandlers(...$args): array
+	{
+		if(empty($args)) {
+			return [];
+		}
+		$combined = [];
+		foreach ($args as $events) {
+			foreach ($events as $name => $handler) {
+				if (!isset($combined[$name])) {
+					$combined[$name] = [];
+				}
+				if (is_string($handler) || is_callable($handler)) {
+					$combined[$name][] = $handler;
+				} elseif (is_array($handler)) {
+					$combined[$name] += $handler;
+				}
+			}
+		}
+		return $combined;
+	}
+
+	/**
+	 * Attaches the behavior object to a new owner component.
+	 * The default implementation will synchronize attachment of event handlers declared
+	 * in {@link eventsLog}.
+	 * Make sure you call the parent implementation if you override this method.
+	 * @param TComponent $component the component that this behavior is being attached to.
+	 */
+	public function attach($component)
+	{
+		$this->syncEventHandlers($component);
+	}
+
+	/**
+	 * Detaches the behavior object from an owner component.
+	 * The default implementation will detach event handlers declared in {@link eventsLog}.
+	 * Make sure you call this parent implementation if you override this method.
+	 * @param TComponent $component the component that this behavior is being detached from.
+	 */
+	public function detach($component)
+	{
+		$this->detachEventHandlers($component);
+	}
+
+	/**
+	 * @return ?string The name of the behavior in the owner[s].
+	 */
+	public function getName(): ?string
+	{
+		return $this->_name;
+	}
+
+	/**
+	 * @param ?string $value The name of the behavior in the owner[s].
+	 * @throws TInvalidOperationException When there is an owner and the new name is
+	 *   not the same as the given name.
+	 */
+	public function setName($value)
+	{
+		if (!$this->hasOwner()) {
+			$this->_name = TPropertyValue::ensureString($value);
+		} elseif ($value !== $this->_name) {
+			throw new TInvalidOperationException('basebehavior_cannot_setname_with_owner', $this->_name, $value);
+		}
+	}
+
+	/**
+	 * @return bool Whether this behavior is enabled, Default true.
+	 */
+	public function getEnabled(): bool
+	{
+		return $this->_enabled;
+	}
+
+	/**
+	 * This method sets the enabled flag and synchronizes the behavior's handlers with
+	 * its owner[s].
+	 * @param bool|string $value Whether this behavior is enabled.
+	 */
+	public function setEnabled($value)
+	{
+		$value = TPropertyValue::ensureBoolean($value);
+		if ($this->_enabled !== $value) {
+			$this->_enabled = $value;
+			$this->syncEventHandlers();
+		}
+	}
+
+	/**
+	 * RetainDisabledHandlers has three states:
+	 *   1) "true" is to always install the event handlers regardless of behavior enabled
+	 *      or owner behaviors enabled status.
+	 *   2) "false" is the default attachment logic to remove the event handlers when
+	 *      the behavior or owner behaviors are disabled. (default)
+	 *   3) "null" is to always remove the event handlers.
+	 * @return null|bool Does the behavior retain the handlers when disabled (true),
+	 *   remove the handlers when the behavior/owner is disabled (false), or always
+	 *   remove the handlers (null).
+	 */
+	public function getRetainDisabledHandlers()
+	{
+		return $this->_retainDisabledHandlers;
+	}
+
+	/**
+	 * This changes the retaining of disabled behavior handlers and then synchronizes
+	 * the behavior's handlers with its owner[s].  There are three acceptable values:
+	 *   1) "true" is to always install the event handlers regardless of behavior enabled
+	 *      or owner behaviors enabled status.
+	 *   2) "false" is the default attachment logic to remove the event handlers when
+	 *      the behavior or owner behaviors are disabled. (default)
+	 *   3) "null" is to always remove the event handlers.
+	 * @param null|bool $value Does the behavior retain the handlers when disabled (true),
+	 *   remove the handlers when the behavior/owner is disabled (false), or always
+	 *   remove handlers (null).
+	 */
+	public function setRetainDisabledHandlers($value)
+	{
+		if ($value !== 0 && $value !== null && (!is_string($value) || strtolower($value) !== 'null' && $value !== '0')) {
+			$value = TPropertyValue::ensureBoolean($value);
+		} else {
+			$value = null;
+		}
+		if ($this->_retainDisabledHandlers !== $value) {
+			$this->_retainDisabledHandlers = $value;
+			$this->syncEventHandlers();
+		}
+	}
+
+	/**
+	 * This synchronizes an owner's events of the behavior event handlers by attaching
+	 * or detaching where needed.  A behaviors handlers are attached depending on whether
+	 * {@link getRetainDisabledHandlers} is true (or null) or both the owner and behavior are
+	 * [Behavior] enabled.  The $attachOverride will set RetainDisabledHandlers when not
+	 * its default value 0 and thus can act like {@link setRetainDisabledHandlers}.
+	 * @param ?object $component The component to manage the behaviors handlers on. Default
+	 *   is null for synchronizing all owners.
+	 * @param null|bool|int $attachOverride Overrides the default attachment logic or whether
+	 *   to install and forcibly attach or detach the handlers when true or null.  false resets
+	 *   RetainDisabledHandlers to the default attachment logic (of when enabled). Default is 0
+	 *   for normal action and no override (true/null) or reset (false).
+	 * @throws TInvalidOperationException When synchronizing a component without owners
+	 *   or the component that isn't an owner.
+	 * @since 4.2.3
+	 */
+	public function syncEventHandlers(?object $component = null, $attachOverride = 0)
+	{
+		$hasOwner = $this->hasOwner();
+		if ($component && !$hasOwner) {
+			throw new TInvalidOperationException('basebehavior_sync_no_owner', $this->getName());
+		}
+		if (!$hasOwner) {
+			return;
+		}
+		if ($component && !$this->isOwner($component)) {
+			throw new TInvalidOperationException('basebehavior_sync_not_owner', $this->getName());
+		}
+		foreach ($component ? [$component] : $this->getOwners() as $component) {
+			if (is_bool($attachOverride) || $attachOverride === null) {
+				$this->_retainDisabledHandlers = $attachOverride;
+			}
+			if ($this->_retainDisabledHandlers !== false) {
+				$install = (bool) $this->_retainDisabledHandlers;
+			} else {
+				$install = $this->getEnabled() && $component->getBehaviorsEnabled();
+			}
+			if ($this->getHandlersStatus($component) ^ $install) {
+				if ($install) {
+					$this->attachEventHandlers($component);
+				} else {
+					$this->detachEventHandlers($component);
+				}
+			}
+		}
+	}
+
+	/*
+	 * Attaches the behavior event handlers to an owner component. This tracks of the
+	 * attachment status of handlers on the owner components.
+	 * @param TComponent $component The component to attach the behavior event handlers to.
+	 * @since 4.2.3
+	 */
+	protected function attachEventHandlers(TComponent $component): void
+	{
+		if ($this->setHandlersStatus($component, true)) {
+			$priority = $this->getPriority();
+			$strict = $this->getStrictEvents();
+			foreach ($this->eventsLog() as $event => $handlers) {
+				if ($strict || $this->hasEvent($event)) {
+					foreach($handlers as $handler) {
+						$component->attachEventHandler($event, is_string($handler) ? [$this, $handler] : $handler, $priority);
+					}
+				}
+			}
+		}
+	}
+
+	/*
+	 * Detaches the behavior event handlers from an owner component. This tracks of the
+	 * attachment status of handlers on the owner components.
+	 * @param TComponent $component The component to detach the behavior event handlers from.
+	 * @since 4.2.3
+	 */
+	protected function detachEventHandlers(TComponent $component): void
+	{
+		if ($this->setHandlersStatus($component, false)) {
+			$strict = $this->getStrictEvents();
+			foreach ($this->eventsLog() as $event => $handlers) {
+				if ($strict || $this->hasEvent($event)) {
+					foreach($handlers as $handler) {
+						$component->detachEventHandler($event, is_string($handler) ? [$this, $handler] : $handler);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * This gets the attachment status of the behavior event handlers on the given
+	 * component.
+	 * @param ?TComponent $component The component to check the status of the handlers.
+	 *   Null only works for IBehavior and returns the status of the single owner.
+	 * @return bool Are the behavior handlers attached to the given owner events.
+	 * @since 4.2.3
+	 */
+	abstract protected function getHandlersStatus(?TComponent $component = null): ?bool;
+
+	/**
+	 * This sets the attachment status of the behavior event handlers on the given
+	 * component.
+	 * @param TComponent $component The component to set the status of.
+	 * @param bool $attach "true" to attach the handlers or "false" detach them.
+	 * @return bool Is there a change in the attachment status for the given owner
+	 *   component.
+	 * @since 4.2.3
+	 */
+	abstract protected function setHandlersStatus(TComponent $component, bool $attach): bool;
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array &$exprops Properties of the object to exclude.
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		$exprops[] = "\0*\0_name";
+		if ($this->_enabled === true) {
+			$exprops[] = "\0" . __CLASS__ . "\0_enabled";
+		}
+		if ($this->_retainDisabledHandlers === null) {
+			$exprops[] = "\0" . __CLASS__ . "\0_retainDisabledHandlers";
+		}
+		$exprops[] = "\0" . __CLASS__ . "\0_eventsLog";
+		$this->_priorityItemZappableSleepProps($exprops);
+	}
+}

--- a/framework/Util/TBehavior.php
+++ b/framework/Util/TBehavior.php
@@ -3,126 +3,243 @@
  * TBehavior class file.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @link http://www.yiiframework.com/
- * @license http://www.yiiframework.com/license/
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
  */
 
 namespace Prado\Util;
 
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\TComponent;
 use Prado\TPropertyValue;
+use Prado\Util\TCallChain;
+
+use WeakReference;
 
 /**
- * TBehavior is a convenient base class for behavior classes.
- * @author Qiang Xue <qiang.xue@gmail.com>
+ * TBehavior is the base class for behaviors that extend owner components with new
+ * state information, properties, run time methods, and process modification.  Each
+ * instance of the TBehavior can only have one owner.  This tracks behavior event
+ * handlers attachment status on its owner.
+ *
+ * TBehavior is one of two types of behaviors in PRADO. The other type is the
+ * {@link TClassBehavior} where each instance can have multiple owners and is
+ * is designed to not retain per object information (acting stateless).
+ *
+ * Behaviors can be attached to instanced objects, with {@link TComponent::attachbehavior},
+ * or to each class, the parent classes, interfaces, and first level traits used by
+ * the class(es) with {@link TComponent::attachClassBehavior}. Class-wide behaviors
+ * cannot be attached to the root class {@link TComponent} but can attach to any subclass.
+ * All new components with an attached class behavior will receive the behavior on
+ * instancing.  Instances of a class will receive the class behavior if they are
+ * {@link TComponent::listen}ing.
+ *
+ * TComponent clones instanced IBehavior when applied to whole classes.
+ *
+ * TBehavior is a subclass of {@link TBaseBehavior} that implements the core
+ * behavior functionality.  See {@link IBehavior} for implementation details.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.2.3
  */
-class TBehavior extends \Prado\TComponent implements IBehavior
+class TBehavior extends TBaseBehavior implements IBehavior
 {
-	private $_enabled = true;
-	private $_owner;
+	/** @var ?WeakReference The owner component of the behavior. Default: null */
+	private ?WeakReference $_owner = null;
+
+	/** @var bool Are the handlers installed on the owner. Default: false */
+	private bool $_handlersInstalled = false;
 
 	/**
-	 * This processes configuration elements from TBehaviorsModule.  This is usually
-	 * called after attach but cannot be guaranteed to be called outside the {@link
-	 * TBehaviorsModule} environment. This is only needed for complex behavior
-	 * configurations.
-	 * @param array|\Prado\Xml\TXmlElement $config any innards to the behavior configuration.
-	 */
-	public function init($config)
-	{
-	}
-
-	/**
-	 * Declares events and the corresponding event handler methods.
-	 * The events are defined by the {@link owner} component, while the handler
-	 * methods by the behavior class. The handlers will be attached to the corresponding
-	 * events when the behavior is attached to the {@link owner} component; and they
-	 * will be detached from the events when the behavior is detached from the component.
-	 * @return array events (array keys) and the corresponding event handler methods (array values).
-	 */
-	public function events()
-	{
-		return [];
-	}
-
-	/**
-	 * Attaches the behavior object to the component.
-	 * The default implementation will set the {@link owner} property
-	 * and attach event handlers as declared in {@link events}.
-	 * Make sure you call the parent implementation if you override this method.
-	 * @param \Prado\TComponent $owner the component that this behavior is to be attached to.
-	 */
-	public function attach($owner)
-	{
-		$this->_owner = $owner;
-		foreach ($this->events() as $event => $handler) {
-			$owner->attachEventHandler($event, [$this, $handler]);
-		}
-	}
-
-	/**
-	 * Detaches the behavior object from the component.
-	 * The default implementation will unset the {@link owner} property
-	 * and detach event handlers declared in {@link events}.
-	 * Make sure you call the parent implementation if you override this method.
-	 * @param \Prado\TComponent $owner the component that this behavior is to be detached from.
-	 */
-	public function detach($owner)
-	{
-		foreach ($this->events() as $event => $handler) {
-			$owner->detachEventHandler($event, [$this, $handler]);
-		}
-		$this->_owner = null;
-	}
-
-	/**
-	 * @return object the owner component that this behavior is attached to.
-	 */
-	public function getOwner()
-	{
-		return $this->_owner;
-	}
-
-	/**
-	 * @return bool whether this behavior is enabled
-	 */
-	public function getEnabled()
-	{
-		return $this->_enabled;
-	}
-
-	/**
-	 * @param bool $value whether this behavior is enabled
-	 */
-	public function setEnabled($value)
-	{
-		$this->_enabled = TPropertyValue::ensureBoolean($value);
-	}
-
-	/**
-	 * This resets the Owner on cloning.
+	 * This resets the owner and _handlersInstalled flag on cloning.
 	 * @since 4.2.3
 	 */
 	public function __clone()
 	{
 		$this->_owner = null;
+		$this->_handlersInstalled = false;
 		parent::__clone();
 	}
 
 	/**
-	 * Returns an array with the names of all variables of this object that should NOT be serialized
-	 * because their value is the default one or useless to be cached for the next page loads.
-	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
-	 * implementation first.
+	 * Attaches the behavior object to the new owner component.  This is normally called
+	 * by the new owner when attaching a behavior, by {@link TComponent::attachBehavior},
+	 * and not directly called.
+	 *
+	 * The default implementation will set the {@link getOwner Owner} property and
+	 * synchronized the behavior event handlers (cached in {@link eventsLog}) with
+	 * the owner.  Make sure you call the parent implementation if you override this method.
+	 * @param TComponent $owner The owner component that this behavior is being attached.
+	 * @throws TInvalidOperationException When attaching a behavior that is already
+	 *   attached to an owner or the owner isn't a TComponent.
+	 */
+	public function attach($owner)
+	{
+		if ($this->_owner !== null) {
+			throw new TInvalidOperationException('behavior_has_owner', $this->getName());
+		}
+		if (!($owner instanceof TComponent)) {
+			throw new TInvalidOperationException('behavior_bad_attach_component', $this->getName());
+		}
+		$this->_owner = WeakReference::create($owner);
+		parent::attach($owner);
+	}
+
+	/**
+	 * Detaches the behavior object from the owner component.  This is normally called
+	 * by the owner when detaching a behavior, by {@link TComponent::detachBehavior},
+	 * and not directly called.
+	 *
+	 * The default implementation detaches the behavior event handlers (cached in {@link
+	 * eventsLog}) and resets the owner. Make sure you call this parent implementation
+	 * if you override this method.
+	 * @param TComponent $owner The component this behavior is being detached from.
+	 * @throws TInvalidOperationException When detaching without an owner or from a
+	 *   component that isn't the behaviors owner.
+	 */
+	public function detach($owner)
+	{
+		if ($this->_owner === null) {
+			throw new TInvalidOperationException('behavior_detach_without_owner', $this->getName());
+		}
+		if (!$owner || $this->getOwner() !== $owner) {
+			throw new TInvalidOperationException('behavior_detach_wrong_owner', $this->getName());
+		}
+		parent::detach($owner);
+		$this->_owner = null;
+		$this->_name = null;
+	}
+
+	/**
+	 * This class stores the owner as a WeakReference.  This method retrieves and re-references
+	 * the owner.
+	 * @return ?object The owner component that this behavior is attached to.
+	 *   Default null before the behavior is attached to an owner.
+	 */
+	public function getOwner(): ?object
+	{
+		if ($this->_owner) {
+			return $this->_owner->get();
+		}
+		return null;
+	}
+
+	/**
+	 * This returns an array of the one owner that the TBehavior is attached to.
+	 * TClassBehavior could return multiple owners, but this type of behavior only
+	 *  has one.
+	 * @return array An array of the owner component.
+	 * @since 4.2.3
+	 */
+	public function getOwners(): array
+	{
+		if ($owner = $this->getOwner()) {
+			return [$owner];
+		}
+		return [];
+	}
+
+	/**
+	 * @return bool Is the behavior attached to an owner.
+	 * @since 4.2.3
+	 */
+	public function hasOwner(): bool
+	{
+		return $this->_owner !== null;
+	}
+
+	/**
+	 * @param object $component The object to check if its the owner of the behavior.
+	 * @return bool Is the object an owner of the behavior.
+	 * @since 4.2.3
+	 */
+	public function isOwner(object $component): bool
+	{
+		return $this->_owner && $this->getOwner() === $component;
+	}
+
+	/**
+	 * This dynamic event method tracks the "behaviors enabled" status of an owner. Subclasses
+	 * can call this method (as "parent::dyEnableBehaviors()") without the $chain and it will
+	 * delegate the $chain continuation to the subclass implementation. At this point,
+	 * the behaviors are already enabled in the owner.
+	 * @param ?TCallChain $chain The chain of dynamic events being raised.  Default
+	 *   is null for no chain continuation.
+	 * @since 4.2.3
+	 */
+	public function dyEnableBehaviors(?TCallChain $chain = null)
+	{
+		$this->syncEventHandlers();
+		if ($chain) {
+			$chain->dyEnableBehaviors();
+		}
+	}
+
+	/**
+	 * This dynamic event method tracks the "behaviors disabled" status of an owner. Subclasses
+	 * can call this parent method (as "parent::dyDisableBehaviors()") without the $chain
+	 * and it will delegate the $chain continuation to the subclass implementation.
+	 * @param ?TCallChain $chain The chain of dynamic events being raised.  Default
+	 *   is null for no chain continuation.
+	 * @since 4.2.3
+	 */
+	public function dyDisableBehaviors(?TCallChain $chain = null)
+	{
+		$this->syncEventHandlers();
+		if ($chain) {
+			$chain->dyDisableBehaviors();
+		}
+	}
+
+	/**
+	 * This gets the attachment status of the behavior event handlers on the owner
+	 * component.
+	 * @param ?TComponent $component The component to check the attachment status.
+	 *   Default null for the IBehavior owner status.  This must match the owner if/when
+	 *   provided.
+	 * @return bool Are the behavior handlers attached to the owner events.
+	 * @since 4.2.3
+	 */
+	protected function getHandlersStatus(?TComponent $component = null): ?bool
+	{
+		if ($component && $this->getOwner() !== $component) {
+			return null;
+		}
+		return $this->_handlersInstalled;
+	}
+
+	/**
+	 * This sets the attachment status of the behavior handlers on the owner. It only
+	 * returns true when there is a change in status.
+	 * @param ?TComponent $component The owner of the behavior.
+	 * @param bool $attach "true" to attach the handlers or "false" to detach.
+	 * @return bool Is there a change in the attachment status on the owner.
+	 * @since 4.2.3
+	 */
+	protected function setHandlersStatus(TComponent $component, bool $attach): bool
+	{
+		if ($this->getOwner() !== $component) {
+			return false;
+		}
+		if($attach ^ $this->_handlersInstalled) {
+			$this->_handlersInstalled = $attach;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should
+	 * NOT be serialized because their value is the default one or useless to be cached
+	 * for the next page loads.  Reimplement in derived classes to add new variables,
+	 * but remember to also to call the parent implementation first.
 	 * @param array $exprops by reference
 	 * @since 4.2.3
 	 */
 	protected function _getZappableSleepProps(&$exprops)
 	{
 		parent::_getZappableSleepProps($exprops);
-		if ($this->_enabled === true) {
-			$exprops[] = "\0Prado\\Util\\TBehavior\0_enabled";
-		}
-		$exprops[] = "\0Prado\\Util\\TBehavior\0_owner";
+		$exprops[] = "\0" . __CLASS__ . "\0_owner";
+		$exprops[] = "\0" . __CLASS__ . "\0_handlersInstalled";
 	}
 }

--- a/framework/Util/TBehavior.php
+++ b/framework/Util/TBehavior.php
@@ -211,7 +211,7 @@ class TBehavior extends TBaseBehavior implements IBehavior
 	/**
 	 * This sets the attachment status of the behavior handlers on the owner. It only
 	 * returns true when there is a change in status.
-	 * @param ?TComponent $component The owner of the behavior.
+	 * @param TComponent $component The owner of the behavior.
 	 * @param bool $attach "true" to attach the handlers or "false" to detach.
 	 * @return bool Is there a change in the attachment status on the owner.
 	 * @since 4.2.3

--- a/framework/Util/TClassBehavior.php
+++ b/framework/Util/TClassBehavior.php
@@ -51,7 +51,7 @@ class TClassBehavior extends TBaseBehavior implements IClassBehavior
 	 */
 	private ?TWeakList $_owners = null;
 
-	/** @var null|array|WeakMap This tracks whether an owner has event handlers attached. */
+	/** @var null|array|\WeakMap This tracks whether an owner has event handlers attached. */
 	private $_handlersInstalled;
 
 	/**

--- a/framework/Util/TClassBehavior.php
+++ b/framework/Util/TClassBehavior.php
@@ -2,44 +2,256 @@
 /**
  * TClassBehavior class file.
  *
- * @author Brad Anderson <javalizard@gmail.com>
+ * @author Brad Anderson <belisoful@icloud.com>
  * @link https://github.com/pradosoft/prado
  * @license https://github.com/pradosoft/prado/blob/master/LICENSE
  */
 
 namespace Prado\Util;
 
+use Prado\Collections\TWeakList;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\TComponent;
+use Prado\Util\TCallChain;
+
 /**
- * TClassBehavior is a convenient base class for whole class behaviors.
- * @author Brad Anderson <javalizard@gmail.com>
+ * TClassBehavior is the base class for class-wide behaviors that extend owner components
+ * with new stateless information, properties, run time methods, and process modification.
+ * Each instance of the TClassBehavior can have multiple owners.  TClassBehavior
+ * tracks all its owners.  It manages the attachment status of the behavior event
+ * handlers on each owner.
+ *
+ * TClassBehavior is one of two types of behaviors in PRADO. The other type is the
+ * {@link TBehavior} where each instance can have only one owner and has per object
+ * state.
+ *
+ * TClassBehavior must attach to owner components with the same behavior name.
+ *
+ * Behaviors can be attached to instanced objects, with {@link TComponent::attachbehavior},
+ * or to each class, the parent classes, interfaces, and first level traits used by
+ * the class(es) with {@link TComponent::attachClassBehavior}. Class-wide behaviors
+ * cannot be attached to the root class {@link TComponent} but can attach to any subclass.
+ * All new components with an attached class behavior will receive the behavior on
+ * instancing.  Instances of a class will receive the class behavior if they are
+ * {@link TComponent::listen}ing.
+ *
+ * TClassBehavior is a subclass of {@link TBaseBehavior} that implements the core
+ * behavior functionality.  See {@link IClassBehavior} for implementation details.
+ *
+ * The interface IClassBehavior is used by TComponent to inject the owner as the
+ * first method parameter, when the behavior method is called on the owner, so the
+ * behavior knows which owner is calling it.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.2.3
  */
-class TClassBehavior extends \Prado\TComponent implements IClassBehavior
+class TClassBehavior extends TBaseBehavior implements IClassBehavior
 {
-	/**
-	 * This processes configuration elements [from TBehaviorsModule].  This is usually
-	 * called before attach but cannot be guaranteed to be called outside the {@link
-	 * TBehaviorsModule} environment. This is only needed for complex behavior
-	 * configurations.
-	 * @param array|\Prado\Xml\TXmlElement $config any innards to the behavior configuration.
+	/** @var ?TWeakList The WeakReference list of owner components. Default null
 	 */
-	public function init($config)
+	private ?TWeakList $_owners = null;
+
+	/** @var null|array|WeakMap This tracks whether an owner has event handlers attached. */
+	private $_handlersInstalled;
+
+	/**
+	 * Cloning a new instance clears both the owners and handler attachment tracking
+	 */
+	public function __clone()
 	{
+		$this->_owners = null;
+		$this->_handlersInstalled = null;
+		parent::__clone();
 	}
 
 	/**
-	 * Attaches the behavior object to the component.
-	 * @param \Prado\TComponent $component the component that this behavior is to be attached to.
+	 * Initializes the WeakMap to manager the attachment status of owners.
+	 * Prior to PHP 8, this will use an array rather than a WeakMap.
+	 */
+	protected function initMap()
+	{
+		if (class_exists('\WeakMap')) {
+			$this->_handlersInstalled = new \WeakMap();
+		} else {
+			$this->_handlersInstalled = [];
+		}
+	}
+
+	/**
+	 * Attaches the behavior object to a new owner component.  This is normally called
+	 * by the new owner when attaching a behavior, by {@link TComponent::attachBehavior},
+	 * and not directly called.
+	 *
+	 * The default implementation will add the new owner to the {@link getOwners} and
+	 * synchronize the behavior event handlers (cached in {@link eventsLog}) with the
+	 * new owner. Make sure you call this parent implementation if you override this
+	 * method.
+	 * @param TComponent $component The component this behavior is being attached to.
+	 * @throws TInvalidOperationException When attaching to a component that is already
+	 *   attached.  Otherwise handlers would not be unique.
+	 * @throws TInvalidOperationException When the owner component is not a TComponent.
 	 */
 	public function attach($component)
 	{
+		if (!($component instanceof TComponent)) {
+			throw new TInvalidOperationException('classbehavior_bad_attach_component', $this->getName());
+		}
+		if (!$this->_owners) {
+			$this->_owners = new TWeakList();
+			$this->initMap();
+		} elseif ($this->_owners->contains($component)) {
+			throw new TInvalidOperationException('classbehavior_owner_attach_once', $this->getName());
+		}
+		$this->_owners->add($component);
+		parent::attach($component);
 	}
 
 	/**
-	 * Detaches the behavior object from the component.
-	 * @param \Prado\TComponent $component the component that this behavior is to be detached from.
+	 * Detaches the behavior object from an owner component.  This is normally called
+	 * by the owner when detaching a behavior, by {@link TComponent::detachBehavior},
+	 * and not directly called.
+	 *
+	 * The default implementation will remove the behavior event handlers (cached in
+	 * {@link eventsLog}) from the owner and remove the owner from the {@link getOwners}.
+	 * Make sure you call this parent implementation if you override this method.
+	 * @param TComponent $component The component this behavior is being detached from.
+	 * @throws TInvalidOperationException When detaching without an owner or from a
+	 *   component that isn't the behaviors owner.
 	 */
 	public function detach($component)
 	{
+		if ($this->_owners === null) {
+			throw new TInvalidOperationException('classbehavior_detach_without_owner', $this->getName());
+		}
+		if (!$component || !$this->_owners->contains($component)) {
+			throw new TInvalidOperationException('classbehavior_detach_wrong_owner', $this->getName());
+		}
+		parent::detach($component);
+		if($this->_owners->remove($component) === 0 && !$this->_owners->getCount()) {
+			$this->_owners = null;
+			$this->_name = null;
+			$this->_handlersInstalled = null;
+		}
+	}
+
+	/**
+	 * @return array The owner components that this behavior is attached to.
+	 * @since 4.2.3
+	 */
+	public function getOwners(): array
+	{
+		if ($this->_owners) {
+			return $this->_owners->toArray();
+		}
+		return [];
+	}
+
+	/**
+	 * @return bool Is the behavior attached to an owner.
+	 * @since 4.2.3
+	 */
+	public function hasOwner(): bool
+	{
+		return $this->_owners !== null;
+	}
+
+	/**
+	 * @param object $component
+	 * @return bool Is the object an owner of the behavior.
+	 * @since 4.2.3
+	 */
+	public function isOwner(object $component): bool
+	{
+		return $this->_owners && $this->_owners->contains($component);
+	}
+
+	/**
+	 * This dynamic event method tracks the behaviors enabled status of an owner. Subclasses
+	 * can call this method (as "parent::dyEnableBehaviors()") without the $chain and it
+	 * will delegate the $chain continuation to the subclass implementation. At this point,
+	 * the behaviors are already enabled in the owner.
+	 * @param TComponent $owner The owner enabling their behaviors.
+	 * @param ?TCallChain $chain The chain of dynamic events being raised.  Default
+	 *   is null for no continuation.
+	 * @since 4.2.3
+	 */
+	public function dyEnableBehaviors($owner, ?TCallChain $chain = null)
+	{
+		$this->syncEventHandlers($owner);
+		if ($chain) {
+			$chain->dyEnableBehaviors();
+		}
+	}
+
+	/**
+	 * This dynamic event method tracks the "behaviors disabled" status of an owner. Subclasses
+	 * can call this method (as "parent::dyDisableBehaviors()") without the $chain and
+	 * it will delegate the $chain continuation to the subclass implementation.
+	 * @param TComponent $owner The owner disabling their behaviors.
+	 * @param ?TCallChain $chain The chain of dynamic events being raised.  Default
+	 *   is null for no continuation.
+	 * @since 4.2.3
+	 */
+	public function dyDisableBehaviors($owner, ?TCallChain $chain = null)
+	{
+		$this->syncEventHandlers($owner);
+		if ($chain) {
+			$chain->dyDisableBehaviors();
+		}
+	}
+
+	/**
+	 * This gets the attachment status of the behavior handlers on the given component.
+	 * @param ?TComponent $component The component to check the handlers attachment status.
+	 *   This parameter must be provided; null is not supported in TClassBehavior.
+	 * @return bool Are the behavior handlers attached to the given owner events.
+	 * @since 4.2.3
+	 */
+	protected function getHandlersStatus(?TComponent $component = null): ?bool
+	{
+		if (!$component) {
+			return null;
+		}
+		$ref = is_array($this->_handlersInstalled) ? spl_object_id($component) : $component;
+		return isset($this->_handlersInstalled[$ref]);
+	}
+
+	/**
+	 * This sets the attachment status of the behavior handlers on the given owner
+	 * component.  It only returns true when there is a change in status.
+	 * @param TComponent $component The component to set the handlers attachment status.
+	 * @param bool $attach "true" to attach the handlers or "false" to detach.
+	 * @return bool Is there a change in the attachment status for the given owner
+	 *   component.
+	 * @since 4.2.3
+	 */
+	protected function setHandlersStatus(TComponent $component, bool $attach): bool
+	{
+		$ref = is_array($this->_handlersInstalled) ? spl_object_id($component) : $component;
+		if($attach) {
+			if ($this->_owners && $this->_owners->contains($component) && !isset($this->_handlersInstalled[$ref])) {
+				$this->_handlersInstalled[$ref] = true;
+				return true;
+			}
+		} elseif (isset($this->_handlersInstalled[$ref])) {
+			unset($this->_handlersInstalled[$ref]);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Returns an array with the names of all variables of this object that should NOT be serialized
+	 * because their value is the default one or useless to be cached for the next page loads.
+	 * Reimplement in derived classes to add new variables, but remember to  also to call the parent
+	 * implementation first.
+	 * @param array $exprops by reference
+	 * @since 4.2.3
+	 */
+	protected function _getZappableSleepProps(&$exprops)
+	{
+		parent::_getZappableSleepProps($exprops);
+		$exprops[] = "\0" . __CLASS__ . "\0_owners";
+		$exprops[] = "\0" . __CLASS__ . "\0_handlersInstalled";
 	}
 }

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -284,6 +284,7 @@ return [
 'IDynamicMethods' => 'Prado\Util\IDynamicMethods',
 'IInstanceCheck' => 'Prado\Util\IInstanceCheck',
 'IPluginModule' => 'Prado\Util\IPluginModule',
+'TBaseBehavior' => 'Prado\Util\TBaseBehavior',
 'TBehavior' => 'Prado\Util\TBehavior',
 'TBehaviorsModule' => 'Prado\Util\TBehaviorsModule',
 'TBrowserLogRoute' => 'Prado\Util\TBrowserLogRoute',

--- a/tests/unit/Util/Behaviors/TParameterizedBehaviorTest.php
+++ b/tests/unit/Util/Behaviors/TParameterizedBehaviorTest.php
@@ -84,7 +84,7 @@ class TParameterizeBehaviorTest extends PHPUnit\Framework\TestCase
 			$ownerNoSet->attachBehavior($behaviorName, $this->obj);
 			$this->fail("Attaching should have thrown TConfigurationException as object doesn't have the Property");
 		} catch(TConfigurationException $e) {}
-		$owner->detachBehavior($behaviorName);
+		$ownerNoSet->detachBehavior($behaviorName);
 		
 		$this->obj->setParameter('');
 		try {

--- a/tests/unit/Util/TBaseBehaviorTest.php
+++ b/tests/unit/Util/TBaseBehaviorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\Util\TBaseBehavior;
+use Prado\Util\TBehavior;
+
+class StrictEventsBehavior extends TBehavior
+{
+	public function events()
+	{
+		return ['onMyEvent' => 'myHandler'];
+	}
+	public function myHandler($sender, $param)
+	{
+	}
+}
+
+class NonStrictEventsBehavior extends StrictEventsBehavior
+{
+	public function getStrictEvents(): bool
+	{
+		return false;
+	}
+}
+
+class TBaseBehaviorTest extends PHPUnit\Framework\TestCase
+{	
+	public function testMergeHandlers()
+	{
+		self::assertEquals([], TBaseBehavior::mergeHandlers());
+		self::assertEquals([], TBaseBehavior::mergeHandlers([]));
+		self::assertEquals([
+			'onEvent1' => [ 'behaviorHandler' ],
+			'onEvent2' => [$closure = function ($sender, $param) {}, [$this, 'testMergeHandlers']],
+			'onEvent3' => ['behaviorHandler2', [$this, 'testMergeHandlers']],
+		], TBaseBehavior::mergeHandlers( ['onEvent2' => $closure],
+			['onEvent1' => 'behaviorHandler', 'onEvent2' => [$this, 'testMergeHandlers'], 'onEvent3' => ['behaviorHandler2', [$this, 'testMergeHandlers']]]));
+	}
+	
+	public function testStrictEvents() 
+	{
+		// We cannot attach when behavior event handlers are strict.
+		$component = new TComponent();
+		$strictBehavior = new StrictEventsBehavior();
+		self::assertTrue($strictBehavior->getStrictEvents());
+		try {
+			$component->attachBehavior('strict', $strictBehavior);
+			self::fail("TInvalidOperationException not thrown when attaching strict behavior event handlers");
+		} catch(TInvalidOperationException $e){
+		}
+	}
+	
+	public function testNonStrictEvents()
+	{
+		$component = new TComponent();
+		// We can attach when behavior event handlers are not strict.
+		$nonStrictBehavior = new NonStrictEventsBehavior();
+		self::assertFalse($nonStrictBehavior->getStrictEvents());
+		$component->attachBehavior('nonstrict', $nonStrictBehavior);
+	}
+}


### PR DESCRIPTION
This fixes #891, #851, and #838

- TClassBehavior tracks owners with TWeakList
- Attaching IBehavior to Class clones instances for each owner/instance. the standard action was to instance from a class name string or array of class/properties.
- TComponent::__destruct clears the behaviors and event handlers for better garbage collection.
- IBaseBehavior has Enabled flag.  Thus, IClassBehavior has enabled flag.  Simplifies TComponent behavior processing.
- TBaseBehavior records its unique attachment name in the owner.  IClassBehavior can only install on one name across all owners.
- Attaching a behavior over an existing name properly removes the prior behavior.
- TBehavior and TClassBehavior track the behavior enabled status of their owner by dynamic event dyEnableBehaviors and dyDisableBehaviors for turning on and off their attached event handlers.  This is eating your own dog food.
- Changing the enabled status of a component synchronizes its behaviors event handler attachments.
- Disabling an owner behaviors or disabling a single behavior will detach its registered handlers from all.
- Flag for whether to detach handlers when disabled
- EventsLog to hold a cache of the behavior events, for Closure retainment.  Now supports Closures as behavior event handlers properly.
- TBehavior tracks its owner with WeakReference.  For better garbage collection.
   - Both track the attachment status of the event handlers in their owner and owners.
- IClassBehavior file creation author properly attributed.  Class Behaviors were never a thing in that time in PRADO.
- Behaviors can implement TComponent dynamic events on owners without being self called when calling their own TComponent methods (that call the dynamic event).  Behaviors work better with its own dynamic events.
-TComponent::disableBehaviors makes special implementation for dyDisableBehaviors after Behaviors are Disabled so behaviors can act accordingly because behaviors are disabled when the behaviors' dynamic events are raised.
-TBaseBehavior implements getStrictEvents to say whether the events are mandatory to attach or optional.
- Error Messages
- Updated documentation on behaviors in TComponent and in Behaviors.