### PR TITLE
#956 Stripping the priority keys for merge/replace, not needed after sorting away

### DIFF
--- a/framework/Collections/TPriorityCollectionTrait.php
+++ b/framework/Collections/TPriorityCollectionTrait.php
@@ -195,9 +195,9 @@ trait TPriorityCollectionTrait
 		}
 		$this->sortPriorities();
 		if ($this->getPriorityCombineStyle()) {
-			$this->_fd = array_merge(...$this->_d);
+			$this->_fd = array_merge(...array_values($this->_d));
 		} else {
-			$this->_fd = array_replace(...$this->_d);
+			$this->_fd = array_replace(...array_values($this->_d));
 		}
 	}
 


### PR DESCRIPTION
#872. moving to PHP8 makes this change required.