### PR TITLE
#944 TExitException for graceful exit of application & TException chaining

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ ENH: Issue #886 - Lists the 1st level traits of the class and its parents in TCo
 ENH: Issue #904 - TRational and TURational for reading, writing, and computing EXIF-Tiff (GPS) Rational and URational unit types; in Prado\Util\Math. (belisoful)
 BUG: Issue #911 - Protect the message cache file to be thread safe. (majuca)
 ENH: Issue #939 - TEventHandler for embedding data with a specific event handler callable. (belisoful)
+ENH: Issue #944 - TExitException for gracefully exiting the application anywhere. Exception chaining with the last parameter being the previous Exception. (belisoful)
 
 ## Version 4.2.2 - April 6, 2023
 

--- a/framework/Exceptions/TException.php
+++ b/framework/Exceptions/TException.php
@@ -12,6 +12,8 @@ namespace Prado\Exceptions;
 use Prado\Prado;
 use Prado\TPropertyValue;
 
+use Throwable;
+
 /**
  * TException class
  *
@@ -41,22 +43,28 @@ class TException extends \Exception
 	/**
 	 * Constructor.
 	 * @param string $errorMessage error message. This can be a string that is listed
-	 * in the message file. If so, the message in the preferred language
-	 * will be used as the error message. Any rest parameters will be used
-	 * to replace placeholders ({0}, {1}, {2}, etc.) in the message.
+	 *   in the message file. If so, the message in the preferred language
+	 *   will be used as the error message.
+	 * @param array $args These are used to replace placeholders ({0}, {1}, {2}, etc.)
+	 *   in the message except the last argument.  If the last argument is a Throwable
+	 *   it is treated as the $previous Exception for exception chaining.
 	 */
-	public function __construct($errorMessage)
+	public function __construct($errorMessage, ...$args)
 	{
 		$this->_errorCode = $errorMessage;
 		$errorMessage = $this->translateErrorMessage($errorMessage);
-		$args = func_get_args();
 		array_shift($args);
 		$n = count($args);
+		$previous = null;
+		if($n > 0 && ($args[$n - 1] instanceof Throwable)) {
+			$previous = array_pop($args);
+			$n--;
+		}
 		$tokens = [];
 		for ($i = 0; $i < $n; ++$i) {
 			$tokens['{' . $i . '}'] = TPropertyValue::ensureString($args[$i]);
 		}
-		parent::__construct(strtr($errorMessage, $tokens));
+		parent::__construct(strtr($errorMessage, $tokens), 0, $previous);
 	}
 
 	/**

--- a/framework/Exceptions/TExitException.php
+++ b/framework/Exceptions/TExitException.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * TExitException file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Exceptions;
+
+/**
+ * TExitException class
+ *
+ * Throwing TExitException will interrupt the application and gracefully terminate.
+ * The application will exit with the specified {@link getExitCode Exit Code}.
+ *
+ * This exception is not designed to be caught by any class other than TApplication.
+ * If this exception is caught, it may interfere with the graceful termination of
+ * the application.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+class TExitException extends TSystemException
+{
+	/**
+	 * @var int The exit code
+	 */
+	protected int $_exitCode;
+
+	/**
+	 * Constructor.
+	 * @param int $exitCode The status exit code.
+	 * @param ?string $message The error message.
+	 * @param array $args All the additional parameters.
+	 */
+	public function __construct(int $exitCode = 0, ?string $message = null, ...$args)
+	{
+		$this->_exitCode = $exitCode;
+		parent::__construct($message, ...$args);
+	}
+
+	/**
+	 * @return int The exit code to end the application process.
+	 */
+	public function getExitCode(): int
+	{
+		return $this->_exitCode;
+	}
+}

--- a/framework/Exceptions/TUserException.php
+++ b/framework/Exceptions/TUserException.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * TUserException file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Exceptions;
+
+/**
+ * TUserException class
+ *
+ * The TUserException is the base class for designed for display to end users.
+ * These are usually thrown because of a mistake made by the end user.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.2.3
+ */
+class TUserException extends TException
+{
+}

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -10,6 +10,7 @@
 namespace Prado;
 
 use Prado\Exceptions\TErrorHandler;
+use Prado\Exceptions\TExitException;
 use Prado\Exceptions\THttpException;
 use Prado\Exceptions\TConfigurationException;
 use Prado\I18N\TGlobalization;
@@ -396,6 +397,9 @@ class TApplication extends \Prado\TComponent
 				$this->$method();
 				$this->_step++;
 			}
+		} catch (TExitException $e) {
+			$this->onEndRequest();
+			exit($e->getExitCode());
 		} catch (\Exception $e) {
 			$this->onError($e);
 		}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -185,6 +185,7 @@ return [
 'TPhpErrorException' => 'Prado\Exceptions\TPhpErrorException',
 'TSystemException' => 'Prado\Exceptions\TSystemException',
 'TTemplateException' => 'Prado\Exceptions\TTemplateException',
+'TUserException' => 'Prado\Exceptions\TUserException',
 'ChoiceFormat' => 'Prado\I18N\core\ChoiceFormat',
 'CultureInfo' => 'Prado\I18N\core\CultureInfo',
 'TGettext' => 'Prado\I18N\core\Gettext\TGettext',

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -175,6 +175,7 @@ return [
 'TDbException' => 'Prado\Exceptions\TDbException',
 'TErrorHandler' => 'Prado\Exceptions\TErrorHandler',
 'TException' => 'Prado\Exceptions\TException',
+'TExitException' => 'Prado\Exceptions\TExitException',
 'THttpException' => 'Prado\Exceptions\THttpException',
 'TInvalidDataTypeException' => 'Prado\Exceptions\TInvalidDataTypeException',
 'TInvalidDataValueException' => 'Prado\Exceptions\TInvalidDataValueException',


### PR DESCRIPTION
In TException, when the final parameter is a Throwable, it becomes the $previous Exception of the exception.

Yay for Exception chaining support.

I saw this in a PHP doc comment and then saw it implemented in Yii.  We should have it too.

"back porting?"

This also adds the TUserException designed for display to the end user.