### PR TITLE
THttpSession deprecation updates

### DIFF
--- a/framework/Data/ActiveRecord/TActiveRecordGateway.php
+++ b/framework/Data/ActiveRecord/TActiveRecordGateway.php
@@ -90,6 +90,7 @@ class TActiveRecordGateway extends \Prado\TComponent
 			}
 			return $value;
 		} elseif ($class->hasMethod(self::TABLE_METHOD)) {
+			// @phpstan-ignore method.notFound
 			$value = $record->{self::TABLE_METHOD}();
 			if (empty($value)) {
 				throw new TActiveRecordException(

--- a/framework/Data/Common/Mssql/TMssqlMetaData.php
+++ b/framework/Data/Common/Mssql/TMssqlMetaData.php
@@ -133,6 +133,7 @@ class TMssqlMetaData extends TDbMetaData
 		if (count($result) > 2) {
 			return [$result[0], $result[1], $result[2]];
 		}
+		return [$result[0], $result[1], $result[2]];
 	}
 
 	/**

--- a/framework/Exceptions/TPhpErrorException.php
+++ b/framework/Exceptions/TPhpErrorException.php
@@ -43,7 +43,7 @@ class TPhpErrorException extends TSystemException
 			E_USER_WARNING => "User Warning",
 			E_USER_NOTICE => "User Notice",
 		];
-		if(PHP_VERSION_ID < 80400) {
+		if (PHP_VERSION_ID < 80400) {
 			$errorTypes[E_STRICT] = "Runtime Notice";
 		}
 		$errorType = $errorTypes[$errno] ?? 'Unknown Error';

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -106,6 +106,7 @@ httpsession_gcprobability_invalid		= THttpSession.GCProbability must be an integ
 httpsession_transid_unchangeable		= THttpSession.UseTransparentSessionID cannot be modified after the session is started.
 httpsession_transid_cookieonly			= THttpSession.UseTransparentSessionID cannot be set when THttpSession.CookieMode is set to Only.
 httpsession_maxlifetime_unchangeable	= THttpSession.Timeout cannot be modified after the session is started.
+httpsession_handler_invalid             = THttpSessionHandler can only accept a THttpSession object as constructor parameter
 
 assetmanager_basepath_invalid			= TAssetManager.BasePath '{0}' is invalid. Make sure it is in namespace form and points to a directory writable by the Web server process.
 assetmanager_basepath_unchangeable		= TAssetManager.BasePath cannot be modified after the module is initialized.

--- a/framework/Web/THttpSession.php
+++ b/framework/Web/THttpSession.php
@@ -138,7 +138,8 @@ class THttpSession extends \Prado\TApplicationComponent implements \IteratorAggr
 	{
 		if (!$this->_started) {
 			if ($this->_customStorage) {
-				session_set_save_handler([$this, '_open'], [$this, '_close'], [$this, '_read'], [$this, '_write'], [$this, '_destroy'], [$this, '_gc']);
+				$handler = new THttpSessionHandler($this);
+				session_set_save_handler($handler);
 			}
 			if ($this->_cookie !== null) {
 				session_set_cookie_params($this->_cookie->getPhpOptions('lifetime'));
@@ -310,6 +311,8 @@ class THttpSession extends \Prado\TApplicationComponent implements \IteratorAggr
 	/**
 	 * @param THttpSessionCookieMode $value how to use cookie to store session ID
 	 * @throws TInvalidOperationException if session is started already
+	 * @deprecated 4.3.1 Since PHP 8.4 disabling session.use_only_cookies
+	 * INI setting is deprecated; Only THttpSessionCookieMode::Only is supported.
 	 */
 	public function setCookieMode($value)
 	{

--- a/framework/Web/THttpSessionCookieMode.php
+++ b/framework/Web/THttpSessionCookieMode.php
@@ -25,7 +25,17 @@ namespace Prado\Web;
  */
 class THttpSessionCookieMode extends \Prado\TEnumerable
 {
+	/**
+	 * @deprecated 4.3.1 Since PHP 8.4 disabling session.use_only_cookies
+	 * INI setting is deprecated; use THttpSessionCookieMode::Only instead.
+	 */
 	public const None = 'None';
+
+	/**
+	 * @deprecated 4.3.1 Since PHP 8.4 disabling session.use_only_cookies
+	 * INI setting is deprecated; use THttpSessionCookieMode::Only instead.
+	 */
 	public const Allow = 'Allow';
+
 	public const Only = 'Only';
 }

--- a/framework/Web/THttpSessionHandler.php
+++ b/framework/Web/THttpSessionHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * THttpSessionHandler class
+ *
+ * @author Fabio Bas <ctraltca@gmail.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Web;
+
+use Prado\Exceptions\TInvalidDataTypeException;
+
+/**
+ * THttpSessionHandler class
+ *
+ * THttpSessionHandler contains methods called internally by PHP when using
+ * {@see THttpSession::setUseCustomStorage THttpSession::UseCustomStorage}
+ *
+ * @author Fabio Bas <ctraltca@gmail.com>
+ * @since 4.3.1
+ */
+class THttpSessionHandler implements \SessionHandlerInterface
+{
+	/**
+	 * @var THttpSession
+	 */
+	private $_session;
+
+	/**
+	 * Constructor.
+	 * @param object $session
+	 * @throws TInvalidDataTypeException if the object is not a THttpSession
+	 */
+	public function __construct($session)
+	{
+		if (!($session instanceof THttpSession)) {
+			throw new TInvalidDataTypeException(500, 'httpsession_handler_invalid');
+		}
+
+		$this->_session = $session;
+	}
+
+	/**
+	 * Session close handler.
+	 * @return bool whether session is closed successfully
+	 */
+	public function close(): bool
+	{
+		return $this->_session->_close();
+	}
+
+	/**
+	 * Session destroy handler.
+	 * @param string $id session ID
+	 * @return bool whether session is destroyed successfully
+	 */
+	public function destroy(string $id): bool
+	{
+		return $this->_session->_destroy($id);
+	}
+
+	/**
+	 * Session GC (garbage collection) handler.
+	 * @param int $max_lifetime the number of seconds after which data will be seen as 'garbage' and cleaned up.
+	 * @return false|int whether session is GCed successfully
+	 */
+	public function gc(int $max_lifetime): int|false
+	{
+		return $this->_session->_gc($max_lifetime);
+	}
+
+	/**
+	 * Session open handler.
+	 * @param string $path session save path
+	 * @param string $name session name
+	 * @return bool whether session is opened successfully
+	 */
+	public function open(string $path, string $name): bool
+	{
+		return $this->_session->_open($path, $name);
+	}
+
+	/**
+	 * Session read handler.
+	 * @param string $id session ID
+	 * @return false|string the session data
+	 */
+	public function read(string $id): string|false
+	{
+		return $this->_session->_read($id);
+	}
+
+	/**
+	 * Session write handler.
+	 * @param string $id session ID
+	 * @param string $data session data
+	 * @return bool whether session write is successful
+	 */
+	public function write(string $id, string $data): bool
+	{
+		return $this->_session->_write($id, $data);
+	}
+}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -383,6 +383,7 @@ return [
 'THttpResponseAdapter' => 'Prado\Web\THttpResponseAdapter',
 'THttpSession' => 'Prado\Web\THttpSession',
 'THttpSessionCookieMode' => 'Prado\Web\THttpSessionCookieMode',
+'THttpSessionHandler' => 'Prado\Web\THttpSessionHandler',
 'THttpUtility' => 'Prado\Web\THttpUtility',
 'TSessionIterator' => 'Prado\Web\TSessionIterator',
 'TUri' => 'Prado\Web\TUri',

--- a/tests/unit/Util/TSignalsDispatcherTest.php
+++ b/tests/unit/Util/TSignalsDispatcherTest.php
@@ -222,13 +222,13 @@ class TSignalsDispatcherTest extends PHPUnit\Framework\TestCase
 	public function testTEventSubscription()
 	{
 		$this->dispatcher = TSignalsDispatcher::singleton();
-		$this->subscription = new TEventSubscription($this->dispatcher, SIGTERM, $handler = function($sender, $param) {return true;}, 5);
-		self::assertTrue($this->subscription->getIsSubscribed());
+		$subscription = new TEventSubscription($this->dispatcher, SIGTERM, $handler = function($sender, $param) {return true;}, 5);
+		self::assertTrue($subscription->getIsSubscribed());
 		$handlers = $this->dispatcher->getEventHandlers('fxSignalTerminate');
-		self::assertEquals($handlers, $this->subscription->getCollection());
+		self::assertEquals($handlers, $subscription->getCollection());
 		self::assertTrue($handlers->contains($handler));
-		$this->subscription->unsubscribe();
-		self::assertFalse($this->subscription->getIsSubscribed());
+		$subscription->unsubscribe();
+		self::assertFalse($subscription->getIsSubscribed());
 		self::assertFalse($handlers->contains($handler));
 	}
 	

--- a/tests/unit/Web/THttpSessionTest.php
+++ b/tests/unit/Web/THttpSessionTest.php
@@ -55,6 +55,10 @@ class THttpSessionTest extends PHPUnit\Framework\TestCase
 	 */
 	public function testSetCookieModeNone()
 	{
+		if(PHP_VERSION_ID >= 80400) {
+			$this->markTestSkipped('Disabling session.use_only_cookies INI setting is deprecated on PHP => 8.4 ');
+			return;
+		}
 		$session = new THttpSession();
 		$session->CookieMode = THttpSessionCookieMode::None;
 
@@ -68,6 +72,10 @@ class THttpSessionTest extends PHPUnit\Framework\TestCase
 	 */
 	public function testSetCookieModeAllow()
 	{
+		if(PHP_VERSION_ID >= 80400) {
+			$this->markTestSkipped('Disabling session.use_only_cookies INI setting is deprecated on PHP => 8.4 ');
+			return;
+		}
 		$session = new THttpSession();
 		$session->CookieMode = THttpSessionCookieMode::Allow;
 


### PR DESCRIPTION
1. Add THttpSessionhandler to avoid use of deprecated session_set_save_handler() ctor
2. Also deprecated THttpSessionCookieMode(s) that enables usage of session IDs in the url
See https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.session

Added minor fixes to accomodate phpstan and php-cs-fixer and get a green build