### PR TITLE
#966 TWeakCollection can insert array of handlers. (this first)

### DIFF
--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -496,7 +496,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * Inserts an item at the specified index within a priority.  This does not scrub the
 	 * list of WeakReference.  This converts the item into a WeakReference if it is an object
 	 * or contains an object in its callable.  This does not convert Closure into WeakReference.
-	 * @param mixed $item item to add within the list.
+	 * @param mixed $items item to add within the list.
 	 * @param null|false|int $index index within the priority to add the item, defaults to null
 	 *    which appends the item at the priority
 	 * @param null|numeric $priority priority of the item.  defaults to null, which sets it
@@ -508,22 +508,41 @@ class TWeakCallableCollection extends TPriorityList
 	 * @throws \Prado\Exceptions\TInvalidOperationException if the list is read-only
 	 * @since 4.2.3
 	 */
-	protected function internalInsertAtIndexInPriority($item, $index = null, $priority = null, $preserveCache = false)
+	protected function internalInsertAtIndexInPriority($items, $index = null, $priority = null, $preserveCache = false)
 	{
 		$this->collapseDiscardInvalid();
-		$itemPriority = null;
-		if (($isPriorityItem = ($item instanceof IPriorityItem)) && ($priority === null || !is_numeric($priority))) {
-			$itemPriority = $priority = $item->getPriority();
+		if (is_callable($items, true)) {
+			$items = [$items];
+		} elseif (!is_array($items)) {
+			throw new TInvalidDataValueException('weakcallablecollection_callable_required');
 		}
-		$priority = $this->ensurePriority($priority);
-		if (($item instanceof IPriorityCapture) && (!$isPriorityItem || $itemPriority !== $priority)) {
-			$item->setPriority($priority);
+		$return = null;
+		foreach($items as $item) {
+			$itemPriority = null;
+			if (($isPriorityItem = ($item instanceof IPriorityItem)) && ($priority === null || !is_numeric($priority))) {
+				$itemPriority = $priority = $item->getPriority();
+			}
+			$priority = $this->ensurePriority($priority);
+			if (($item instanceof IPriorityCapture) && (!$isPriorityItem || $itemPriority !== $priority)) {
+				$item->setPriority($priority);
+			}
+			if (($isObj = is_object($item)) || is_array($item) && is_object($item[0])) {
+				$this->weakCustomAdd($isObj ? $item : $item[0]);
+			}
+			$this->filterItemForInput($item, true);
+			$result = parent::insertAtIndexInPriority($item, $index, $priority, $preserveCache);
+			if ($return === null) {
+				$return = $result;
+			} elseif(!is_array($return)) {
+				$return = [$return, $result];
+			} else {
+				$return[] = $result;
+			}
+			if (is_int($index)) {
+				$index++;
+			}
 		}
-		if (($isObj = is_object($item)) || is_array($item) && is_object($item[0])) {
-			$this->weakCustomAdd($isObj ? $item : $item[0]);
-		}
-		$this->filterItemForInput($item, true);
-		return parent::insertAtIndexInPriority($item, $index, $priority, $preserveCache);
+		return $return;
 	}
 
 	/**

--- a/framework/Collections/TWeakCallableCollection.php
+++ b/framework/Collections/TWeakCallableCollection.php
@@ -496,7 +496,7 @@ class TWeakCallableCollection extends TPriorityList
 	 * Inserts an item at the specified index within a priority.  This does not scrub the
 	 * list of WeakReference.  This converts the item into a WeakReference if it is an object
 	 * or contains an object in its callable.  This does not convert Closure into WeakReference.
-	 * @param mixed $items item to add within the list.
+	 * @param mixed $items item or array of items to add within the list.
 	 * @param null|false|int $index index within the priority to add the item, defaults to null
 	 *    which appends the item at the priority
 	 * @param null|numeric $priority priority of the item.  defaults to null, which sets it

--- a/tests/unit/Collections/TWeakCallableCollectionTest.php
+++ b/tests/unit/Collections/TWeakCallableCollectionTest.php
@@ -204,8 +204,7 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 		//Test for that only callables can be inserted into the collection
 		$item1 = $list[] = 'foo';
 		$item2 = $list[] = [CallableListItem::class, 'staticHandler'];
-		$item3 = $list[] = [$this->item1, 'eventHandler'];
-		$item4 = $list[] = CallableListItem::class . '::staticHandler';
+		$item3 = $list[] = [$item3 = [$this->item1, 'eventHandler'], $item4 = CallableListItem::class . '::staticHandler'];
 		$item5 = $list[] = [CallableListItemChild::class,'staticHandler'];
 		$item6 = $list[] = $this->item2;
 		$item7 = $list[] = function($n) { return $n + $n; };  //Test retaining of Closure
@@ -232,23 +231,28 @@ class TWeakCallableCollectionTest extends TPriorityListTest
 			$list[] = 'notAFunctionCallable';
 			$this->fail('TInvalidDataValueException string that is not a function did not throw error');
 		} catch(TInvalidDataValueException $e){}
+		self::assertEquals(10, count($list));
 		try {
 			$list[] = ['CallableListItem', 'noStaticMethod'];
 			$this->fail('TInvalidDataValueException [valid static object, \'noStaticMethod\'] that is not a method did not throw error');
 		} catch(TInvalidDataValueException $e){}
+		self::assertEquals(10, count($list));
 		try {
 			$list[] = [$this->item1, 'noMethod'];
 			$this->fail('TInvalidDataValueException [valid  object, \'noMethod\'] that is not a method did not throw error');
 		} catch(TInvalidDataValueException $e){}
+		self::assertEquals(10, count($list));
 		try {
 			$list[] = 'CallableListItem::noStaticMethod';
 			$this->fail('TInvalidDataValueException string of \'object::nostaticmethod\' that is not a method did not throw error');
 		} catch(TInvalidDataValueException $e){}
+		self::assertEquals(10, count($list));
 		try {
 			$list[] = ['CallableListItemChild','parent::noMethod'];
 			$this->fail('TInvalidDataValueException string of [valid static object, \'parent::nostaticmethod\'] that is not a method did not throw error');
 		} catch(TInvalidDataValueException $e) {// Catch PHP 8.1
 		} catch(TPhpErrorException $e) {} // Catch PHP 8.2+
+		self::assertEquals(10, count($list));
 		try {
 			$list[] = $component;
 			$this->fail('TInvalidDataValueException object without  __invocke did not throw error');

--- a/tests/unit/TComponentTest.php
+++ b/tests/unit/TComponentTest.php
@@ -1997,6 +1997,10 @@ class TComponentTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals(1, $this->component->getEventHandlers('onMyEvent')->getCount());
 		$this->component->onMyEvent[] = [$this->component, 'Object.myEventHandler'];
 		$this->assertEquals(2, $this->component->getEventHandlers('onMyEvent')->getCount());
+		$c1 = new NewComponent();
+		$c2 = new NewComponent();
+		$this->component->onMyEvent = [[$c1, 'myEventHandler'], [$c2, 'myEventHandler']];
+		$this->assertEquals(4, $this->component->getEventHandlers('onMyEvent')->getCount());
 
 		$this->component->getEventHandlers('onMyEvent')->clear();
 


### PR DESCRIPTION
Basically,`Prado::createComponent` only attaches one event handler per event but it should be able to attach multiple handlers to each event.  This requires TWeakCallableCollection to accept and insert an array of handlers rather than just one handler at a time.