### PR TITLE
#1044 corrects TNoUnserializeBehaviorTrait `if`value (from array_search) compares to false

### DIFF
--- a/framework/Util/Behaviors/TNoUnserializeBehaviorTrait.php
+++ b/framework/Util/Behaviors/TNoUnserializeBehaviorTrait.php
@@ -34,7 +34,7 @@ trait TNoUnserializeBehaviorTrait
 	public function dyWakeUp(TCallChain $chain)
 	{
 		$owner = $this->getOwner();
-		if ($index = array_search($this, $owner->getBehaviors())) {
+		if (($index = array_search($this, $owner->getBehaviors())) !== false) {
 			$owner->detachBehavior($index);
 		}
 		return $chain->dyWakeUp();

--- a/framework/Util/Behaviors/TNoUnserializeClassBehaviorTrait.php
+++ b/framework/Util/Behaviors/TNoUnserializeClassBehaviorTrait.php
@@ -34,7 +34,7 @@ trait TNoUnserializeClassBehaviorTrait
 	 */
 	public function dyWakeUp(object $owner, TCallChain $chain)
 	{
-		if ($index = array_search($this, $owner->getBehaviors())) {
+		if (($index = array_search($this, $owner->getBehaviors())) !== false) {
 			$owner->detachBehavior($index);
 		}
 		return $chain->dyWakeUp();

--- a/tests/unit/Util/Behaviors/TNoUnserializeBehaviorTraitTest.php
+++ b/tests/unit/Util/Behaviors/TNoUnserializeBehaviorTraitTest.php
@@ -43,4 +43,21 @@ class TNoUnserializeBehaviorTraitTest extends PHPUnit\Framework\TestCase
 		self::assertNotNull($component->asa('b1'));
 		self::assertNull($component->asa('b2'));
 	}
+
+	public function testDyWakeUpAtIndexZero()
+	{
+		$component = new DeprecatedTestTComponent();
+		$component->attachBehavior(null, $deprecated = new TTestDeprecatedBehaviorClass());
+		$component->attachBehavior(null, $normal = new TTestNonDeprecatedBehaviorClass());
+		
+		$behaviors = $component->getBehaviors();
+		$deprecatedIndex = array_search($deprecated, $behaviors, true);
+		self::assertEquals(0, $deprecatedIndex, 'Deprecated behavior should be at index 0');
+		
+		$data = serialize($component);
+		
+		$copy = unserialize($data);
+		self::assertNotNull($copy->asa(1));
+		self::assertNull($copy->asa(0), 'Deprecated behavior should be detached after unserialize at index 0');
+	}
 }

--- a/tests/unit/Util/Behaviors/TNoUnserializeClassBehaviorTraitTest.php
+++ b/tests/unit/Util/Behaviors/TNoUnserializeClassBehaviorTraitTest.php
@@ -43,4 +43,21 @@ class TNoUnserializeClassBehaviorTraitTest extends PHPUnit\Framework\TestCase
 		self::assertNotNull($component->asa('b1'));
 		self::assertNull($component->asa('b2'));
 	}
+
+	public function testDyWakeUpAtIndexZero()
+	{
+		$component = new DeprecatedClassTestTComponent();
+		$component->attachBehavior(null, $deprecated = new TTestDeprecatedClassBehaviorClass());
+		$component->attachBehavior(null, $normal = new TTestNonDeprecatedClassBehaviorClass());
+		
+		$behaviors = $component->getBehaviors();
+		$deprecatedIndex = array_search($deprecated, $behaviors, true);
+		self::assertEquals(0, $deprecatedIndex, 'Deprecated behavior should be at index 0');
+		
+		$data = serialize($component);
+		
+		$copy = unserialize($data);
+		self::assertNotNull($copy->asa(1));
+		self::assertNull($copy->asa(0), 'Deprecated behavior should be detached after unserialize at index 0');
+	}
 }


### PR DESCRIPTION
These unit tests fail without the fix, and they pass with the test.