### PR TITLE
#848 TComponent Events support Closures and all callable types (with unit tests)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 ## Version 4.2.3 - TBA
 
 ENH: Issues #824, #838, #851, #891, #910, #917 - General Behaviors Update: Cloning and Serializing supports behaviors.  IBaseBehavior has init($config) method. TClassBehavior tracks their owners.  Behaviors attach their registered event handlers at the behavior priority.  Registered Behavior event can optionally attached and detached automatically when the behavior is enabled or disabled (default).  Behavior events() support Closures. IBehavior are attachable class-wide by cloning. Behaviors for behaviors has better support.  Behaviors are case insensitive.  Supports Anonymous (unnamed/numeric) behaviors.  Wakeup updates the component behaviors with new named class behaviors. (belisoful)
-ENH: ISSUE #848 - TComponent events support Closure (anonymous functions) as handlers. (belisoful)
+ENH: Issue #848 - TComponent events support Closure (anonymous functions) as handlers. (belisoful)
 ENH: Issue #886 - Lists the 1st level traits of the class and its parents in TComponent::getClassHierarchy.  Class-wide behaviors support attaching to Traits as well as interfaces, classes, and their parents. (belisoful)
 ENH: Issue #845 - PHP Clone and Unserialize of TComponent objects supports behaviors. (belisoful)
 BUG: Issue #843 - Permissions Manager behaviors rename the method 'getManager' to 'getPermissionsManager' for specificity. (belisoful)

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1429,14 +1429,10 @@ class TComponent
 						$response = call_user_func($handler, $sender, $param, $name);
 					}
 				} elseif (is_callable($handler, true)) {
-					if (is_array($handler)) {
-						[$object, $method] = $handler;
-					} else {
-						$object = $method = null;
-					}
-					if (is_object($handler) || is_string($object)) {
+					if (is_object($handler) || is_string($handler[0])) {
 						$response = call_user_func($handler, $sender, $param, $name);
 					} else {
+						[$object, $method] = $handler;
 						if (($pos = strrpos($method, '.')) !== false) {
 							$object = $object->getSubProperty(substr($method, 0, $pos));
 							$method = substr($method, $pos + 1);

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1429,8 +1429,12 @@ class TComponent
 						$response = call_user_func($handler, $sender, $param, $name);
 					}
 				} elseif (is_callable($handler, true)) {
-					[$object, $method] = $handler;
-					if (is_string($object)) {
+					if (is_array($handler)) {
+						[$object, $method] = $handler;
+					} else {
+						$object = $method = null;
+					}
+					if (is_object($handler) || is_string($handler) || is_string($object)) {
 						$response = call_user_func($handler, $sender, $param, $name);
 					} else {
 						if (($pos = strrpos($method, '.')) !== false) {

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1434,7 +1434,7 @@ class TComponent
 					} else {
 						$object = $method = null;
 					}
-					if (is_object($handler) || is_string($handler) || is_string($object)) {
+					if (is_object($handler) || is_string($object)) {
 						$response = call_user_func($handler, $sender, $param, $name);
 					} else {
 						if (($pos = strrpos($method, '.')) !== false) {

--- a/tests/unit/TComponentTest.php
+++ b/tests/unit/TComponentTest.php
@@ -2475,6 +2475,8 @@ class TComponentTest extends PHPUnit\Framework\TestCase
 	public function testRaiseEvent()
 	{
 		$component = new NewComponent();
+		
+		// object method callable
 		$component->attachEventHandler('OnMyEvent', [$this->component, 'myEventHandler']);
 		$this->assertFalse($this->component->isEventHandled());
 		$this->assertFalse($this->component->Object->isEventHandled());
@@ -2486,7 +2488,7 @@ class TComponentTest extends PHPUnit\Framework\TestCase
 		$this->component->Object->resetEventHandled();
 		$component->detachEventHandler('OnMyEvent', [$this->component, 'myEventHandler']);
 		
-		
+		// object sub-property method
 		$component->attachEventHandler('OnMyEvent', [$this->component, 'Object.myEventHandler']);
 		$this->assertFalse($this->component->isEventHandled());
 		$this->assertFalse($this->component->Object->isEventHandled());
@@ -2495,6 +2497,21 @@ class TComponentTest extends PHPUnit\Framework\TestCase
 		$this->assertTrue($this->component->Object->isEventHandled());
 		
 		$component->detachEventHandler('OnMyEvent', [$this->component, 'myEventHandler']);
+		$this->component->resetEventHandled();
+		$this->component->Object->resetEventHandled();
+		
+		// closure
+		$raised = false;
+		$eventCount = $component->OnMyEvent->count();
+		$component->attachEventHandler('OnMyEvent', $closure = function () use (&$raised) {
+			$raised = true;
+		});
+		$this->assertEquals($eventCount + 1, $component->OnMyEvent->count());
+		$component->raiseEvent('OnMyEvent', $this, null);
+		$this->assertTrue($raised);
+		
+		$component->detachEventHandler('OnMyEvent', $closure);
+		$this->assertEquals($eventCount, $component->OnMyEvent->count());
 		$this->component->resetEventHandled();
 		$this->component->Object->resetEventHandled();
 


### PR DESCRIPTION
Unit tests to make sure Closures work.  Minor change to TComponent to support Closures.