### PR TITLE
#925 TMap::keyOf is added, additional checks on TPriorityMap

### DIFF
--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -193,7 +193,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 * @param mixed $item the item
 	 * @return false|mixed the key of the item in the map, false if not found.
 	 */
-	public function indexOf($item)
+	public function keyOf($item)
 	{
 		return array_search($item, $this->_d, true);
 	}

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -190,6 +190,15 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	}
 
 	/**
+	 * @param mixed $item the item
+	 * @return false|mixed the key of the item in the map, false if not found.
+	 */
+	public function indexOf($item)
+	{
+		return array_search($item, $this->_d, true);
+	}
+
+	/**
 	 * @return array<int|string, mixed> the list of items in array
 	 */
 	public function toArray(): array

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -228,7 +228,7 @@ class TPriorityMap extends TMap
 				if (array_key_exists($key, $this->_d[$innerpriority])) {
 					unset($this->_d[$innerpriority][$key]);
 					$this->_c--;
-					if (count($this->_d[$innerpriority]) === 0) {
+					if (empty($this->_d[$innerpriority])) {
 						unset($this->_d[$innerpriority]);
 					}
 					break;
@@ -271,7 +271,7 @@ class TPriorityMap extends TMap
 						$value = $this->_d[$priority][$key];
 						unset($this->_d[$priority][$key]);
 						$this->_c--;
-						if (count($this->_d[$priority]) === 0) {
+						if (empty($this->_d[$priority])) {
 							unset($this->_d[$priority]);
 							$this->_o = false;
 						}
@@ -287,7 +287,7 @@ class TPriorityMap extends TMap
 					$value = $this->_d[$priority][$key];
 					unset($this->_d[$priority][$key]);
 					$this->_c--;
-					if (count($this->_d[$priority]) === 0) {
+					if (empty($this->_d[$priority])) {
 						unset($this->_d[$priority]);
 						$this->_o = false;
 					}
@@ -324,6 +324,16 @@ class TPriorityMap extends TMap
 	{
 		$this->flattenPriorities();
 		return isset($this->_fd[$key]) || array_key_exists($key, $this->_fd);
+	}
+
+	/**
+	 * @param mixed $item the item
+	 * @return false|mixed the key of the item in the map, false if not found.
+	 */
+	public function indexOf($item)
+	{
+		$this->flattenPriorities();
+		return array_search($item, $this->_fd, true);
 	}
 
 	/**

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -330,7 +330,7 @@ class TPriorityMap extends TMap
 	 * @param mixed $item the item
 	 * @return false|mixed the key of the item in the map, false if not found.
 	 */
-	public function indexOf($item)
+	public function keyOf($item)
 	{
 		$this->flattenPriorities();
 		return array_search($item, $this->_fd, true);

--- a/tests/unit/Collections/TMapTest.php
+++ b/tests/unit/Collections/TMapTest.php
@@ -189,6 +189,19 @@ class TMapTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse($this->map->contains('key3'));
 	}
 
+	public function testIndexOf()
+	{
+		$item4 = new $this->_baseItemClass(4);
+		$item5 = new $this->_baseItemClass(5);
+		$this->map[2] = $item4;
+		$this->map[] = $item5;
+		$this->assertEquals('key1', $this->map->indexOf($this->item1));
+		$this->assertEquals('key2', $this->map->indexOf($this->item2));
+		$this->assertFalse($this->map->indexOf($this->item3));
+		$this->assertEquals(2, $this->map->indexOf($item4));
+		$this->assertEquals(3, $this->map->indexOf($item5));
+	}
+
 	public function testCopyFrom()
 	{
 		$array = ['key3' => $this->item3, 'key4' => $this->item1];

--- a/tests/unit/Collections/TMapTest.php
+++ b/tests/unit/Collections/TMapTest.php
@@ -189,17 +189,17 @@ class TMapTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse($this->map->contains('key3'));
 	}
 
-	public function testIndexOf()
+	public function testKeyOf()
 	{
 		$item4 = new $this->_baseItemClass(4);
 		$item5 = new $this->_baseItemClass(5);
 		$this->map[2] = $item4;
 		$this->map[] = $item5;
-		$this->assertEquals('key1', $this->map->indexOf($this->item1));
-		$this->assertEquals('key2', $this->map->indexOf($this->item2));
-		$this->assertFalse($this->map->indexOf($this->item3));
-		$this->assertEquals(2, $this->map->indexOf($item4));
-		$this->assertEquals(3, $this->map->indexOf($item5));
+		$this->assertEquals('key1', $this->map->keyOf($this->item1));
+		$this->assertEquals('key2', $this->map->keyOf($this->item2));
+		$this->assertFalse($this->map->keyOf($this->item3));
+		$this->assertEquals(2, $this->map->keyOf($item4));
+		$this->assertEquals(3, $this->map->keyOf($item5));
 	}
 
 	public function testCopyFrom()

--- a/tests/unit/Collections/TPriorityMapTest.php
+++ b/tests/unit/Collections/TPriorityMapTest.php
@@ -224,6 +224,23 @@ class TPriorityMapTest extends TMapTest
 		$this->assertTrue($this->map->contains(10));
 	}
 	
+	public function testIndexOfTPriorityMap()
+	{
+		$this->map->add(null, $this->item2, 5);
+		$this->map->add(null, $this->item4, 15);
+		$this->map[] = $this->item3;
+		$this->map[] = $this->item1;
+		
+		$this->map[10] = $this->item5;
+		
+		$this->assertEquals('key1', $this->map->indexOf($this->item1), "indexOf did not find the first instance of item1 properly.");
+		$this->assertEquals(0, $this->map->indexOf($this->item2), "indexOf did not find the first _priority_ instance of item2 properly.");
+		$this->assertEquals(2, $this->map->indexOf($this->item3));
+		$this->assertEquals(1, $this->map->indexOf($this->item4));
+		$this->assertEquals(10, $this->map->indexOf($this->item5));
+		$this->assertFalse($this->map->indexOf($this));
+	}
+	
 	public function testCopyFromTPriorityMap()
 	{
 		//Test TPriorityMap

--- a/tests/unit/Collections/TPriorityMapTest.php
+++ b/tests/unit/Collections/TPriorityMapTest.php
@@ -224,7 +224,7 @@ class TPriorityMapTest extends TMapTest
 		$this->assertTrue($this->map->contains(10));
 	}
 	
-	public function testIndexOfTPriorityMap()
+	public function testKeyOfTPriorityMap()
 	{
 		$this->map->add(null, $this->item2, 5);
 		$this->map->add(null, $this->item4, 15);
@@ -233,12 +233,12 @@ class TPriorityMapTest extends TMapTest
 		
 		$this->map[10] = $this->item5;
 		
-		$this->assertEquals('key1', $this->map->indexOf($this->item1), "indexOf did not find the first instance of item1 properly.");
-		$this->assertEquals(0, $this->map->indexOf($this->item2), "indexOf did not find the first _priority_ instance of item2 properly.");
-		$this->assertEquals(2, $this->map->indexOf($this->item3));
-		$this->assertEquals(1, $this->map->indexOf($this->item4));
-		$this->assertEquals(10, $this->map->indexOf($this->item5));
-		$this->assertFalse($this->map->indexOf($this));
+		$this->assertEquals('key1', $this->map->keyOf($this->item1), "keyOf did not find the first instance of item1 properly.");
+		$this->assertEquals(0, $this->map->keyOf($this->item2), "keyOf did not find the first _priority_ instance of item2 properly.");
+		$this->assertEquals(2, $this->map->keyOf($this->item3));
+		$this->assertEquals(1, $this->map->keyOf($this->item4));
+		$this->assertEquals(10, $this->map->keyOf($this->item5));
+		$this->assertFalse($this->map->keyOf($this));
 	}
 	
 	public function testCopyFromTPriorityMap()


### PR DESCRIPTION
TPriorityMap should not just return the first instance of a value but it should depend on the priority.  higher priorities are first in the map.