### PR TITLE
#918 fixing spot DBCron test failure.

### DIFF
--- a/framework/Util/Cron/TDbCronModule.php
+++ b/framework/Util/Cron/TDbCronModule.php
@@ -815,8 +815,8 @@ class TDbCronModule extends TCronModule implements \Prado\Util\IDbModule
 			$sortingDesc ??= true;
 		}
 		if ($sortingDesc !== null) {
-			$sortingDesc = TPropertyValue::ensureBoolean($sortingDesc) ? "DESC" : "ASC";
-			$orderby = " ORDER BY lastExecTime $sortingDesc, processCount $sortingDesc";
+			$sortingDesc = TPropertyValue::ensureBoolean($sortingDesc) ? 'DESC' : 'ASC';
+			$orderby = " ORDER BY lastExecTime $sortingDesc, tabuid $sortingDesc, processCount $sortingDesc";
 		}
 		$cmd = $db->createCommand(
 			"SELECT * FROM {$this->_tableName} WHERE {$where}active IS NULL{$orderby}{$limit}"

--- a/tests/unit/Util/Cron/TDbCronModuleTest.php
+++ b/tests/unit/Util/Cron/TDbCronModuleTest.php
@@ -240,7 +240,7 @@ class TDbCronModuleTest extends TCronModuleTest
 		
 		self::assertEquals(5, $this->obj->getCronLogCount());
 		
-		$log = $this->obj->getCronLog(null, false, false, true);
+		$log = $this->obj->getCronLog(null, false, false, false);
 		self::assertEquals(5, count($log));
 		
 		self::assertEquals('testTaskAA', $log[0]['name']);


### PR DESCRIPTION
The test itself wasn't quite right.  it should sort by asc (false), not descending (true). and ordering by uid (aka entry order) as well.

This should fix the issue.  I think it was spotty when TDBCron executing the test between seconds and the ordering was by time....

Thus when they were all the in the same second, it was ordering by UID correctly on the log