### PR TITLE
#918 TDBCron updated SQL to "Order By" to stop random test failure

### DIFF
--- a/framework/Util/Cron/TDbCronModule.php
+++ b/framework/Util/Cron/TDbCronModule.php
@@ -192,7 +192,7 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 			$this->ensureTable();
 			$this->_taskRows = $this->_tasks = [];
 			$cmd = $this->getDbConnection()->createCommand(
-				"SELECT * FROM {$this->_tableName} WHERE active IS NOT NULL"
+				"SELECT * FROM {$this->_tableName} WHERE active IS NOT NULL ORDER BY tabuid"
 			);
 			$results = $cmd->query();
 


### PR DESCRIPTION
I am taking a wild swing at this one.  I do hope this fixes the bug, but it's hard to tell when the bug is so spotty.  I think this is more of a bug with the DB than PRADO, but hey, this should fix that quirk.

I didn't think this was necessary because.... wouldn't the DB return the table in the order of insertion?

apparently, randomly, it switches rows unless explicitly ordered