### PR TITLE
#940 Correcting the scope of getClassFxEvents::$_classfx

### DIFF
--- a/framework/TApplicationComponent.php
+++ b/framework/TApplicationComponent.php
@@ -51,10 +51,11 @@ class TApplicationComponent extends \Prado\TComponent
 	 */
 	protected function getClassFxEvents($class)
 	{
+		static $_classfx = null;
+
 		$app = $this->getApplication();
 		$mode = $className = $cache = null;
 		if ($app && (($mode = $app->getMode()) === TApplicationMode::Normal || $mode === TApplicationMode::Performance) && ($cache = $app->getCache())) {
-			static $_classfx = null;
 			if ($_classfx === null) {
 				$_classfx = $cache->get(self::APP_COMPONENT_FX_CACHE) ?? [];
 			}


### PR DESCRIPTION
"Restoring order to the force." - Not Yoda

presuming scope and data that isn't there can lead to errors.