### PR TITLE
#939 IWeakRetainable consistency for objects in callable array

### DIFF
--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -208,7 +208,7 @@ class TWeakCallableCollection extends TPriorityList
 		if ($validate && !is_callable($handler)) {
 			throw new TInvalidDataValueException('weakcallablecollection_callable_required');
 		}
-		if (is_array($handler) && is_object($handler[0])) {
+		if (is_array($handler) && is_object($handler[0]) && !($handler[0] instanceof IWeakRetainable)) {
 			$handler[0] = WeakReference::create($handler[0]);
 		} elseif (is_object($handler) && !($handler instanceof Closure) && !($handler instanceof IWeakRetainable)) {
 			$handler = WeakReference::create($handler);

--- a/framework/TEventHandler.php
+++ b/framework/TEventHandler.php
@@ -111,7 +111,7 @@ class TEventHandler implements IWeakRetainable, \ArrayAccess, \Countable
 			throw new TInvalidDataTypeException('eventhandler_not_callable');
 		}
 
-		if (is_array($handler) && is_object($handler[0])) {
+		if (is_array($handler) && is_object($handler[0]) && !($handler[0] instanceof IWeakRetainable)) {
 			$handler[0] = WeakReference::create($handler[0]);
 			$this->_weakObject = true;
 		} elseif (is_object($handler) && !($handler instanceof Closure) && !($handler instanceof IWeakRetainable)) {

--- a/tests/unit/TEventHandlerTest.php
+++ b/tests/unit/TEventHandlerTest.php
@@ -64,26 +64,53 @@ class TEventHandlerTest extends PHPUnit\Framework\TestCase
 	{
 		$handler = new TEventHandler($callable = 'trim', $data = 5);
 		self::assertEquals($callable, $handler->getHandler());
+		self::assertFalse($handler->hasWeakObject());
 		self::assertEquals($data, $handler->getData());
 		
 		$handler = new TEventHandler($callable = [$this::class, 'myTestFunction'], $data = ['key0' => 'element0']);
 		self::assertEquals($callable, $handler->getHandler());
+		self::assertFalse($handler->hasWeakObject());
 		self::assertEquals($data, $handler->getData());
 			
 		$handler = new TEventHandler($callable = function() {return -1;}, $data = 8);
 		self::assertEquals($callable, $handler->getHandler());
+		self::assertFalse($handler->hasWeakObject());
 		self::assertEquals($data, $handler->getData());
 		
 		$handler2 = new TEventHandler($callable = [$this, 'myTestFunction'], $data = 13);
 		self::assertEquals($callable, $handler2->getHandler());
+		self::assertTrue($handler2->hasWeakObject());
 		self::assertEquals($data, $handler2->getData());
 		
 		$handler = new TEventHandler($handler2, $data = 21);
 		self::assertEquals($handler2, $handler->getHandler());
+		self::assertTrue($handler->hasWeakObject());
+		self::assertEquals($data, $handler->getData());
+		
+		$invokable = new EventHandlerObject();
+		$handler = new TEventHandler($invokable, $data = 22);
+		self::assertEquals($invokable, $handler->getHandler());
+		self::assertTrue($handler->hasWeakObject());
+		self::assertEquals($data, $handler->getData());
+			
+		$handler = new TEventHandler($callable = [$invokable, 'myHandler'], $data = 23);
+		self::assertEquals($callable, $handler->getHandler());
+		self::assertTrue($handler->hasWeakObject());
+		self::assertEquals($data, $handler->getData());
+		
+		$invokableRetainable = new RetainableEventHandlerObject();
+		$handler = new TEventHandler($invokableRetainable, $data = 24);
+		self::assertEquals($invokableRetainable, $handler->getHandler());
+		self::assertFalse($handler->hasWeakObject());
+		self::assertEquals($data, $handler->getData());
+			
+		$handler = new TEventHandler($callable = [$invokableRetainable, 'myHandler'], $data = 25);
+		self::assertEquals($callable, $handler->getHandler());
+		self::assertFalse($handler->hasWeakObject());
 		self::assertEquals($data, $handler->getData());
 		
 		self::expectException(TInvalidDataTypeException::class);
-		$handler = new TEventHandler([$this, 'nonexistingMethod'], 34);
+		$handler = new TEventHandler([$this, 'nonexistingMethod'], 26);
 	}
 	
 	public function testInvoke()


### PR DESCRIPTION
For TEventHandler and TWeakCallableCollection
with unit tests

The TWeakList doesn't WeakReference array objects that implement IWeakRetainable.  This commit makes that behavior consistent in TEventHandler and TWeakCallableCollection.

Not sure what the use case would be for having something respond to an event where it is the only instance in the application, but it is the proper maths.