### PR TITLE
TRational offsetExists and offsetUnset handles null, unit tests

### DIFF
--- a/framework/Util/Math/TRational.php
+++ b/framework/Util/Math/TRational.php
@@ -259,7 +259,7 @@ class TRational implements \ArrayAccess
 	 */
 	public function offsetExists(mixed $offset): bool
 	{
-		if (is_numeric($offset) && ($offset == 0 || $offset == 1) || is_string($offset) && ($offset === self::NUMERATOR || $offset === self::DENOMINATOR)) {
+		if ($offset === null || is_numeric($offset) && ($offset == 0 || $offset == 1) || is_string($offset) && ($offset === self::NUMERATOR || $offset === self::DENOMINATOR)) {
 			return true;
 		}
 		return false;
@@ -352,6 +352,10 @@ class TRational implements \ArrayAccess
 				$this->setDenominator(1);
 				return;
 			}
+		} elseif ($offset === null) {
+			$this->setNumerator(0);
+			$this->setDenominator(1);
+			return;
 		}
 		throw new TInvalidDataValueException('rational_bad_offset', $offset);
 	}

--- a/tests/unit/Util/Math/TRationalTest.php
+++ b/tests/unit/Util/Math/TRationalTest.php
@@ -265,6 +265,7 @@ class TRationalTest extends PHPUnit\Framework\TestCase
 	public function testOffsetExists()
 	{
 		self::assertFalse($this->obj->offsetExists(-1));
+		self::assertTrue($this->obj->offsetExists(null));
 		self::assertTrue($this->obj->offsetExists(0));
 		self::assertTrue($this->obj->offsetExists(1));
 		self::assertFalse($this->obj->offsetExists(2));
@@ -316,7 +317,7 @@ class TRationalTest extends PHPUnit\Framework\TestCase
 		$this->obj->setValue([3, 2]);
 		self::assertEquals(3, $this->obj->getNumerator(), "Numerator was not initialized properly");
 		self::assertEquals(2, $this->obj->getDenominator(), "Denominator was not initialized properly");
-			
+		
 		$this->obj->offsetUnset(0);
 		self::assertEquals(0, $this->obj->getNumerator());
 		$this->obj->offsetUnset(1);
@@ -324,6 +325,12 @@ class TRationalTest extends PHPUnit\Framework\TestCase
 			
 		$this->obj->setValue([3, 2]);
 		$this->obj->offsetUnset('numerator');
+		self::assertEquals(0, $this->obj->getNumerator());
+		$this->obj->offsetUnset('denominator');
+		self::assertEquals(1, $this->obj->getDenominator());
+		
+		$this->obj->setValue([3, 2]);
+		$this->obj->offsetUnset(null);
 		self::assertEquals(0, $this->obj->getNumerator());
 		$this->obj->offsetUnset('denominator');
 		self::assertEquals(1, $this->obj->getDenominator());


### PR DESCRIPTION
Minor update to handle null with unit tests.

null value was missing from offsetExists and offsetUnset.  This makes the handling of null uniform