### PR TITLE
Nginx fixes

### DIFF
--- a/framework/Web/THttpRequest.php
+++ b/framework/Web/THttpRequest.php
@@ -188,6 +188,10 @@ class THttpRequest extends \Prado\TApplicationComponent implements \IteratorAggr
 			$this->_pathInfo = $_SERVER['PATH_INFO'];
 		} elseif (strpos($_SERVER['PHP_SELF'], $_SERVER['SCRIPT_NAME']) === 0 && $_SERVER['PHP_SELF'] !== $_SERVER['SCRIPT_NAME']) {
 			$this->_pathInfo = substr($_SERVER['PHP_SELF'], strlen($_SERVER['SCRIPT_NAME']));
+		} elseif ($this->_urlFormat === THttpRequestUrlFormat::Path) {
+			$this->_pathInfo = substr($this->_requestUri, strlen($_SERVER['SCRIPT_NAME']));
+		} elseif ($this->_urlFormat === THttpRequestUrlFormat::HiddenPath) {
+			$this->_pathInfo = substr($this->_requestUri, strlen(dirname($_SERVER['SCRIPT_NAME'])));
 		} else {
 			$this->_pathInfo = '';
 		}

--- a/framework/Web/TUrlManager.php
+++ b/framework/Web/TUrlManager.php
@@ -124,7 +124,7 @@ class TUrlManager extends \Prado\TModule
 	public function parseUrl()
 	{
 		$request = $this->getRequest();
-		$pathInfo = trim($request->getPathInfo(), '/');
+		$pathInfo = urldecode(trim($request->getPathInfo(), '/'));
 		if (($request->getUrlFormat() === THttpRequestUrlFormat::Path ||
 			$request->getUrlFormat() === THttpRequestUrlFormat::HiddenPath) &&
 			$pathInfo !== '') {


### PR DESCRIPTION
Recently I had to move some webapps from Apache to Nginx.
While apps working in the main domain folder (eg. www.test.com/) works fine, apps running in a subfolder (eg. www.test.com/app/)  has problems in determining the requested page when `THttpRequest` 's `UrlFormat` is set to `Path` or `HiddenPath`.
This PR contains 2 changes.
The first one adds some fallbacks for determining the requested page path (pathInfo) when the app is using `Path` or `HiddenPath` url formats.
The second change adds a urldecode() call to request parameters when the app is using `Path` or `HiddenPath` url formats. This is meant to fix a niche problem when using array parameters, aka "repeated parameters" from [rfc1738](https://datatracker.ietf.org/doc/html/rfc1738), eg: www.test.com/page,Home/ids[],1/ids[],2/ids[],3
Without the urldecode the square brackets would appear like eg: www.test.com/page,Home/ids%5B%5D,1/ids%5B%5D,2/ids%5B%5D,3