### PR TITLE
#898 TList/TMap:: setReadOnly made public, only allow first set & self set

### DIFF
--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -99,7 +99,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	/**
 	 * This sets the read only property.
 	 */
-	protected function ensureReadOnly(): void
+	protected function collapseReadOnly(): void
 	{
 		$this->_r = (bool) $this->_r;
 	}
@@ -171,8 +171,8 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 */
 	public function insertAt($index, $item)
 	{
+		$this->collapseReadOnly();
 		if (!$this->_r) {
-			$this->ensureReadOnly();
 			if ($index === $this->_c) {
 				$this->_d[$this->_c++] = $item;
 			} elseif ($index >= 0 && $index < $this->_c) {

--- a/framework/Collections/TList.php
+++ b/framework/Collections/TList.php
@@ -12,6 +12,7 @@ namespace Prado\Collections;
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Prado;
 use Prado\TPropertyValue;
 
 /**
@@ -51,22 +52,23 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 */
 	protected int $_c = 0;
 	/**
-	 * @var bool whether this list is read-only
+	 * @var ?bool whether this list is read-only
 	 */
-	private bool $_r = false;
+	protected ?bool $_r = null;
 
 	/**
 	 * Constructor.
 	 * Initializes the list with an array or an iterable object.
 	 * @param null|array|\Iterator $data the initial data. Default is null, meaning no initialization.
-	 * @param bool $readOnly whether the list is read-only
+	 * @param ?bool $readOnly whether the list is read-only, default null.
 	 * @throws TInvalidDataTypeException If data is not null and neither an array nor an iterator.
 	 */
-	public function __construct($data = null, $readOnly = false)
+	public function __construct($data = null, $readOnly = null)
 	{
 		parent::__construct();
 		if ($data !== null) {
 			$this->copyFrom($data);
+			$readOnly = (bool) $readOnly;
 		}
 		$this->setReadOnly($readOnly);
 	}
@@ -76,15 +78,30 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	 */
 	public function getReadOnly(): bool
 	{
-		return $this->_r;
+		return (bool) $this->_r;
 	}
 
 	/**
-	 * @param bool $value whether this list is read-only or not
+	 * @param null|bool|string $value whether this list is read-only or not
 	 */
-	protected function setReadOnly($value)
+	public function setReadOnly($value)
 	{
-		$this->_r = TPropertyValue::ensureBoolean($value);
+		if ($value === null) {
+			return;
+		}
+		if($this->_r === null || Prado::isCallingSelf()) {
+			$this->_r = TPropertyValue::ensureBoolean($value);
+		} else {
+			throw new TInvalidOperationException('list_readonly_set', $this::class);
+		}
+	}
+
+	/**
+	 * This sets the read only property.
+	 */
+	protected function ensureReadOnly(): void
+	{
+		$this->_r = (bool) $this->_r;
 	}
 
 	/**
@@ -155,6 +172,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 	public function insertAt($index, $item)
 	{
 		if (!$this->_r) {
+			$this->ensureReadOnly();
 			if ($index === $this->_c) {
 				$this->_d[$this->_c++] = $item;
 			} elseif ($index >= 0 && $index < $this->_c) {
@@ -407,7 +425,7 @@ class TList extends \Prado\TComponent implements \IteratorAggregate, \ArrayAcces
 			$exprops[] = "\0*\0_d";
 			$exprops[] = "\0*\0_c";
 		}
-		if ($this->_r === false) {
+		if ($this->_r === null) {
 			$exprops[] = "\0" . __CLASS__ . "\0_r";
 		}
 	}

--- a/framework/Collections/TMap.php
+++ b/framework/Collections/TMap.php
@@ -92,7 +92,7 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	/**
 	 * This sets the read only property.
 	 */
-	protected function ensureReadOnly(): void
+	protected function collapseReadOnly(): void
 	{
 		$this->_r = (bool) $this->_r;
 	}
@@ -153,8 +153,8 @@ class TMap extends \Prado\TComponent implements \IteratorAggregate, \ArrayAccess
 	 */
 	public function add($key, $value)
 	{
+		$this->collapseReadOnly();
 		if (!$this->_r) {
-			$this->ensureReadOnly();
 			if ($key === null) {
 				$this->_d[] = $value;
 			} else {

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -168,10 +168,10 @@ class TPriorityList extends TList
 	 */
 	public function insertAtIndexInPriority($item, $index = null, $priority = null, $preserveCache = false)
 	{
+		$this->collapseReadOnly();
 		if ($this->getReadOnly()) {
 			throw new TInvalidOperationException('list_readonly', $this::class);
 		}
-		$this->ensureReadOnly();
 		if ($index === false) {
 			$index = null; // conversion, remove for PRADO 4.3
 		}

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -57,12 +57,13 @@ class TPriorityList extends TList
 	 * Constructor.
 	 * Initializes the list with an array or an iterable object.
 	 * @param null|array|\Iterator $data the initial data. Default is null, meaning no initial data.
-	 * @param bool $readOnly whether the list is read-only
-	 * @param numeric $defaultPriority the default priority of items without specified priorities.
-	 * @param int $precision the precision of the numeric priorities
+	 * @param ?bool $readOnly whether the list is read-only
+	 * @param numeric $defaultPriority the default priority of items without specified
+	 *   priorities. Default null for 10.
+	 * @param int $precision the precision of the numeric priorities.  Default null for 8.
 	 * @throws TInvalidDataTypeException If data is not null and is neither an array nor an iterator.
 	 */
-	public function __construct($data = null, $readOnly = false, $defaultPriority = 10, $precision = 8)
+	public function __construct($data = null, $readOnly = null, $defaultPriority = null, $precision = null)
 	{
 		$this->setPrecision($precision);
 		$this->setDefaultPriority($defaultPriority);
@@ -170,6 +171,7 @@ class TPriorityList extends TList
 		if ($this->getReadOnly()) {
 			throw new TInvalidOperationException('list_readonly', $this::class);
 		}
+		$this->ensureReadOnly();
 		if ($index === false) {
 			$index = null; // conversion, remove for PRADO 4.3
 		}

--- a/framework/Collections/TPriorityList.php
+++ b/framework/Collections/TPriorityList.php
@@ -58,9 +58,9 @@ class TPriorityList extends TList
 	 * Initializes the list with an array or an iterable object.
 	 * @param null|array|\Iterator $data the initial data. Default is null, meaning no initial data.
 	 * @param ?bool $readOnly whether the list is read-only
-	 * @param numeric $defaultPriority the default priority of items without specified
+	 * @param ?numeric $defaultPriority the default priority of items without specified
 	 *   priorities. Default null for 10.
-	 * @param int $precision the precision of the numeric priorities.  Default null for 8.
+	 * @param ?int $precision the precision of the numeric priorities.  Default null for 8.
 	 * @throws TInvalidDataTypeException If data is not null and is neither an array nor an iterator.
 	 */
 	public function __construct($data = null, $readOnly = null, $defaultPriority = null, $precision = null)

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -75,12 +75,13 @@ class TPriorityMap extends TMap
 	 * Constructor.
 	 * Initializes the array with an array or an iterable object.
 	 * @param null|array|TPriorityList|TPriorityMap|\Traversable $data the initial data. Default is null, meaning no initialization.
-	 * @param bool $readOnly whether the list is read-only
-	 * @param numeric $defaultPriority the default priority of items without specified priorities.
-	 * @param int $precision the precision of the numeric priorities
+	 * @param ?bool $readOnly whether the list is read-only
+	 * @param numeric $defaultPriority the default priority of items without specified
+	 *   priorities.  Default null for 10.
+	 * @param int $precision the precision of the numeric priorities.  Default null for 8.
 	 * @throws TInvalidDataTypeException If data is not null and neither an array nor an iterator.
 	 */
-	public function __construct($data = null, $readOnly = false, $defaultPriority = 10, $precision = 8)
+	public function __construct($data = null, $readOnly = null, $defaultPriority = null, $precision = null)
 	{
 		$this->setPrecision($precision);
 		$this->setDefaultPriority($defaultPriority);
@@ -219,6 +220,7 @@ class TPriorityMap extends TMap
 		}
 
 		if (!$this->getReadOnly()) {
+			$this->ensureReadOnly();
 			if ($key === null) {
 				$key = $this->_ic++;
 			} elseif (is_numeric($key)) {

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -219,8 +219,8 @@ class TPriorityMap extends TMap
 			$value->setPriority($priority);
 		}
 
+		$this->collapseReadOnly();
 		if (!$this->getReadOnly()) {
-			$this->ensureReadOnly();
 			if ($key === null) {
 				$key = $this->_ic++;
 			} elseif (is_numeric($key)) {

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -76,9 +76,9 @@ class TPriorityMap extends TMap
 	 * Initializes the array with an array or an iterable object.
 	 * @param null|array|TPriorityList|TPriorityMap|\Traversable $data the initial data. Default is null, meaning no initialization.
 	 * @param ?bool $readOnly whether the list is read-only
-	 * @param numeric $defaultPriority the default priority of items without specified
+	 * @param ?numeric $defaultPriority the default priority of items without specified
 	 *   priorities.  Default null for 10.
-	 * @param int $precision the precision of the numeric priorities.  Default null for 8.
+	 * @param ?int $precision the precision of the numeric priorities.  Default null for 8.
 	 * @throws TInvalidDataTypeException If data is not null and neither an array nor an iterator.
 	 */
 	public function __construct($data = null, $readOnly = null, $defaultPriority = null, $precision = null)

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -63,7 +63,7 @@ class TWeakCallableCollection extends TPriorityList
 	 *   Default null for the opposite of Read-Only.  Mutable Lists expunge invalid
 	 *   WeakReferences and Read only lists do not.  Set this bool to override the default
 	 *   behavior.
-	 * @param null|mixed $precision
+	 * @param null|int $precision The numeric precision of the priority.
 	 * @throws \Prado\Exceptions\TInvalidDataTypeException If data is not null and
 	 *   is neither an array nor an iterator.
 	 */

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -12,6 +12,7 @@ namespace Prado\Collections;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\Prado;
 use Prado\TPropertyValue;
 
 use Closure;
@@ -45,8 +46,8 @@ class TWeakCallableCollection extends TPriorityList
 {
 	use TWeakCollectionTrait;
 
-	/** @var bool Should invalid WeakReferences automatically be deleted from the list */
-	private bool $_discardInvalid = true;
+	/** @var ?bool Should invalid WeakReferences automatically be deleted from the list */
+	private ?bool $_discardInvalid = null;
 
 	/**
 	 * Constructor.
@@ -68,23 +69,13 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	public function __construct($data = null, $readOnly = null, $defaultPriority = null, $precision = null, $discardInvalid = null)
 	{
-		if ($readOnly === null) {
-			$readOnly = false;
-		}
-		if ($discardInvalid === null) {
-			$discardInvalid = !$readOnly;
-		}
-		$this->_discardInvalid = $discardInvalid;
-		if ($discardInvalid) {
-			$this->weakStart();
-		}
-		if ($defaultPriority === null) {
-			$defaultPriority = 10;
-		}
-		if ($precision === null) {
-			$precision = 8;
+		if ($set = ($discardInvalid === false || $discardInvalid === null && $readOnly === true)) {
+			$this->setDiscardInvalid(false);
 		}
 		parent::__construct($data, $readOnly, $defaultPriority, $precision);
+		if (!$set) {
+			$this->setDiscardInvalid($discardInvalid);
+		}
 	}
 
 	/**
@@ -182,7 +173,7 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	protected function scrubWeakReferences()
 	{
-		if (!$this->_discardInvalid || !$this->weakChanged()) {
+		if (!$this->getDiscardInvalid() || !$this->weakChanged()) {
 			return;
 		}
 		foreach (array_keys($this->_d) as $priority) {
@@ -213,17 +204,34 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	public function getDiscardInvalid(): bool
 	{
-		return $this->_discardInvalid;
+		$this->ensureDiscardInvalid();
+		return (bool) $this->_discardInvalid;
+	}
+
+	/**
+	 * Ensures that DiscardInvalid is set.
+	 */
+	protected function ensureDiscardInvalid()
+	{
+		if ($this->_discardInvalid === null) {
+			$this->setDiscardInvalid(!$this->getReadOnly());
+		}
 	}
 
 	/**
 	 * All invalid WeakReference[s] are optionally removed from the list on $value
 	 *  being "true".
-	 * @param bool $value Sets the TWeakList scrubbing of invalid WeakReferences.
+	 * @param null|bool|string $value Sets the TWeakList scrubbing of invalid WeakReferences.
 	 * @since 4.2.3
 	 */
-	protected function setDiscardInvalid($value): void
+	public function setDiscardInvalid($value): void
 	{
+		if($value === $this->_discardInvalid) {
+			return;
+		}
+		if ($this->_discardInvalid !== null && !Prado::isCallingSelf()) {
+			throw new TInvalidOperationException('weak_no_set_discard_invalid', $this::class);
+		}
 		$value = TPropertyValue::ensureBoolean($value);
 		if ($value && !$this->_discardInvalid) {
 			$this->weakStart();
@@ -238,7 +246,7 @@ class TWeakCallableCollection extends TPriorityList
 							} else {
 								parent::removeAtIndexInPriority($i, $priority);
 							}
-						} else {
+						} else { // Closure
 							$this->weakAdd($obj);
 						}
 					}
@@ -433,6 +441,7 @@ class TWeakCallableCollection extends TPriorityList
 	 */
 	protected function internalInsertAtIndexInPriority($item, $index = null, $priority = null, $preserveCache = false)
 	{
+		$this->ensureDiscardInvalid();
 		$itemPriority = null;
 		if (($isPriorityItem = ($item instanceof IPriorityItem)) && ($priority === null || !is_numeric($priority))) {
 			$itemPriority = $priority = $item->getPriority();
@@ -907,7 +916,7 @@ class TWeakCallableCollection extends TPriorityList
 		$this->_c = $c;
 
 		$this->_weakZappableSleepProps($exprops);
-		if ($this->_discardInvalid === true) {
+		if ($this->_discardInvalid === null) {
 			$exprops[] = "\0" . __CLASS__ . "\0_discardInvalid";
 		}
 	}

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -25,12 +25,17 @@ list_index_invalid						= Index '{0}' is out of range.
 list_item_inexistent					= The item cannot be found in the list.
 list_data_not_iterable					= Data must be either an array or an object implementing Traversable interface.
 list_readonly							= {0} is read-only.
+list_readonly_set						= {0} cannot change Read-Only once it is already set.
 prioritylist_index_invalid				= Index '{0}' of '{1}' at Priority '{2}' is out of range.
+prioritytrait_no_set_default_priority	= Default Priority can only be set once or by the object itself.
+prioritytrait_no_set_precision			= Precision can only be set once or by the object itself.
+weak_no_set_discard_invalid				= '{0}'.DiscardInvalid can only be set once or by the object itself.
 
 map_addition_disallowed					= The new item cannot be added to the map.
 map_item_unremovable					= The item cannot be removed from the map.
 map_data_not_iterable					= Data must be either an array or an object implementing Traversable interface.
 map_readonly							= {0} is read-only.
+map_readonly_set						= {0} cannot change Read-Only once it is already set.
 
 weakcallablecollection_callable_required = TWeakCallableCollection can only accept callables.
 

--- a/framework/Prado.php
+++ b/framework/Prado.php
@@ -435,19 +435,19 @@ class Prado
 	}
 
 	/**
-	 * PHP's method_exists only checks for existence of a method and not if it can
-	 * be accessed by the calling object.  This checks if the caller of the
-	 * component matches the context of the component; if the caller class and the method
-	 * class are the same class, private methods access is allowed.  In effect,
-	 * $this can call magic methods and run protected and private methods, while other
-	 * classes can only access public methods.
-	 * Otherwise, external objects can only call public methods.
-	 * @param object|string $object_or_class The object to check for the method within.
+	 * This conforms PHP's Magic Methods to PHP's Visibility standards for public,
+	 * protected, and private properties, methods, and constants. This method checks
+	 * if the object calling your method can access your object's property, method,
+	 * or constant based upon the defined visibility.  External objects can only access
+	 * public properties, methods, and constants.  When calling the self, private
+	 * properties, methods, and constants are allowed to be accessed by the same class.
+	 * @param object|string $object_or_class The object to check for the method within
+	 *   and for visibility to the calling object.
 	 * @param string $method
 	 * @return bool Does the method exist and is publicly callable.
 	 * @since 4.2.3
 	 */
-	public static function method_accessible($object_or_class, string $method): bool
+	public static function method_visible($object_or_class, string $method): bool
 	{
 		if (method_exists($object_or_class, $method)) {
 			$trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 3);
@@ -460,6 +460,32 @@ class Prado
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * This checks if object calling your object method is the same object.  In effect,
+	 * this signifies if self, parents, and children have visibility to "protected"
+	 * properties, methods, and constants.
+	 * @return bool Does the method exist and is publicly callable.
+	 * @since 4.2.3
+	 */
+	public static function isCallingSelf(): bool
+	{
+		$trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+		return isset($trace[2]) && isset($trace[1]['object']) && isset($trace[2]['object']) && $trace[1]['object'] === $trace[2]['object'];
+	}
+
+	/**
+	 * This checks if object calling your object method is the same object and same class.
+	 * In effect, this allows only the self to have visibility to "private" properties,
+	 * methods, and constants.
+	 * @return bool Does the method exist and is publicly callable.
+	 * @since 4.2.3
+	 */
+	public static function isCallingSelfClass(): bool
+	{
+		$trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+		return isset($trace[2]) && isset($trace[1]['object']) && isset($trace[2]['object']) && $trace[1]['object'] === $trace[2]['object'] && $trace[1]['class'] === $trace[2]['class'];
 	}
 
 	/**

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -735,7 +735,7 @@ class TComponent
 		if (($getset == 'get') || ($getset == 'set')) {
 			$propname = substr($method, 3);
 			$jsmethod = $getset . 'js' . $propname;
-			if (Prado::method_accessible($this, $jsmethod)) {
+			if (Prado::method_visible($this, $jsmethod)) {
 				if (count($args) > 0) {
 					if ($args[0] && !($args[0] instanceof TJavaScriptString)) {
 						$args[0] = new TJavaScriptString($args[0]);
@@ -744,7 +744,7 @@ class TComponent
 				return $this->$jsmethod(...$args);
 			}
 
-			if (($getset == 'set') && Prado::method_accessible($this, 'getjs' . $propname)) {
+			if (($getset == 'set') && Prado::method_visible($this, 'getjs' . $propname)) {
 				throw new TInvalidOperationException('component_property_readonly', $this::class, $method);
 			}
 		}
@@ -784,10 +784,10 @@ class TComponent
 	 */
 	public function __get($name)
 	{
-		if (Prado::method_accessible($this, $getter = 'get' . $name)) {
+		if (Prado::method_visible($this, $getter = 'get' . $name)) {
 			// getting a property
 			return $this->$getter();
-		} elseif (Prado::method_accessible($this, $jsgetter = 'getjs' . $name)) {
+		} elseif (Prado::method_visible($this, $jsgetter = 'getjs' . $name)) {
 			// getting a javascript property
 			return (string) $this->$jsgetter();
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
@@ -838,12 +838,12 @@ class TComponent
 	 */
 	public function __set($name, $value)
 	{
-		if (Prado::method_accessible($this, $setter = 'set' . $name)) {
+		if (Prado::method_visible($this, $setter = 'set' . $name)) {
 			if (strncasecmp($name, 'js', 2) === 0 && $value && !($value instanceof TJavaScriptLiteral)) {
 				$value = new TJavaScriptLiteral($value);
 			}
 			return $this->$setter($value);
-		} elseif (Prado::method_accessible($this, $jssetter = 'setjs' . $name)) {
+		} elseif (Prado::method_visible($this, $jssetter = 'setjs' . $name)) {
 			if ($value && !($value instanceof TJavaScriptString)) {
 				$value = new TJavaScriptString($value);
 			}
@@ -863,7 +863,7 @@ class TComponent
 			}
 		}
 
-		if (Prado::method_accessible($this, 'get' . $name) || Prado::method_accessible($this, 'getjs' . $name)) {
+		if (Prado::method_visible($this, 'get' . $name) || Prado::method_visible($this, 'getjs' . $name)) {
 			throw new TInvalidOperationException('component_property_readonly', $this::class, $name);
 		} else {
 			throw new TInvalidOperationException('component_property_undefined', $this::class, $name);
@@ -884,9 +884,9 @@ class TComponent
 	 */
 	public function __isset($name)
 	{
-		if (Prado::method_accessible($this, $getter = 'get' . $name)) {
+		if (Prado::method_visible($this, $getter = 'get' . $name)) {
 			return $this->$getter() !== null;
-		} elseif (Prado::method_accessible($this, $jsgetter = 'getjs' . $name)) {
+		} elseif (Prado::method_visible($this, $jsgetter = 'getjs' . $name)) {
 			return $this->$jsgetter() !== null;
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
 			$name = strtolower($name);
@@ -920,9 +920,9 @@ class TComponent
 	 */
 	public function __unset($name)
 	{
-		if (Prado::method_accessible($this, $setter = 'set' . $name)) {
+		if (Prado::method_visible($this, $setter = 'set' . $name)) {
 			$this->$setter(null);
-		} elseif (Prado::method_accessible($this, $jssetter = 'setjs' . $name)) {
+		} elseif (Prado::method_visible($this, $jssetter = 'setjs' . $name)) {
 			$this->$jssetter(null);
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
 			$this->_e[strtolower($name)]->clear();
@@ -940,11 +940,11 @@ class TComponent
 						$unset++;
 					}
 				}
-				if (!$unset && Prado::method_accessible($this, 'get' . $name)) {
+				if (!$unset && Prado::method_visible($this, 'get' . $name)) {
 					throw new TInvalidOperationException('component_property_readonly', $this::class, $name);
 				}
 			}
-		} elseif (Prado::method_accessible($this, 'get' . $name)) {
+		} elseif (Prado::method_visible($this, 'get' . $name)) {
 			throw new TInvalidOperationException('component_property_readonly', $this::class, $name);
 		}
 	}
@@ -972,7 +972,7 @@ class TComponent
 	 */
 	public function canGetProperty($name)
 	{
-		if (Prado::method_accessible($this, 'get' . $name) || Prado::method_accessible($this, 'getjs' . $name)) {
+		if (Prado::method_visible($this, 'get' . $name) || Prado::method_visible($this, 'getjs' . $name)) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			foreach ($this->_m->toArray() as $behavior) {
@@ -995,7 +995,7 @@ class TComponent
 	 */
 	public function canSetProperty($name)
 	{
-		if (Prado::method_accessible($this, 'set' . $name) || Prado::method_accessible($this, 'setjs' . $name)) {
+		if (Prado::method_visible($this, 'set' . $name) || Prado::method_visible($this, 'setjs' . $name)) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			foreach ($this->_m->toArray() as $behavior) {
@@ -1076,7 +1076,7 @@ class TComponent
 				}
 			} else {
 				foreach ($this->_m->toArray() as $behavior) {
-					if ($behavior->getEnabled() && Prado::method_accessible($behavior, $method)) {
+					if ($behavior->getEnabled() && Prado::method_visible($behavior, $method)) {
 						if ($behavior instanceof IClassBehavior) {
 							array_unshift($args, $this);
 						}
@@ -1110,7 +1110,7 @@ class TComponent
 	{
 		$classArgs = $callchain = null;
 		foreach ($this->_m->toArray() as $behavior) {
-			if ($behavior->getEnabled() && (Prado::method_accessible($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
+			if ($behavior->getEnabled() && (Prado::method_visible($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
 				if ($classArgs === null) {
 					$classArgs = $args;
 					array_unshift($classArgs, $this);
@@ -1136,12 +1136,12 @@ class TComponent
 	 */
 	public function hasMethod($name)
 	{
-		if (Prado::method_accessible($this, $name) || strncasecmp($name, 'fx', 2) === 0 || strncasecmp($name, 'dy', 2) === 0) {
+		if (Prado::method_visible($this, $name) || strncasecmp($name, 'fx', 2) === 0 || strncasecmp($name, 'dy', 2) === 0) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			foreach ($this->_m->toArray() as $behavior) {
-				//Prado::method_accessible($behavior, $name) rather than $behavior->hasMethod($name) b/c only one layer is supported, @4.2.2
-				if ($behavior->getEnabled() && Prado::method_accessible($behavior, $name)) {
+				//Prado::method_visible($behavior, $name) rather than $behavior->hasMethod($name) b/c only one layer is supported, @4.2.2
+				if ($behavior->getEnabled() && Prado::method_visible($behavior, $name)) {
 					return true;
 				}
 			}
@@ -1416,7 +1416,7 @@ class TComponent
 					if (($pos = strrpos($handler, '.')) !== false) {
 						$object = $this->getSubProperty(substr($handler, 0, $pos));
 						$method = substr($handler, $pos + 1);
-						if (Prado::method_accessible($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
+						if (Prado::method_visible($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
 							if ($method == '__dycall') {
 								$response = $object->__dycall($name, [$sender, $param, $name]);
 							} else {
@@ -1437,7 +1437,7 @@ class TComponent
 							$object = $object->getSubProperty(substr($method, 0, $pos));
 							$method = substr($method, $pos + 1);
 						}
-						if (Prado::method_accessible($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
+						if (Prado::method_visible($object, $method) || strncasecmp($method, 'dy', 2) === 0 || strncasecmp($method, 'fx', 2) === 0) {
 							if ($method == '__dycall') {
 								$response = $object->__dycall($name, [$sender, $param, $name]);
 							} else {

--- a/tests/unit/Collections/TListTest.php
+++ b/tests/unit/Collections/TListTest.php
@@ -13,6 +13,18 @@ class ListItem
 		$this->data = $d;
 	}
 }
+trait TListResetTrait 
+{
+	public function resetReadOnly($value)
+	{
+		$this->setReadOnly($value);
+	}
+}
+
+class TListUnit extends TList
+{
+	use TListResetTrait;
+}
 
 class TListTest extends PHPUnit\Framework\TestCase
 {
@@ -27,11 +39,11 @@ class TListTest extends PHPUnit\Framework\TestCase
 	
 	protected function newList()
 	{
-		return  'TList';
+		return  TListUnit::class;
 	}
 	protected function newListItem()
 	{
-		return 'ListItem';
+		return ListItem::class;
 	}
 	protected function getCanAddNull()
 	{
@@ -71,7 +83,7 @@ class TListTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals(2, $list2->getCount());
 	}
 
-	public function testGetReadOnlyTList()
+	public function testReadOnlyTList()
 	{
 		$list = new $this->_baseClass(null, true);
 		self::assertEquals(true, $list->getReadOnly(), 'List is not read-only');
@@ -81,6 +93,18 @@ class TListTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(true, $list->getReadOnly(), 'List is not read-only');
 		$list = new $this->_baseClass(null, "false");
 		self::assertEquals(false, $list->getReadOnly(), 'List is read-only');
+		
+		$list = new $this->_baseClass(null, null);
+		self::assertEquals(false, $list->getReadOnly(), 'List read only property is not set and not false');
+		$list->setReadOnly(true);
+		self::assertEquals(true, $list->getReadOnly(), 'List is not read-only after set to true');
+		$list->resetReadOnly(false);
+		self::assertEquals(false, $list->getReadOnly(), 'List is read-only after reset to false');
+		
+		// Cannot change Read Only once set
+		$list = new $this->_baseClass(null, false);
+		self::expectException(TInvalidOperationException::class);
+		$list->setReadOnly(true);
 	}
 
 	public function testGetCountTList()

--- a/tests/unit/Collections/TMapTest.php
+++ b/tests/unit/Collections/TMapTest.php
@@ -20,10 +20,7 @@ class TMapTest_MapItem
 
 class TTestMap extends TMap
 {
-	public function _setReadOnly($value)
-	{
-		$this->setReadOnly($value);
-	}
+	use TListResetTrait;
 }
 
 class TMapTestBehavior extends TBehavior implements IDynamicMethods
@@ -98,20 +95,29 @@ class TMapTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals(2, $map2->getCount());
 	}
 	
-	public function testGetReadOnly()
+	public function testReadOnly()
 	{
 		$map = new $this->_baseClass(null, true);
-		self::assertEquals(true, $map->getReadOnly(), 'List is not read-only');
+		self::assertEquals(true, $map->getReadOnly(), 'Map is not read-only');
 		$map = new $this->_baseClass(null, false);
-		self::assertEquals(false, $map->getReadOnly(), 'List is read-only');
-	}
-	
-	public function testSetReadOnly()
-	{
-		// Requires testing unit on base class to implement _setReadOnly as public
+		self::assertEquals(false, $map->getReadOnly(), 'Map is read-only');
+		
+		// Requires testing unit on base class to implement resetReadOnly as public
 		$map = new $this->_baseClass(null, false);
-		$map->_setReadOnly(true);
-		self::assertEquals(true, $map->getReadOnly(), 'List is not converted to Read Only');
+		$map->resetReadOnly(true);
+		self::assertEquals(true, $map->getReadOnly(), 'Map is not converted to Read Only');
+		
+		$map = new $this->_baseClass(null, null);
+		self::assertEquals(false, $map->getReadOnly(), 'Map read only property is not set and not false');
+		$map->setReadOnly(true);
+		self::assertEquals(true, $map->getReadOnly(), 'Map is not read-only after set to true');
+		$map->resetReadOnly(false);
+		self::assertEquals(false, $map->getReadOnly(), 'Map is read-only after reset to false');
+		
+		// Cannot change Read Only once set
+		$map = new $this->_baseClass(null, false);
+		self::expectException(TInvalidOperationException::class);
+		$map->setReadOnly(true);
 	}
 
 	public function testGetCount()

--- a/tests/unit/Collections/TPriorityListTest.php
+++ b/tests/unit/Collections/TPriorityListTest.php
@@ -73,6 +73,21 @@ class PriorityPropertyListItem extends PriorityListItem implements IPriorityProp
 	}
 }
 
+class TPriorityListUnit extends TPriorityList
+{
+	use TListResetTrait;
+	
+	public function resetDefaultPriority($value)
+	{
+		$this->setDefaultPriority($value);
+	}
+	
+	public function resetPrecision($value)
+	{
+		$this->setPrecision($value);
+	}
+}
+
 /**
  *	All Test cases for the TList are here.  The TPriorityList should act just like a TList when used exactly like a TList
  *
@@ -90,11 +105,11 @@ class TPriorityListTest extends TListTest
 
 	protected function newList()
 	{
-		return  'TPriorityList';
+		return  TPriorityListUnit::class;
 	}
 	protected function newListItem()
 	{
-		return 'PriorityListItem';
+		return PriorityListItem::class;
 	}
 	protected function getCanAddNull()
 	{
@@ -169,6 +184,40 @@ class TPriorityListTest extends TListTest
 		$this->assertEquals(-10000000, $list2->priorityAt(0));
 		$this->assertEquals($list2->DefaultPriority, $list2->priorityAt(2));
 		$this->assertEquals(100, $list2->priorityAt(3));
+	}
+	
+	public function testDefaultPriority()
+	{
+		$this->assertEquals(10, $this->list->getDefaultPriority());
+		
+		$list = new $this->_baseClass();
+		$this->assertEquals(10, $list->getDefaultPriority());
+		
+		$list = new $this->_baseClass();
+		$list->setDefaultPriority(21);
+		$this->assertEquals(21, $list->getDefaultPriority());
+		$list->resetDefaultPriority(15);
+		$this->assertEquals(15, $list->getDefaultPriority());
+		
+		self::expectException(TInvalidOperationException::class);
+		$list->setDefaultPriority(20);
+	}
+	
+	public function testPrecision()
+	{
+		$this->assertEquals(8, $this->list->getPrecision());
+		
+		$list = new $this->_baseClass();
+		$this->assertEquals(8, $list->getPrecision());
+		
+		$list = new $this->_baseClass();
+		$list->setPrecision(4);
+		$this->assertEquals(4, $list->getPrecision());
+		$list->resetPrecision(5);
+		$this->assertEquals(5, $list->getPrecision());
+		
+		self::expectException(TInvalidOperationException::class);
+		$list->setPrecision(6);
 	}
 
 	public function testGetPriorityCountTPriorityList()

--- a/tests/unit/Collections/TPriorityMapTest.php
+++ b/tests/unit/Collections/TPriorityMapTest.php
@@ -76,6 +76,8 @@ class TPriorityMapTestNoItemBehavior extends TBehavior
 
 class TPriorityMapUnit extends TPriorityMap
 {
+	use TListResetTrait;
+	
 	public function _setDefaultPriority($value)
 	{
 		$this->setDefaultPriority($value);

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -2,7 +2,7 @@
 
 use Prado\Prado;
 
-class MethodAccessibleTestClassA
+class MethodVisibleTestClassA
 {
 	public function getPublicPropertyA()
 	{
@@ -18,113 +18,135 @@ class MethodAccessibleTestClassA
 	}
 	
 	//Access Self
-	public function methodAccessibleAAccessPublicPropertyA()
+	public function methodVisibleAAccessPublicPropertyA()
 	{
 		return method_exists($this, 'getPublicPropertyA');
 	}
-	public function methodAccessibleAAccessProtectedPropertyA()
+	public function methodVisibleAAccessProtectedPropertyA()
 	{
 		return method_exists($this, 'getProtectedPropertyA');
 	}
-	public function methodAccessibleAAccessPrivatePropertyA()
+	public function methodVisibleAAccessPrivatePropertyA()
 	{
 		return method_exists($this, 'getPrivatePropertyA');
 	}
-	public function pradoMethodAccessibleAAccessPublicPropertyA()
+	public function pradoMethodVisibleAAccessPublicPropertyA()
 	{
-		return Prado::method_accessible($this, 'getPublicPropertyA');
+		return Prado::method_visible($this, 'getPublicPropertyA');
 	}
-	public function pradoMethodAccessibleAAccessProtectedPropertyA()
+	public function pradoMethodVisibleAAccessProtectedPropertyA()
 	{
-		return Prado::method_accessible($this, 'getProtectedPropertyA');
+		return Prado::method_visible($this, 'getProtectedPropertyA');
 	}
-	public function pradoMethodAccessibleAAccessPrivatePropertyA()
+	public function pradoMethodVisibleAAccessPrivatePropertyA()
 	{
-		return Prado::method_accessible($this, 'getPrivatePropertyA');
+		return Prado::method_visible($this, 'getPrivatePropertyA');
 	}
 	
 	//Access Child
-	public function methodAccessibleAAccessPublicPropertyB()
+	public function methodVisibleAAccessPublicPropertyB()
 	{
 		return method_exists($this, 'getPublicPropertyB');
 	}
-	public function methodAccessibleAAccessProtectedPropertyB()
+	public function methodVisibleAAccessProtectedPropertyB()
 	{
 		return method_exists($this, 'getProtectedPropertyB');
 	}
-	public function methodAccessibleAAccessPrivatePropertyB()
+	public function methodVisibleAAccessPrivatePropertyB()
 	{
 		return method_exists($this, 'getPrivatePropertyB');
 	}
-	public function pradoMethodAccessibleAAccessPublicPropertyB()
+	public function pradoMethodVisibleAAccessPublicPropertyB()
 	{
-		return Prado::method_accessible($this, 'getPublicPropertyB');
+		return Prado::method_visible($this, 'getPublicPropertyB');
 	}
-	public function pradoMethodAccessibleAAccessProtectedPropertyB()
+	public function pradoMethodVisibleAAccessProtectedPropertyB()
 	{
-		return Prado::method_accessible($this, 'getProtectedPropertyB');
+		return Prado::method_visible($this, 'getProtectedPropertyB');
 	}
-	public function pradoMethodAccessibleAAccessPrivatePropertyB()
+	public function pradoMethodVisibleAAccessPrivatePropertyB()
 	{
-		return Prado::method_accessible($this, 'getPrivatePropertyB');
+		return Prado::method_visible($this, 'getPrivatePropertyB');
 	}
 	
-	public function testFromClassA($tester, $instance)
+	
+	public function isCallingSelfInA()
+	{
+		return Prado::isCallingSelf();
+	}
+	public function isCallingSelfClassInA()
+	{
+		return Prado::isCallingSelfClass();
+	}
+	
+	public function testMethodVisibleFromClassA($tester, $instance)
 	{
 		//  calling self from parent
 		{ // Parent calls Parent Accesses Parent
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleAAccessPublicPropertyA());
-			$tester->assertTrue($instance->methodAccessibleAAccessProtectedPropertyA());
-			$tester->assertTrue($instance->methodAccessibleAAccessPrivatePropertyA());
+			$tester->assertTrue($instance->methodVisibleAAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodVisibleAAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodVisibleAAccessPrivatePropertyA());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessPublicPropertyA());
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessProtectedPropertyA());
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessPrivatePropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessProtectedPropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessPrivatePropertyA());
 		}
 		
 		{ // Parent calls Child Accesses child
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleBAccessPublicPropertyB());
-			$tester->assertTrue($instance->methodAccessibleBAccessProtectedPropertyB());
-			$tester->assertTrue($instance->methodAccessibleBAccessPrivatePropertyB());
+			$tester->assertTrue($instance->methodVisibleBAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodVisibleBAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodVisibleBAccessPrivatePropertyB());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessPublicPropertyB());
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessProtectedPropertyB());
-			$tester->assertFalse($instance->pradoMethodAccessibleBAccessPrivatePropertyB(), "Parent cannot access child private method.");
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessProtectedPropertyB());
+			$tester->assertFalse($instance->pradoMethodVisibleBAccessPrivatePropertyB(), "Parent cannot access child private method.");
 		}
 		
 		
 		{ // Parent calls Parent Accesses Child
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleAAccessPublicPropertyB());
-			$tester->assertTrue($instance->methodAccessibleAAccessProtectedPropertyB());
-			$tester->assertTrue($instance->methodAccessibleAAccessPrivatePropertyB());
+			$tester->assertTrue($instance->methodVisibleAAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodVisibleAAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodVisibleAAccessPrivatePropertyB());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessPublicPropertyB());
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessProtectedPropertyB());
-			$tester->assertFalse($instance->pradoMethodAccessibleAAccessPrivatePropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessProtectedPropertyB());
+			$tester->assertFalse($instance->pradoMethodVisibleAAccessPrivatePropertyB());
 		}
 		
 		
 		{ // Parent calls Child Accesses Parent
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleBAccessPublicPropertyA());
-			$tester->assertTrue($instance->methodAccessibleBAccessProtectedPropertyA());
-			$tester->assertTrue($instance->methodAccessibleBAccessPrivatePropertyA());
+			$tester->assertTrue($instance->methodVisibleBAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodVisibleBAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodVisibleBAccessPrivatePropertyA());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessPublicPropertyA());
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessProtectedPropertyA());
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessPrivatePropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessProtectedPropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessPrivatePropertyA());
 		}
+	}
+	
+	public function testIsCallingSelfFromClassA($tester, $instance)
+	{
+		$tester->assertTrue($instance->isCallingSelfInA());
+		$tester->assertTrue($instance->isCallingSelfInB());
+	}
+	
+	public function testIsCallingSelfClassFromClassA($tester, $instance)
+	{
+		$tester->assertTrue($instance->isCallingSelfClassInA());
+		$tester->assertFalse($instance->isCallingSelfClassInB());
 	}
 }
 
-class MethodAccessibleTestClassB extends MethodAccessibleTestClassA
+class MethodVisibleTestClassB extends MethodVisibleTestClassA
 {
 	public function getPublicPropertyB()
 	{
@@ -140,109 +162,131 @@ class MethodAccessibleTestClassB extends MethodAccessibleTestClassA
 	}
 	
 	//Access Self
-	public function methodAccessibleBAccessPublicPropertyB()
+	public function methodVisibleBAccessPublicPropertyB()
 	{
 		return method_exists($this, 'getPublicPropertyB');
 	}
-	public function methodAccessibleBAccessProtectedPropertyB()
+	public function methodVisibleBAccessProtectedPropertyB()
 	{
 		return method_exists($this, 'getProtectedPropertyB');
 	}
-	public function methodAccessibleBAccessPrivatePropertyB()
+	public function methodVisibleBAccessPrivatePropertyB()
 	{
 		return method_exists($this, 'getPrivatePropertyB');
 	}
-	public function pradoMethodAccessibleBAccessPublicPropertyB()
+	public function pradoMethodVisibleBAccessPublicPropertyB()
 	{
-		return Prado::method_accessible($this, 'getPublicPropertyB');
+		return Prado::method_visible($this, 'getPublicPropertyB');
 	}
-	public function pradoMethodAccessibleBAccessProtectedPropertyB()
+	public function pradoMethodVisibleBAccessProtectedPropertyB()
 	{
-		return Prado::method_accessible($this, 'getProtectedPropertyB');
+		return Prado::method_visible($this, 'getProtectedPropertyB');
 	}
-	public function pradoMethodAccessibleBAccessPrivatePropertyB()
+	public function pradoMethodVisibleBAccessPrivatePropertyB()
 	{
-		return Prado::method_accessible($this, 'getPrivatePropertyB');
+		return Prado::method_visible($this, 'getPrivatePropertyB');
 	}
 	
 	// Access Parent
-	public function methodAccessibleBAccessPublicPropertyA()
+	public function methodVisibleBAccessPublicPropertyA()
 	{
 		return method_exists($this, 'getPublicPropertyA');
 	}
-	public function methodAccessibleBAccessProtectedPropertyA()
+	public function methodVisibleBAccessProtectedPropertyA()
 	{
 		return method_exists($this, 'getProtectedPropertyA');
 	}
-	public function methodAccessibleBAccessPrivatePropertyA()
+	public function methodVisibleBAccessPrivatePropertyA()
 	{
 		return method_exists($this, 'getPrivatePropertyA');
 	}
-	public function pradoMethodAccessibleBAccessPublicPropertyA()
+	public function pradoMethodVisibleBAccessPublicPropertyA()
 	{
-		return Prado::method_accessible($this, 'getPublicPropertyA');
+		return Prado::method_visible($this, 'getPublicPropertyA');
 	}
-	public function pradoMethodAccessibleBAccessProtectedPropertyA()
+	public function pradoMethodVisibleBAccessProtectedPropertyA()
 	{
-		return Prado::method_accessible($this, 'getProtectedPropertyA');
+		return Prado::method_visible($this, 'getProtectedPropertyA');
 	}
-	public function pradoMethodAccessibleBAccessPrivatePropertyA()
+	public function pradoMethodVisibleBAccessPrivatePropertyA()
 	{
-		return Prado::method_accessible($this, 'getPrivatePropertyA');
+		return Prado::method_visible($this, 'getPrivatePropertyA');
 	}
 	
-	public function testFromClassB($tester, $instance)
+	
+	public function isCallingSelfInB()
+	{
+		return Prado::isCallingSelf();
+	}
+	public function isCallingSelfClassInB()
+	{
+		return Prado::isCallingSelfClass();
+	}
+	
+	public function testMethodVisibleFromClassB($tester, $instance)
 	{
 		//  calling self from child
 		{ // Child calls Parent Accesses Parent
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleAAccessPublicPropertyA());
-			$tester->assertTrue($instance->methodAccessibleAAccessProtectedPropertyA());
-			$tester->assertTrue($instance->methodAccessibleAAccessPrivatePropertyA());
+			$tester->assertTrue($instance->methodVisibleAAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodVisibleAAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodVisibleAAccessPrivatePropertyA());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessPublicPropertyA());
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessProtectedPropertyA());
-			$tester->assertFalse($instance->pradoMethodAccessibleAAccessPrivatePropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessProtectedPropertyA());
+			$tester->assertFalse($instance->pradoMethodVisibleAAccessPrivatePropertyA());
 		}
 		
 		{ // Child calls Child Accesses child
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleBAccessPublicPropertyB());
-			$tester->assertTrue($instance->methodAccessibleBAccessProtectedPropertyB());
-			$tester->assertTrue($instance->methodAccessibleBAccessPrivatePropertyB());
+			$tester->assertTrue($instance->methodVisibleBAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodVisibleBAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodVisibleBAccessPrivatePropertyB());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessPublicPropertyB());
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessProtectedPropertyB());
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessPrivatePropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessProtectedPropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessPrivatePropertyB());
 		}
 		
 		
 		{ // Child calls Parent Accesses Child
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleAAccessPublicPropertyB());
-			$tester->assertTrue($instance->methodAccessibleAAccessProtectedPropertyB());
-			$tester->assertTrue($instance->methodAccessibleAAccessPrivatePropertyB());
+			$tester->assertTrue($instance->methodVisibleAAccessPublicPropertyB());
+			$tester->assertTrue($instance->methodVisibleAAccessProtectedPropertyB());
+			$tester->assertTrue($instance->methodVisibleAAccessPrivatePropertyB());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessPublicPropertyB());
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessProtectedPropertyB());
-			$tester->assertTrue($instance->pradoMethodAccessibleAAccessPrivatePropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessPublicPropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessProtectedPropertyB());
+			$tester->assertTrue($instance->pradoMethodVisibleAAccessPrivatePropertyB());
 		}
 		
 		
 		{ // Child calls Child Accesses Parent
 			//	Normal method_exists
-			$tester->assertTrue($instance->methodAccessibleBAccessPublicPropertyA());
-			$tester->assertTrue($instance->methodAccessibleBAccessProtectedPropertyA());
-			$tester->assertTrue($instance->methodAccessibleBAccessPrivatePropertyA());
+			$tester->assertTrue($instance->methodVisibleBAccessPublicPropertyA());
+			$tester->assertTrue($instance->methodVisibleBAccessProtectedPropertyA());
+			$tester->assertTrue($instance->methodVisibleBAccessPrivatePropertyA());
 			
 			//	Prado method_exists
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessPublicPropertyA());
-			$tester->assertTrue($instance->pradoMethodAccessibleBAccessProtectedPropertyA());
-			$tester->assertFalse($instance->pradoMethodAccessibleBAccessPrivatePropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessPublicPropertyA());
+			$tester->assertTrue($instance->pradoMethodVisibleBAccessProtectedPropertyA());
+			$tester->assertFalse($instance->pradoMethodVisibleBAccessPrivatePropertyA());
 		}
+	}
+	
+	public function testIsCallingSelfFromClassB($tester, $instance)
+	{
+		$tester->assertTrue($instance->isCallingSelfInA());
+		$tester->assertTrue($instance->isCallingSelfInB());
+	}
+	
+	public function testIsCallingSelfClassFromClassB($tester, $instance)
+	{
+		$tester->assertFalse($instance->isCallingSelfClassInA());
+		$tester->assertTrue($instance->isCallingSelfClassInB());
 	}
 }
 
@@ -270,63 +314,85 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 		$this->assertTrue(interface_exists(self::INTERFACE_SHORT_NAME, false));
 	}
 	
-	public function testMethod_Exists()
+	public function testMethod_Visible()
 	{
-		$instance = new MethodAccessibleTestClassB();
+		$instance = new MethodVisibleTestClassB();
 		
 		// calling instance from external
 		{ //Parent Accesses Parent
 			//	Normal method_exists
-			$this->assertTrue($instance->methodAccessibleAAccessPublicPropertyA());
-			$this->assertTrue($instance->methodAccessibleAAccessProtectedPropertyA());
-			$this->assertTrue($instance->methodAccessibleAAccessPrivatePropertyA());
+			$this->assertTrue($instance->methodVisibleAAccessPublicPropertyA());
+			$this->assertTrue($instance->methodVisibleAAccessProtectedPropertyA());
+			$this->assertTrue($instance->methodVisibleAAccessPrivatePropertyA());
 			
 			//	Prado method_exists
-			$this->assertTrue($instance->pradoMethodAccessibleAAccessPublicPropertyA());
-			$this->assertFalse($instance->pradoMethodAccessibleAAccessProtectedPropertyA());
-			$this->assertFalse($instance->pradoMethodAccessibleAAccessPrivatePropertyA());
+			$this->assertTrue($instance->pradoMethodVisibleAAccessPublicPropertyA());
+			$this->assertFalse($instance->pradoMethodVisibleAAccessProtectedPropertyA());
+			$this->assertFalse($instance->pradoMethodVisibleAAccessPrivatePropertyA());
 		}
 		
 		{ // Child Accesses child
 			//	Normal method_exists
-			$this->assertTrue($instance->methodAccessibleBAccessPublicPropertyB());
-			$this->assertTrue($instance->methodAccessibleBAccessProtectedPropertyB());
-			$this->assertTrue($instance->methodAccessibleBAccessPrivatePropertyB());
+			$this->assertTrue($instance->methodVisibleBAccessPublicPropertyB());
+			$this->assertTrue($instance->methodVisibleBAccessProtectedPropertyB());
+			$this->assertTrue($instance->methodVisibleBAccessPrivatePropertyB());
 			
 			//	Prado method_exists
-			$this->assertTrue($instance->pradoMethodAccessibleBAccessPublicPropertyB());
-			$this->assertFalse($instance->pradoMethodAccessibleBAccessProtectedPropertyB());
-			$this->assertFalse($instance->pradoMethodAccessibleBAccessPrivatePropertyB());
+			$this->assertTrue($instance->pradoMethodVisibleBAccessPublicPropertyB());
+			$this->assertFalse($instance->pradoMethodVisibleBAccessProtectedPropertyB());
+			$this->assertFalse($instance->pradoMethodVisibleBAccessPrivatePropertyB());
 		}
 		
 		
 		{ //Parent Accesses Child
 			//	Normal method_exists
-			$this->assertTrue($instance->methodAccessibleAAccessPublicPropertyB());
-			$this->assertTrue($instance->methodAccessibleAAccessProtectedPropertyB());
-			$this->assertTrue($instance->methodAccessibleAAccessPrivatePropertyB());
+			$this->assertTrue($instance->methodVisibleAAccessPublicPropertyB());
+			$this->assertTrue($instance->methodVisibleAAccessProtectedPropertyB());
+			$this->assertTrue($instance->methodVisibleAAccessPrivatePropertyB());
 			
 			//	Prado method_exists
-			$this->assertTrue($instance->pradoMethodAccessibleAAccessPublicPropertyB());
-			$this->assertFalse($instance->pradoMethodAccessibleAAccessProtectedPropertyB());
-			$this->assertFalse($instance->pradoMethodAccessibleAAccessPrivatePropertyB());
+			$this->assertTrue($instance->pradoMethodVisibleAAccessPublicPropertyB());
+			$this->assertFalse($instance->pradoMethodVisibleAAccessProtectedPropertyB());
+			$this->assertFalse($instance->pradoMethodVisibleAAccessPrivatePropertyB());
 		}
 		
 		
 		{ //Child Accesses Parent
 			//	Normal method_exists
-			$this->assertTrue($instance->methodAccessibleBAccessPublicPropertyA());
-			$this->assertTrue($instance->methodAccessibleBAccessProtectedPropertyA());
-			$this->assertTrue($instance->methodAccessibleBAccessPrivatePropertyA());
+			$this->assertTrue($instance->methodVisibleBAccessPublicPropertyA());
+			$this->assertTrue($instance->methodVisibleBAccessProtectedPropertyA());
+			$this->assertTrue($instance->methodVisibleBAccessPrivatePropertyA());
 			
 			//	Prado method_exists
-			$this->assertTrue($instance->pradoMethodAccessibleBAccessPublicPropertyA());
-			$this->assertFalse($instance->pradoMethodAccessibleBAccessProtectedPropertyA());
-			$this->assertFalse($instance->pradoMethodAccessibleBAccessPrivatePropertyA());
+			$this->assertTrue($instance->pradoMethodVisibleBAccessPublicPropertyA());
+			$this->assertFalse($instance->pradoMethodVisibleBAccessProtectedPropertyA());
+			$this->assertFalse($instance->pradoMethodVisibleBAccessPrivatePropertyA());
 		}
 		
-		$instance->testFromClassA($this, $instance);
-		$instance->testFromClassB($this, $instance);
+		$instance->testMethodVisibleFromClassA($this, $instance);
+		$instance->testMethodVisibleFromClassB($this, $instance);
+	}
+	
+	public function testIsCallingSelf()
+	{
+		$instance = new MethodVisibleTestClassB();
+		
+		$this->assertFalse($instance->isCallingSelfInA());
+		$this->assertFalse($instance->isCallingSelfInB());
+		
+		$instance->testIsCallingSelfFromClassA($this, $instance);
+		$instance->testIsCallingSelfFromClassB($this, $instance);
+	}
+	
+	public function testIsCallingSelfClass()
+	{
+		$instance = new MethodVisibleTestClassB();
+		
+		$this->assertFalse($instance->isCallingSelfClassInA());
+		$this->assertFalse($instance->isCallingSelfClassInB());
+		
+		$instance->testIsCallingSelfClassFromClassA($this, $instance);
+		$instance->testIsCallingSelfClassFromClassB($this, $instance);
 	}
 
 	public function testCreateComponentWithNamespace()


### PR DESCRIPTION
This resolves the issue of setting TList/TMap::ReadOnly in configuration.  while preserving access control over the property.

This converts TMap and TList Read only into a null and accepts first set and self set.

Regression.

With unit tests.