### PR TITLE
Fixed #1009 phpstan correction in TSignalDispatcher

### DIFF
--- a/framework/Util/TSignalsDispatcher.php
+++ b/framework/Util/TSignalsDispatcher.php
@@ -235,7 +235,9 @@ class TSignalsDispatcher extends TComponent implements \Prado\ISingleton
 			$callable = is_callable($handler);
 			if ($callable) {
 				$handler = function ($sender, $param) use ($handler) {
-					return $handler($param->getSignal(), $param->getParameter());
+					if (is_callable($handler)) {
+						return $handler($param->getSignal(), $param->getParameter());
+					}
 				};
 				self::$_priorHandlers[$signal][1] = $handler;
 			}


### PR DESCRIPTION
This adds a wrapper around calling the handler in the anonymous function so phpstan knows that the $handler is_callable within the anonymous function scope.