### PR TITLE
TException shouldn't be shifting off the first arg

### DIFF
--- a/framework/Exceptions/TException.php
+++ b/framework/Exceptions/TException.php
@@ -53,7 +53,6 @@ class TException extends \Exception
 	{
 		$this->_errorCode = $errorMessage;
 		$errorMessage = $this->translateErrorMessage($errorMessage);
-		array_shift($args);
 		$n = count($args);
 		$previous = null;
 		if($n > 0 && ($args[$n - 1] instanceof Throwable)) {


### PR DESCRIPTION
When updating TException I accidentally left in an array_shift.

It shouldn't be shifting off the first argument like before.