### PR TITLE
IUserManager/TUserManager update

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
+## Version 4.4.0 - TBD
+
+ENH: Issue #1xxx - Adds IUserManager::getUniqueRoles, getUniqueRoleCount, and onFinalizeUser. Composer Extensions may need this information.
+
 ## Version 4.3.3 - TBA
 
-ENH: Issue #1032 - Adds IUserManager::getUserClass, getUniqueRoles, getUniqueRoleCount, and onFinalizeUser; TUserManager support for `hash` password modes and custom hashes; TDbUserManager has roles from TDbUser, specified App Parameter, or Module Property.
+ENH: Issue #1032 - TUserManagerTrait with core User Manager functions. TUserManager support for PHP `hash` password modes and custom hashes; TDbUserManager has roles from TDbUser, a specified App Parameter, or Module Property.
 ENH: Issue #1027 - Adds TNull to represent `null` in Collections.
 ENH: Issue #776 - TDataSize supports ronna- and quetta- sizes, and uses cultural units for peta- and under (decimal only).
 ENH: Issue #782 - CultureInfo loads and formats units from ICU.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## Version 4.3.3 - TBA
 
-ENH: Issue #1032 - Adds IUserManager::onFinalizeUser and TUserManager support for `hash` password modes.
+ENH: Issue #1032 - Adds IUserManager::getUserClass, getUniqueRoles, getUniqueRoleCount, and onFinalizeUser; TUserManager support for `hash` password modes and custom hashes; TDbUserManager has roles from TDbUser, specified App Parameter, or Module Property.
 ENH: Issue #1027 - Adds TNull to represent `null` in Collections.
 ENH: Issue #776 - TDataSize supports ronna- and quetta- sizes, and uses cultural units for peta- and under (decimal only).
 ENH: Issue #782 - CultureInfo loads and formats units from ICU.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ## Version 4.3.3 - TBA
 
+ENH: Issue #1032 - Adds IUserManager::onFinalizeUser and TUserManager support for `hash` password modes.
 ENH: Issue #1027 - Adds TNull to represent `null` in Collections.
 ENH: Issue #776 - TDataSize supports ronna- and quetta- sizes, and uses cultural units for peta- and under (decimal only).
 ENH: Issue #782 - CultureInfo loads and formats units from ICU.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,7 +9,8 @@ for both A and B.
 
 Upgrading from v4.3.2
 ---------------------
-- IUserManager implementations must implement `onFinalizeUser` at the end of `getUser` (or equivalent). 3rd party PRADO Composer Extensions may require it.
+- IUserManager requires implementation of `onFinalizeUser` and calling it at the end of `getUser` (or equivalent).
+- IUserManager requires `getUserClass` to return the base class for the User. 3rd party PRADO Composer Extensions will require it.
 
 Upgrading from v4.2.2
 ---------------------

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,7 +9,7 @@ for both A and B.
 
 Upgrading from v4.3.2
 ---------------------
-- IUserManager classes must implement `onFinalizeUser` at the end of `getUser` (or equivalent). PRADO Composer Extensions may require it.
+- IUserManager implementations must implement `onFinalizeUser` at the end of `getUser` (or equivalent). 3rd party PRADO Composer Extensions may require it.
 
 Upgrading from v4.2.2
 ---------------------

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,10 @@ if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
 
+Upgrading from v4.3.2
+---------------------
+- IUserManager classes must implement `onFinalizeUser` at the end of `getUser` (or equivalent). PRADO Composer Extensions may require it.
+
 Upgrading from v4.2.2
 ---------------------
 - Deprecated TTextBoxAutoCompleteType values have been removed since they are not supported anymore by no browser.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,8 +9,12 @@ for both A and B.
 
 Upgrading from v4.3.2
 ---------------------
-- IUserManager requires implementation of `onFinalizeUser` and calling it at the end of `getUser` (or equivalent).
-- IUserManager requires `getUserClass` to return the base class for the User. 3rd party PRADO Composer Extensions will require it.
+- IUserManager requires implementation of:
+  * `onFinalizeUser`: called at the end of `getUser` (or equivalent).
+  * `getUserClass`: return the base class for the User.
+  * `getUniqueRoles`: the unique roles in the application.
+  * `getUniqueRoleCount`: number of unique roles.
+  These additions are for PRADO composer extensions.
 
 Upgrading from v4.2.2
 ---------------------

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -528,6 +528,8 @@ dbusermanager_userclass_required		= TDbUserManager.UserClass is required.
 dbusermanager_userclass_invalid			= TDbUserManager.UserClass '{0}' is not a valid user class. The class must extend TDbUser.
 dbusermanager_connectionid_invalid		= TDbUserManager.ConnectionID '{0}' does not point to a valid TDataSourceConfig module.
 dbusermanager_connectionid_required		= TDbUserManager.ConnectionID is required.
+dbusermanager_uniqueroles_bad_data		= TDbUserManager.UniqueRoles must be a string or array.
+dbusermanager_property_unchangeable 	= TDbUserManager.{0} is already set and cannot be changed.
 
 dbpluginmodule_connectionid_invalid		= TDbPluginModule.ConnectionID '{0}' does not point to a valid TDataSourceConfig module.
 dbpluginmodule_connectionid_required		= TDbPluginModule.ConnectionID is required.

--- a/framework/Security/IUserManager.php
+++ b/framework/Security/IUserManager.php
@@ -26,12 +26,14 @@ interface IUserManager
 	 * @return string name for a guest user.
 	 */
 	public function getGuestName();
+
 	/**
 	 * Returns a user instance given the user name.
 	 * @param null|string $username user name, null if it is a guest.
-	 * @return TUser the user instance, null if the specified username is not in the user database.
+	 * @return ?TUser the user instance, null if the specified username is not in the user database.
 	 */
 	public function getUser($username = null);
+
 	/**
 	 * Returns a user instance according to auth data stored in a cookie.
 	 * @param \Prado\Web\THttpCookie $cookie the cookie storing user authentication information
@@ -39,12 +41,14 @@ interface IUserManager
 	 * @since 3.1.1
 	 */
 	public function getUserFromCookie($cookie);
+
 	/**
 	 * Saves user auth data into a cookie.
 	 * @param \Prado\Web\THttpCookie $cookie the cookie to receive the user auth data.
 	 * @since 3.1.1
 	 */
 	public function saveUserToCookie($cookie);
+
 	/**
 	 * Validates if the username and password are correct.
 	 * @param string $username user name
@@ -52,4 +56,12 @@ interface IUserManager
 	 * @return bool true if validation is successful, false otherwise.
 	 */
 	public function validateUser($username, #[\SensitiveParameter] $password);
+
+	/**
+	 * Provides for finalizing a user object after it is created but before its returned
+	 * from the implementing User Manager.
+	 * @param TUser $user The user to finalize.
+	 * @since 4.3.3
+	 */
+	public function onFinalizeUser($user);
 }

--- a/framework/Security/IUserManager.php
+++ b/framework/Security/IUserManager.php
@@ -48,6 +48,14 @@ interface IUserManager
 	public function getUserFromCookie($cookie);
 
 	/**
+	 * Provides for finalizing a user object after it is created but before its returned
+	 * from the implementing User Manager.
+	 * @param TUser $user The user to finalize.
+	 * @since 4.3.3
+	 */
+	public function onFinalizeUser($user);
+
+	/**
 	 * Saves user auth data into a cookie.
 	 * @param \Prado\Web\THttpCookie $cookie the cookie to receive the user auth data.
 	 * @since 3.1.1
@@ -63,10 +71,17 @@ interface IUserManager
 	public function validateUser($username, #[\SensitiveParameter] $password);
 
 	/**
-	 * Provides for finalizing a user object after it is created but before its returned
-	 * from the implementing User Manager.
-	 * @param TUser $user The user to finalize.
+	 * Returns the unique roles in the application. If there are none, `return [];`
+	 * @return array The unique roles in the User Manager.
 	 * @since 4.3.3
 	 */
-	public function onFinalizeUser($user);
+	public function getUniqueRoles();
+
+	/**
+	 * Returns the number of unique roles in the application. This may be handy if there
+	 * are a lot of rolls.
+	 * @return int The number of unique roles.
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoleCount();
 }

--- a/framework/Security/IUserManager.php
+++ b/framework/Security/IUserManager.php
@@ -23,11 +23,6 @@ namespace Prado\Security;
 interface IUserManager
 {
 	/**
-	 * @return string the user class name in namespace format.
-	 */
-	public function getUserClass();
-
-	/**
 	 * @return string name for a guest user.
 	 */
 	public function getGuestName();
@@ -48,14 +43,6 @@ interface IUserManager
 	public function getUserFromCookie($cookie);
 
 	/**
-	 * Provides for finalizing a user object after it is created but before its returned
-	 * from the implementing User Manager.
-	 * @param TUser $user The user to finalize.
-	 * @since 4.3.3
-	 */
-	public function onFinalizeUser($user);
-
-	/**
 	 * Saves user auth data into a cookie.
 	 * @param \Prado\Web\THttpCookie $cookie the cookie to receive the user auth data.
 	 * @since 3.1.1
@@ -71,17 +58,25 @@ interface IUserManager
 	public function validateUser($username, #[\SensitiveParameter] $password);
 
 	/**
+	 * Provides for finalizing a user object after it is created but before its returned
+	 * from the implementing User Manager.
+	 * @param TUser $user The user to finalize.
+	 * @todo for v4.4, not for v4.3
+	 */
+	//public function onFinalizeUser($user);
+
+	/**
 	 * Returns the unique roles in the application. If there are none, `return [];`
 	 * @return array The unique roles in the User Manager.
-	 * @since 4.3.3
+	 * @todo for v4.4, not for v4.3
 	 */
-	public function getUniqueRoles();
+	//public function getUniqueRoles();
 
 	/**
 	 * Returns the number of unique roles in the application. This may be handy if there
-	 * are a lot of rolls.
+	 * are a lot of roles.
 	 * @return int The number of unique roles.
-	 * @since 4.3.3
+	 * @todo for v4.4, not for v4.3
 	 */
-	public function getUniqueRoleCount();
+	//public function getUniqueRoleCount();
 }

--- a/framework/Security/IUserManager.php
+++ b/framework/Security/IUserManager.php
@@ -23,6 +23,11 @@ namespace Prado\Security;
 interface IUserManager
 {
 	/**
+	 * @return string the user class name in namespace format.
+	 */
+	public function getUserClass();
+
+	/**
 	 * @return string name for a guest user.
 	 */
 	public function getGuestName();

--- a/framework/Security/TDbUser.php
+++ b/framework/Security/TDbUser.php
@@ -118,4 +118,24 @@ abstract class TDbUser extends TUser
 	public function saveUserToCookie($cookie)
 	{
 	}
+
+	/**
+	 * Returns the unique roles in the application.
+	 * @return ?array The unique roles in the User Manager. null if not supported.
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoles()
+	{
+		return null;
+	}
+
+	/**
+	 * Returns the number of unique roles in the application.
+	 * @return ?int The number of unique roles. null if not supported.
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoleCount()
+	{
+		return null;
+	}
 }

--- a/framework/Security/TDbUserManager.php
+++ b/framework/Security/TDbUserManager.php
@@ -208,7 +208,7 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 
 	/**
 	 * Finalizes a user with the application after it is set up but before it is returned
-	 * from {@see getUser() and {@see getUserFromCookie()}
+	 * from {@see getUser() and {@see getUserFromCookie()}.
 	 * @param TUser $user The user to finalize.
 	 * @since 4.3.3
 	 */

--- a/framework/Security/TDbUserManager.php
+++ b/framework/Security/TDbUserManager.php
@@ -10,6 +10,7 @@
 
 namespace Prado\Security;
 
+use Prado\Security\Traits\TUserManagerTrait;
 use Prado\Data\TDataSourceConfig;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataTypeException;
@@ -56,43 +57,30 @@ use Prado\Util\IDbModule;
  */
 class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 {
-	/**
-	 * @var \Prado\Data\TDbConnection The connection to the database.
-	 */
+	use TUserManagerTrait;
+
+	/** @var \Prado\Data\TDbConnection The connection to the database. */
 	private $_dbConnection;
-	/**
-	 * @var string The string ID of the TDataSourceConfig.
-	 */
+
+	/** @var string The string ID of the TDataSourceConfig. */
 	private $_connectionID = '';
 
-	/**
-	 * @var string The name of users who are not logged in.
-	 */
+	/** @var string The name of users who are not logged in. */
 	private $_guestName = 'Guest';
 
-	/**
-	 * @var string The namespaced class of the User Factory.
-	 */
+	/** @var string The namespaced class of the User Factory. */
 	private $_userClass = '';
 
-	/**
-	 * @var ?array The application parameter ID of the unique roles.
-	 */
+	/** @var ?array The application parameter ID of the unique roles. */
 	private $_rolesAppParameterId;
 
-	/**
-	 * @var ?array The unique roles set on the module by configuration.
-	 */
+	/** @var ?array The unique roles set on the module by configuration. */
 	private $_uniqueRoles;
 
-	/**
-	 * @var TDbUser The Factory for users.
-	 */
+	/** @var TDbUser The Factory for users. */
 	private $_userFactory;
 
-	/**
-	 * @var bool whether the module has been initialized.
-	 */
+	/** @var bool whether the module has been initialized. */
 	private $_initialized = false;
 
 	/**
@@ -351,17 +339,6 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 			$this->onFinalizeUser($user);
 		}
 		return $user;
-	}
-
-	/**
-	 * Finalizes a user with the application after it is set up but before it is returned
-	 * from {@see getUser()} and {@see getUserFromCookie()}.
-	 * @param TUser $user The user to finalize.
-	 * @since 4.3.3
-	 */
-	public function onFinalizeUser($user): void
-	{
-		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 
 	/**

--- a/framework/Security/TDbUserManager.php
+++ b/framework/Security/TDbUserManager.php
@@ -122,10 +122,11 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 		if ($username === null) {
 			$user = Prado::createComponent($this->_userClass, $this);
 			$user->setIsGuest(true);
-			return $user;
 		} else {
-			return $this->_userFactory->createUser($username);
+			$user = $this->_userFactory->createUser($username);
 		}
+		$this->onFinalizeUser($user);
+		return $user;
 	}
 
 	/**
@@ -187,7 +188,9 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	 */
 	public function getUserFromCookie($cookie)
 	{
-		return $this->_userFactory->createUserFromCookie($cookie);
+		$user = $this->_userFactory->createUserFromCookie($cookie);
+		$this->onFinalizeUser($user);
+		return $user;
 	}
 
 	/**
@@ -201,5 +204,16 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 		if ($user instanceof TDbUser) {
 			$user->saveUserToCookie($cookie);
 		}
+	}
+
+	/**
+	 * Finalizes a user with the application after it is set up but before it is returned
+	 * from {@see getUser() and {@see getUserFromCookie()}
+	 * @param TUser $user The user to finalize.
+	 * @since 4.3.3
+	 */
+	public function onFinalizeUser($user): void
+	{
+		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 }

--- a/framework/Security/TDbUserManager.php
+++ b/framework/Security/TDbUserManager.php
@@ -65,9 +65,6 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	/** @var string The string ID of the TDataSourceConfig. */
 	private $_connectionID = '';
 
-	/** @var string The name of users who are not logged in. */
-	private $_guestName = 'Guest';
-
 	/** @var string The namespaced class of the User Factory. */
 	private $_userClass = '';
 
@@ -138,22 +135,6 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 		}
 
 		$this->_rolesAppParameterId = $value;
-	}
-
-	/**
-	 * @return string guest name, defaults to 'Guest'
-	 */
-	public function getGuestName()
-	{
-		return $this->_guestName;
-	}
-
-	/**
-	 * @param string $value name to be used for guest users.
-	 */
-	public function setGuestName($value)
-	{
-		$this->_guestName = $value;
 	}
 
 	/**

--- a/framework/Security/TDbUserManager.php
+++ b/framework/Security/TDbUserManager.php
@@ -13,6 +13,8 @@ namespace Prado\Security;
 use Prado\Data\TDataSourceConfig;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Exceptions\TInvalidOperationException;
 use Prado\Prado;
 use Prado\Util\IDbModule;
 
@@ -42,16 +44,56 @@ use Prado\Util\IDbModule;
  * {@see setConnectionID ConnectionID} refers to the ID of a {@see \Prado\Data\TDataSourceConfig} module
  * which specifies how to establish database connection to retrieve user information.
  *
+ * Roles for the class can be set up by comma-separated string or by PHP array via
+ * {@see setUniqueRoles()}. Roles can also be set in the Application Parameters via
+ * {@see setRolesAppParameterId()}. The resolution order for unique roles is:
+ *   1. The user class ({@see TDbUser::getUniqueRoles()}) — highest priority
+ *   2. Application Parameters (identified by {@see setRolesAppParameterId()})
+ *   3. The {@see setUniqueRoles()} value set directly on this module — lowest priority
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
  */
 class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 {
-	private $_connID = '';
-	private $_conn;
+	/**
+	 * @var \Prado\Data\TDbConnection The connection to the database.
+	 */
+	private $_dbConnection;
+	/**
+	 * @var string The string ID of the TDataSourceConfig.
+	 */
+	private $_connectionID = '';
+
+	/**
+	 * @var string The name of users who are not logged in.
+	 */
 	private $_guestName = 'Guest';
+
+	/**
+	 * @var string The namespaced class of the User Factory.
+	 */
 	private $_userClass = '';
+
+	/**
+	 * @var ?array The application parameter ID of the unique roles.
+	 */
+	private $_rolesAppParameterId;
+
+	/**
+	 * @var ?array The unique roles set on the module by configuration.
+	 */
+	private $_uniqueRoles;
+
+	/**
+	 * @var TDbUser The Factory for users.
+	 */
 	private $_userFactory;
+
+	/**
+	 * @var bool whether the module has been initialized.
+	 */
+	private $_initialized = false;
 
 	/**
 	 * Initializes.
@@ -67,6 +109,7 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 			throw new TInvalidDataTypeException('dbusermanager_userclass_invalid', $this->_userClass);
 		}
 		parent::init($config);
+		$this->_initialized = true;
 	}
 
 	/**
@@ -83,6 +126,30 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	public function setUserClass($value)
 	{
 		$this->_userClass = $value;
+	}
+
+	/**
+	 * This gets the ID of the Application Parameter for Roles.
+	 * @return ?string The parameter ID of the application roles. Default is null.
+	 */
+	public function getRolesAppParameterId()
+	{
+		return $this->_rolesAppParameterId;
+	}
+
+	/**
+	 * This sets the ID of the Application Parameter for Roles.
+	 * It may not be set after initialization.
+	 * @param ?string $value The parameter ID of the application roles.
+	 * @throws TInvalidOperationException when called after the module has been initialized.
+	 */
+	public function setRolesAppParameterId($value)
+	{
+		if ($this->_initialized) {
+			throw new TInvalidOperationException('dbusermanager_property_unchangeable', 'RolesAppParameterId');
+		}
+
+		$this->_rolesAppParameterId = $value;
 	}
 
 	/**
@@ -125,8 +192,99 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 		} else {
 			$user = $this->_userFactory->createUser($username);
 		}
-		$this->onFinalizeUser($user);
+		if ($user) {
+			$this->onFinalizeUser($user);
+		}
 		return $user;
+	}
+
+	/**
+	 * If the module is configured for roles by Application Parameter or by Module
+	 * parameter, then it is returned. Otherwise null.
+	 * @return ?array The unique roles from the application parameter, or null if no
+	 *   parameter ID is configured. Returns an empty array if the parameter ID is
+	 *   configured but not present in the application parameters.
+	 * @since 4.3.3
+	 */
+	protected function getUniqueRolesFromAppParameter()
+	{
+		$rolesParamId = $this->getRolesAppParameterId();
+		if (!$rolesParamId) {
+			return null;
+		}
+
+		$appParameters = $this->getApplication()->getParameters();
+		if (!$appParameters->contains($rolesParamId)) {
+			return [];
+		}
+		$appRoles = $appParameters->itemAt($rolesParamId);
+		return array_filter(array_map('trim', explode(',', (string) $appRoles)));
+	}
+
+	/**
+	 * Returns the unique roles in the application using the following priority order:
+	 *   1. The user class ({@see TDbUser::getUniqueRoles()}) — if it returns non-null, it wins.
+	 *   2. Application Parameters (identified by {@see getRolesAppParameterId()}) — if a
+	 *      parameter ID is configured and the parameter exists, its value is used.
+	 *   3. The {@see setUniqueRoles()} value set directly on this module.
+	 * @return array The unique roles in the User Manager.
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoles()
+	{
+		$roles = $this->_userFactory->getUniqueRoles();
+		if ($roles !== null) {
+			return $roles;
+		}
+		$roles = $this->getUniqueRolesFromAppParameter();
+		if ($roles !== null) {
+			return $roles;
+		}
+		return $this->_uniqueRoles;
+	}
+
+	/**
+	 * Returns the number of unique roles in the application, applying the same
+	 * priority order as {@see getUniqueRoles()}:
+	 *   1. The user class ({@see TDbUser::getUniqueRoleCount()}) — if it returns non-null, it wins.
+	 *   2. Application Parameters (identified by {@see getRolesAppParameterId()}).
+	 *   3. The {@see setUniqueRoles()} value set directly on this module.
+	 * @return int The number of unique roles.
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoleCount()
+	{
+		$roleCount = $this->_userFactory->getUniqueRoleCount();
+		if ($roleCount !== null) {
+			return $roleCount;
+		}
+		$roles = $this->getUniqueRolesFromAppParameter();
+		return count($roles ?? $this->_uniqueRoles ?? []);
+	}
+
+	/**
+	 * Sets the unique roles for the application directly on this module.
+	 * This is the lowest-priority source; it is overridden by Application Parameters
+	 * and by the user class. Accepts either a comma-separated string (e.g. `"admin,editor,viewer"`)
+	 * or a PHP array of role name strings. Must be set before the module is initialized.
+	 *
+	 * @param array|string $value The unique roles in the application
+	 * @throws TInvalidOperationException when called after the module has been initialized.
+	 * @throws TInvalidDataValueException when $value is neither a string nor an array.
+	 * @since 4.3.3
+	 */
+	public function setUniqueRoles($value)
+	{
+		if ($this->_initialized) {
+			throw new TInvalidOperationException('dbusermanager_property_unchangeable', 'UniqueRoles');
+		}
+
+		if (is_string($value)) {
+			$value = array_filter(array_map('trim', explode(',', (string) $value)));
+		} elseif (!is_array($value)) {
+			throw new TInvalidDataValueException('dbusermanager_uniqueroles_bad_data');
+		}
+		$this->_uniqueRoles = $value;
 	}
 
 	/**
@@ -134,7 +292,7 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	 */
 	public function getConnectionID()
 	{
-		return $this->_connID;
+		return $this->_connectionID;
 	}
 
 	/**
@@ -145,7 +303,7 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	 */
 	public function setConnectionID($value)
 	{
-		$this->_connID = $value;
+		$this->_connectionID = $value;
 	}
 
 	/**
@@ -153,11 +311,11 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	 */
 	public function getDbConnection()
 	{
-		if ($this->_conn === null) {
-			$this->_conn = $this->createDbConnection($this->_connID);
-			$this->_conn->setActive(true);
+		if ($this->_dbConnection === null) {
+			$this->_dbConnection = $this->createDbConnection($this->_connectionID);
+			$this->_dbConnection->setActive(true);
 		}
-		return $this->_conn;
+		return $this->_dbConnection;
 	}
 
 	/**
@@ -189,8 +347,21 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 	public function getUserFromCookie($cookie)
 	{
 		$user = $this->_userFactory->createUserFromCookie($cookie);
-		$this->onFinalizeUser($user);
+		if ($user) {
+			$this->onFinalizeUser($user);
+		}
 		return $user;
+	}
+
+	/**
+	 * Finalizes a user with the application after it is set up but before it is returned
+	 * from {@see getUser()} and {@see getUserFromCookie()}.
+	 * @param TUser $user The user to finalize.
+	 * @since 4.3.3
+	 */
+	public function onFinalizeUser($user): void
+	{
+		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 
 	/**
@@ -204,16 +375,5 @@ class TDbUserManager extends \Prado\TModule implements IUserManager, IDbModule
 		if ($user instanceof TDbUser) {
 			$user->saveUserToCookie($cookie);
 		}
-	}
-
-	/**
-	 * Finalizes a user with the application after it is set up but before it is returned
-	 * from {@see getUser() and {@see getUserFromCookie()}.
-	 * @param TUser $user The user to finalize.
-	 * @since 4.3.3
-	 */
-	public function onFinalizeUser($user): void
-	{
-		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 }

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -12,10 +12,12 @@ namespace Prado\Security;
 
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Prado;
 use Prado\TApplication;
 use Prado\TPropertyValue;
 use Prado\Xml\TXmlDocument;
+use Prado\Xml\TXmlElement;
 
 /**
  * TUserManager class
@@ -58,8 +60,11 @@ use Prado\Xml\TXmlDocument;
  * only accepts a file path in namespace format. The user file format is
  * similar to the above sample.
  *
- * The user passwords may be specified as clear text, SH1 or MD5 hashed by setting
- * {@see setPasswordMode PasswordMode} as <b>Clear</b>, <b>SHA1</b> or <b>MD5</b>.
+ * User passwords may be specified as Clear text, or hashed in MD5, SHA1, or any algorithm
+ * listed in `hash_algos` (when available). {@see setPasswordMode PasswordMode} is used to
+ * set how the the password is hashed. Valid values for setPasswordMode are <b>Clear</b>,
+ * <b>MD5</b>, <b>SHA1</b>, or any algorithm accepted by `hash`.
+ *
  * The default name for a guest user is <b>Guest</b>. It may be changed
  * by setting {@see setGuestName GuestName} property.
  *
@@ -68,7 +73,9 @@ use Prado\Xml\TXmlDocument;
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Carl Mathisen <carl@kamikazemedia.no>
+ * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.0
+ * @see `hash` https://www.php.net/manual/en/function.hash.php
  */
 class TUserManager extends \Prado\TModule implements IUserManager
 {
@@ -77,7 +84,11 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	 */
 	private $_users = [];
 	/**
-	 * @var array list of roles managed by this module
+	 * @var array list of unique roles managed by this module
+	 */
+	private $_uniqueRoles = [];
+	/**
+	 * @var array list of users and their rolls $_roles[user][(rolls)]
 	 */
 	private $_roles = [];
 	/**
@@ -109,15 +120,57 @@ class TUserManager extends \Prado\TModule implements IUserManager
 		if ($this->_userFile !== null) {
 			if ($this->getApplication()->getConfigurationType() == TApplication::CONFIG_TYPE_PHP) {
 				$userFile = include $this->_userFile;
-				$this->loadUserDataFromPhp($userFile);
 			} else {
 				$dom = new TXmlDocument();
 				$dom->loadFromFile($this->_userFile);
-				$this->loadUserDataFromXml($dom);
+				$userFile = $this->configXml2Php($dom);
 			}
+			$this->loadUserDataFromPhp($userFile);
 		}
 		$this->_initialized = true;
 		parent::init($config);
+	}
+
+	/*
+	 * This selects the children elements with a tag name from $xmlNode.
+	 * Each selected elements' attributes (array) are saved in an array and
+	 * returned.
+	 * @param TXmlElement $xmlNode The XML Element with children to search.
+	 * @param string	  $tagName The tagName for selecting children by tag.
+	 * @return array A list of arrays containing found elements' attributes.
+	 * @since 4.3.3
+	 * @note this may need to be elevated to TModule for more general use.
+	 */
+	protected function xmlChildren2AttributesArray(TXmlElement $xmlNode, string $tagName): array
+	{
+		$results = [];
+		foreach ($xmlNode->getElementsByTagName($tagName) as $node) {
+			$results[] = $node->getAttributes()->toArray();
+		}
+
+		return $results;
+	}
+
+	/*
+	 * Converts XML configuration to PHP configuration for TUserManager.
+	 * @param TXmlElement $xmlNode the variable containing the user information
+	 * @since 4.3.3
+	 * @note this may need to be elevated to TModule for more general use.
+	 */
+	protected function configXml2Php(?TXmlElement $xmlNode): array
+	{
+		$phpConfig = [];
+		if ($xmlNode) {
+			$users = $this->xmlChildren2AttributesArray($xmlNode, 'user');
+			if (!empty($users)) {
+				$phpConfig['users'] = $users;
+			}
+			$roles = $this->xmlChildren2AttributesArray($xmlNode, 'role');
+			if (!empty($roles)) {
+				$phpConfig['roles'] = $roles;
+			}
+		}
+		return $phpConfig;
 	}
 
 	/*
@@ -126,11 +179,10 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	 */
 	private function loadUserData($config)
 	{
-		if ($this->getApplication()->getConfigurationType() == TApplication::CONFIG_TYPE_PHP) {
-			$this->loadUserDataFromPhp($config);
-		} else {
-			$this->loadUserDataFromXml($config);
+		if ($this->getApplication()->getConfigurationType() == TApplication::CONFIG_TYPE_XML && $config instanceof TXmlElement) {
+			$config = $this->configXml2Php($config);
 		}
+		$this->loadUserDataFromPhp($config);
 	}
 
 	/**
@@ -143,12 +195,17 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			foreach ($config['users'] as $user) {
 				$name = trim(strtolower($user['name'] ?? ''));
 				$password = $user['password'] ?? '';
+
 				$this->_users[$name] = $password;
+
 				$roles = $user['roles'] ?? '';
 				if ($roles !== '') {
 					foreach (explode(',', $roles) as $role) {
 						if (($role = trim($role)) !== '') {
 							$this->_roles[$name][] = $role;
+							if (!in_array($role, $this->_uniqueRoles)) {
+								$this->_uniqueRoles[] = $role;
+							}
 						}
 					}
 				}
@@ -157,37 +214,14 @@ class TUserManager extends \Prado\TModule implements IUserManager
 		if (isset($config['roles']) && is_array($config['roles'])) {
 			foreach ($config['roles'] as $role) {
 				$name = $role['name'] ?? '';
+				if (!in_array($role, $this->_uniqueRoles)) {
+					$this->_uniqueRoles[] = $role;
+				}
 				$users = $role['users'] ?? '';
 				foreach (explode(',', $users) as $user) {
 					if (($user = trim($user)) !== '') {
 						$this->_roles[strtolower($user)][] = $name;
 					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Loads user/role information from an XML node.
-	 * @param \Prado\Xml\TXmlElement $xmlNode the XML node containing the user information
-	 */
-	private function loadUserDataFromXml($xmlNode)
-	{
-		foreach ($xmlNode->getElementsByTagName('user') as $node) {
-			$name = trim(strtolower($node->getAttribute('name')));
-			$this->_users[$name] = $node->getAttribute('password');
-			if (($roles = trim($node->getAttribute('roles') ?? '')) !== '') {
-				foreach (explode(',', $roles) as $role) {
-					if (($role = trim($role)) !== '') {
-						$this->_roles[$name][] = $role;
-					}
-				}
-			}
-		}
-		foreach ($xmlNode->getElementsByTagName('role') as $node) {
-			foreach (explode(',', $node->getAttribute('users')) as $user) {
-				if (($user = trim($user)) !== '') {
-					$this->_roles[strtolower($user)][] = $node->getAttribute('name');
 				}
 			}
 		}
@@ -203,6 +237,16 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	public function getUsers()
 	{
 		return $this->_users;
+	}
+
+	/**
+	 * Returns the configured unique roles for users.
+	 * @return array list of user role information
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoles()
+	{
+		return $this->_uniqueRoles;
 	}
 
 	/**
@@ -269,7 +313,21 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	 */
 	public function setPasswordMode($value)
 	{
-		$this->_passwordMode = TPropertyValue::ensureEnum($value, TUserManagerPasswordMode::class);
+		try {
+			$this->_passwordMode = TPropertyValue::ensureEnum($value, TUserManagerPasswordMode::class);
+		} catch (TInvalidDataValueException $e) {
+			$throw = true;
+			if (function_exists('hash_algos')) {
+				$availableHashes = array_flip(hash_algos());
+				if (isset($availableHashes[$value])) {
+					$this->_passwordMode = $value;
+					$throw = false;
+				}
+			}
+			if ($throw) {
+				throw $e;
+			}
+		}
 	}
 
 	/**
@@ -284,6 +342,8 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			$password = md5($password);
 		} elseif ($this->_passwordMode === TUserManagerPasswordMode::SHA1) {
 			$password = sha1($password);
+		} elseif (function_exists('hash') && $this->_passwordMode !== TUserManagerPasswordMode::Clear) {
+			$password = hash($this->_passwordMode, $password);
 		}
 		$username = strtolower($username);
 		return (isset($this->_users[$username]) && $this->_users[$username] === $password);
@@ -299,7 +359,6 @@ class TUserManager extends \Prado\TModule implements IUserManager
 		if ($username === null) {
 			$user = new TUser($this);
 			$user->setIsGuest(true);
-			return $user;
 		} else {
 			$username = strtolower($username);
 			if (isset($this->_users[$username])) {
@@ -309,15 +368,18 @@ class TUserManager extends \Prado\TModule implements IUserManager
 				if (isset($this->_roles[$username])) {
 					$user->setRoles($this->_roles[$username]);
 				}
-				return $user;
 			} else {
 				return null;
 			}
 		}
+
+		$this->onFinalizeUser($user);
+		return $user;
 	}
 
 	/**
 	 * Returns a user instance according to auth data stored in a cookie.
+	 * {@see getUserFromCookie()} uses {@see getUser()} to get the user.
 	 * @param \Prado\Web\THttpCookie $cookie the cookie storing user authentication information
 	 * @return TUser the user instance generated based on the cookie auth data, null if the cookie does not have valid auth data.
 	 * @since 3.1.1
@@ -349,5 +411,16 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			$data = [$username, md5($username . $this->_users[$username])];
 			$cookie->setValue(serialize($data));
 		}
+	}
+
+	/**
+	 * Finalizes a user with the application after it is set up but before it is returned
+	 * from {@see getUser()}.
+	 * @param TUser $user The user to finalize.
+	 * @since 4.3.3
+	 */
+	public function onFinalizeUser($user): void
+	{
+		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 }

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -258,6 +258,16 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	}
 
 	/**
+	 * Returns the number of unique roles in the application.
+	 * @return int The number of unique roles.
+	 * @since 4.3.3
+	 */
+	public function getUniqueRoleCount()
+	{
+		return count($this->_uniqueRoles);
+	}
+
+	/**
 	 * Returns an array of user role information.
 	 * Each array element represents the roles for a single user.
 	 * The array key is the username in lower case, and the array value is
@@ -407,6 +417,17 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	}
 
 	/**
+	 * Finalizes a user with the application after it is set up but before it is returned
+	 * from {@see getUser()}.
+	 * @param TUser $user The user to finalize.
+	 * @since 4.3.3
+	 */
+	public function onFinalizeUser($user): void
+	{
+		$this->raiseEvent('onFinalizeUser', $this, $user);
+	}
+
+	/**
 	 * Saves user auth data into a cookie.
 	 * @param \Prado\Web\THttpCookie $cookie the cookie to receive the user auth data.
 	 * @since 3.1.1
@@ -419,16 +440,5 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			$data = [$username, md5($username . $this->_users[$username])];
 			$cookie->setValue(serialize($data));
 		}
-	}
-
-	/**
-	 * Finalizes a user with the application after it is set up but before it is returned
-	 * from {@see getUser()}.
-	 * @param TUser $user The user to finalize.
-	 * @since 4.3.3
-	 */
-	public function onFinalizeUser($user): void
-	{
-		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 }

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -228,6 +228,14 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	}
 
 	/**
+	 * @return string The user class name.
+	 */
+	public function getUserClass()
+	{
+		return TUser::class;
+	}
+
+	/**
 	 * Returns an array of all users.
 	 * Each array element represents a single user.
 	 * The array key is the username in lower case, and the array value is the

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -337,7 +337,7 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			$throw = true;
 			if (function_exists('hash_algos')) {
 				$availableHashes = array_flip(hash_algos());
-				if (isset($availableHashes[$value])) {
+				if (isset($availableHashes[$value]) || $this->dyHasHash(false, $value)) {
 					$this->_passwordMode = $value;
 					$throw = false;
 				}
@@ -361,7 +361,11 @@ class TUserManager extends \Prado\TModule implements IUserManager
 		} elseif ($this->_passwordMode === TUserManagerPasswordMode::SHA1) {
 			$password = sha1($password);
 		} elseif (function_exists('hash') && $this->_passwordMode !== TUserManagerPasswordMode::Clear) {
-			$password = hash($this->_passwordMode, $password);
+			if ($this->dyHasHash(false, $this->_passwordMode)) {
+				$password = $this->dyHash($password, $this->_passwordMode);
+			} else {
+				$password = hash($this->_passwordMode, $password);
+			}
 		}
 		$username = strtolower($username);
 		return (isset($this->_users[$username]) && $this->_users[$username] === $password);

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -119,8 +119,8 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			}
 			$this->loadUserDataFromPhp($userFile);
 		}
-		$this->_initialized = true;
 		parent::init($config);
+		$this->_initialized = true;
 	}
 
 	/**

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -10,6 +10,7 @@
 
 namespace Prado\Security;
 
+use Prado\Security\Traits\TUserManagerTrait;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Exceptions\TInvalidDataValueException;
@@ -79,33 +80,24 @@ use Prado\Xml\TXmlElement;
  */
 class TUserManager extends \Prado\TModule implements IUserManager
 {
-	/**
-	 * @var array list of users managed by this module
-	 */
+	use TUserManagerTrait;
+
+	/** @var array List of users managed by this module. */
 	private $_users = [];
-	/**
-	 * @var array list of unique roles managed by this module
-	 */
+
+	/** @var array List of unique roles managed by this module. */
 	private $_uniqueRoles = [];
-	/**
-	 * @var array list of users and their rolls $_roles[user][(rolls)]
-	 */
+
+	/** @var array Array of users, each array element is an array of the users' roles. */
 	private $_roles = [];
-	/**
-	 * @var string guest name
-	 */
-	private $_guestName = 'Guest';
-	/**
-	 * @var TUserManagerPasswordMode password mode
-	 */
+
+	/** @var TUserManagerPasswordMode Password mode. */
 	private $_passwordMode = TUserManagerPasswordMode::MD5;
-	/**
-	 * @var bool whether the module has been initialized
-	 */
+
+	/** @var bool Whether the module has been initialized. */
 	private $_initialized = false;
-	/**
-	 * @var string user/role information file
-	 */
+
+	/** @var string User/role information file. */
 	private $_userFile;
 
 	/**
@@ -129,6 +121,14 @@ class TUserManager extends \Prado\TModule implements IUserManager
 		}
 		$this->_initialized = true;
 		parent::init($config);
+	}
+
+	/**
+	 * @return string The user class name.
+	 */
+	public function getUserClass()
+	{
+		return TUser::class;
 	}
 
 	/*
@@ -225,14 +225,6 @@ class TUserManager extends \Prado\TModule implements IUserManager
 				}
 			}
 		}
-	}
-
-	/**
-	 * @return string The user class name.
-	 */
-	public function getUserClass()
-	{
-		return TUser::class;
 	}
 
 	/**
@@ -418,17 +410,6 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Finalizes a user with the application after it is set up but before it is returned
-	 * from {@see getUser()}.
-	 * @param TUser $user The user to finalize.
-	 * @since 4.3.3
-	 */
-	public function onFinalizeUser($user): void
-	{
-		$this->raiseEvent('onFinalizeUser', $this, $user);
 	}
 
 	/**

--- a/framework/Security/Traits/TUserManagerTrait.php
+++ b/framework/Security/Traits/TUserManagerTrait.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * TUserManagerTrait class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Security\Traits;
+
+use Prado\Security\IUser;
+
+/**
+ * TUserManagerTrait class.
+ *
+ * This trait provides common functionality for user managers with the additions to IUserManager.
+ *
+ * All future additions to IUserManager should have the base implementation here.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+trait TUserManagerTrait
+{
+	/** @var string The name of users who are not logged in. */
+	private $_guestName = 'Guest';
+
+	/**
+	 * @return string the user class name in namespace format.
+	 */
+	public function getUserClass()
+	{
+		return IUser::class;
+	}
+
+	/**
+	 * @return string guest name, defaults to 'Guest'
+	 */
+	public function getGuestName()
+	{
+		return $this->_guestName;
+	}
+
+	/**
+	 * @param string $value name to be used for guest users.
+	 */
+	public function setGuestName($value)
+	{
+		$this->_guestName = $value;
+	}
+
+	/**
+	 * @return array The unique roles in the User Manager. The trait returns `[]`.
+	 */
+	public function getUniqueRoles()
+	{
+		return [];
+	}
+
+	/**
+	 * @return int The number of unique roles. The trait returns `0`.
+	 */
+	public function getUniqueRoleCount()
+	{
+		return 0;
+	}
+
+	/**
+	 * Finalizes a user with the application after it is set up but before it is returned
+	 * from {@see getUser()}.
+	 * @param IUser $user The user to finalize.
+	 */
+	public function onFinalizeUser($user): void
+	{
+		$this->raiseEvent('onFinalizeUser', $this, $user);
+	}
+}

--- a/tests/unit/Security/TDbUserManagerTest.php
+++ b/tests/unit/Security/TDbUserManagerTest.php
@@ -1,0 +1,1310 @@
+<?php
+
+/**
+ * TDbUserManagerTest
+ *
+ * Comprehensive unit tests for {@see \Prado\Security\TDbUserManager}.
+ *
+ * Design notes
+ * ------------
+ * • TDbUserManagerTestable subclasses TDbUserManager and overrides
+ *   getApplication() to return a MockApplication, eliminating the need
+ *   for a live PRADO service registry.
+ * • Reflection helpers on TDbUserManagerTestable let tests inject
+ *   _userFactory and toggle _initialized without going through init().
+ * • A concrete TDbUserTestStub (extends TDbUser) is used for the small
+ *   set of tests that must exercise the real Prado::createComponent path
+ *   (init success, getUser guest path).
+ * • All database-layer classes (TDataSourceConfig, TDbConnection) are
+ *   mocked; no connection is ever established.
+ *
+ * Changelog vs previous version
+ * ------------------------------
+ * • Reflection references updated: $_conn → $_dbConnection,
+ *   $_connID → $_connectionID (field renames in TDbUserManager v4).
+ * • Two new tests added (section 15) that assert the corrected error
+ *   message keys ('dbusermanager_connectionid_*') are used by
+ *   createDbConnection(), catching any future regression of the typo
+ *   'dbConnectionectionid' that appeared in the submitted v4 source.
+ *
+ * @requires PHPUnit >= 10.0
+ */
+
+namespace Prado\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Prado\Security\TDbUserManager;
+use Prado\Security\TDbUser;
+use Prado\Security\TUser;
+use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\Data\TDataSourceConfig;
+use Prado\Data\TDbConnection;
+use Prado\Web\THttpCookie;
+
+// ====================================================================
+// Concrete TDbUser stub
+// Extends TDbUser so that the instanceof check in init() passes.
+// All abstract methods return safe, do-nothing defaults.
+// Constructor signature mirrors TDbUser(TUserManager $manager).
+// ====================================================================
+
+class TDbUserTestStub extends TDbUser
+{
+	/** @inheritdoc */
+	public function createUser($username): ?TDbUser
+	{
+		return null;
+	}
+
+	/** @inheritdoc */
+	public function validateUser($username, $password): bool
+	{
+		return false;
+	}
+
+	/** @inheritdoc */
+	public function createUserFromCookie($cookie): ?TDbUser
+	{
+		return null;
+	}
+
+	/** @inheritdoc */
+	public function saveUserToCookie($cookie): void
+	{
+	}
+
+	/** @inheritdoc */
+	public function getUniqueRoles(): ?array
+	{
+		return null;
+	}
+
+	/** @inheritdoc */
+	public function getUniqueRoleCount(): ?int
+	{
+		return null;
+	}
+}
+
+// ====================================================================
+// A class that is NOT a TDbUser — used to trigger the
+// TInvalidDataTypeException path inside init().
+// ====================================================================
+
+class NotATDbUser
+{
+	/** Must accept the same constructor arg that Prado::createComponent passes. */
+	public function __construct($manager) {}
+}
+
+// ====================================================================
+// Minimal application stub
+// ====================================================================
+
+/**
+ * Provides the surface of TApplication that TDbUserManager actually uses:
+ *   getModule(id), getParameters(), getUser().
+ */
+class MockApplication
+{
+	private array              $modules    = [];
+	private MockParameterList  $parameters;
+	private mixed              $currentUser = null;
+
+	public function __construct()
+	{
+		$this->parameters = new MockParameterList();
+	}
+
+	public function getModule(string $id): mixed
+	{
+		return $this->modules[$id] ?? null;
+	}
+
+	public function registerModule(string $id, object $module): void
+	{
+		$this->modules[$id] = $module;
+	}
+
+	public function getParameters(): MockParameterList
+	{
+		return $this->parameters;
+	}
+
+	public function getUser(): mixed
+	{
+		return $this->currentUser;
+	}
+
+	public function setCurrentUser(mixed $user): void
+	{
+		$this->currentUser = $user;
+	}
+}
+
+/**
+ * Minimal parameter list stub implementing the three methods TDbUserManager calls.
+ */
+class MockParameterList
+{
+	private array $params = [];
+
+	public function set(string $key, mixed $value): void
+	{
+		$this->params[$key] = $value;
+	}
+
+	public function contains(string $key): bool
+	{
+		return array_key_exists($key, $this->params);
+	}
+
+	public function itemAt(string $key): mixed
+	{
+		return $this->params[$key] ?? null;
+	}
+}
+
+// ====================================================================
+// Testable subclass
+// ====================================================================
+
+/**
+ * TDbUserManagerTestable
+ *
+ * • Overrides getApplication() → MockApplication (avoids PRADO service registry).
+ * • Exposes protected methods via public wrappers.
+ * • Provides reflection helpers for injecting private state.
+ *
+ * Reflection field names kept in sync with TDbUserManager private fields:
+ *   _userFactory, _initialized, _dbConnection, _connectionID
+ */
+class TDbUserManagerTestable extends TDbUserManager
+{
+	public MockApplication $mockApp;
+
+	public function __construct()
+	{
+		$this->mockApp = new MockApplication();
+	}
+
+	// ------------------------------------------------------------------
+	// Override the application getter
+	// ------------------------------------------------------------------
+
+	public function getApplication(): MockApplication
+	{
+		return $this->mockApp;
+	}
+
+	// ------------------------------------------------------------------
+	// Reflection helpers
+	// ------------------------------------------------------------------
+
+	/**
+	 * Inject a factory directly into _userFactory, bypassing init().
+	 * Lets individual tests set precise mock expectations without running
+	 * the real init() code path.
+	 */
+	public function injectFactory(TDbUser $factory): void
+	{
+		$prop = new \ReflectionProperty(TDbUserManager::class, '_userFactory');
+		$prop->setAccessible(true);
+		$prop->setValue($this, $factory);
+	}
+
+	/**
+	 * Mark the module as initialized so post-init guards activate and
+	 * property locks engage.
+	 */
+	public function markInitialized(): void
+	{
+		$this->setInitializedFlag(true);
+	}
+
+	/**
+	 * Reset the module to its pre-init state so setters that are locked
+	 * post-init can be called again.
+	 */
+	public function markUninitialized(): void
+	{
+		$this->setInitializedFlag(false);
+	}
+
+	private function setInitializedFlag(bool $value): void
+	{
+		$prop = new \ReflectionProperty(TDbUserManager::class, '_initialized');
+		$prop->setAccessible(true);
+		$prop->setValue($this, $value);
+	}
+
+	/**
+	 * Inject a pre-built TDbConnection mock directly into _dbConnection,
+	 * bypassing getDbConnection()'s lazy-init path.
+	 * Used by tests that need to verify caching behaviour at the field level.
+	 */
+	public function injectDbConnection(TDbConnection $conn): void
+	{
+		$prop = new \ReflectionProperty(TDbUserManager::class, '_dbConnection');
+		$prop->setAccessible(true);
+		$prop->setValue($this, $conn);
+	}
+
+	/**
+	 * Read back the cached _dbConnection field so caching tests can assert
+	 * the field was actually populated without going through the public getter.
+	 */
+	public function readDbConnectionField(): mixed
+	{
+		$prop = new \ReflectionProperty(TDbUserManager::class, '_dbConnection');
+		$prop->setAccessible(true);
+		return $prop->getValue($this);
+	}
+
+	// ------------------------------------------------------------------
+	// Protected method exposure
+	// ------------------------------------------------------------------
+
+	public function exposedGetUniqueRolesFromAppParameter(): ?array
+	{
+		return $this->getUniqueRolesFromAppParameter();
+	}
+
+	public function exposedCreateDbConnection(string $id): TDbConnection
+	{
+		return $this->createDbConnection($id);
+	}
+}
+
+// ====================================================================
+// Test case
+// ====================================================================
+
+class TDbUserManagerTest extends TestCase
+{
+	// The fully-initialized manager used by most tests.
+	private TDbUserManagerTestable $manager;
+
+	// Default factory mock wired into $this->manager.
+	private TDbUser|MockObject $factoryMock;
+
+	// ------------------------------------------------------------------
+	// setUp / helpers
+	// ------------------------------------------------------------------
+
+	protected function setUp(): void
+	{
+		$this->manager     = new TDbUserManagerTestable();
+		$this->factoryMock = $this->makeFactoryMock();
+
+		// Most tests need an initialized manager with a controllable factory.
+		$this->manager->setUserClass(TDbUserTestStub::class);
+		$this->manager->injectFactory($this->factoryMock);
+		$this->manager->markInitialized();
+	}
+
+	/**
+	 * Build a PHPUnit mock for TDbUser with the full method surface used by
+	 * TDbUserManager.  Additional methods can be passed if a test needs them.
+	 *
+	 * @return TDbUser&MockObject
+	 */
+	private function makeFactoryMock(array $extra = []): TDbUser|MockObject
+	{
+		$methods = array_unique(array_merge(
+			[
+				'validateUser',
+				'createUser',
+				'createUserFromCookie',
+				'getUniqueRoles',
+				'getUniqueRoleCount',
+				'saveUserToCookie',
+			],
+			$extra
+		));
+
+		return $this->getMockBuilder(TDbUser::class)
+					->disableOriginalConstructor()
+					->onlyMethods($methods)
+					->getMock();
+	}
+
+	/**
+	 * Return a fresh, uninitialized testable manager with no factory injected.
+	 */
+	private function freshManager(): TDbUserManagerTestable
+	{
+		return new TDbUserManagerTestable();
+	}
+
+	/**
+	 * Attach an onFinalizeUser handler that captures its arguments.
+	 * Returns a stdClass; check ->called, ->sender, ->user.
+	 *
+	 * stdClass is used instead of an array because PHP closures receive
+	 * objects by handle, so modifications inside the closure are visible
+	 * through the returned reference without needing a by-ref capture.
+	 * An array would be returned by value, giving the caller a stale copy
+	 * that never reflects changes made when the event fires.
+	 */
+	private function attachFinalizeCapture(TDbUserManagerTestable $mgr): \stdClass
+	{
+		$captured         = new \stdClass();
+		$captured->sender = null;
+		$captured->user   = null;
+		$captured->called = false;
+
+		$mgr->onFinalizeUser[] = function ($sender, $user) use ($captured): void {
+			$captured->sender = $sender;
+			$captured->user   = $user;
+			$captured->called = true;
+		};
+		return $captured;
+	}
+
+	// ==================================================================
+	// 1. Default property values
+	// ==================================================================
+
+	public function testGetUserClassDefaultIsEmptyString(): void
+	{
+		$this->assertSame('', $this->freshManager()->getUserClass());
+	}
+
+	public function testGetGuestNameDefaultIsGuest(): void
+	{
+		$this->assertSame('Guest', $this->freshManager()->getGuestName());
+	}
+
+	public function testGetRolesAppParameterIdDefaultIsNull(): void
+	{
+		$this->assertNull($this->freshManager()->getRolesAppParameterId());
+	}
+
+	public function testGetConnectionIDDefaultIsEmptyString(): void
+	{
+		$this->assertSame('', $this->freshManager()->getConnectionID());
+	}
+
+	// ==================================================================
+	// 2. Property setters / getters (pre-init)
+	// ==================================================================
+
+	public function testSetGetUserClass(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass('My\\App\\User');
+		$this->assertSame('My\\App\\User', $m->getUserClass());
+	}
+
+	public function testSetGetGuestName(): void
+	{
+		$this->manager->setGuestName('Anonymous');
+		$this->assertSame('Anonymous', $this->manager->getGuestName());
+	}
+
+	public function testSetGetConnectionID(): void
+	{
+		$m = $this->freshManager();
+		$m->setConnectionID('mydb');
+		$this->assertSame('mydb', $m->getConnectionID());
+	}
+
+	public function testSetGetRolesAppParameterIdPreInit(): void
+	{
+		$m = $this->freshManager();
+		$m->setRolesAppParameterId('app.roles');
+		$this->assertSame('app.roles', $m->getRolesAppParameterId());
+	}
+
+	public function testSetRolesAppParameterIdToNullPreInit(): void
+	{
+		$m = $this->freshManager();
+		$m->setRolesAppParameterId('something');
+		$m->setRolesAppParameterId(null);
+		$this->assertNull($m->getRolesAppParameterId());
+	}
+
+	// ==================================================================
+	// 3. setUniqueRoles() — pre-init variations
+	// ==================================================================
+
+	/**
+	 * Helper: a fresh manager whose factory returns null for roles, so
+	 * module-level _uniqueRoles is the only source in getUniqueRoles().
+	 */
+	private function freshManagerWithNullFactory(): TDbUserManagerTestable
+	{
+		$m       = $this->freshManager();
+		$factory = $this->makeFactoryMock();
+		$factory->method('getUniqueRoles')->willReturn(null);
+		$factory->method('getUniqueRoleCount')->willReturn(null);
+		$m->injectFactory($factory);
+		$m->markInitialized();
+		return $m;
+	}
+
+	public function testSetUniqueRolesWithArrayStoresCorrectValues(): void
+	{
+		$m = $this->freshManager();
+		$m->setUniqueRoles(['admin', 'editor']);
+		$factory = $this->makeFactoryMock();
+		$factory->method('getUniqueRoles')->willReturn(null);
+		$m->injectFactory($factory);
+		$m->markInitialized();
+		$this->assertSame(['admin', 'editor'], $m->getUniqueRoles());
+	}
+
+	public function testSetUniqueRolesWithCommaStringParsesAllEntries(): void
+	{
+		$m = $this->freshManager();
+		$m->setUniqueRoles('admin,editor,viewer');
+		$factory = $this->makeFactoryMock();
+		$factory->method('getUniqueRoles')->willReturn(null);
+		$m->injectFactory($factory);
+		$m->markInitialized();
+
+		$roles = array_values($m->getUniqueRoles());
+		$this->assertCount(3, $roles);
+		$this->assertContains('admin',  $roles);
+		$this->assertContains('editor', $roles);
+		$this->assertContains('viewer', $roles);
+	}
+
+	public function testSetUniqueRolesStringTrimsWhitespaceAroundEntries(): void
+	{
+		$m = $this->freshManager();
+		$m->setUniqueRoles('  admin , editor , viewer  ');
+		$factory = $this->makeFactoryMock();
+		$factory->method('getUniqueRoles')->willReturn(null);
+		$m->injectFactory($factory);
+		$m->markInitialized();
+
+		$roles = array_values($m->getUniqueRoles());
+		$this->assertSame('admin',  $roles[0]);
+		$this->assertSame('editor', $roles[1]);
+		$this->assertSame('viewer', $roles[2]);
+	}
+
+	public function testSetUniqueRolesStringFiltersEmptySegments(): void
+	{
+		$m = $this->freshManager();
+		$m->setUniqueRoles('admin,,editor,,');
+		$factory = $this->makeFactoryMock();
+		$factory->method('getUniqueRoles')->willReturn(null);
+		$m->injectFactory($factory);
+		$m->markInitialized();
+
+		$this->assertCount(2, $m->getUniqueRoles());
+	}
+
+	public function testSetUniqueRolesWithEmptyStringYieldsEmptyArray(): void
+	{
+		$m = $this->freshManager();
+		$m->setUniqueRoles('');
+		$factory = $this->makeFactoryMock();
+		$factory->method('getUniqueRoles')->willReturn(null);
+		$m->injectFactory($factory);
+		$m->markInitialized();
+
+		$this->assertEmpty($m->getUniqueRoles());
+	}
+
+	public function testSetUniqueRolesWithIntegerThrowsTInvalidDataValueException(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		$this->freshManager()->setUniqueRoles(42);
+	}
+
+	public function testSetUniqueRolesWithObjectThrowsTInvalidDataValueException(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		$this->freshManager()->setUniqueRoles(new \stdClass());
+	}
+
+	public function testSetUniqueRolesWithBooleanThrowsTInvalidDataValueException(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		$this->freshManager()->setUniqueRoles(true);
+	}
+
+	// ==================================================================
+	// 4. Post-init property locks
+	// ==================================================================
+
+	public function testSetUniqueRolesAfterInitThrowsTInvalidOperationException(): void
+	{
+		$this->expectException(TInvalidOperationException::class);
+		$this->manager->setUniqueRoles(['admin']);
+	}
+
+	public function testSetRolesAppParameterIdAfterInitThrowsTInvalidOperationException(): void
+	{
+		$this->expectException(TInvalidOperationException::class);
+		$this->manager->setRolesAppParameterId('locked.param');
+	}
+
+	// ==================================================================
+	// 5. init() — exception paths and success
+	//    These exercise the real Prado::createComponent code path.
+	// ==================================================================
+
+	public function testInitThrowsTConfigurationExceptionWhenUserClassIsEmpty(): void
+	{
+		$m = $this->freshManager();
+		// userClass defaults to '' — init must throw before createComponent
+		$this->expectException(TConfigurationException::class);
+		$m->init(null);
+	}
+
+	public function testInitThrowsTInvalidDataTypeExceptionWhenClassIsNotTDbUser(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(NotATDbUser::class);
+		$this->expectException(TInvalidDataTypeException::class);
+		$m->init(null);
+	}
+
+	public function testInitSucceedsWithValidTDbUserSubclass(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+		// Post-init lock is the observable proxy for _initialized = true.
+		$this->expectException(TInvalidOperationException::class);
+		$m->setUniqueRoles(['any']);
+	}
+
+	public function testInitLocksRolesAppParameterIdAfterwards(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+		$this->expectException(TInvalidOperationException::class);
+		$m->setRolesAppParameterId('locked');
+	}
+
+	public function testInitLocksUniqueRolesAfterwards(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+		$this->expectException(TInvalidOperationException::class);
+		$m->setUniqueRoles(['blocked']);
+	}
+
+	public function testUserClassIsPreservedAfterInit(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+		$this->assertSame(TDbUserTestStub::class, $m->getUserClass());
+	}
+
+	// ==================================================================
+	// 6. validateUser()
+	// ==================================================================
+
+	public function testValidateUserReturnsTrueWhenFactoryReturnsTrue(): void
+	{
+		$this->factoryMock->method('validateUser')->willReturn(true);
+		$this->assertTrue($this->manager->validateUser('alice', 'correct'));
+	}
+
+	public function testValidateUserReturnsFalseWhenFactoryReturnsFalse(): void
+	{
+		$this->factoryMock->method('validateUser')->willReturn(false);
+		$this->assertFalse($this->manager->validateUser('alice', 'wrong'));
+	}
+
+	public function testValidateUserForwardsUsernameAndPasswordToFactory(): void
+	{
+		$this->factoryMock
+			->expects($this->once())
+			->method('validateUser')
+			->with($this->identicalTo('bob'), $this->identicalTo('s3cr3t'))
+			->willReturn(true);
+
+		$this->manager->validateUser('bob', 's3cr3t');
+	}
+
+	public function testValidateUserIsCalledExactlyOnce(): void
+	{
+		$this->factoryMock
+			->expects($this->once())
+			->method('validateUser')
+			->willReturn(false);
+
+		$this->manager->validateUser('x', 'y');
+	}
+
+	// ==================================================================
+	// 7. getUser() — non-null username (found / not-found)
+	// ==================================================================
+
+	public function testGetUserWithUsernameCallsCreateUserOnFactory(): void
+	{
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock
+			->expects($this->once())
+			->method('createUser')
+			->with('alice')
+			->willReturn($userMock);
+
+		$this->manager->getUser('alice');
+	}
+
+	public function testGetUserWithUsernameReturnsUserFromFactory(): void
+	{
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock->method('createUser')->willReturn($userMock);
+
+		$this->assertSame($userMock, $this->manager->getUser('alice'));
+	}
+
+	public function testGetUserFoundCallsOnFinalizeUserWithTheUser(): void
+	{
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock->method('createUser')->willReturn($userMock);
+
+		$captured = $this->attachFinalizeCapture($this->manager);
+		$this->manager->getUser('alice');
+
+		$this->assertTrue($captured->called);
+		$this->assertSame($userMock, $captured->user);
+	}
+
+	public function testGetUserFoundPassesManagerAsSenderToOnFinalizeUser(): void
+	{
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock->method('createUser')->willReturn($userMock);
+
+		$captured = $this->attachFinalizeCapture($this->manager);
+		$this->manager->getUser('alice');
+
+		$this->assertSame($this->manager, $captured->sender);
+	}
+
+	public function testGetUserNotFoundReturnsNull(): void
+	{
+		$this->factoryMock->method('createUser')->willReturn(null);
+		$this->assertNull($this->manager->getUser('nobody'));
+	}
+
+	public function testGetUserNotFoundDoesNotCallOnFinalizeUser(): void
+	{
+		$this->factoryMock->method('createUser')->willReturn(null);
+
+		$captured = $this->attachFinalizeCapture($this->manager);
+		$this->manager->getUser('nobody');
+
+		$this->assertFalse($captured->called,
+			'onFinalizeUser must NOT fire when createUser returns null');
+	}
+
+	// ==================================================================
+	// 8. getUser() — null username (guest path)
+	//    These tests go through the real Prado::createComponent path.
+	// ==================================================================
+
+	public function testGetUserGuestReturnsNonNullUser(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+
+		$this->assertNotNull($m->getUser(null));
+	}
+
+	public function testGetUserGuestSetsIsGuestToTrue(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+
+		$this->assertTrue($m->getUser(null)->getIsGuest());
+	}
+
+	public function testGetUserGuestIsInstanceOfExpectedUserClass(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+
+		$this->assertInstanceOf(TDbUserTestStub::class, $m->getUser(null));
+	}
+
+	public function testGetUserGuestCallsOnFinalizeUser(): void
+	{
+		$m = $this->freshManager();
+		$m->setUserClass(TDbUserTestStub::class);
+		$m->init(null);
+
+		$captured = $this->attachFinalizeCapture($m);
+		$guest    = $m->getUser(null);
+
+		$this->assertTrue($captured->called);
+		$this->assertSame($guest, $captured->user);
+	}
+
+	// ==================================================================
+	// 9. getUserFromCookie()
+	// ==================================================================
+
+	public function testGetUserFromCookieCallsCreateUserFromCookieWithCookie(): void
+	{
+		$cookie = $this->createMock(THttpCookie::class);
+		$this->factoryMock
+			->expects($this->once())
+			->method('createUserFromCookie')
+			->with($this->identicalTo($cookie))
+			->willReturn(null);
+
+		$this->manager->getUserFromCookie($cookie);
+	}
+
+	public function testGetUserFromCookieValidCookieReturnsUser(): void
+	{
+		$cookie   = $this->createMock(THttpCookie::class);
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock->method('createUserFromCookie')->willReturn($userMock);
+
+		$this->assertSame($userMock, $this->manager->getUserFromCookie($cookie));
+	}
+
+	public function testGetUserFromCookieValidCookieCallsOnFinalizeUser(): void
+	{
+		$cookie   = $this->createMock(THttpCookie::class);
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock->method('createUserFromCookie')->willReturn($userMock);
+
+		$captured = $this->attachFinalizeCapture($this->manager);
+		$this->manager->getUserFromCookie($cookie);
+
+		$this->assertTrue($captured->called);
+		$this->assertSame($userMock, $captured->user);
+	}
+
+	public function testGetUserFromCookieValidCookiePassesManagerAsSender(): void
+	{
+		$cookie   = $this->createMock(THttpCookie::class);
+		$userMock = $this->createMock(TDbUser::class);
+		$this->factoryMock->method('createUserFromCookie')->willReturn($userMock);
+
+		$captured = $this->attachFinalizeCapture($this->manager);
+		$this->manager->getUserFromCookie($cookie);
+
+		$this->assertSame($this->manager, $captured->sender);
+	}
+
+	public function testGetUserFromCookieInvalidCookieReturnsNull(): void
+	{
+		$cookie = $this->createMock(THttpCookie::class);
+		$this->factoryMock->method('createUserFromCookie')->willReturn(null);
+
+		$this->assertNull($this->manager->getUserFromCookie($cookie));
+	}
+
+	public function testGetUserFromCookieInvalidCookieDoesNotCallOnFinalizeUser(): void
+	{
+		$cookie = $this->createMock(THttpCookie::class);
+		$this->factoryMock->method('createUserFromCookie')->willReturn(null);
+
+		$captured = $this->attachFinalizeCapture($this->manager);
+		$this->manager->getUserFromCookie($cookie);
+
+		$this->assertFalse($captured->called,
+			'onFinalizeUser must NOT fire when cookie resolves to null');
+	}
+
+	// ==================================================================
+	// 10. saveUserToCookie()
+	// ==================================================================
+
+	public function testSaveUserToCookieDelegatesToTDbUserWhenAppUserIsTDbUser(): void
+	{
+		$cookie   = $this->createMock(THttpCookie::class);
+		$userMock = $this->createMock(TDbUser::class);
+		$userMock->expects($this->once())
+				 ->method('saveUserToCookie')
+				 ->with($this->identicalTo($cookie));
+
+		$this->manager->mockApp->setCurrentUser($userMock);
+		$this->manager->saveUserToCookie($cookie);
+	}
+
+	public function testSaveUserToCookieDoesNothingWhenAppUserIsBaseUser(): void
+	{
+		$cookie    = $this->createMock(THttpCookie::class);
+		$nonDbUser = $this->createMock(TUser::class);
+		// TUser has no saveUserToCookie; if it were called the mock would error.
+		$this->manager->mockApp->setCurrentUser($nonDbUser);
+
+		$this->manager->saveUserToCookie($cookie);
+		$this->assertTrue(true, 'No exception means correct short-circuit');
+	}
+
+	public function testSaveUserToCookieDoesNothingWhenAppUserIsNull(): void
+	{
+		$cookie = $this->createMock(THttpCookie::class);
+		$this->manager->mockApp->setCurrentUser(null);
+
+		$this->manager->saveUserToCookie($cookie);
+		$this->assertTrue(true);
+	}
+
+	// ==================================================================
+	// 11. onFinalizeUser() — event mechanics
+	// ==================================================================
+
+	public function testOnFinalizeUserFiresAttachedHandler(): void
+	{
+		$userMock = $this->createMock(TDbUser::class);
+		$fired    = false;
+		$this->manager->onFinalizeUser[] = function () use (&$fired): void {
+			$fired = true;
+		};
+
+		$this->manager->onFinalizeUser($userMock);
+		$this->assertTrue($fired);
+	}
+
+	public function testOnFinalizeUserPassesManagerAsSender(): void
+	{
+		$userMock       = $this->createMock(TDbUser::class);
+		$receivedSender = null;
+		$this->manager->onFinalizeUser[] = function ($sender) use (&$receivedSender): void {
+			$receivedSender = $sender;
+		};
+
+		$this->manager->onFinalizeUser($userMock);
+		$this->assertSame($this->manager, $receivedSender);
+	}
+
+	public function testOnFinalizeUserPassesUserAsParams(): void
+	{
+		$userMock     = $this->createMock(TDbUser::class);
+		$receivedUser = null;
+		$this->manager->onFinalizeUser[] = function ($sender, $user) use (&$receivedUser): void {
+			$receivedUser = $user;
+		};
+
+		$this->manager->onFinalizeUser($userMock);
+		$this->assertSame($userMock, $receivedUser);
+	}
+
+	public function testOnFinalizeUserFiresAllAttachedHandlers(): void
+	{
+		$userMock  = $this->createMock(TDbUser::class);
+		$callCount = 0;
+		$inc       = function () use (&$callCount): void { $callCount++; };
+
+		$this->manager->onFinalizeUser[] = $inc;
+		$this->manager->onFinalizeUser[] = $inc;
+		$this->manager->onFinalizeUser[] = $inc;
+
+		$this->manager->onFinalizeUser($userMock);
+		$this->assertSame(3, $callCount);
+	}
+
+	// ==================================================================
+	// 12. getUniqueRolesFromAppParameter()
+	// ==================================================================
+
+	public function testGetUniqueRolesFromAppParamReturnsNullWhenNoParamIdConfigured(): void
+	{
+		$this->assertNull($this->manager->exposedGetUniqueRolesFromAppParameter());
+	}
+
+	public function testGetUniqueRolesFromAppParamReturnsEmptyArrayWhenParamAbsent(): void
+	{
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('missing.param');
+		$this->manager->markInitialized();
+
+		$result = $this->manager->exposedGetUniqueRolesFromAppParameter();
+		$this->assertIsArray($result);
+		$this->assertEmpty($result);
+	}
+
+	public function testGetUniqueRolesFromAppParamReturnsCorrectRolesWhenPresent(): void
+	{
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'admin,editor,viewer');
+		$this->manager->markInitialized();
+
+		$result = $this->manager->exposedGetUniqueRolesFromAppParameter();
+		$this->assertCount(3, $result);
+		$this->assertContains('admin',  $result);
+		$this->assertContains('editor', $result);
+		$this->assertContains('viewer', $result);
+	}
+
+	public function testGetUniqueRolesFromAppParamTrimsWhitespaceFromEntries(): void
+	{
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', ' admin , editor ');
+		$this->manager->markInitialized();
+
+		$result = array_values($this->manager->exposedGetUniqueRolesFromAppParameter());
+		$this->assertSame('admin',  $result[0]);
+		$this->assertSame('editor', $result[1]);
+	}
+
+	public function testGetUniqueRolesFromAppParamFiltersEmptySegments(): void
+	{
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'admin,,editor,,');
+		$this->manager->markInitialized();
+
+		$this->assertCount(2, $this->manager->exposedGetUniqueRolesFromAppParameter());
+	}
+
+	public function testGetUniqueRolesFromAppParamWithSingleRoleReturnsOneElement(): void
+	{
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'superadmin');
+		$this->manager->markInitialized();
+
+		$this->assertCount(1, $this->manager->exposedGetUniqueRolesFromAppParameter());
+	}
+
+	// ==================================================================
+	// 13. getUniqueRoles() — priority (factory → appParam → module)
+	// ==================================================================
+
+	public function testGetUniqueRolesFactoryWinsOverAllOtherSources(): void
+	{
+		$this->factoryMock->method('getUniqueRoles')->willReturn(['superadmin']);
+
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'editor');
+		$this->manager->setUniqueRoles(['viewer']);
+		$this->manager->markInitialized();
+
+		$this->assertSame(['superadmin'], $this->manager->getUniqueRoles());
+	}
+
+	public function testGetUniqueRolesFactoryEmptyArrayStillWinsOverOtherSources(): void
+	{
+		// [] !== null — factory wins even with an empty array.
+		$this->factoryMock->method('getUniqueRoles')->willReturn([]);
+
+		$this->manager->markUninitialized();
+		$this->manager->setUniqueRoles(['should-not-appear']);
+		$this->manager->markInitialized();
+
+		$this->assertSame([], $this->manager->getUniqueRoles());
+	}
+
+	public function testGetUniqueRolesAppParamWinsWhenFactoryReturnsNull(): void
+	{
+		$this->factoryMock->method('getUniqueRoles')->willReturn(null);
+
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'editor,viewer');
+		$this->manager->setUniqueRoles(['should-not-appear']);
+		$this->manager->markInitialized();
+
+		$roles = $this->manager->getUniqueRoles();
+		$this->assertContains('editor', $roles);
+		$this->assertContains('viewer', $roles);
+		$this->assertNotContains('should-not-appear', $roles);
+	}
+
+	public function testGetUniqueRolesModuleConfigWinsWhenFactoryAndAppParamBothNull(): void
+	{
+		$this->factoryMock->method('getUniqueRoles')->willReturn(null);
+		// No RolesAppParameterId → appParam returns null.
+
+		$this->manager->markUninitialized();
+		$this->manager->setUniqueRoles(['module-role-a', 'module-role-b']);
+		$this->manager->markInitialized();
+
+		$this->assertSame(['module-role-a', 'module-role-b'], $this->manager->getUniqueRoles());
+	}
+
+	public function testGetUniqueRolesReturnsNullWhenAllSourcesAreNull(): void
+	{
+		$this->factoryMock->method('getUniqueRoles')->willReturn(null);
+		// No param ID, no module roles → _uniqueRoles is null.
+
+		$this->assertNull($this->manager->getUniqueRoles());
+	}
+
+	public function testGetUniqueRolesAppParamConfiguredButMissingYieldsEmptyNotModuleConfig(): void
+	{
+		// Param ID set, key absent → getUniqueRolesFromAppParameter returns []
+		// (non-null) → module config is NOT reached.
+		$this->factoryMock->method('getUniqueRoles')->willReturn(null);
+
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('missing.param');
+		$this->manager->setUniqueRoles(['module-role']);
+		$this->manager->markInitialized();
+
+		$this->assertSame([], $this->manager->getUniqueRoles());
+	}
+
+	// ==================================================================
+	// 14. getUniqueRoleCount() — priority mirrors getUniqueRoles()
+	// ==================================================================
+
+	public function testGetUniqueRoleCountFactoryWinsOverAllOtherSources(): void
+	{
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(99);
+
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'a,b');
+		$this->manager->setUniqueRoles(['x', 'y', 'z']);
+		$this->manager->markInitialized();
+
+		$this->assertSame(99, $this->manager->getUniqueRoleCount());
+	}
+
+	public function testGetUniqueRoleCountFactoryZeroStillWins(): void
+	{
+		// 0 !== null → factory returning 0 still wins.
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(0);
+
+		$this->manager->markUninitialized();
+		$this->manager->setUniqueRoles(['should-not-count']);
+		$this->manager->markInitialized();
+
+		$this->assertSame(0, $this->manager->getUniqueRoleCount());
+	}
+
+	public function testGetUniqueRoleCountAppParamWinsWhenFactoryReturnsNull(): void
+	{
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(null);
+
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'a,b,c');
+		$this->manager->setUniqueRoles(['x']);
+		$this->manager->markInitialized();
+
+		$this->assertSame(3, $this->manager->getUniqueRoleCount());
+	}
+
+	public function testGetUniqueRoleCountModuleConfigWinsWhenFactoryAndAppParamNull(): void
+	{
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(null);
+
+		$this->manager->markUninitialized();
+		$this->manager->setUniqueRoles(['x', 'y']);
+		$this->manager->markInitialized();
+
+		$this->assertSame(2, $this->manager->getUniqueRoleCount());
+	}
+
+	public function testGetUniqueRoleCountReturnsZeroWhenAllSourcesNull(): void
+	{
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(null);
+
+		$this->assertSame(0, $this->manager->getUniqueRoleCount());
+	}
+
+	public function testGetUniqueRoleCountMatchesCountOfGetUniqueRolesForModuleConfig(): void
+	{
+		$this->factoryMock->method('getUniqueRoles')->willReturn(null);
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(null);
+
+		$this->manager->markUninitialized();
+		$this->manager->setUniqueRoles(['a', 'b', 'c', 'd']);
+		$this->manager->markInitialized();
+
+		$this->assertCount(
+			$this->manager->getUniqueRoleCount(),
+			$this->manager->getUniqueRoles()
+		);
+	}
+
+	public function testGetUniqueRoleCountMatchesCountOfGetUniqueRolesForAppParam(): void
+	{
+		$this->factoryMock->method('getUniqueRoles')->willReturn(null);
+		$this->factoryMock->method('getUniqueRoleCount')->willReturn(null);
+
+		$this->manager->markUninitialized();
+		$this->manager->setRolesAppParameterId('app.roles');
+		$this->manager->mockApp->getParameters()->set('app.roles', 'r1,r2,r3,r4,r5');
+		$this->manager->markInitialized();
+
+		$this->assertCount(
+			$this->manager->getUniqueRoleCount(),
+			$this->manager->getUniqueRoles()
+		);
+	}
+
+	// ==================================================================
+	// 15. createDbConnection() — error message key regression tests
+	//     These guard against re-introduction of the 'dbConnectionectionid'
+	//     typo that appeared in the v4 source file.
+	// ==================================================================
+
+	public function testCreateDbConnectionInvalidModuleExceptionMessageKeyIsCorrect(): void
+	{
+		$this->manager->mockApp->registerModule('badmod', new \stdClass());
+		try {
+			$this->manager->exposedCreateDbConnection('badmod');
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (TConfigurationException $e) {
+			$this->assertStringNotContainsStringIgnoringCase(
+				'dbConnectionectionid',
+				$e->getErrorCode(),
+				'Error key must not contain the doubled "ection" typo'
+			);
+			$this->assertSame('dbusermanager_connectionid_invalid', $e->getErrorCode());
+		}
+	}
+
+	public function testCreateDbConnectionEmptyIdExceptionMessageKeyIsCorrect(): void
+	{
+		try {
+			$this->manager->exposedCreateDbConnection('');
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (TConfigurationException $e) {
+			$this->assertStringNotContainsStringIgnoringCase(
+				'dbConnectionectionid',
+				$e->getErrorCode(),
+				'Error key must not contain the doubled "ection" typo'
+			);
+			$this->assertSame('dbusermanager_connectionid_required', $e->getErrorCode());
+		}
+	}
+
+	// ==================================================================
+	// 16. createDbConnection() — routing logic
+	// ==================================================================
+
+	public function testCreateDbConnectionThrowsWhenConnectionIdIsEmpty(): void
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->manager->exposedCreateDbConnection('');
+	}
+
+	public function testCreateDbConnectionThrowsWhenModuleIdIsNotRegistered(): void
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->manager->exposedCreateDbConnection('nonexistent');
+	}
+
+	public function testCreateDbConnectionThrowsWhenModuleIsWrongType(): void
+	{
+		$this->manager->mockApp->registerModule('badmod', new \stdClass());
+		$this->expectException(TConfigurationException::class);
+		$this->manager->exposedCreateDbConnection('badmod');
+	}
+
+	public function testCreateDbConnectionReturnsTDbConnectionFromValidDataSource(): void
+	{
+		$connMock       = $this->createMock(TDbConnection::class);
+		$datasourceMock = $this->createMock(TDataSourceConfig::class);
+		$datasourceMock->method('getDbConnection')->willReturn($connMock);
+
+		$this->manager->mockApp->registerModule('db', $datasourceMock);
+
+		$this->assertSame($connMock, $this->manager->exposedCreateDbConnection('db'));
+	}
+
+	public function testCreateDbConnectionCallsGetDbConnectionOnDataSource(): void
+	{
+		$connMock       = $this->createMock(TDbConnection::class);
+		$datasourceMock = $this->createMock(TDataSourceConfig::class);
+		$datasourceMock->expects($this->once())
+					   ->method('getDbConnection')
+					   ->willReturn($connMock);
+
+		$this->manager->mockApp->registerModule('db', $datasourceMock);
+		$this->manager->exposedCreateDbConnection('db');
+	}
+
+	// ==================================================================
+	// 17. getDbConnection() — public method
+	// ==================================================================
+
+	public function testGetDbConnectionSetsConnectionActiveOnFirstCall(): void
+	{
+		$connMock       = $this->createMock(TDbConnection::class);
+		$connMock->expects($this->once())->method('setActive')->with(true);
+
+		$datasourceMock = $this->createMock(TDataSourceConfig::class);
+		$datasourceMock->method('getDbConnection')->willReturn($connMock);
+
+		$this->manager->mockApp->registerModule('db', $datasourceMock);
+		$this->manager->setConnectionID('db');
+		$this->manager->getDbConnection();
+	}
+
+	public function testGetDbConnectionReturnsSameInstanceOnSecondCall(): void
+	{
+		$connMock       = $this->createMock(TDbConnection::class);
+		$connMock->method('setActive');
+
+		$datasourceMock = $this->createMock(TDataSourceConfig::class);
+		$datasourceMock->method('getDbConnection')->willReturn($connMock);
+
+		$this->manager->mockApp->registerModule('db', $datasourceMock);
+		$this->manager->setConnectionID('db');
+
+		$this->assertSame(
+			$this->manager->getDbConnection(),
+			$this->manager->getDbConnection()
+		);
+	}
+
+	public function testGetDbConnectionCallsCreateDbConnectionOnlyOnce(): void
+	{
+		$connMock       = $this->createMock(TDbConnection::class);
+		$connMock->method('setActive');
+
+		$datasourceMock = $this->createMock(TDataSourceConfig::class);
+		$datasourceMock->expects($this->once())
+					   ->method('getDbConnection')
+					   ->willReturn($connMock);
+
+		$this->manager->mockApp->registerModule('db', $datasourceMock);
+		$this->manager->setConnectionID('db');
+
+		$this->manager->getDbConnection();
+		$this->manager->getDbConnection(); // second call — must use cache
+	}
+
+	public function testGetDbConnectionPopulatesInternalCacheField(): void
+	{
+		$connMock       = $this->createMock(TDbConnection::class);
+		$connMock->method('setActive');
+
+		$datasourceMock = $this->createMock(TDataSourceConfig::class);
+		$datasourceMock->method('getDbConnection')->willReturn($connMock);
+
+		$this->manager->mockApp->registerModule('db', $datasourceMock);
+		$this->manager->setConnectionID('db');
+
+		$this->assertNull($this->manager->readDbConnectionField(),
+			'_dbConnection must be null before first call');
+
+		$this->manager->getDbConnection();
+
+		$this->assertSame($connMock, $this->manager->readDbConnectionField(),
+			'_dbConnection must be populated after first call');
+	}
+
+	public function testGetDbConnectionThrowsWhenConnectionIdIsEmpty(): void
+	{
+		// _connectionID defaults to '' → createDbConnection throws.
+		$this->expectException(TConfigurationException::class);
+		$this->manager->getDbConnection();
+	}
+}

--- a/tests/unit/Security/TUserManagerTest.php
+++ b/tests/unit/Security/TUserManagerTest.php
@@ -4,6 +4,7 @@ use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Prado;
+use Prado\Security\TUser;
 use Prado\Security\TUserManager;
 use Prado\TApplication;
 use Prado\Xml\TXmlDocument;
@@ -177,6 +178,14 @@ class TUserManagerTest extends PHPUnit\Framework\TestCase
 			self::fail('Exception TInvalidDataValueException not thrown');
 		} catch (TInvalidDataValueException $e) {
 		}
+	}
+	
+	public function testGetUserClass()
+	{
+		$userManager = new TUserManager();
+		$userManager->init(self::$configXml);
+		
+		self::assertEquals(TUser::class, $userManager->getUserClass());
 	}
 
 	public function testValidateUser()

--- a/tests/unit/Security/TUserManagerTest.php
+++ b/tests/unit/Security/TUserManagerTest.php
@@ -9,6 +9,26 @@ use Prado\Security\TUserManager;
 use Prado\TApplication;
 use Prado\Xml\TXmlDocument;
 
+class CustomTestHashBehavior extends TBehavior {
+	
+	public function dyHasHash($value, $passwordMode, $callchain)
+	{
+		if (strtolower($passwordMode) == 'reverse' || strtolower($passwordMode) == 'esrever') {
+			$value |= true;
+		}
+		return $callchain->dyHasHash($value, $passwordMode);
+	}
+	
+	public function dyHash($password, $passwordMode, $callchain)
+	{
+		if (strtolower($passwordMode) == 'reverse' || strtolower($passwordMode) == 'esrever') {
+			$password = strrev($password);
+		}
+		return $callchain->dyHash($password, $passwordMode);
+	}
+}
+
+
 class TUserManagerTest extends PHPUnit\Framework\TestCase
 {
 	public static $app = null;
@@ -307,5 +327,25 @@ class TUserManagerTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(['Writer'], $user->getRoles());
 		self::assertFalse($user->getIsGuest());
 		self::assertNull($userManager->getUser('badUser'));
+	}
+	
+	public function testCustomHash()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+			
+		$config = self::$configPhp;
+		$password = $config['users'][0]['password'];
+		$config['users'][0]['password'] = strrev($password);
+		
+		$userManager = new TUserManager();
+		$userManager->attachBehavior(null, new CustomTestHashBehavior());
+		$userManager->init($config);
+		$userManager->setPasswordMode('reverse');
+		
+		self::assertTrue($userManager->validateUser('Mary', $password));
+		self::assertTrue($userManager->validateUser('mary', $password));
+		self::assertFalse($userManager->validateUser('Mary', $password . '-'));
+		self::assertFalse($userManager->validateUser('Amy', $password));
 	}
 }

--- a/tests/unit/Security/TUserManagerTest.php
+++ b/tests/unit/Security/TUserManagerTest.php
@@ -11,82 +11,140 @@ use Prado\Xml\TXmlDocument;
 class TUserManagerTest extends PHPUnit\Framework\TestCase
 {
 	public static $app = null;
-	public static $config = null;
-
+	public static $configXml = null;
+	public static $configPhp = null;
 
 	protected function setUp(): void
 	{
-		if (self::$app === null) {
-			self::$app = new TApplication(__DIR__ . '/app');
-			prado::setPathofAlias('App', __DIR__);
-		}
-
-		if (self::$config === null) {
+		// Config type might change per test and the property must be fresh to change (null)
+		self::$app = new TApplication(__DIR__ . '/app');
+		prado::setPathofAlias('App', __DIR__);
+		
+		if (self::$configXml === null) {
 			// Simulate a config file
-			self::$config = new TXmlDocument('1.0', 'utf8');
-			self::$config->loadFromString('<users><user name="Joe" password="demo"/><user name="John" password="demo" /><user name="test" password="test" roles="Reader, User"/><role name="Administrator" users="John" /><role name="Writer" users="Joe, John" /></users>');
+			self::$configXml = new TXmlDocument('1.0', 'utf8');
+			self::$configXml->loadFromString('<users><user name="Joe" password="demo"/><user name="John" password="demo" /><user name="test" password="test" roles="Reader, User"/><role name="Administrator" users="John" /><role name="Writer" users="Joe, John" /></users>');
+		}
+		
+		if (self::$configPhp === null) {
+			// Simulate a config file
+			self::$configPhp = [
+				'users' => [['name' => 'Mary', 'password' => 'mpass'], 
+							['name' => 'Amy', 'password' => 'apass'], 
+							['name' => 'Pamela', 'password' => 'ppass', 'roles' => 'Boss, User']],
+				
+				'roles' => [['name' => 'Supervisor', 'users' => 'Amy'],
+							['name' => 'Author', 'users' => 'Mary, Pamela']],
+			];
 		}
 	}
 
 	protected function tearDown(): void
 	{
 	}
-
-	public function testInit()
+	
+	public function testInitXml()
 	{
 		$userManager = new TUserManager();
-		$userManager->init(self::$config);
+		$userManager->init(self::$configXml);
 		self::assertEquals(['joe' => 'demo', 'john' => 'demo', 'test' => 'test'], $userManager->getUsers());
 		$userManager = null;
+		
 		// Test with a file
 		if (is_writable(__DIR__)) {
-			self::$config->saveToFile(__DIR__ . '/users.xml');
+			$xmlPath = __DIR__ . '/users.xml';
+			self::$configXml->saveToFile($xmlPath);
 			$userManager = new TUserManager();
 			$userManager->setUserFile('App.users');
 			$userManager->init(new TXmlDocument()); // Empty config
+			self::assertEquals($xmlPath, $userManager->getUserFile());
 			self::assertEquals(['joe' => 'demo', 'john' => 'demo', 'test' => 'test'], $userManager->getUsers());
-			unlink(__DIR__ . '/users.xml');
+			unlink($xmlPath);
 		}
 	}
-
-	public function testUsers()
+	
+	public function testInitPhp()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+		
+		{
+			$userManager = new TUserManager();
+			$userManager->init(self::$configPhp);
+			self::assertEquals(['mary' => 'mpass', 'amy' => 'apass', 'pamela' => 'ppass'], $userManager->getUsers());
+			$userManager = null;
+			
+			// Test with a file
+			if (is_writable(__DIR__)) {
+				$phpPath = __DIR__ . '/users.php';
+				$writeBytes = file_put_contents($phpPath, $fileContents = "<?php\nreturn " . var_export(self::$configPhp, true) . ";\n");
+				self::assertEquals($fileContents, file_get_contents($phpPath));
+				self::assertEquals(TApplication::CONFIG_TYPE_PHP, self::$app->getConfigurationType());
+				self::assertEquals(TApplication::CONFIG_FILE_EXT_PHP, self::$app->getConfigurationFileExt());
+				if ($writeBytes !== false) {
+					$userManager = new TUserManager();
+					$userManager->setUserFile('App.users');
+					$userManager->init([]); // Empty config
+					self::assertEquals($phpPath, $userManager->getUserFile());
+					self::assertEquals(['mary' => 'mpass', 'amy' => 'apass', 'pamela' => 'ppass'], $userManager->getUsers());
+					unlink($phpPath);
+				}
+			}
+		}
+		
+		self::$app->setConfigurationType($appMode);
+	}
+	
+	public function testUsersXml()
 	{
 		$userManager = new TUserManager();
-		$userManager->init(self::$config);
+		$userManager->init(self::$configXml);
 		self::assertEquals(['joe' => 'demo', 'john' => 'demo', 'test' => 'test'], $userManager->getUsers());
 	}
-
-	public function testRoles()
+	
+	public function testUsersPhp()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+		
+		{
+			$userManager = new TUserManager();
+			$userManager->init(self::$configPhp);
+			self::assertEquals(['mary' => 'mpass', 'amy' => 'apass', 'pamela' => 'ppass'], $userManager->getUsers());
+		}
+		
+		self::$app->setConfigurationType($appMode);
+	}
+	
+	public function testRolesXml()
 	{
 		$userManager = new TUserManager();
-		$userManager->init(self::$config);
+		$userManager->init(self::$configXml);
 		self::assertEquals(['joe' => ['Writer'], 'john' => ['Administrator', 'Writer'], 'test' => ['Reader', 'User']], $userManager->getRoles());
 	}
+	
+	public function testRolesPhp()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+		
+		{
+			$userManager = new TUserManager();
+			$userManager->init(self::$configPhp);
+			self::assertEquals(['mary' => ['Author'], 'amy' => ['Supervisor'], 'pamela' => ['Boss', 'User', 'Author']], $userManager->getRoles());
+		}
+		
+		self::$app->setConfigurationType($appMode);
+	}
 
-	public function testUserFile()
+	public function testUserFileEdgeCases()
 	{
 		$userManager = new TUserManager();
 		try {
 			$userManager->setUserFile('invalidFile');
 			self::fail('Exception TConfigurationException not thrown');
 		} catch (TConfigurationException $e) {
-		}
-		$userManager = null;
-		if (is_writable(__DIR__)) {
-			self::$config->saveToFile(__DIR__ . '/users.xml');
-			$userManager = new TUserManager();
-			$userManager->setUserFile('App.users');
-			$userManager->init(new TXmlDocument()); // Empty config
-			self::assertEquals(__DIR__ . '/users.xml', $userManager->getUserFile());
-			unlink(__DIR__ . '/users.xml');
-			$userManager = null;
-		}
-		$userManager = new TUserManager();
-		$userManager->init(self::$config);
-		try {
-			$userManager->setUserFile('App.users');
-			self::fail('Exception TInvalidOperationException not thrown');
-		} catch (TInvalidOperationException $e) {
+			self::assertTrue(true); // if didn't fail, still succeeds
 		}
 	}
 
@@ -107,6 +165,13 @@ class TUserManagerTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(TUserManagerPasswordMode::MD5, $userManager->getPasswordMode());
 		$userManager->setPasswordMode('SHA1');
 		self::assertEquals(TUserManagerPasswordMode::SHA1, $userManager->getPasswordMode());
+		
+		
+		foreach(hash_algos() as $algorithm) {
+			$userManager->setPasswordMode($algorithm);
+			self::assertEquals($algorithm, $userManager->getPasswordMode());
+		}
+		
 		try {
 			$userManager->setPasswordMode('Invalid');
 			self::fail('Exception TInvalidDataValueException not thrown');
@@ -117,20 +182,117 @@ class TUserManagerTest extends PHPUnit\Framework\TestCase
 	public function testValidateUser()
 	{
 		$userManager = new TUserManager();
-		$userManager->init(self::$config);
+		$userManager->init(self::$configXml);
 		$userManager->setPasswordMode('Clear');
+		
 		self::assertTrue($userManager->validateUser('Joe', 'demo'));
+		self::assertTrue($userManager->validateUser('joe', 'demo'));
+		self::assertFalse($userManager->validateUser('Joe', 'incorrect'));
 		self::assertFalse($userManager->validateUser('John', 'bad'));
 	}
-
-	public function testUser()
+	
+	public function testPasswordMode_Clear()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+		
+		$config = self::$configPhp;
+		$password = $config['users'][0]['password'];
+		
+		$userManager = new TUserManager();
+		$userManager->init($config);
+		$userManager->setPasswordMode('Clear');
+		
+		self::assertTrue($userManager->validateUser('Mary', $password));
+		self::assertTrue($userManager->validateUser('mary', $password));
+		self::assertFalse($userManager->validateUser('Mary', $password . '-'));
+		self::assertFalse($userManager->validateUser('Amy', $password));
+	}
+	
+	public function testPasswordMode_MD5()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+			
+		$config = self::$configPhp;
+		$password = $config['users'][0]['password'];
+		$config['users'][0]['password'] = md5($password);
+		
+		$userManager = new TUserManager();
+		$userManager->init($config);
+		$userManager->setPasswordMode('MD5');
+		
+		self::assertTrue($userManager->validateUser('Mary', $password));
+		self::assertTrue($userManager->validateUser('mary', $password));
+		self::assertFalse($userManager->validateUser('Mary', $password . '-'));
+		self::assertFalse($userManager->validateUser('Amy', $password));
+	}
+	
+	public function testPasswordMode_SHA1()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+			
+		$config = self::$configPhp;
+		$password = $config['users'][0]['password'];
+		$config['users'][0]['password'] = sha1($password);
+		
+		$userManager = new TUserManager();
+		$userManager->init($config);
+		$userManager->setPasswordMode('SHA1');
+		
+		self::assertTrue($userManager->validateUser('Mary', $password));
+		self::assertTrue($userManager->validateUser('mary', $password));
+		self::assertFalse($userManager->validateUser('Mary', $password . '-'));
+		self::assertFalse($userManager->validateUser('Amy', $password));
+	}
+	
+	public function testPasswordMode_Alt()
+	{
+		$appMode = self::$app->getConfigurationType();
+		self::$app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+		
+		foreach(hash_algos() as $algorithm) {
+			$config = self::$configPhp;
+			$password = $config['users'][0]['password'];
+			$config['users'][0]['password'] = hash($algorithm, $password);
+			
+			$userManager = new TUserManager();
+			$userManager->init($config);
+			$userManager->setPasswordMode($algorithm);
+			
+			self::assertTrue($userManager->validateUser('Mary', $password));
+			self::assertTrue($userManager->validateUser('mary', $password));
+			self::assertFalse($userManager->validateUser('Mary', $password . '-'));
+			self::assertFalse($userManager->validateUser('Amy', $password));
+		}
+	}
+	
+	public function testGetUser()
 	{
 		$userManager = new TUserManager();
-		$userManager->init(self::$config);
+		$userManager->init(self::$configXml);
+		
+		$count = 0;
+		$eventSender = $eventParam = null;
+		$userManager->onFinalizeUser[] = function($sender, $param) use (&$count, &$eventSender, &$eventParam) {
+			$count++;
+			$eventSender = $sender;
+			$eventParam = $param;
+		};
+			
 		$guest = $userManager->getUser(null);
+		self::assertEquals(1, $count);
+		self::assertEquals($userManager, $eventSender);
+		self::assertEquals($guest, $eventParam);
 		self::assertInstanceOf(\Prado\Security\TUser::class, $guest);
 		self::assertTrue($guest->getIsGuest());
+		
+		$eventSender = $eventParam = null;
 		$user = $userManager->getUser('joe');
+		self::assertEquals(2, $count);
+		self::assertEquals($userManager, $eventSender);
+		self::assertEquals($user, $eventParam);
 		self::assertInstanceOf(\Prado\Security\TUser::class, $user);
 		self::assertEquals('joe', $user->getName());
 		self::assertEquals(['Writer'], $user->getRoles());


### PR DESCRIPTION
Adds IUserManager::onFinalizeUser.

Update TUserManager: 
- xml config -> php config (xml converted to php)
- removed xml config (only one config method to support)
- getUniqueRoles
- supports all hash algorithms of PHP `hash`, when available
- much better unit tests

The purpose is to start moving in the direction of PHP style configurations in total.
This converts XML into PHP and then the configuration is processed in PHP.  We only need one configuration method.
TUserManager should support all the hash functions found in `hash`; beyond the basic PRADO provided modes.
This also expands the unit tests.