### PR TITLE
#835 TBitHelper::crc32 for continued running crc32 computation.

### DIFF
--- a/framework/Util/Helpers/TBitHelper.php
+++ b/framework/Util/Helpers/TBitHelper.php
@@ -122,6 +122,142 @@ class TBitHelper
 	}
 
 	/**
+	 * This is a CRC32 replacement multi-tool.  This acts exactly as crc32 with the
+	 * added functionality that it accepts file paths (when $crc = true) which computes
+	 * the CRC32 of the file.  This also accepts a $crc computed from existing data and
+	 * continues to update the $crc with new data form $string as if $string were appended.
+	 *
+	 * If an array is passed in $string, [0] is the string data, filepath, or stream
+	 * resource, element [1] is the size to read, and element [2] is the startOffset.
+	 * If an array is passed, $crc = true still means that the $string is a FilePath.
+	 * If the $string is a stream-resource, it reads until fgetc returns false or '',
+	 * or size is hit.
+	 *
+	 * If using this on a file (with $crc = true) then $crc2 can be used for the existing
+	 * crc32 for continued computation.
+	 *
+	 * A continued CRC32 can also be generated with HashContext using {@link hash_init},
+	 * {@link hash_update}, and {@link hash_update_stream}, and {@link hash_final}.
+	 * @param mixed $string String of Data, File Path, Stream Resource, or array.
+	 *   An Array format is [0] => String Data, File Path, or Stream Resource, [1] is
+	 *   the total size to read, and [2] is the startOffset.
+	 * @param bool|int $crc The running CRC32 to continue calculating.  When true,
+	 *   this expects $string to be a File Path rather than data.  Default 0 for normal
+	 *   crc32 function without any prior running data.
+	 * @param ?int $crc2 The existing CRC to update when specifying $string as a file
+	 *   (with $crc = true).  Default null for new initial $crc for a file.
+	 */
+	public static function crc32(mixed $string, bool|int $crc = 0, ?int $crc2 = null): false|int
+	{
+		static $crc_table = [
+			0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+			0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+			0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+			0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+			0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+			0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+			0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+			0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+			0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+			0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+			0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+			0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+			0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+			0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+			0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+			0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+			0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+			0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+			0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+			0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+			0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+			0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+			0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+			0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+			0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+			0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+			0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+			0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+			0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+			0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+			0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+			0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D,
+		];
+		$length = null;
+		$startOffset = 0;
+		$close = false;
+		if (is_array($string)) {
+			$startOffset = $string[2] ?? $string['offset'] ?? 0;
+			$length = $string[1] ?? $string['length'] ?? null;
+			$string = $string[0] ?? $string['source'] ?? null;
+		}
+		if ($crc === false) {
+			$crc = $crc2 === null ? 0 : $crc2;
+		}
+		if (is_string($string)) {
+			if (is_int($crc)) {
+				if ($length !== null || $startOffset) {
+					$string = substr($string, $startOffset, $length);
+				}
+				if ($crc === 0) {
+					return crc32($string);
+				}
+				$crc ^= 0xFFFFFFFF;
+				$length = strlen($string);
+				for ($i = 0; $i < $length; $i++) {
+					$crc = (($crc >> 8) & 0x00FFFFFF) ^ $crc_table[($crc & 0xFF) ^ ord($string[$i])];
+				}
+				$crc ^= 0xFFFFFFFF;
+				return $crc;
+			} elseif (realpath($string) || preg_match('/^[-+\.\w\d]{1,20}\:\/\//i', $string)) {
+				if ($length === null && !$startOffset && !$crc2) {
+					$hash = hash_file('crc32b', $string, true);
+					$value = unpack('N', $hash)[1];
+					if(PHP_INT_SIZE === 4 && $value > self::PHP_INT32_MAX) {
+						$value = (int) ($value - self::PHP_INT32_UMAX - 1);
+					}
+					return $value;
+				}
+				$string = fopen($string, 'rb');
+				if (!$string) {
+					return false;
+				}
+				$close = true;
+			}
+		}
+		if (is_resource($string) && get_resource_type($string) === 'stream') {
+			if ($crc === true) {
+				$crc = $crc2 === null ? 0 : $crc2;
+			}
+			if ($startOffset) {
+				$meta = stream_get_meta_data($string);
+				if ($meta['seekable']) {
+					fseek($string, $startOffset);
+				} else {
+					fread($string, $startOffset);
+				}
+			}
+			$crc ^= 0xFFFFFFFF;
+			while($length === null || $length > 0) {
+				$d = fgetc($string);
+				if ($d === false || strlen($d) === 0) {
+					break;
+				}
+				$crc = (($crc >> 8) & 0x00FFFFFF) ^ $crc_table[($crc & 0xFF) ^ ord($d)];
+				if ($length !== null) {
+					$length--;
+				}
+			}
+			$crc ^= 0xFFFFFFFF;
+			if ($close) {
+				fclose($string);
+			}
+			return $length === null || $length === 0 ? $crc : false;
+		}
+		return false;
+	}
+
+	/**
 	 * This returns true with all negative floats, including -0.0.  Normally "$float < 0"
 	 * will not include -0.0, where this function does include -0.0.
 	 * @param float $value The float to check for being negative.

--- a/tests/unit/Util/Helpers/TBitHelperTest.php
+++ b/tests/unit/Util/Helpers/TBitHelperTest.php
@@ -10,6 +10,57 @@ class TBitHelperTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(PHP_INT_SIZE >= 8, TBitHelper::hasLongLong());
 	}
 	
+	public function testCrc32()
+	{
+		self::assertEquals(crc32(''), TBitHelper::crc32(''));
+		self::assertEquals(crc32(''), TBitHelper::crc32('', false));
+		self::assertEquals(crc32('test'), $crc = TBitHelper::crc32('test'));
+		self::assertEquals(crc32('1234'), TBitHelper::crc32('1234', false));
+		self::assertEquals(crc32('test1234'), TBitHelper::crc32('1234', $crc));
+		self::assertEquals(crc32('test1234'), TBitHelper::crc32('1234', false, $crc));
+		self::assertEquals(crc32('0123456789'), TBitHelper::crc32(['0123456789', null]));
+		self::assertEquals(crc32('012'), TBitHelper::crc32(['0123456789', 3]));
+		self::assertEquals(crc32('3456789'), TBitHelper::crc32(['0123456789', null, 3]));
+		self::assertEquals(crc32('345'), TBitHelper::crc32(['0123456789', 3, 3]));
+		
+		$filename = realpath(__DIR__ . '/../../Web/data/pradoheader.gif');
+		$fileContents = file_get_contents($filename);
+		
+		self::assertEquals($fileCrc32 = crc32($fileContents), TBitHelper::crc32($filename, true));
+		self::assertEquals(crc32(substr($fileContents, 0, 10)), TBitHelper::crc32([$filename, 10], true));
+		self::assertEquals(crc32(substr($fileContents, 2)), TBitHelper::crc32([$filename, null, 2], true));
+		self::assertEquals(crc32(substr($fileContents, 2, 10)), TBitHelper::crc32([$filename, 10, 2], true));
+		self::assertEquals(crc32('data' . substr($fileContents, 2, 10)), TBitHelper::crc32([$filename, 10, 2], true, crc32('data')));
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals($fileCrc32, TBitHelper::crc32($handle, true));
+		fclose($handle);
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals($fileCrc32, TBitHelper::crc32($handle));
+		fclose($handle);
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals($fileCrc32, TBitHelper::crc32($handle, false));
+		fclose($handle);
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals(crc32(substr($fileContents, 0, 10)), TBitHelper::crc32([$handle, 10]));
+		fclose($handle);
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals(crc32(substr($fileContents, 2)), TBitHelper::crc32([$handle, null, 2]));
+		fclose($handle);
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals(crc32(substr($fileContents, 2, 10)), TBitHelper::crc32([$handle, 10, 2]));
+		fclose($handle);
+		
+		$handle = fopen($filename, 'rb');
+		self::assertEquals(crc32(substr($fileContents, 2, 10)), TBitHelper::crc32([$handle, 10, 2]));
+		fclose($handle);
+	}
+	
 	public function testIsNegativeFloat()
 	{
 		self::assertEquals(false, TBitHelper::isNegativeFloat(0.0));


### PR DESCRIPTION
PHPs crc32 only works on a $string.  this is a multi-tool.  it can crc32 a file path, or part of a file, and will work on streams when given a stream (similar to `stream_get_contents($stream, $length, $offset)` but `[$stream, $length, $offset]` is fed as $string).

One of the key features is that an existing $crc32 can be fed to this method and it will continue the CRC32 computation as if the new $string data (any source: string, file, file part, or stream) were appended to the prior data.