### PR TITLE
#898 Magic Method access to getter/setter/methods is determined by caller relation to implementation

### DIFF
--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -717,7 +717,7 @@ class TComponent
 		if (($getset == 'get') || ($getset == 'set')) {
 			$propname = substr($method, 3);
 			$jsmethod = $getset . 'js' . $propname;
-			if (method_exists($this, $jsmethod)) {
+			if (Prado::method_exists($this, $jsmethod)) {
 				if (count($args) > 0) {
 					if ($args[0] && !($args[0] instanceof TJavaScriptString)) {
 						$args[0] = new TJavaScriptString($args[0]);
@@ -726,7 +726,7 @@ class TComponent
 				return $this->$jsmethod(...$args);
 			}
 
-			if (($getset == 'set') && method_exists($this, 'getjs' . $propname)) {
+			if (($getset == 'set') && Prado::method_exists($this, 'getjs' . $propname)) {
 				throw new TInvalidOperationException('component_property_readonly', $this::class, $method);
 			}
 		}
@@ -766,10 +766,10 @@ class TComponent
 	 */
 	public function __get($name)
 	{
-		if (method_exists($this, $getter = 'get' . $name)) {
+		if (Prado::method_exists($this, $getter = 'get' . $name)) {
 			// getting a property
 			return $this->$getter();
-		} elseif (method_exists($this, $jsgetter = 'getjs' . $name)) {
+		} elseif (Prado::method_exists($this, $jsgetter = 'getjs' . $name)) {
 			// getting a javascript property
 			return (string) $this->$jsgetter();
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
@@ -820,12 +820,12 @@ class TComponent
 	 */
 	public function __set($name, $value)
 	{
-		if (method_exists($this, $setter = 'set' . $name)) {
+		if (Prado::method_exists($this, $setter = 'set' . $name)) {
 			if (strncasecmp($name, 'js', 2) === 0 && $value && !($value instanceof TJavaScriptLiteral)) {
 				$value = new TJavaScriptLiteral($value);
 			}
 			return $this->$setter($value);
-		} elseif (method_exists($this, $jssetter = 'setjs' . $name)) {
+		} elseif (Prado::method_exists($this, $jssetter = 'setjs' . $name)) {
 			if ($value && !($value instanceof TJavaScriptString)) {
 				$value = new TJavaScriptString($value);
 			}
@@ -845,7 +845,7 @@ class TComponent
 			}
 		}
 
-		if (method_exists($this, 'get' . $name) || method_exists($this, 'getjs' . $name)) {
+		if (Prado::method_exists($this, 'get' . $name) || Prado::method_exists($this, 'getjs' . $name)) {
 			throw new TInvalidOperationException('component_property_readonly', $this::class, $name);
 		} else {
 			throw new TInvalidOperationException('component_property_undefined', $this::class, $name);
@@ -866,9 +866,9 @@ class TComponent
 	 */
 	public function __isset($name)
 	{
-		if (method_exists($this, $getter = 'get' . $name)) {
+		if (Prado::method_exists($this, $getter = 'get' . $name)) {
 			return $this->$getter() !== null;
-		} elseif (method_exists($this, $jsgetter = 'getjs' . $name)) {
+		} elseif (Prado::method_exists($this, $jsgetter = 'getjs' . $name)) {
 			return $this->$jsgetter() !== null;
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
 			$name = strtolower($name);
@@ -902,9 +902,9 @@ class TComponent
 	 */
 	public function __unset($name)
 	{
-		if (method_exists($this, $setter = 'set' . $name)) {
+		if (Prado::method_exists($this, $setter = 'set' . $name)) {
 			$this->$setter(null);
-		} elseif (method_exists($this, $jssetter = 'setjs' . $name)) {
+		} elseif (Prado::method_exists($this, $jssetter = 'setjs' . $name)) {
 			$this->$jssetter(null);
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
 			$this->_e[strtolower($name)]->clear();
@@ -922,11 +922,11 @@ class TComponent
 						$unset++;
 					}
 				}
-				if (!$unset && method_exists($this, 'get' . $name)) {
+				if (!$unset && Prado::method_exists($this, 'get' . $name)) {
 					throw new TInvalidOperationException('component_property_readonly', $this::class, $name);
 				}
 			}
-		} elseif (method_exists($this, 'get' . $name)) {
+		} elseif (Prado::method_exists($this, 'get' . $name)) {
 			throw new TInvalidOperationException('component_property_readonly', $this::class, $name);
 		}
 	}
@@ -954,7 +954,7 @@ class TComponent
 	 */
 	public function canGetProperty($name)
 	{
-		if (method_exists($this, 'get' . $name) || method_exists($this, 'getjs' . $name)) {
+		if (Prado::method_exists($this, 'get' . $name) || Prado::method_exists($this, 'getjs' . $name)) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			foreach ($this->_m->toArray() as $behavior) {
@@ -977,7 +977,7 @@ class TComponent
 	 */
 	public function canSetProperty($name)
 	{
-		if (method_exists($this, 'set' . $name) || method_exists($this, 'setjs' . $name)) {
+		if (Prado::method_exists($this, 'set' . $name) || Prado::method_exists($this, 'setjs' . $name)) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			foreach ($this->_m->toArray() as $behavior) {
@@ -1058,7 +1058,7 @@ class TComponent
 				}
 			} else {
 				foreach ($this->_m->toArray() as $behavior) {
-					if ($behavior->getEnabled() && method_exists($behavior, $method)) {
+					if ($behavior->getEnabled() && Prado::method_exists($behavior, $method)) {
 						if ($behavior instanceof IClassBehavior) {
 							array_unshift($args, $this);
 						}
@@ -1086,12 +1086,13 @@ class TComponent
 	 * @param array $args The arguments to the behaviors method being chained.
 	 * @return ?TCallChain The chain of methods implemented by behaviors or null when
 	 *   there are no methods to call.
+	 * @since 4.2.3
 	 */
 	protected function getCallChain($method, ...$args): ?TCallChain
 	{
 		$classArgs = $callchain = null;
 		foreach ($this->_m->toArray() as $behavior) {
-			if ($behavior->getEnabled() && (method_exists($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
+			if ($behavior->getEnabled() && (Prado::method_exists($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
 				if ($classArgs === null) {
 					$classArgs = $args;
 					array_unshift($classArgs, $this);
@@ -1117,12 +1118,12 @@ class TComponent
 	 */
 	public function hasMethod($name)
 	{
-		if (method_exists($this, $name) || strncasecmp($name, 'fx', 2) === 0 || strncasecmp($name, 'dy', 2) === 0) {
+		if (Prado::method_exists($this, $name) || strncasecmp($name, 'fx', 2) === 0 || strncasecmp($name, 'dy', 2) === 0) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			foreach ($this->_m->toArray() as $behavior) {
-				//method_exists($behavior, $name) rather than $behavior->hasMethod($name) b/c only one layer is supported, @4.2.2
-				if ($behavior->getEnabled() && method_exists($behavior, $name)) {
+				//Prado::method_exists($behavior, $name) rather than $behavior->hasMethod($name) b/c only one layer is supported, @4.2.2
+				if ($behavior->getEnabled() && Prado::method_exists($behavior, $name)) {
 					return true;
 				}
 			}
@@ -1397,7 +1398,7 @@ class TComponent
 					if (($pos = strrpos($handler, '.')) !== false) {
 						$object = $this->getSubProperty(substr($handler, 0, $pos));
 						$method = substr($handler, $pos + 1);
-						if (method_exists($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
+						if (Prado::method_exists($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
 							if ($method == '__dycall') {
 								$response = $object->__dycall($name, [$sender, $param, $name]);
 							} else {
@@ -1418,7 +1419,7 @@ class TComponent
 							$object = $object->getSubProperty(substr($method, 0, $pos));
 							$method = substr($method, $pos + 1);
 						}
-						if (method_exists($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
+						if (Prado::method_exists($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
 							if ($method == '__dycall') {
 								$response = $object->__dycall($name, [$sender, $param, $name]);
 							} else {

--- a/tests/unit/Collections/TPriorityMapTest.php
+++ b/tests/unit/Collections/TPriorityMapTest.php
@@ -76,6 +76,10 @@ class TPriorityMapTestNoItemBehavior extends TBehavior
 
 class TPriorityMapUnit extends TPriorityMap
 {
+	public function _setDefaultPriority($value)
+	{
+		$this->setDefaultPriority($value);
+	}
 	public function _setPrecision($value)
 	{
 		$this->setPrecision($value);
@@ -320,7 +324,7 @@ class TPriorityMapTest extends TMapTest
 	{
 		$this->assertEquals(10, $this->map->DefaultPriority);
 
-		$this->map->DefaultPriority = 5;
+		$this->map->_setDefaultPriority(5);
 		$this->assertEquals(5, $this->map->getDefaultPriority());
 
 		$this->assertEquals(8, $this->map->Precision);

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -2,6 +2,250 @@
 
 use Prado\Prado;
 
+class MethodExistsTestClassA
+{
+	public function getPublicPropertyA()
+	{
+		return 'publicDataA';
+	}
+	protected function getProtectedPropertyA()
+	{
+		return 'protectedDataA';
+	}
+	private function getPrivatePropertyA()
+	{
+		return 'privateDataA';
+	}
+	
+	//Access Self
+	public function methodExistsAAccessPublicPropertyA()
+	{
+		return method_exists($this, 'getPublicPropertyA');
+	}
+	public function methodExistsAAccessProtectedPropertyA()
+	{
+		return method_exists($this, 'getProtectedPropertyA');
+	}
+	public function methodExistsAAccessPrivatePropertyA()
+	{
+		return method_exists($this, 'getPrivatePropertyA');
+	}
+	public function pradoMethodExistsAAccessPublicPropertyA()
+	{
+		return Prado::method_exists($this, 'getPublicPropertyA');
+	}
+	public function pradoMethodExistsAAccessProtectedPropertyA()
+	{
+		return Prado::method_exists($this, 'getProtectedPropertyA');
+	}
+	public function pradoMethodExistsAAccessPrivatePropertyA()
+	{
+		return Prado::method_exists($this, 'getPrivatePropertyA');
+	}
+	
+	//Access Child
+	public function methodExistsAAccessPublicPropertyB()
+	{
+		return method_exists($this, 'getPublicPropertyB');
+	}
+	public function methodExistsAAccessProtectedPropertyB()
+	{
+		return method_exists($this, 'getProtectedPropertyB');
+	}
+	public function methodExistsAAccessPrivatePropertyB()
+	{
+		return method_exists($this, 'getPrivatePropertyB');
+	}
+	public function pradoMethodExistsAAccessPublicPropertyB()
+	{
+		return Prado::method_exists($this, 'getPublicPropertyB');
+	}
+	public function pradoMethodExistsAAccessProtectedPropertyB()
+	{
+		return Prado::method_exists($this, 'getProtectedPropertyB');
+	}
+	public function pradoMethodExistsAAccessPrivatePropertyB()
+	{
+		return Prado::method_exists($this, 'getPrivatePropertyB');
+	}
+	
+	public function testFromClassA($tester, $instance)
+	{
+		//  calling self from parent
+		{ // Parent calls Parent Accesses Parent
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsAAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodExistsAAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodExistsAAccessPrivatePropertyA());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsAAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodExistsAAccessProtectedPropertyA());
+			$tester->assertTrue($instance->pradoMethodExistsAAccessPrivatePropertyA());
+		}
+		
+		{ // Parent calls Child Accesses child
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsBAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodExistsBAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodExistsBAccessPrivatePropertyB());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsBAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodExistsBAccessProtectedPropertyB());
+			$tester->assertFalse($instance->pradoMethodExistsBAccessPrivatePropertyB(), "Parent cannot access child private method.");
+		}
+		
+		
+		{ // Parent calls Parent Accesses Child
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsAAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodExistsAAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodExistsAAccessPrivatePropertyB());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsAAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodExistsAAccessProtectedPropertyB());
+			$tester->assertFalse($instance->pradoMethodExistsAAccessPrivatePropertyB());
+		}
+		
+		
+		{ // Parent calls Child Accesses Parent
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsBAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodExistsBAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodExistsBAccessPrivatePropertyA());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsBAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodExistsBAccessProtectedPropertyA());
+			$tester->assertTrue($instance->pradoMethodExistsBAccessPrivatePropertyA());
+		}
+	}
+}
+
+class MethodExistsTestClassB extends MethodExistsTestClassA
+{
+	public function getPublicPropertyB()
+	{
+		return 'publicDataB';
+	}
+	protected function getProtectedPropertyB()
+	{
+		return 'protectedDataB';
+	}
+	private function getPrivatePropertyB()
+	{
+		return 'privateDataB';
+	}
+	
+	//Access Self
+	public function methodExistsBAccessPublicPropertyB()
+	{
+		return method_exists($this, 'getPublicPropertyB');
+	}
+	public function methodExistsBAccessProtectedPropertyB()
+	{
+		return method_exists($this, 'getProtectedPropertyB');
+	}
+	public function methodExistsBAccessPrivatePropertyB()
+	{
+		return method_exists($this, 'getPrivatePropertyB');
+	}
+	public function pradoMethodExistsBAccessPublicPropertyB()
+	{
+		return Prado::method_exists($this, 'getPublicPropertyB');
+	}
+	public function pradoMethodExistsBAccessProtectedPropertyB()
+	{
+		return Prado::method_exists($this, 'getProtectedPropertyB');
+	}
+	public function pradoMethodExistsBAccessPrivatePropertyB()
+	{
+		return Prado::method_exists($this, 'getPrivatePropertyB');
+	}
+	
+	// Access Parent
+	public function methodExistsBAccessPublicPropertyA()
+	{
+		return method_exists($this, 'getPublicPropertyA');
+	}
+	public function methodExistsBAccessProtectedPropertyA()
+	{
+		return method_exists($this, 'getProtectedPropertyA');
+	}
+	public function methodExistsBAccessPrivatePropertyA()
+	{
+		return method_exists($this, 'getPrivatePropertyA');
+	}
+	public function pradoMethodExistsBAccessPublicPropertyA()
+	{
+		return Prado::method_exists($this, 'getPublicPropertyA');
+	}
+	public function pradoMethodExistsBAccessProtectedPropertyA()
+	{
+		return Prado::method_exists($this, 'getProtectedPropertyA');
+	}
+	public function pradoMethodExistsBAccessPrivatePropertyA()
+	{
+		return Prado::method_exists($this, 'getPrivatePropertyA');
+	}
+	
+	public function testFromClassB($tester, $instance)
+	{
+		//  calling self from child
+		{ // Child calls Parent Accesses Parent
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsAAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodExistsAAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodExistsAAccessPrivatePropertyA());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsAAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodExistsAAccessProtectedPropertyA());
+			$tester->assertFalse($instance->pradoMethodExistsAAccessPrivatePropertyA());
+		}
+		
+		{ // Child calls Child Accesses child
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsBAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodExistsBAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodExistsBAccessPrivatePropertyB());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsBAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodExistsBAccessProtectedPropertyB());
+			$tester->assertTrue($instance->pradoMethodExistsBAccessPrivatePropertyB());
+		}
+		
+		
+		{ // Child calls Parent Accesses Child
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsAAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodExistsAAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodExistsAAccessPrivatePropertyB());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsAAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodExistsAAccessProtectedPropertyB());
+			$tester->assertTrue($instance->pradoMethodExistsAAccessPrivatePropertyB());
+		}
+		
+		
+		{ // Child calls Child Accesses Parent
+			//	Normal method_exists
+			$tester->assertTrue($instance->methodExistsBAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodExistsBAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodExistsBAccessPrivatePropertyA());
+			
+			//	Prado method_exists
+			$tester->assertTrue($instance->pradoMethodExistsBAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodExistsBAccessProtectedPropertyA());
+			$tester->assertFalse($instance->pradoMethodExistsBAccessPrivatePropertyA());
+		}
+	}
+}
+
 /**
  * @package System
  */
@@ -24,6 +268,65 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse(interface_exists(self::INTERFACE_SHORT_NAME, false));
 		Prado::using(self::INTERFACE_FQN);
 		$this->assertTrue(interface_exists(self::INTERFACE_SHORT_NAME, false));
+	}
+	
+	public function testMethod_Exists()
+	{
+		$instance = new MethodExistsTestClassB();
+		
+		// calling instance from external
+		{ //Parent Accesses Parent
+			//	Normal method_exists
+			$this->assertTrue($instance->methodExistsAAccessPublicPropertyA());
+			$this->assertTrue($instance->methodExistsAAccessProtectedPropertyA());
+			$this->assertTrue($instance->methodExistsAAccessPrivatePropertyA());
+			
+			//	Prado method_exists
+			$this->assertTrue($instance->pradoMethodExistsAAccessPublicPropertyA());
+			$this->assertFalse($instance->pradoMethodExistsAAccessProtectedPropertyA());
+			$this->assertFalse($instance->pradoMethodExistsAAccessPrivatePropertyA());
+		}
+		
+		{ // Child Accesses child
+			//	Normal method_exists
+			$this->assertTrue($instance->methodExistsBAccessPublicPropertyB());
+			$this->assertTrue($instance->methodExistsBAccessProtectedPropertyB());
+			$this->assertTrue($instance->methodExistsBAccessPrivatePropertyB());
+			
+			//	Prado method_exists
+			$this->assertTrue($instance->pradoMethodExistsBAccessPublicPropertyB());
+			$this->assertFalse($instance->pradoMethodExistsBAccessProtectedPropertyB());
+			$this->assertFalse($instance->pradoMethodExistsBAccessPrivatePropertyB());
+		}
+		
+		
+		{ //Parent Accesses Child
+			//	Normal method_exists
+			$this->assertTrue($instance->methodExistsAAccessPublicPropertyB());
+			$this->assertTrue($instance->methodExistsAAccessProtectedPropertyB());
+			$this->assertTrue($instance->methodExistsAAccessPrivatePropertyB());
+			
+			//	Prado method_exists
+			$this->assertTrue($instance->pradoMethodExistsAAccessPublicPropertyB());
+			$this->assertFalse($instance->pradoMethodExistsAAccessProtectedPropertyB());
+			$this->assertFalse($instance->pradoMethodExistsAAccessPrivatePropertyB());
+		}
+		
+		
+		{ //Child Accesses Parent
+			//	Normal method_exists
+			$this->assertTrue($instance->methodExistsBAccessPublicPropertyA());
+			$this->assertTrue($instance->methodExistsBAccessProtectedPropertyA());
+			$this->assertTrue($instance->methodExistsBAccessPrivatePropertyA());
+			
+			//	Prado method_exists
+			$this->assertTrue($instance->pradoMethodExistsBAccessPublicPropertyA());
+			$this->assertFalse($instance->pradoMethodExistsBAccessProtectedPropertyA());
+			$this->assertFalse($instance->pradoMethodExistsBAccessPrivatePropertyA());
+		}
+		
+		$instance->testFromClassA($this, $instance);
+		$instance->testFromClassB($this, $instance);
 	}
 
 	public function testCreateComponentWithNamespace()

--- a/tests/unit/TComponentTest.php
+++ b/tests/unit/TComponentTest.php
@@ -93,6 +93,16 @@ class NewComponent extends TComponent
 	{
 		$this->_colorattribute = $colorattribute;
 	}
+	
+	public $_protectedValue = 'protectedData';
+	protected function getProtectedValue()
+	{
+		return $this->_protectedValue;
+	}
+	protected function setProtectedValue($value )
+	{
+		$this->_protectedValue = $value;
+	}
 }
 
 class NewComponentBehavior extends TBehavior
@@ -2902,6 +2912,25 @@ class TComponentTest extends PHPUnit\Framework\TestCase
 		
 		NewComponent::detachClassBehavior('ClassBehavior1');
 		NewComponent::detachClassBehavior('ClassBehavior3');
+		
+	}
+	
+	public function testProtectedSetter()
+	{
+		
+		// Calling protected method doesn't fail, but doesn't call the method
+		//   and returns null.
+		$this->assertEquals(null, $this->component->getProtectedValue());
+		
+		//
+		$value = null;
+		try {
+			$value = $this->component->ProtectedValue;
+			$this->fail("TInvalidOperationException was not properly thrown when accessing a protected property.");
+		} catch(TInvalidOperationException $e) {
+		}
+		$this->assertEquals(null, $value);
+		
 		
 	}
 }


### PR DESCRIPTION
There is a large number of test units to make sure that access is proper from all angles: // Test public
External calls parent access Parent property (public, protected, and private)
External calls child access child property.       "
External calls parent access child property.    "
External calls child access parent property.    "

// test protected and private:
Parent calls parent access Parent property (public, protected, and private)
Parent calls child access child property.       "
Parent calls parent access child property.    "
Parent calls child access parent property.    "

child calls parent access Parent property (public, protected, and private)
child calls child access child property.       "
child calls parent access child property.    "
child calls child access parent property.    "