### PR TITLE
TComponent upgrade: raiseEvents in reverse [option], search for behavior by class

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ ENH: Issue #904 - TRational and TURational for reading, writing, and computing E
 BUG: Issue #911 - Protect the message cache file to be thread safe. (majuca)
 ENH: Issue #939 - TEventHandler for embedding data with a specific event handler callable. (belisoful)
 ENH: Issue #944 - TExitException for gracefully exiting the application anywhere. Exception chaining with the last parameter being the previous Exception. (belisoful)
+ENH: Issue #979 - TComponent::raiseEvent optionally execute handlers in reverse; asa() and getBehaviors() searches for behaviors based on class after failing on name. (belisoful)
 
 ## Version 4.2.2 - April 6, 2023
 

--- a/framework/Collections/TPriorityMap.php
+++ b/framework/Collections/TPriorityMap.php
@@ -328,26 +328,26 @@ class TPriorityMap extends TMap
 		return isset($this->_fd[$key]) || array_key_exists($key, $this->_fd);
 	}
 
-	 /**
-	  * @param mixed $item the item
-	  * @param bool $multiple Return an array of all the keys. Default true.
-	  * @return false|mixed the key of the item in the map, false if not found.
-	  */
-	 public function keyOf($item, bool $multiple = true): mixed
-	 {
-	 	$this->flattenPriorities();
-	 	if ($multiple) {
-	 		$return = [];
-	 		foreach ($this->_fd as $key => $value) {
-	 			if ($item === $value) {
-	 				$return[$key] = $item;
-	 			}
-	 		}
-	 		return $return;
-	 	} else {
-	 		return array_search($item, $this->_fd, true);
-	 	}
-	 }
+	/**
+	 * @param mixed $item the item
+	 * @param bool $multiple Return an array of all the keys. Default true.
+	 * @return false|mixed the key of the item in the map, false if not found.
+	 */
+	public function keyOf($item, bool $multiple = true): mixed
+	{
+		$this->flattenPriorities();
+		if ($multiple) {
+			$return = [];
+			foreach ($this->_fd as $key => $value) {
+				if ($item === $value) {
+					$return[$key] = $item;
+				}
+			}
+			return $return;
+		} else {
+			return array_search($item, $this->_fd, true);
+		}
+	}
 
 	/**
 	 * Copies iterable data into the map.

--- a/framework/TEventResults.php
+++ b/framework/TEventResults.php
@@ -5,7 +5,7 @@
  * @author Qiang Xue <qiang.xue@gmail.com>
  *
  * Global Events, intra-object events, Class behaviors, expanded behaviors
- * @author Brad Anderson <javalizard@mac.com>
+ * @author Brad Anderson <belisoful@icloud.com>
  *
  * @link https://github.com/pradosoft/prado
  * @license https://github.com/pradosoft/prado/blob/master/LICENSE
@@ -16,11 +16,12 @@ namespace Prado;
 /**
  * TEventResults class
  *
- * @author Brad Anderson <javalizard@mac.com>
+ * @author Brad Anderson <belisoful@icloud.com>
  */
 class TEventResults extends \Prado\TEnumerable
 {
 	public const EVENT_RESULT_FEED_FORWARD = 1;
 	public const EVENT_RESULT_FILTER = 2;
 	public const EVENT_RESULT_ALL = 4;
+	public const EVENT_REVERSE = 8;
 }


### PR DESCRIPTION
There are 5 upgrades to TComponent:
- __destruct ordering is corrected so behaviors are removed before unlisten. this is to properly unwind and reverses the order of __construct.
- raiseEvent can execute the handlers in reverse.  This is needed if the first handlers needs to be executed last for proper priority/importance of the result.   This adds TEventResults::EVENT_REVERSE
- asA is updated so that if a behavior name is not found it, and the $behaviorname is a class/interface, it will look for the first behavior instanceof
- isa is updated to include traits so traits can properly have global class behaviors.
-getBehaviors is updated to return all behaviors of a select class if a class is provided

this also updates and refactors the TComponent unit tests to not use behavior classes as behavior names.