### PR TITLE
TDbCommandBuilder - Replace stripos with preg_match for 'AS' check

### DIFF
--- a/framework/Data/Common/TDbCommandBuilder.php
+++ b/framework/Data/Common/TDbCommandBuilder.php
@@ -231,12 +231,12 @@ class TDbCommandBuilder extends \Prado\TComponent
 					continue;
 				}
 
-				if (preg_match('/\bAS\b/i', (string) $key)) {
+				if (preg_match('/\bAS\b/i', $key)) {
 					$result[] = $key;
 					continue;
 				}
 
-				if (preg_match('/\bAS\b/i', (string) $value)) {
+				if (preg_match('/\bAS\b/i', $value)) {
 					$result[] = $value;
 					continue;
 				}

--- a/framework/Data/Common/TDbCommandBuilder.php
+++ b/framework/Data/Common/TDbCommandBuilder.php
@@ -231,12 +231,12 @@ class TDbCommandBuilder extends \Prado\TComponent
 					continue;
 				}
 
-				if (stripos($key, 'AS') !== false) {
+				if (preg_match('/\bAS\b/i', (string) $key)) {
 					$result[] = $key;
 					continue;
 				}
 
-				if (stripos($value, 'AS') !== false) {
+				if (preg_match('/\bAS\b/i', (string) $value)) {
 					$result[] = $value;
 					continue;
 				}


### PR DESCRIPTION
It should be testing for a word boundary around "AS"

Otherwise, It could match the terms containing _"AS"_; like "alias" or "astro"

Agents found this and marked it during documentation.  In different branch this unit test is failing.  
