### PR TITLE
#940 TApplicationComponent::getClassFxEvents update and TDBCache::setValue uses atomic SQL

### DIFF
--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -496,7 +496,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			$this->initializeCache();
 		}
 		$expire = ($expire <= 0) ? 0 : time() + $expire;
-		$sql = "INSERT OR REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
+		$sql = "REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
 		$command = $this->getDbConnection()->createCommand($sql);
 		$command->bindValue(':key', $key, \PDO::PARAM_STR);
 		$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -497,7 +497,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 		}
 		$db = $this->getDbConnection();
 		$driver = $db->getDriverName();
-		if (0 && in_array($driver, ['mysql', 'mysqli', 'sqlite', 'ibm', 'oci', 'sqlsrv', 'mssql', 'dblib', 'pgsql'])) {
+		if (in_array($driver, ['mysql', 'mysqli', 'sqlite', 'ibm', 'oci', 'sqlsrv', 'mssql', 'dblib', 'pgsql'])) {
 			$expire = ($expire <= 0) ? 0 : time() + $expire;
 			if (in_array($driver, ['mysql', 'mysqli', 'sqlite'])) {
 				$sql = "REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -496,7 +496,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			$this->initializeCache();
 		}
 		$expire = ($expire <= 0) ? 0 : time() + $expire;
-		$sql = "INSERT INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire) ON DUPLICATE KEY UPDATE value=VALUES(value), expire=VALUES(expire)";
+		$sql = "INSERT OR REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
 		$command = $this->getDbConnection()->createCommand($sql);
 		$command->bindValue(':key', $key, \PDO::PARAM_STR);
 		$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -495,23 +495,53 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 		if (!$this->_cacheInitialized) {
 			$this->initializeCache();
 		}
-		$expire = ($expire <= 0) ? 0 : time() + $expire;
-		$sql = "REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
-		$command = $this->getDbConnection()->createCommand($sql);
-		$command->bindValue(':key', $key, \PDO::PARAM_STR);
-		$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);
+		$db = $this->getDbConnection();
+		$driver = $db->getDriverName();
+		if (0 && in_array($driver, ['mysql', 'mysqli', 'sqlite', 'ibm', 'oci', 'sqlsrv', 'mssql', 'dblib', 'pgsql'])) {
+			$expire = ($expire <= 0) ? 0 : time() + $expire;
+			if (in_array($driver, ['mysql', 'mysqli', 'sqlite'])) {
+				$sql = "REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
+			} elseif ($driver === 'pgsql') {
+				$sql = "INSERT INTO {$this->_cacheTable} (itemkey, value, expire) VALUES (:key, :value, :expire) " .
+					"ON CONFLICT (itemkey) DO UPDATE SET value = EXCLUDED.value, expire = EXCLUDED.expire";
+			} else {
+				$sql = "MERGE INTO {$this->_cacheTable} AS c " .
+				"USING (SELECT :key AS itemkey, :value AS value, $expire AS expire) AS data " .
+				"ON c.itemkey = data.itemkey " .
+				"WHEN MATCHED THEN " .
+					"UPDATE SET c.value = data.value, c.expire = data.expire " .
+				"WHEN NOT MATCHED THEN " .
+					"INSERT (itemkey, value, expire) " .
+					"VALUES (data.itemkey, data.value, data.expire)";
+			}
+			$command = $db->createCommand($sql);
+			$command->bindValue(':key', $key, \PDO::PARAM_STR);
+			$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);
 
-		try {
-			$command->execute();
-			return true;
-		} catch (\Exception $e) {
 			try {
-				$this->initializeCache(true);
 				$command->execute();
 				return true;
 			} catch (\Exception $e) {
-				return false;
+				try {
+					$this->initializeCache(true);
+					$command->execute();
+					return true;
+				} catch (\Exception $e) {
+					return false;
+				}
 			}
+		} else {
+			$isCurrentTransaction = $this->getDbConnection()->getCurrentTransaction();
+			$transaction = $this->getDbConnection()->getCurrentTransaction() ?? $this->getDbConnection()->beginTransaction();
+
+			$this->deleteValue($key);
+			$return = $this->addValue($key, $value, $expire);
+
+			if (!$isCurrentTransaction) {
+				$transaction->commit();
+			}
+
+			return $return;
 		}
 	}
 

--- a/framework/TApplicationComponent.php
+++ b/framework/TApplicationComponent.php
@@ -76,7 +76,7 @@ class TApplicationComponent extends \Prado\TComponent
 		if ($cacheFile) {
 			if ($mode === TApplicationMode::Performance) {
 				file_put_contents($cacheFile, serialize($_classfx), LOCK_EX);
-			} else {
+			} elseif ($mode === TApplicationMode::Normal) {
 				static $_flipClassMap = null;
 
 				if ($_flipClassMap === null) {

--- a/framework/TApplicationStatePersister.php
+++ b/framework/TApplicationStatePersister.php
@@ -41,7 +41,7 @@ class TApplicationStatePersister extends \Prado\TModule implements IStatePersist
 	 */
 	protected function getStateFilePath()
 	{
-		return $this->getApplication()->getRuntimePath() . '/global.cache';
+		return $this->getApplication()->getRuntimePath() . DIRECTORY_SEPARATOR . 'global.cache';
 	}
 
 	/**

--- a/tests/unit/Data/SqlMap/Ticket589Test.php
+++ b/tests/unit/Data/SqlMap/Ticket589Test.php
@@ -1,9 +1,21 @@
 <?php
 
 use Prado\Data\SqlMap\TSqlMapManager;
+use Prado\TApplicationComponent;
 
 class Ticket589Test extends PHPUnit\Framework\TestCase
 {
+	
+	
+	// ****   Delete the fxevent.cache file from testing.   ****
+	//  If there are further tests, this should be moved to the last test using this application.
+	protected function tearDown(): void
+	{
+		$app = Prado::getApplication();
+		if ($app !== null) {
+			unlink($app->getRuntimePath() . DIRECTORY_SEPARATOR . TApplicationComponent::FX_CACHE_FILE);
+		}
+	}
 	public function test()
 	{
 		$manager = new TSqlMapManager();

--- a/tests/unit/Data/SqlMap/Ticket589Test.php
+++ b/tests/unit/Data/SqlMap/Ticket589Test.php
@@ -5,17 +5,6 @@ use Prado\TApplicationComponent;
 
 class Ticket589Test extends PHPUnit\Framework\TestCase
 {
-	
-	
-	// ****   Delete the fxevent.cache file from testing.   ****
-	//  If there are further tests, this should be moved to the last test using this application.
-	protected function tearDown(): void
-	{
-		$app = Prado::getApplication();
-		if ($app !== null) {
-			unlink($app->getRuntimePath() . DIRECTORY_SEPARATOR . TApplicationComponent::FX_CACHE_FILE);
-		}
-	}
 	public function test()
 	{
 		$manager = new TSqlMapManager();

--- a/tests/unit/Data/SqlMap/Ticket589Test.php
+++ b/tests/unit/Data/SqlMap/Ticket589Test.php
@@ -1,7 +1,6 @@
 <?php
 
 use Prado\Data\SqlMap\TSqlMapManager;
-use Prado\TApplicationComponent;
 
 class Ticket589Test extends PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
I have been testing the SQL with SqlLite3 and it works.  From what I know, this should work in MySQL and other databases as well, as REPLACE is  (edit: NOT) part of SQL common language.

The update to getClassFxEvents is also a win.  I think it's at least a little faster.

I'm doing further testing on this after a good nights rest.