### PR TITLE
Proper random keygen in TSecurityManager and TCaptcha

### DIFF
--- a/framework/Security/TSecurityManager.php
+++ b/framework/Security/TSecurityManager.php
@@ -74,7 +74,13 @@ class TSecurityManager extends \Prado\TModule
 	 */
 	protected function generateRandomKey()
 	{
-		return sprintf('%08x%08x%08x%08x', mt_rand(), mt_rand(), mt_rand(), mt_rand());
+		try {
+			return bin2hex(random_bytes(16));
+		} catch (\Exception $e) {
+			// @todo from PHP 8.2, this is \Random\RandomException
+			// Fallback for environments without proper random support
+			return sha1(uniqid(mt_rand(), true));
+		}
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TCaptcha.php
+++ b/framework/Web/UI/WebControls/TCaptcha.php
@@ -443,7 +443,13 @@ class TCaptcha extends TImage
 	 */
 	protected function generateRandomKey()
 	{
-		return md5(rand() . rand() . rand() . rand());
+		try {
+			return bin2hex(random_bytes(16));
+		} catch (\Exception $e) {
+			// @todo from PHP 8.2, this is \Random\RandomException
+			// Fallback for environments without proper random support
+			return sha1(uniqid(mt_rand(), true));
+		}
 	}
 
 	/**

--- a/tests/unit/Security/TSecurityManagerTest.php
+++ b/tests/unit/Security/TSecurityManagerTest.php
@@ -5,6 +5,14 @@ use Prado\Exceptions\TNotSupportedException;
 use Prado\Security\TSecurityManager;
 use Prado\TApplication;
 
+class TCustomTestSecurityManager extends TSecurityManager
+{
+	public function publicGenerateRandomKey()
+	{
+		return $this->generateRandomKey();
+	}
+}
+
 class TSecurityManagerTest extends PHPUnit\Framework\TestCase
 {
 	public static $app;
@@ -25,6 +33,16 @@ class TSecurityManagerTest extends PHPUnit\Framework\TestCase
 		$sec = new TSecurityManager();
 		$sec->init(null);
 		self::assertEquals($sec, self::$app->getSecurityManager());
+	}
+	
+	public function testGenerateRandomKey()
+	{
+		$sec = new TCustomTestSecurityManager();
+		$sec->init(null);
+		$randomKey = $sec->publicGenerateRandomKey();
+		
+		self::assertIsString($randomKey);
+		$this->assertSame(32, strlen($randomKey));
 	}
 
 	public function testValidationKey()


### PR DESCRIPTION
Also added unit tests to ensure protected function generateRandomKey has a proper output, backward compatible.