### PR TITLE
TMappedStatement fix calling TActiveRecord::createRecord

### DIFF
--- a/framework/Data/SqlMap/Statements/TMappedStatement.php
+++ b/framework/Data/SqlMap/Statements/TMappedStatement.php
@@ -512,7 +512,7 @@ class TMappedStatement extends \Prado\TComponent implements IMappedStatement
 		} else {
 			$obj = $this->fillDefaultResultMap(null, $row, $resultObject);
 		}
-		if (class_exists('TActiveRecord', false) && $obj instanceof TActiveRecord) {
+		if (class_exists('\Prado\Data\ActiveRecord\TActiveRecord', false) && $obj instanceof TActiveRecord) {
 			//Create a new clean active record.
 			$obj = TActiveRecord::createRecord($obj::class, $obj);
 		}


### PR DESCRIPTION
- The creation of a TActiveRecord as a resultClass of a SqlMap did not work because of the detection of the presence of the TActiveRecord class. The class namespace was missing from the string.
- The result was an unloaded object (recordState=0) that could not be saved. Saving triggered a duplicate key error by SQL.