### PR TITLE
Adds verbs to TUrlMappingPattern

### DIFF
--- a/framework/Web/TUrlMapping.php
+++ b/framework/Web/TUrlMapping.php
@@ -69,6 +69,15 @@ use Prado\Xml\TXmlElement;
  * to constructUrl() and every parameter in the {@see getPattern Pattern} is found
  * in the GET variables.
  *
+ * Since PRADO 4.3.3, URL patterns support HTTP verb matching via the {@see \Prado\Web\TUrlMappingPattern::getVerbs Verbs} attribute.
+ * This allows restricting URL patterns to specific HTTP methods (GET, POST, PUT, DELETE, etc.).
+ * Use a comma-separated list for multiple verbs. Use the prefix '~' or '!' to negate a verb.
+ * For example:
+ * - verbs="GET" - only matches GET requests
+ * - verbs="POST,PUT" - matches POST or PUT requests
+ * - verbs="~GET" or verbs="!GET" - matches any request except GET requests
+ * - verbs="~GET,!PUT" - multiple negative verbs can be matched
+ *
  * @author Wei Zhuo <weizhuo[at]gmail[dot]com>
  * @since 3.0.5
  */

--- a/framework/Web/TUrlMappingPattern.php
+++ b/framework/Web/TUrlMappingPattern.php
@@ -107,9 +107,17 @@ use Prado\TPropertyValue;
  * <url ServiceParameter="MyPage" pattern="/mypage/mypath/list/detail/{pageidx}" parameters.pageidx="\d+" constants.listtype="detailed"/>
  * <url ServiceParameter="MyPage" pattern="/mypage/mypath/list/summary/{pageidx}" parameters.pageidx="\d+" constants.listtype="summarized"/>
  *
- * These rules, when matched by the actual request, will make the application see a "lisstype" parameter present
+ * These rules, when matched by the actual request, will make the application see a "listtype" parameter present
  * (even through not supplied in the request) and equal to "detailed" or "summarized", depending on the friendly url matched.
  * The constants is practically a table-based validation and translation of specified, fixed-set parameter values.
+ *
+ * Since 4.3.3 you can also use HTTP verb matching. The Verbs property restricts a pattern to match only
+ * specific HTTP methods (GET, POST, PUT, DELETE, etc.). Use a comma-separated list for multiple verbs.
+ * Use the prefix '~' or '!' to negate a verb. For example:
+ * - verbs="GET" - only matches GET requests
+ * - verbs="POST,PUT" - matches POST or PUT requests
+ * - verbs="!DELETE" or verbs="~DELETE" - matches any request except DELETE requests
+ * - verbs="!PUT, ~DELETE" - matches any request except PUT and DELETE
  *
  * @author Wei Zhuo <weizhuo[at]gmail[dot]com>
  * @since 3.0.5
@@ -158,6 +166,12 @@ class TUrlMappingPattern extends \Prado\TComponent
 	 * @since 3.2
 	 */
 	private $_secureConnection = TUrlMappingPatternSecureConnection::Automatic;
+
+	/**
+	 * @var null|array list of allowed HTTP verbs for this pattern. Null means any verb is allowed.
+	 * @since 4.3.3
+	 */
+	private $_verbs;
 
 	/**
 	 * Constructor.
@@ -348,6 +362,14 @@ class TUrlMappingPattern extends \Prado\TComponent
 	 */
 	public function getPatternMatches($request)
 	{
+		$verbs = $this->getVerbs();
+		if ($verbs !== null) {
+			$requestVerb = $request->getRequestType();
+			if (!in_array($requestVerb, $verbs) || in_array('!' . $requestVerb, $verbs) || in_array('~' . $requestVerb, $verbs)) {
+				return [];
+			}
+		}
+
 		$matches = [];
 		if (($pattern = $this->getRegularExpression()) !== '') {
 			preg_match($pattern, $request->getPathInfo(), $matches);
@@ -473,6 +495,36 @@ class TUrlMappingPattern extends \Prado\TComponent
 	public function setSecureConnection($value)
 	{
 		$this->_secureConnection = TPropertyValue::ensureEnum($value, TUrlMappingPatternSecureConnection::class);
+	}
+
+	/**
+	 * @return null|array list of allowed HTTP verbs for this pattern, null means any verb is allowed.
+	 *                       Use prefixes '~' or '!' to negate a verb (e.g., '~GET' means NOT GET).
+	 * @since 4.3.3
+	 */
+	public function getVerbs()
+	{
+		return $this->_verbs;
+	}
+
+	/**
+	 * Sets the list of allowed HTTP verbs for this pattern.
+	 * @param null|array|string $value list of verbs (e.g., 'GET,POST'), null for any verb.
+	 *                          Use prefix '~' or '!' to negate (e.g., '~GET' or '!GET' excludes GET).
+	 * @since 4.3.3
+	 */
+	public function setVerbs($value)
+	{
+		if (is_string($value)) {
+			$value = explode(',', $value);
+		}
+		if (is_array($value)) {
+			$value = array_filter(array_map('trim', $value));
+		}
+		if (empty($value)) {
+			$value = null;
+		}
+		$this->_verbs = $value;
 	}
 
 	/**

--- a/tests/unit/Web/TUrlManagerTest.php
+++ b/tests/unit/Web/TUrlManagerTest.php
@@ -1,0 +1,247 @@
+<?php
+
+use Prado\Web\THttpRequest;
+use Prado\Web\THttpRequestUrlFormat;
+use Prado\Web\TUrlManager;
+use Prado\TApplication;
+
+/**
+ * Test class for TUrlManager.
+ */
+class TUrlManagerTest extends PHPUnit\Framework\TestCase
+{
+	protected static $app = null;
+
+	protected function setUp(): void
+	{
+		// Fake environment variables
+		$_SERVER['HTTP_HOST'] = 'localhost';
+		$_SERVER['SERVER_NAME'] = 'localhost';
+		$_SERVER['SERVER_PORT'] = '80';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = '/index.php?page=Home';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['PHP_SELF'] = '/index.php';
+		$_SERVER['QUERY_STRING'] = 'page=Home';
+		$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+		$_SERVER['PATH_INFO'] = '';
+
+		if (self::$app === null) {
+			self::$app = new TApplication(__DIR__ . '/app/');
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		$_GET = [];
+		$_POST = [];
+		$_SERVER['PATH_INFO'] = '';
+		$_SERVER['QUERY_STRING'] = '';
+	}
+
+	public function testConstructUrlGetFormat()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Get);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', ['param1' => 'value1'], true, true);
+		$this->assertEquals('/index.php?page=Home&amp;param1=value1', $url);
+	}
+
+	public function testConstructUrlGetFormatNoEncodeAmpersand()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Get);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', ['param1' => 'value1'], false, true);
+		$this->assertEquals('/index.php?page=Home&param1=value1', $url);
+	}
+
+	public function testConstructUrlPathFormat()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', ['param1' => 'value1'], true, true);
+		$this->assertEquals('/index.php/page,Home/param1,value1', $url);
+	}
+
+	public function testConstructUrlHiddenPathFormat()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::HiddenPath);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', ['param1' => 'value1'], true, true);
+		$this->assertEquals('/page,Home/param1,value1', $url);
+	}
+
+	public function testConstructUrlWithArrayValues()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Get);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', ['items' => ['a', 'b', 'c']], true, true);
+		$this->assertEquals('/index.php?page=Home&amp;items%5B%5D=a&amp;items%5B%5D=b&amp;items%5B%5D=c', $url);
+	}
+
+	public function testConstructUrlWithNullGetItems()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Get);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', null, true, true);
+		$this->assertEquals('/index.php?page=Home', $url);
+	}
+
+	public function testConstructUrlWithEmptyArrayGetItems()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Get);
+		$request->init(null);
+
+		$url = $urlManager->constructUrl('page', 'Home', [], true, true);
+		$this->assertEquals('/index.php?page=Home', $url);
+	}
+
+	public function testParseUrlGetFormat()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_GET['page'] = 'Home';
+		$_GET['param1'] = 'value1';
+		$request->setUrlFormat(THttpRequestUrlFormat::Get);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals([], $result);
+	}
+
+	public function testParseUrlPathFormat()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/page,Home/param1,value1';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals(['page' => 'Home', 'param1' => 'value1'], $result);
+	}
+
+	public function testParseUrlHiddenPathFormat()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/page,Home/param1,value1';
+		$request->setUrlFormat(THttpRequestUrlFormat::HiddenPath);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals(['page' => 'Home', 'param1' => 'value1'], $result);
+	}
+
+	public function testParseUrlEmptyPathInfo()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals([], $result);
+	}
+
+	public function testParseUrlWithArrayParameter()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/items[],a/items[],b';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals(['items' => ['a', 'b']], $result);
+	}
+
+	public function testParseUrlWithCustomSeparator()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/page-Home/param1-value1';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->setUrlParamSeparator('-');
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals(['page' => 'Home', 'param1' => 'value1'], $result);
+	}
+
+	public function testParseUrlWithTrailingSlash()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/page,Home/';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals(['page' => 'Home'], $result);
+	}
+
+	public function testParseUrlWithOnlyKey()
+	{
+		$urlManager = new TUrlManager();
+		$urlManager->init(null);
+
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/page,Home/flag';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+
+		$result = $urlManager->parseUrl();
+		$this->assertEquals(['page' => 'Home', 'flag' => ''], $result);
+	}
+}

--- a/tests/unit/Web/TUrlMappingPatternTest.php
+++ b/tests/unit/Web/TUrlMappingPatternTest.php
@@ -1,0 +1,474 @@
+<?php
+
+use Prado\Web\THttpRequest;
+use Prado\Web\THttpRequestUrlFormat;
+use Prado\Web\TUrlManager;
+use Prado\Web\TUrlMappingPattern;
+use Prado\Web\TUrlMappingPatternSecureConnection;
+use Prado\TApplication;
+use Prado\Collections\TAttributeCollection;
+
+/**
+ * Test class for TUrlMappingPattern.
+ * 
+ * @coversDefaultClass Prado\Web\TUrlMappingPattern
+ */
+class TUrlMappingPatternTest extends PHPUnit\Framework\TestCase
+{
+	protected static $app = null;
+	private $urlManager;
+
+	protected function setUp(): void
+	{
+		$_SERVER['HTTP_HOST'] = 'localhost';
+		$_SERVER['SERVER_NAME'] = 'localhost';
+		$_SERVER['SERVER_PORT'] = '80';
+		$_SERVER['REQUEST_URI'] = '/index.php?page=Home';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['PHP_SELF'] = '/index.php';
+		$_SERVER['QUERY_STRING'] = 'page=Home';
+		$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+		$_SERVER['PATH_INFO'] = '';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		if (self::$app === null) {
+			self::$app = new TApplication(__DIR__ . '/app');
+		}
+		
+		$this->urlManager = new TUrlManager();
+		$this->urlManager->init(null);
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		$_GET = [];
+		$_POST = [];
+		$_SERVER['PATH_INFO'] = '';
+		$_SERVER['QUERY_STRING'] = '';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+	}
+
+	private function createRequest($pathInfo = '', $method = 'GET')
+	{
+		$_SERVER['PATH_INFO'] = $pathInfo;
+		$_SERVER['REQUEST_METHOD'] = $method;
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		return $request;
+	}
+
+	public function testConstructor()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertInstanceOf(TUrlMappingPattern::class, $pattern);
+		$this->assertSame($this->urlManager, $pattern->getManager());
+	}
+
+	public function testInitWithServiceParameter()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->init(null);
+		$this->assertFalse($pattern->getIsWildCardPattern());
+	}
+
+	public function testInitWithWildcardServiceParameter()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.*');
+		$pattern->setPattern('test');
+		$pattern->init(null);
+		$this->assertTrue($pattern->getIsWildCardPattern());
+	}
+
+	public function testInitThrowsException()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setPattern('test');
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$pattern->init(null);
+	}
+
+	public function testGetSetServiceParameter()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$this->assertEquals('Test.Page', $pattern->getServiceParameter());
+	}
+
+	public function testGetSetServiceID()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertEquals('page', $pattern->getServiceID());
+		$pattern->setServiceID('custom');
+		$this->assertEquals('custom', $pattern->getServiceID());
+	}
+
+	public function testGetSetPattern()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertEquals('', $pattern->getPattern());
+		$pattern->setPattern('test/{id}');
+		$this->assertEquals('test/{id}', $pattern->getPattern());
+	}
+
+	public function testGetSetParameters()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$params = $pattern->getParameters();
+		$this->assertInstanceOf(TAttributeCollection::class, $params);
+	}
+
+	public function testGetSetConstants()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$constants = $pattern->getConstants();
+		$this->assertInstanceOf(TAttributeCollection::class, $constants);
+	}
+
+	public function testGetSetRegularExpression()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertEquals('', $pattern->getRegularExpression());
+		$pattern->setRegularExpression('#^test/(?P<id>\d+)$#');
+		$this->assertEquals('#^test/(?P<id>\d+)$#', $pattern->getRegularExpression());
+	}
+
+	public function testGetSetCaseSensitive()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertTrue($pattern->getCaseSensitive());
+		$pattern->setCaseSensitive(false);
+		$this->assertFalse($pattern->getCaseSensitive());
+	}
+
+	public function testGetSetEnableCustomUrl()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertTrue($pattern->getEnableCustomUrl());
+		$pattern->setEnableCustomUrl(false);
+		$this->assertFalse($pattern->getEnableCustomUrl());
+	}
+
+	public function testGetSetUrlFormat()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertEquals(THttpRequestUrlFormat::Get, $pattern->getUrlFormat());
+		$pattern->setUrlFormat(THttpRequestUrlFormat::Path);
+		$this->assertEquals(THttpRequestUrlFormat::Path, $pattern->getUrlFormat());
+	}
+
+	public function testGetSetUrlParamSeparator()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertEquals('/', $pattern->getUrlParamSeparator());
+		$pattern->setUrlParamSeparator('-');
+		$this->assertEquals('-', $pattern->getUrlParamSeparator());
+	}
+
+	public function testSetUrlParamSeparatorInvalid()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		$pattern->setUrlParamSeparator('too-long');
+	}
+
+	public function testGetSetSecureConnection()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertEquals(TUrlMappingPatternSecureConnection::Automatic, $pattern->getSecureConnection());
+		$pattern->setSecureConnection(TUrlMappingPatternSecureConnection::Enable);
+		$this->assertEquals(TUrlMappingPatternSecureConnection::Enable, $pattern->getSecureConnection());
+	}
+
+	// ===== Verb Tests =====
+
+	public function testGetSetVerbsNull()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertNull($pattern->getVerbs());
+		$pattern->setVerbs(null);
+		$this->assertNull($pattern->getVerbs());
+	}
+
+	public function testGetSetVerbsEmptyString()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setVerbs('');
+		$this->assertNull($pattern->getVerbs());
+	}
+
+	public function testGetSetVerbsString()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setVerbs('GET, POST, PUT');
+		$this->assertEquals(['GET', 'POST', 'PUT'], $pattern->getVerbs());
+	}
+
+	public function testGetSetVerbsArray()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setVerbs(['GET', 'POST']);
+		$this->assertEquals(['GET', 'POST'], $pattern->getVerbs());
+	}
+
+	public function testGetSetVerbsWithNegationTilde()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setVerbs('~GET,POST');
+		$this->assertEquals(['~GET', 'POST'], $pattern->getVerbs());
+	}
+
+	public function testGetSetVerbsWithNegationExclamation()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setVerbs('!GET,POST');
+		$this->assertEquals(['!GET', 'POST'], $pattern->getVerbs());
+	}
+
+	public function testGetSetVerbsEmptyArray()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setVerbs([]);
+		$this->assertNull($pattern->getVerbs());
+	}
+
+	public function testGetIsWildCardPattern()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$this->assertFalse($pattern->getIsWildCardPattern());
+		$pattern->setServiceParameter('Test.*');
+		$pattern->setPattern('test');
+		$pattern->init(null);
+		$this->assertTrue($pattern->getIsWildCardPattern());
+	}
+
+	// ===== getPatternMatches tests - All Branches =====
+
+	public function testGetPatternMatchesVerbsNullAllowsAnyVerb()
+	{
+		// Branch: $verbs === null - skip verb check, path doesn't match
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(null);
+		
+		$request = $this->createRequest('/other');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesVerbNotInList()
+	{
+		// Branch: !in_array(requestVerb, verbs) - return []
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(['POST']);
+		
+		$request = $this->createRequest('/test', 'GET');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesVerbExcludedWithTilde()
+	{
+		// Branch: in_array('~verb', verbs) - return []
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(['~GET']);
+		
+		$request = $this->createRequest('/test', 'GET');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesVerbExcludedWithExclamation()
+	{
+		// Branch: in_array('!verb', verbs) - return []
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(['!GET']);
+		
+		$request = $this->createRequest('/test', 'GET');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesNoRegexNoMatch()
+	{
+		// Branch: no regexp, no pattern match
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test/{id}');
+		$pattern->getParameters()->add('id', '\d+');
+		
+		$request = $this->createRequest('/other/123');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesEmptyPathInfo()
+	{
+		// Branch: empty path info
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		
+		$request = $this->createRequest('');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesWildcardNoMatch()
+	{
+		// Branch: wildcard but no match for serviceID key
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.SubPage');
+		$pattern->setPattern('test/{*}');
+		$pattern->setServiceID('page');
+		$pattern->init(null);
+		
+		$request = $this->createRequest('/other/value');
+		$result = $pattern->getPatternMatches($request);
+		
+		// No match for serviceID, returns empty
+		$this->assertEquals([], $result);
+	}
+
+	public function testGetPatternMatchesUrlParamsWithUrlFormat()
+	{
+		// Branch: urlparams with Path format, separator = /
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setUrlFormat(THttpRequestUrlFormat::Path);
+		
+		$request = $this->createRequest('/test/foo/bar');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertArrayHasKey('foo', $result);
+		$this->assertEquals('bar', $result['foo']);
+	}
+
+	public function testGetPatternMatchesUrlParamsCustomSeparator()
+	{
+		// Branch: urlparams with custom separator
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setUrlFormat(THttpRequestUrlFormat::Path);
+		$pattern->setUrlParamSeparator('-');
+		
+		$request = $this->createRequest('/test/foo-bar');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertArrayHasKey('foo', $result);
+		$this->assertEquals('bar', $result['foo']);
+	}
+
+	public function testGetPatternMatchesConstantsWithNoPatternMatch()
+	{
+		// Branch: constants but no pattern match - constants not added
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->getConstants()->add('type', 'detailed');
+		
+		$request = $this->createRequest('/other');
+		$result = $pattern->getPatternMatches($request);
+		
+		$this->assertArrayNotHasKey('type', $result);
+	}
+
+	public function testGetPatternMatchesVerbInListAllowsMatch()
+	{
+		// Branch: verb in list, pattern matches
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(['GET']);
+		
+		$request = $this->createRequest('/test', 'GET');
+		$result = $pattern->getPatternMatches($request);
+		
+		// Result has 'page' key because of ServiceID default
+		$this->assertNotEquals([], $result);
+	}
+
+	// ===== supportCustomUrl tests =====
+
+	public function testSupportCustomUrlNoParams()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test/{id}');
+		$pattern->getParameters()->add('id', '\d+');
+		$pattern->setEnableCustomUrl(true);
+		
+		$this->assertFalse($pattern->supportCustomUrl([]));
+	}
+
+	public function testSupportCustomUrlWithParams()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test/{id}');
+		$pattern->getParameters()->add('id', '\d+');
+		$pattern->setEnableCustomUrl(true);
+		
+		$this->assertTrue($pattern->supportCustomUrl(['id' => '123']));
+	}
+
+	public function testSupportCustomUrlDisabled()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setEnableCustomUrl(false);
+		
+		$this->assertFalse($pattern->supportCustomUrl(['id' => '123']));
+	}
+
+	public function testSupportCustomUrlNoPattern()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setEnableCustomUrl(true);
+		
+		$this->assertFalse($pattern->supportCustomUrl([]));
+	}
+
+	public function testSupportCustomUrlWithConstantsMatch()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->getConstants()->add('type', 'detailed');
+		$pattern->setEnableCustomUrl(true);
+		
+		$this->assertTrue($pattern->supportCustomUrl(['type' => 'detailed']));
+	}
+
+	public function testSupportCustomUrlWithConstantsMismatch()
+	{
+		$pattern = new TUrlMappingPattern($this->urlManager);
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->getConstants()->add('type', 'detailed');
+		$pattern->setEnableCustomUrl(true);
+		
+		$this->assertFalse($pattern->supportCustomUrl(['type' => 'other']));
+	}
+}

--- a/tests/unit/Web/TUrlMappingTest.php
+++ b/tests/unit/Web/TUrlMappingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+use Prado\Web\THttpRequest;
+use Prado\Web\THttpRequestUrlFormat;
+use Prado\Web\TUrlMapping;
+use Prado\Web\TUrlMappingPattern;
+use Prado\Web\TUrlManager;
+use Prado\TApplication;
+use Prado\Xml\TXmlDocument;
+
+/**
+ * Test class for TUrlMapping.
+ */
+class TUrlMappingTest extends PHPUnit\Framework\TestCase
+{
+	protected static $app = null;
+
+	protected function setUp(): void
+	{
+		$_SERVER['HTTP_HOST'] = 'localhost';
+		$_SERVER['SERVER_NAME'] = 'localhost';
+		$_SERVER['SERVER_PORT'] = '80';
+		$_SERVER['REQUEST_URI'] = '/index.php?page=Home';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['PHP_SELF'] = '/index.php';
+		$_SERVER['QUERY_STRING'] = 'page=Home';
+		$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+		$_SERVER['PATH_INFO'] = '';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		if (self::$app === null) {
+			self::$app = new TApplication(__DIR__ . '/app');
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		$_GET = [];
+		$_POST = [];
+		$_SERVER['PATH_INFO'] = '';
+		$_SERVER['QUERY_STRING'] = '';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+	}
+
+	public function testParseUrlWithMatchingPattern()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ViewPost" pattern="post/{id}/" parameters.id="\d+"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/post/123/';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['id' => '123', 'page' => 'Posts.ViewPost'], $result);
+	}
+
+	public function testParseUrlNoMatchingPatternFallsBack()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ViewPost" pattern="post/{id}/" parameters.id="\d+"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/other/';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['other' => ''], $result);
+	}
+
+	public function testConstructUrlEnabled()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ViewPost" pattern="post/{id}/" parameters.id="\d+"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->setEnableCustomUrl(true);
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$url = $module->constructUrl('page', 'Posts.ViewPost', ['id' => '123'], true, true);
+		$this->assertEquals('/index.php/post/123/', $url);
+	}
+
+	public function testParseUrlVerbWithParameters()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ViewPost" pattern="post/{id}" parameters.id="\d+" verbs="GET,POST"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/post/123';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['id' => '123', 'page' => 'Posts.ViewPost'], $result);
+	}
+
+	public function testGetMatchingPattern()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ViewPost" pattern="post/{id}/" parameters.id="\d+"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/post/123/';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$module->parseUrl();
+		$matched = $module->getMatchingPattern();
+		$this->assertInstanceOf(TUrlMappingPattern::class, $matched);
+		$this->assertEquals('Posts.ViewPost', $matched->getServiceParameter());
+	}
+
+	public function testParseUrlWithMultipleVerbs()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ListPost" pattern="posts/" verbs="GET,POST"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/posts/';
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['page' => 'Posts.ListPost'], $result);
+	}
+
+	public function testParseUrlVerbNullAllowsAny()
+	{
+		$confstr = '<config><url ServiceParameter="Posts.ListPost" pattern="posts/"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/posts/';
+		$_SERVER['REQUEST_METHOD'] = 'DELETE';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['page' => 'Posts.ListPost'], $result);
+	}
+
+	public function testParseUrlWildcardPattern()
+	{
+		$confstr = '<config><url ServiceParameter="adminpages.*" pattern="admin/{*}"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/admin/users/';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['page' => 'adminpages.users'], $result);
+	}
+
+	public function testParseUrlWithConstants()
+	{
+		$confstr = '<config><url ServiceParameter="MyPage" pattern="/mypage/" ServiceID="page" constants.type="detailed"/></config>';
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString($confstr);
+		
+		$module = new TUrlMapping();
+		$module->init($config);
+		
+		$request = new THttpRequest();
+		$_SERVER['PATH_INFO'] = '/mypage/';
+		$request->setUrlFormat(THttpRequestUrlFormat::Path);
+		$request->init(null);
+		
+		$result = $module->parseUrl();
+		$this->assertEquals(['page' => 'MyPage', 'type' => 'detailed'], $result);
+	}
+
+	public function testSetVerbsWithString()
+	{
+		$pattern = new TUrlMappingPattern(new TUrlManager());
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs('GET, POST');
+		$this->assertEquals(['GET', 'POST'], $pattern->getVerbs());
+	}
+
+	public function testSetVerbsWithArray()
+	{
+		$pattern = new TUrlMappingPattern(new TUrlManager());
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(['GET', 'POST', 'PUT']);
+		$this->assertEquals(['GET', 'POST', 'PUT'], $pattern->getVerbs());
+	}
+
+	public function testSetVerbsWithNull()
+	{
+		$pattern = new TUrlMappingPattern(new TUrlManager());
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs(null);
+		$this->assertNull($pattern->getVerbs());
+	}
+
+	public function testSetVerbsWithEmptyString()
+	{
+		$pattern = new TUrlMappingPattern(new TUrlManager());
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs('');
+		$this->assertNull($pattern->getVerbs());
+	}
+	
+	public function testSetVerbsWithTildaNegation()
+	{
+		$pattern = new TUrlMappingPattern(new TUrlManager());
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs('~GET,POST');
+		$this->assertEquals(['~GET', 'POST'], $pattern->getVerbs());
+	}
+	
+	public function testSetVerbsWithBangNegation()
+	{
+		$pattern = new TUrlMappingPattern(new TUrlManager());
+		$pattern->setServiceParameter('Test.Page');
+		$pattern->setPattern('test');
+		$pattern->setVerbs('!GET,POST');
+		$this->assertEquals(['!GET', 'POST'], $pattern->getVerbs());
+	}
+}


### PR DESCRIPTION
This is more for fine grain control over REST, SOAP, JSON, or urls for other services.  Specifically in denying patterns to request types, or setting up different parameters of the same pattern based on request type.
unit tests for TUrlManager, TUrlMapping, and TUrlMappingPattern.

URL mapping based on verb may be uncommon, but it should be an option.