### PR TITLE
Replace Exception by Throwable to catch eval ParseError and Error.

### DIFF
--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1567,7 +1567,7 @@ class TComponent
 		$this->callBehaviorsMethod('dyEvaluateExpressionFilter', $expression, $expression);
 		try {
 			return eval("return $expression;");
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
 			throw new TInvalidOperationException('component_expression_invalid', $this::class, $expression, $e->getMessage());
 		}
 	}


### PR DESCRIPTION
Bug: When the expression in component template  is invalid eval() throw a ParseError or Error , and TErrorHandler cannot determine the file or line of the error.

So we should use \Throwable instead of \Exception to catch all possible errors, including ParseError and Error.

Because in PHP 7 and later, ParseError and Error  implement the \Throwable interface and are not subclasses of \Exception.

Examples: 
<com:TButton Text="Click me" OnClick="buttonClicked" Visible="<%= undefinedFunction() %>" /> <com:TButton Text="Click me" OnClick="buttonClicked" Visible="<%= parse,error%>" />