### PR TITLE
ActiveControl/TClientScriptManager update

### DIFF
--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -415,7 +415,11 @@ Prado.Element =
 	{
 		var el = jQuery("#" + element);
 		if(!el) return;
-		if((attribute == "disabled" || attribute == "multiple" || attribute == "readonly" || attribute == "href") && value==false)
+		// "disabled" is for <button>, <fieldset>, <input>, <optgroup>, <option>, <select>, <textarea>
+		// "readonly is for <input>, <textarea>
+		// global presence attributes: hidden, inert, popover
+		// removed 'href' and 'multiple' was a hack - they use removeAttribute now
+		if((attribute == "disabled" || attribute == "readonly" || attribute == "hidden" || attribute == "inert" || attribute == "popover") && value==false)
 			el.removeAttr(attribute);
 		else if(attribute.match(/^on/i)) //event methods
 		{
@@ -432,6 +436,20 @@ Prado.Element =
 		}
 		else
 			el.attr(attribute, value);
+	},
+	
+	/**
+	 * Removes an attribute of a DOM element.
+	 * @function ?
+	 * @param {string} element - Element id
+	 * @param {string} attribute - Name of attribute
+	 * @since 4.3.3
+	 */
+	removeAttribute : function(element, attribute)
+	{
+		var el = jQuery("#" + element);
+		if(!el) return;
+		el.removeAttr(attribute);
 	},
 
 	scrollTo : function(element, options)

--- a/framework/Web/UI/ActiveControls/TActiveLinkButton.php
+++ b/framework/Web/UI/ActiveControls/TActiveLinkButton.php
@@ -156,7 +156,7 @@ class TActiveLinkButton extends TLinkButton implements IActiveControl, ICallback
 					$this->getPostBackOptions()
 				);
 			} else {
-				$this->getPage()->getCallbackClient()->setAttribute($this, 'href', false);
+				$this->getPage()->getCallbackClient()->removeAttribute($this, 'href');
 			}
 		}
 	}

--- a/framework/Web/UI/ActiveControls/TActiveListBox.php
+++ b/framework/Web/UI/ActiveControls/TActiveListBox.php
@@ -98,7 +98,11 @@ class TActiveListBox extends TListBox implements IActiveControl, ICallbackEventH
 		$multi_id = $id . '[]';
 		if ($this->getActiveControl()->canUpdateClientSide()) {
 			$client = $this->getPage()->getCallbackClient();
-			$client->setAttribute($this, 'multiple', $multiple ? 'multiple' : false);
+			if ($multiple) {
+				$client->setAttribute($this, 'multiple', 'multiple');
+			} else {
+				$client->removeAttribute($this, 'multiple');
+			}
 			$client->setAttribute($this, 'name', $multiple ? $multi_id : $id);
 		}
 	}

--- a/framework/Web/UI/ActiveControls/TCallbackClientScript.php
+++ b/framework/Web/UI/ActiveControls/TCallbackClientScript.php
@@ -249,6 +249,21 @@ class TCallbackClientScript extends \Prado\TApplicationComponent
 	}
 
 	/**
+	 * Removes the attribute of a particular control.
+	 * @param \Prado\Web\UI\TControl $control control element or element id
+	 * @param string $name attribute name
+	 * @since 4.3.3
+	 */
+	public function removeAttribute($control, $name)
+	{
+		// Attributes should be applied on Surrounding tag, except for 'disabled' attribute
+		if ($control instanceof ISurroundable && strtolower($name) !== 'disabled') {
+			$control = $control->getSurroundingTagID();
+		}
+		$this->callClientFunction('Prado.Element.removeAttribute', [$control, $name]);
+	}
+
+	/**
 	 * Sets the options of a select input element.
 	 * @param \Prado\Web\UI\TControl $control control element or element id
 	 * @param array|TListControl $items a list of new options

--- a/framework/Web/UI/TClientScriptManager.php
+++ b/framework/Web/UI/TClientScriptManager.php
@@ -13,6 +13,7 @@ namespace Prado\Web\UI;
 
 use Prado\Prado;
 use Prado\TApplicationMode;
+use Prado\TEventResults;
 use Prado\Exceptions\TInvalidOperationException;
 use Prado\Web\Javascripts\TJavaScript;
 use Prado\Web\Javascripts\TJavaScriptAsset;
@@ -23,6 +24,75 @@ use Prado\Web\THttpUtility;
  * TClientScriptManager class.
  *
  * TClientScriptManager manages javascript and CSS stylesheets for a page.
+ *
+ * This class provides functionality for registering and rendering JavaScript files
+ * and blocks, CSS stylesheets and blocks, hidden fields, and callback/postback
+ * scripts. It integrates with the PRADO framework's asset management system
+ * to publish and manage JavaScript libraries.
+ *
+ * ## JavaScript Package System
+ *
+ * PRADO uses a package-based JavaScript loading system defined in
+ * {@see PACKAGES_FILE} (Web/Javascripts/packages.php). Each package consists of:
+ * - **Folders**: Base folders for JavaScript libraries in PRADO namespace notation
+ * - **Packages**: Named collections of JavaScript files
+ * - **Dependencies**: Package dependency mappings determining load order
+ *
+ * Available default packages include: 'prado', 'jquery', 'ajax', 'validator',
+ * 'datepicker', 'tabpanel', 'accordion', 'slider', 'keyboard', 'htmlarea',
+ * 'htmlarea5', 'colorpicker', 'ratings', 'inlineeditor', 'activefileupload',
+ * 'activedatepicker', 'logger', 'tinymce', 'highlightjs', 'clipboard', etc.
+ *
+ * ## Global Event fxLoadPradoJavascript
+ *
+ * When {@see ensurePradoJavascript} is called, it raises the global event
+ * `fxLoadPradoJavascript` to allow plugins to extend the JavaScript package
+ * system. This event uses the feed-forward pattern via
+ * {@see \Prado\TEventResults::EVENT_RESULT_FEED_FORWARD}, allowing event
+ * handlers to modify the folders, packages, and dependencies arrays.
+ *
+ * The event signature is:
+ * ```php
+ * function fxLoadPradoJavascript($sender, $foldersPackagesDependencies)
+ * ```
+ *
+ * - `string $sender` The class name raising the event ('TClientScriptManager')
+ * - `array $foldersPackagesDependencies` Array containing:
+ *   - `[0] => array $folders` Map of package base folder keys to PRADO namespace paths
+ *   - `[1] => array $packages` Map of package names to arrays of script file paths
+ *   - `[2] => array $dependencies` Map of package names to arrays of dependency package names
+ *
+ * Handlers should return the modified `$foldersPackagesDependencies` array
+ * to feed forward the updated data. Multiple handlers can progressively modify
+ * the data. Returning null is no results, and is skipped in the feed forward.
+ *
+ * Example plugin implementation:
+ * ```php
+ * class TMyPlugin extends \Prado\Util\TBehavior
+ * {
+ *     public function fxLoadPradoJavascript($sender, $foldersPackagesDependencies)
+ *     {
+ *         [$folders, $packages, $dependencies] = $foldersPackagesDependencies;
+ *
+ *         // Add new JavaScript folder
+ *         $folders['myplugin'] = 'MyPlugin\\Javascript';
+ *
+ *         // Add new package
+ *         $packages['myplugin'] = ['myplugin/myplugin.js'];
+ *
+ *         // Add dependencies
+ *         $dependencies['myplugin'] = ['jquery', 'prado'];
+ *
+ *         return [$folders, $packages, $dependencies];
+ *     }
+ * }
+ * ```
+ *
+ * ## CSS Package System
+ *
+ * CSS stylesheets use a similar package system defined in
+ * {@see CSS_PACKAGES_FILE} (Web/Javascripts/css-packages.php) with the same
+ * folder, package, and dependency structure.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Gabor Berczi <gabor.berczi@devworx.hu> (lazyload additions & progressive rendering)
@@ -94,30 +164,45 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	 */
 	private static $_scriptsFolders;
 	/**
-	 * @var array registered PRADO style libraries
+	 * @var array registered PRADO style libraries, keyed by style name.
 	 */
 	private $_registeredStyles = [];
 	/**
-	 * Client-side style library dependencies, loads from CSS_PACKAGES_FILE;
+	 * Client-side style library dependencies, keyed by package name.
+	 * Loaded from CSS_PACKAGES_FILE and fxLoadPradoJavascript.
 	 * @var array
 	 */
 	private static $_styles;
 	/**
-	 * Client-side style library packages, loads from CSS_PACKAGES_FILE;
+	 * Client-side style library packages, keyed by package name.
+	 * Loaded from CSS_PACKAGES_FILE and fxLoadPradoJavascript.
 	 * @var array
 	 */
 	private static $_stylesPackages;
 	/**
-	 * Client-side style library folders, loads from CSS_PACKAGES_FILE;
+	 * Client-side style library folders, keyed by base folder key.
+	 * Loaded from CSS_PACKAGES_FILE and fxLoadPradoJavascript.
 	 * @var array
 	 */
 	private static $_stylesFolders;
 
+	/**
+	 * @var array Tracks which hidden fields have been rendered to prevent duplicate rendering.
+	 */
 	private $_renderedHiddenFields;
 
+	/**
+	 * @var array Map of script URLs that have been rendered.
+	 */
 	private $_renderedScriptFiles = [];
 
+	/**
+	 * @var array Map of expanded JavaScript scripts to prevent duplicate expansion.
+	 */
 	private $_expandedScripts;
+	/**
+	 * @var array Map of expanded CSS styles to prevent duplicate expansion.
+	 */
 	private $_expandedStyles;
 
 	/**
@@ -140,14 +225,97 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 			|| count($this->_headScriptFiles) || count($this->_headScripts);
 	}
 
+	/**
+	 * Returns the PRADO JavaScript packages definitions.
+	 *
+	 * Packages define named collections of JavaScript files and their dependencies.
+	 * Ensures JavaScript packages are loaded via {@see ensurePradoJavascript}.
+	 *
+	 * @return array Map of package names to arrays of script file paths relative to their package folder.
+	 */
 	public static function getPradoPackages()
 	{
+		static::ensurePradoJavascript();
 		return self::$_scriptsPackages;
 	}
 
+	/**
+	 * Returns the PRADO JavaScript package dependencies.
+	 *
+	 * Dependencies map each package name to an array of its dependency package names.
+	 * The dependencies determine the load order when registering scripts.
+	 * Ensures JavaScript packages are loaded via {@see ensurePradoJavascript}.
+	 *
+	 * @return array Map of package names to arrays of dependency package names.
+	 */
 	public static function getPradoScripts()
 	{
+		static::ensurePradoJavascript();
 		return self::$_scripts;
+	}
+
+	/**
+	 * Returns the PRADO JavaScript source folder mappings.
+	 *
+	 * Folders map package base keys (e.g., 'prado', 'jquery') to PRADO namespace
+	 * paths where the JavaScript files are located.
+	 * Ensures JavaScript packages are loaded via {@see ensurePradoJavascript}.
+	 *
+	 * @return array Map of package base keys to PRADO namespace paths.
+	 * @since 4.3.3
+	 */
+	public static function getPradoScriptsFolders()
+	{
+		static::ensurePradoJavascript();
+		return self::$_scriptsFolders;
+	}
+
+	/**
+	 * Ensures the PRADO JavaScript packages are loaded.
+	 *
+	 * This method loads the JavaScript package definitions from {@see PACKAGES_FILE}
+	 * and raises the global event `fxLoadPradoJavascript` to allow plugins to extend
+	 * the package system with custom JavaScript libraries.
+	 *
+	 * The event uses {@see \Prado\TEventResults::EVENT_RESULT_FEED_FORWARD}, meaning
+	 * handlers can modify and return the folders/packages/dependencies array to
+	 * feed forward their changes. See the class docblock for the full event signature
+	 * and example implementation.
+	 *
+	 * {@see TPage::getClientScript()} calls {@see TPageService::getClientScriptManagerClass()}
+	 * to instantiate its own client script manager.
+	 *
+	 * @since 4.3.3
+	 * @see loadPradoJavascript
+	 */
+	public static function ensurePradoJavascript()
+	{
+		if (self::$_scripts === null) {
+			$foldersPackagesDependencies = static::loadPradoJavascript();
+
+			// Connect Plugins
+			$results = Prado::getApplication()->raiseEvent('fxLoadPradoJavascript', static::class, $foldersPackagesDependencies, TEventResults::EVENT_RESULT_FEED_FORWARD);
+			if (!empty($results)) {
+				$foldersPackagesDependencies = array_pop($results);
+			}
+
+			[$folders, $packages, $deps] = $foldersPackagesDependencies;
+
+			self::$_scriptsFolders = $folders;
+			self::$_scriptsPackages = $packages;
+			self::$_scripts = $deps;
+		}
+	}
+
+	/**
+	 * This loads the Prado Javascript Folders, Packages, and Dependencies.
+	 * @return array[3] Script Folders, Scripts, and Script Packages.
+	 * @since 4.3.3
+	 */
+	public static function loadPradoJavascript()
+	{
+		$packageFile = Prado::getFrameworkPath() . DIRECTORY_SEPARATOR . self::PACKAGES_FILE;
+		return include($packageFile);
 	}
 
 	/**
@@ -170,13 +338,7 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	{
 		// $this->checkIfNotInRender();
 		if (!isset($this->_registeredScripts[$name])) {
-			if (self::$_scripts === null) {
-				$packageFile = Prado::getFrameworkPath() . DIRECTORY_SEPARATOR . self::PACKAGES_FILE;
-				[$folders, $packages, $deps] = include($packageFile);
-				self::$_scriptsFolders = $folders;
-				self::$_scripts = $deps;
-				self::$_scriptsPackages = $packages;
-			}
+			static::ensurePradoJavascript();
 
 			if (isset(self::$_scripts[$name])) {
 				$this->_registeredScripts[$name] = true;
@@ -221,41 +383,66 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * @param mixed $script
-	 * @return string Prado javascript library base asset url.
+	 * Returns the published asset URL for a PRADO JavaScript library.
+	 *
+	 * This method ensures the JavaScript packages are loaded, registers the script
+	 * if not already registered, and returns the published asset URL through the
+	 * application's asset manager.
+	 *
+	 * @param string $script The script package key (e.g., 'prado', 'jquery', 'ajax').
+	 *                       Defaults to 'prado'.
+	 * @return string The published asset URL for the script library.
 	 */
 	public function getPradoScriptAssetUrl($script = 'prado')
 	{
+		static::ensurePradoJavascript();
+
 		if (!isset(self::$_scriptsFolders[$script])) {
 			$this->registerPradoScriptInternal($script);
 		}
 
 		$base = Prado::getPathOfNameSpace(self::$_scriptsFolders[$script]);
-		$assets = Prado::getApplication()->getAssetManager();
+		$assets = $this->getApplication()->getAssetManager();
 		return $assets->getPublishedUrl($base);
 	}
 
 	/**
-	 * @param mixed $script
-	 * @return string Prado javascript library base asset path in local filesystem.
+	 * Returns the local filesystem path for a PRADO JavaScript library asset.
+	 *
+	 * This method ensures the JavaScript packages are loaded, registers the script
+	 * if not already registered, and returns the published filesystem path through
+	 * the application's asset manager.
+	 *
+	 * @param string $script The script package key (e.g., 'prado', 'jquery', 'ajax').
+	 *                       Defaults to 'prado'.
+	 * @return string The published filesystem path for the script library.
 	 */
 	public function getPradoScriptAssetPath($script = 'prado')
 	{
+		static::ensurePradoJavascript();
+
 		if (!isset(self::$_scriptsFolders[$script])) {
 			$this->registerPradoScriptInternal($script);
 		}
 
 		$base = Prado::getPathOfNameSpace(self::$_scriptsFolders[$script]);
-		$assets = Prado::getApplication()->getAssetManager();
+		$assets = $this->getApplication()->getAssetManager();
 		return $assets->getPublishedPath($base);
 	}
 
 	/**
-	 * Returns the URLs of all script files referenced on the page
-	 * @return array Combined list of all script urls used in the page
+	 * Returns all registered JavaScript file URLs.
+	 *
+	 * This includes both head section scripts (registered via {@see registerHeadScriptFile})
+	 * and form-body scripts (registered via {@see registerScriptFile}). URLs are returned
+	 * in registration order with duplicates removed.
+	 *
+	 * @return array Combined list of all unique script URLs used in the page.
 	 */
 	public function getScriptUrls()
 	{
+		static::ensurePradoJavascript();
+
 		$scripts = array_values(array_map(function ($v) {
 			return $v->getUrl();
 		}, $this->_headScriptFiles));
@@ -266,12 +453,20 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * @param string $base javascript or css package path.
-	 * @return array tuple($path,$url).
+	 * Resolves the filesystem path and URL for a package base folder.
+	 *
+	 * If the base path is not already published via the asset manager,
+	 * it will be published. Returns both the local filesystem path and
+	 * the corresponding URL for the published asset.
+	 *
+	 * @param string $base The base folder path (javascript or css package path).
+	 * @return array Tuple containing `[$path, $url]` where:
+	 *   - `string $path` Local filesystem path to the published asset
+	 *   - `string $url` URL to access the published asset
 	 */
 	protected function getPackagePathUrl($base)
 	{
-		$assets = Prado::getApplication()->getAssetManager();
+		$assets = $this->getApplication()->getAssetManager();
 		if (strpos($base, $assets->getBaseUrl()) === false) {
 			return [$assets->getPublishedPath($base), $assets->publishFilePath($base)];
 		} else {
@@ -280,11 +475,22 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * @param string $script javascript package source folder path.
-	 * @return array tuple($basepath,$subpath).
+	 * Resolves the base folder and relative path for a JavaScript package script.
+	 *
+	 * Given a script path like 'prado/prado.js', this splits it into the package
+	 * base folder (e.g., 'prado') and the relative script path (e.g., 'prado.js').
+	 * The base folder is resolved from the namespace to a filesystem directory.
+	 *
+	 * @param string $script JavaScript package source path (e.g., 'prado/prado.js').
+	 * @throws TInvalidOperationException if the package base folder is not registered
+	 * @return array Tuple containing `[$basepath, $subpath]` where:
+	 *   - `string $basepath` Resolved filesystem path to the package base folder
+	 *   - `string $subpath` Relative path to the script within the package
 	 */
 	protected function getScriptPackageFolder($script)
 	{
+		static::ensurePradoJavascript();
+
 		[$base, $subPath] = explode("/", $script, 2);
 
 		if (!array_key_exists($base, self::$_scriptsFolders)) {
@@ -300,8 +506,17 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * @param string $script css package source folder path.
-	 * @return array tuple($basepath,$subpath).
+	 * Resolves the base folder and relative path for a CSS package stylesheet.
+	 *
+	 * Given a style path like 'jquery-ui/jquery-ui.css', this splits it into the package
+	 * base folder (e.g., 'jquery-ui') and the relative stylesheet path (e.g., 'jquery-ui.css').
+	 * The base folder is resolved from the namespace to a filesystem directory.
+	 *
+	 * @param string $script CSS package source path (e.g., 'jquery-ui/jquery-ui.css').
+	 * @throws TInvalidOperationException if the package base folder is not registered
+	 * @return array Tuple containing `[$basepath, $subpath]` where:
+	 *   - `string $basepath` Resolved filesystem path to the package base folder
+	 *   - `string $subpath` Relative path to the stylesheet within the package
 	 */
 	protected function getStylePackageFolder($script)
 	{
@@ -328,7 +543,6 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	public function getCallbackReference(ICallbackEventHandler $callbackHandler, $options = null)
 	{
 		$options = !is_array($options) ? [] : $options;
-		$class = new \ReflectionClass($callbackHandler);
 		$clientSide = $callbackHandler->getActiveControl()->getClientSide();
 		$options = array_merge($options, $clientSide->getOptions()->toArray());
 		$optionString = TJavaScript::encode($options);
@@ -338,9 +552,16 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * Registers callback javascript for a control.
-	 * @param string $class javascript class responsible for the control being registered for callback
-	 * @param array $options callback options
+	 * Registers a JavaScript callback control.
+	 *
+	 * This registers a JavaScript class that handles callback requests from a control.
+	 * The callback script will be rendered at the end of the form. This method also
+	 * automatically registers the 'ajax' Prado script package which is required
+	 * for callback functionality.
+	 *
+	 * @param string $class JavaScript class name responsible for handling the callback
+	 *                      (e.g., 'Prado.WebUI.CallbackControl').
+	 * @param array $options Callback options that will be passed to the JavaScript class constructor.
 	 */
 	public function registerCallbackControl($class, $options)
 	{
@@ -354,10 +575,19 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * Registers postback javascript for a control. A null class parameter will prevent
-	 * the javascript code registration.
-	 * @param string $class javascript class responsible for the control being registered for postback
-	 * @param array $options postback options
+	 * Registers a JavaScript postback control.
+	 *
+	 * This registers a JavaScript class that handles postback requests from a control.
+	 * The postback script will be rendered at the end of the form. This method also
+	 * automatically registers the 'prado' Prado script package which is required
+	 * for postback functionality.
+	 *
+	 * If $class is null, no JavaScript code will be registered.
+	 *
+	 * @param null|string $class JavaScript class name responsible for handling the postback
+	 *                           (e.g., 'Prado.WebUI.PostBackControl'), or null to skip registration.
+	 * @param array $options Postback options that will be passed to the JavaScript class constructor.
+	 *                       If 'FormID' is not provided, it will be auto-detected from the page form.
 	 */
 	public function registerPostBackControl($class, $options)
 	{
@@ -406,9 +636,20 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * @param string $panelID the unique ID of the container control
-	 * @param string $buttonID the unique ID of the button control
-	 * @return array default button options.
+	 * Builds the JavaScript options for a default button registration.
+	 *
+	 * These options are used by the Prado.WebUI.DefaultButton JavaScript class
+	 * to handle the default button behavior (pressing Enter in a panel triggers
+	 * the button click).
+	 *
+	 * @param string $panelID The unique ID of the container panel control.
+	 * @param string $buttonID The unique ID of the button control to trigger.
+	 * @return array Default button options containing:
+	 *   - `ID`: Client-side ID of the panel
+	 *   - `Panel`: Client-side ID of the panel (same as ID)
+	 *   - `Target`: Client-side ID of the button
+	 *   - `EventTarget`: Server-side unique ID of the button
+	 *   - `Event`: Event name ('click')
 	 */
 	protected function getDefaultButtonOptions($panelID, $buttonID)
 	{
@@ -437,9 +678,14 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * Registers Prado style by library name. See "Web/Javascripts/packages.php"
-	 * for library names.
-	 * @param string $name style library name.
+	 * Registers a PRADO CSS style library to be loaded.
+	 *
+	 * Style libraries are defined in {@see CSS_PACKAGES_FILE} and include
+	 * packages like 'jquery-ui', etc. The registered styles will be
+	 * automatically expanded to include their dependencies.
+	 *
+	 * @param string $name The CSS library name (e.g., 'jquery-ui').
+	 * @throws TInvalidOperationException if the style name is not a valid registered package.
 	 */
 	public function registerPradoStyle($name)
 	{
@@ -449,8 +695,15 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 	}
 
 	/**
-	 * Registers a Prado style library to be loaded.
-	 * @param mixed $name
+	 * Internal method to register a Prado CSS style library.
+	 *
+	 * This method handles the actual registration logic including loading the CSS
+	 * package definitions, validating the style name, expanding dependencies,
+	 * and registering the stylesheet files. Style registrations are cached.
+	 *
+	 * @param string $name The CSS library name (e.g., 'jquery-ui').
+	 * @throws TInvalidOperationException if the style name is not a valid registered package.
+	 * @see CSS_PACKAGES_FILE
 	 */
 	protected function registerPradoStyleInternal($name)
 	{
@@ -556,7 +809,7 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 			}, $this->_styleSheetFiles)
 		);
 
-		foreach (Prado::getApplication()->getAssetManager()->getPublished() as $path => $url) {
+		foreach ($this->getApplication()->getAssetManager()->getPublished() as $path => $url) {
 			if (substr($url, strlen($url) - 4) == '.css') {
 				$stylesheets[] = $url;
 			}
@@ -789,16 +1042,41 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 		$writer->write(TJavaScript::renderScriptBlocks($this->_headScripts));
 	}
 
+	/**
+	 * Renders pending script files at the beginning of the form.
+	 *
+	 * This is typically called during form rendering to output script file tags.
+	 * Scripts marked as already rendered will be skipped.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
+	 */
 	public function renderScriptFilesBegin($writer)
 	{
 		$this->renderAllPendingScriptFiles($writer);
 	}
 
+	/**
+	 * Renders pending script files at the end of the form.
+	 *
+	 * This is typically called during form rendering to output script file tags.
+	 * Scripts marked as already rendered will be skipped.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
+	 */
 	public function renderScriptFilesEnd($writer)
 	{
 		$this->renderAllPendingScriptFiles($writer);
 	}
 
+	/**
+	 * Marks a script file as rendered to prevent duplicate rendering.
+	 *
+	 * Call this method to indicate that a script file has already been output
+	 * and should not be rendered again by subsequent render calls.
+	 *
+	 * @param string|TJavaScriptAsset $url The URL of the script file to mark as rendered,
+	 *                                      or a TJavaScriptAsset object.
+	 */
 	public function markScriptFileAsRendered($url)
 	{
 		$url = (is_object($url) && ($url instanceof TJavaScriptAsset)) ? $url->getUrl() : $url;
@@ -807,6 +1085,15 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 		$this->_page->registerCachingAction('Page.ClientScript', 'markScriptFileAsRendered', $params);
 	}
 
+	/**
+	 * Renders a collection of script files to the writer.
+	 *
+	 * Each script is output using {@see TJavaScript::renderScriptFile} and
+	 * marked as rendered.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
+	 * @param array $scripts Array of script file URLs or TJavaScriptAsset objects.
+	 */
 	protected function renderScriptFiles($writer, array $scripts)
 	{
 		foreach ($scripts as $script) {
@@ -815,13 +1102,23 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 		}
 	}
 
+	/**
+	 * Returns the list of script files that have been marked as rendered.
+	 *
+	 * @return array Map of rendered script URLs to themselves.
+	 */
 	protected function getRenderedScriptFiles()
 	{
 		return $this->_renderedScriptFiles;
 	}
 
 	/**
-	 * @param \Prado\Web\UI\THtmlWriter $writer writer for the rendering purpose
+	 * Renders all pending (not yet rendered) script files.
+	 *
+	 * Only scripts that have not been marked as rendered will be output.
+	 * After rendering, scripts are marked as rendered to prevent duplicates.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
 	 */
 	public function renderAllPendingScriptFiles($writer)
 	{
@@ -863,20 +1160,42 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 		$writer->write(TJavaScript::renderScriptBlocksCallback($this->_endScripts));
 	}
 
+	/**
+	 * Renders hidden fields at the beginning of the form.
+	 *
+	 * Hidden fields are rendered as text input elements with autocomplete="off"
+	 * to prevent browser restoration of values on page reload.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
+	 */
 	public function renderHiddenFieldsBegin($writer)
 	{
 		$this->renderHiddenFieldsInt($writer, true);
 	}
 
+	/**
+	 * Renders hidden fields at the end of the form.
+	 *
+	 * Hidden fields that were already rendered in begin will be skipped.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
+	 */
 	public function renderHiddenFieldsEnd($writer)
 	{
 		$this->renderHiddenFieldsInt($writer, false);
 	}
 
 	/**
-	 * Flushes all pending script registrations
-	 * @param \Prado\Web\UI\THtmlWriter $writer writer for the rendering purpose
-	 * @param null|TControl $control the control forcing the flush (used only in error messages)
+	 * Flushes all pending script file registrations.
+	 *
+	 * This forces any pending script files to be rendered immediately.
+	 * This is useful when a control needs to ensure its scripts are included
+	 * before rendering completes. On callback requests, this does nothing
+	 * as scripts are handled differently for callbacks.
+	 *
+	 * @param \Prado\Web\UI\THtmlWriter $writer The HTML writer for output.
+	 * @param null|TControl $control The control forcing the flush (used only in error messages).
+	 * @see renderAllPendingScriptFiles
 	 */
 	public function flushScriptFiles($writer, $control = null)
 	{
@@ -919,6 +1238,12 @@ class TClientScriptManager extends \Prado\TApplicationComponent
 		}
 	}
 
+	/**
+	 * Returns all registered hidden fields.
+	 *
+	 * @return array Map of hidden field names to their values.
+	 *                If a value is an array, multiple hidden fields will be rendered.
+	 */
 	public function getHiddenFields()
 	{
 		return $this->_hiddenFields;

--- a/tests/unit/Web/UI/TClientScriptManagerTest.php
+++ b/tests/unit/Web/UI/TClientScriptManagerTest.php
@@ -1,176 +1,1382 @@
 <?php
 
+use Prado\Collections\TMap;
+use Prado\IO\TTextWriter;
+use Prado\Prado;
+use Prado\TApplication;
+use Prado\TApplicationMode;
+use Prado\Web\Javascripts\TJavaScript;
+use Prado\Web\Javascripts\TJavaScriptAsset;
+use Prado\Web\UI\THtmlWriter;
+use Prado\Web\UI\TPage;
+use Prado\Web\UI\TClientScriptManager;
+use Prado\Web\UI\ActiveControls\IActiveControl;
+use Prado\Web\UI\ActiveControls\ICallbackEventHandler;
+use Prado\Web\UI\ActiveControls\TBaseActiveControl;
+use Prado\Web\UI\ActiveControls\TBaseActiveCallbackControl;
+use Prado\Web\UI\ActiveControls\TCallbackClientSide;
+use Prado\Web\UI\TControl;
+use Prado\Web\UI\WebControls\TButton;
 
+class TClientScriptManagerTestable extends TClientScriptManager
+{
+	public static function resetJavascriptCache()
+	{
+		$reflection = new ReflectionClass(TClientScriptManager::class);
+		$prop = $reflection->getProperty('_scripts');
+		$prop->setAccessible(true);
+		$prop->setValue(null, null);
+
+		$prop = $reflection->getProperty('_scriptsPackages');
+		$prop->setAccessible(true);
+		$prop->setValue(null, null);
+
+		$prop = $reflection->getProperty('_scriptsFolders');
+		$prop->setAccessible(true);
+		$prop->setValue(null, null);
+	}
+}
+
+class MockFxLoadPradoJavascriptBehavior extends \Prado\Util\TBehavior
+{
+	public static array $callCount = [];
+	public static array $receivedData = [];
+	public ?array $feedForwardData = null;
+
+	public function fxLoadPradoJavascript($sender, $foldersPackagesDependencies): array
+	{
+		self::$callCount[$sender] = (self::$callCount[$sender] ?? 0) + 1;
+		self::$receivedData[$sender] = $foldersPackagesDependencies;
+
+		if ($this->feedForwardData !== null) {
+			return $this->feedForwardData;
+		}
+
+		[$folders, $packages, $dependencies] = $foldersPackagesDependencies;
+
+		$folders['testplugin'] = 'Test\\Javascript';
+		$packages['testplugin'] = ['testplugin/test.js'];
+		$dependencies['testplugin'] = ['jquery', 'prado'];
+
+		return [$folders, $packages, $dependencies];
+	}
+}
+
+class MockCallbackControl extends TControl implements IActiveControl, ICallbackEventHandler
+{
+	private $_activeControl;
+
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function getActiveControl()
+	{
+		if ($this->_activeControl === null) {
+			$this->_activeControl = new MockBaseActiveCallbackControl($this);
+		}
+		return $this->_activeControl;
+	}
+
+	public function raiseCallbackEvent($eventArgument)
+	{
+	}
+}
+
+class MockBaseActiveCallbackControl extends TBaseActiveControl
+{
+	private $_clientSide;
+
+	public function __construct(TControl $control)
+	{
+		parent::__construct($control);
+	}
+
+	public function getClientSide(): TCallbackClientSide
+	{
+		if ($this->_clientSide === null) {
+			$this->_clientSide = new TCallbackClientSide();
+		}
+		return $this->_clientSide;
+	}
+
+	public function getClientSideOptions(): array
+	{
+		return $this->getClientSide()->getOptions()->toArray();
+	}
+}
+
+class MockButtonControl extends TControl implements \Prado\Web\UI\IButtonControl
+{
+	private $_text = '';
+	private $_causesValidation = true;
+	private $_commandName = '';
+	private $_commandParameter = '';
+	private $_validationGroup = '';
+	private $_isDefaultButton = false;
+
+	public function getText(): string
+	{
+		return $this->_text;
+	}
+
+	public function setText($value): void
+	{
+		$this->_text = $value;
+	}
+
+	public function getCausesValidation(): bool
+	{
+		return $this->_causesValidation;
+	}
+
+	public function setCausesValidation($value): void
+	{
+		$this->_causesValidation = $value;
+	}
+
+	public function getCommandName(): string
+	{
+		return $this->_commandName;
+	}
+
+	public function setCommandName($value): void
+	{
+		$this->_commandName = $value;
+	}
+
+	public function getCommandParameter(): string
+	{
+		return $this->_commandParameter;
+	}
+
+	public function setCommandParameter($value): void
+	{
+		$this->_commandParameter = $value;
+	}
+
+	public function getValidationGroup(): string
+	{
+		return $this->_validationGroup;
+	}
+
+	public function setValidationGroup($value): void
+	{
+		$this->_validationGroup = $value;
+	}
+
+	public function onClick($param): void
+	{
+	}
+
+	public function onCommand($param): void
+	{
+	}
+
+	public function setIsDefaultButton($value): void
+	{
+		$this->_isDefaultButton = $value;
+	}
+
+	public function getIsDefaultButton(): bool
+	{
+		return $this->_isDefaultButton;
+	}
+}
 
 class TClientScriptManagerTest extends PHPUnit\Framework\TestCase
 {
+	public static $app;
+
+	private $_page;
+	private $_cs;
+
+	protected function setUp(): void
+	{
+		self::$app = null;
+		if (self::$app === null) {
+			$_SERVER['HTTP_HOST'] = 'localhost';
+			$_SERVER['SERVER_NAME'] = 'localhost';
+			$_SERVER['SERVER_PORT'] = '80';
+			$_SERVER['REQUEST_METHOD'] = 'GET';
+			$_SERVER['REQUEST_URI'] = '/test/index.php';
+			$_SERVER['PHP_SELF'] = '/test/index.php';
+			$_SERVER['QUERY_STRING'] = '';
+			$_SERVER['PATH_INFO'] = __FILE__;
+			$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+			$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0';
+
+			$_SERVER['SCRIPT_FILENAME'] = realpath(__DIR__ . '/../app/assets');
+
+			$_SERVER['SCRIPT_NAME'] = '/test/index.php';
+
+			self::$app = new TApplication(__DIR__ . '/../app');
+			self::$app->initApplication();
+		}
+
+		$this->_page = new TPage();
+		$this->_cs = new TClientScriptManager($this->_page);
+
+		$assetManager = self::$app->getAssetManager();
+	}
+
+	protected function tearDown(): void
+	{
+		$this->_page = null;
+		$this->_cs = null;
+
+		if (self::$app !== null) {
+			$assetManager = self::$app->getAssetManager();
+			$basePath = $assetManager->getBasePath();
+			if ($basePath !== null && is_dir($basePath)) {
+				$iterator = new RecursiveIteratorIterator(
+					new RecursiveDirectoryIterator($basePath, RecursiveDirectoryIterator::SKIP_DOTS),
+					RecursiveIteratorIterator::CHILD_FIRST
+				);
+				foreach ($iterator as $file) {
+					if ($file->isDir()) {
+						rmdir($file->getPathname());
+					} else {
+						unlink($file->getPathname());
+					}
+				}
+			}
+		}
+	}
+
 	public function testConstruct()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$cs = new TClientScriptManager($this->_page);
+		$this->assertSame($this->_page, $this->getPrivateProperty($cs, '_page'));
 	}
 
-	public function testRegisterPradoScript()
+	public function testGetRequiresHeadEmpty()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->getRequiresHead());
 	}
 
-	public function testGetPradoScriptAssetUrl()
+	public function testGetRequiresHeadWithStyleSheetFile()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerStyleSheetFile('key1', 'http://example.com/style.css');
+		$this->assertTrue($this->_cs->getRequiresHead());
 	}
 
-	public function testRegisterJavascriptPackages()
+	public function testGetRequiresHeadWithStyleSheet()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerStyleSheet('key1', '.myclass { color: red; }');
+		$this->assertTrue($this->_cs->getRequiresHead());
 	}
 
-	public function testGetCallbackReference()
+	public function testGetRequiresHeadWithHeadScriptFile()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerHeadScriptFile('key1', 'http://example.com/script.js');
+		$this->assertTrue($this->_cs->getRequiresHead());
 	}
 
-	public function testRegisterCallbackControl()
+	public function testGetRequiresHeadWithHeadScript()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerHeadScript('key1', 'alert("hello");');
+		$this->assertTrue($this->_cs->getRequiresHead());
 	}
 
-	public function testRegisterPostBackControl()
+	public function testGetPradoPackages()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$packages = TClientScriptManager::getPradoPackages();
+		$this->assertIsArray($packages);
+		$this->assertArrayHasKey('prado', $packages);
+		$this->assertArrayHasKey('ajax', $packages);
+		$this->assertArrayHasKey('jquery', $packages);
 	}
 
-	public function testRegisterDefaultButton()
+	public function testGetPradoScripts()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
-	}
-
-	public function testRegisterFocusControl()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$scripts = TClientScriptManager::getPradoScripts();
+		$this->assertIsArray($scripts);
+		$this->assertArrayHasKey('jquery', $scripts);
+		$this->assertArrayHasKey('prado', $scripts);
 	}
 
 	public function testRegisterStyleSheetFile()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style.css');
+		$this->assertTrue($this->_cs->isStyleSheetFileRegistered('mycss'));
+
+		$files = $this->getPrivateProperty($this->_cs, '_styleSheetFiles');
+		$this->assertEquals('http://example.com/style.css', $files['mycss']);
+	}
+
+	public function testRegisterStyleSheetFileWithMedia()
+	{
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style.css', 'print');
+		$files = $this->getPrivateProperty($this->_cs, '_styleSheetFiles');
+		$this->assertIsArray($files['mycss']);
+		$this->assertEquals('http://example.com/style.css', $files['mycss'][0]);
+		$this->assertEquals('print', $files['mycss'][1]);
+	}
+
+	public function testRegisterStyleSheetFileEmptyMediaIsNotArray()
+	{
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style.css', '');
+		$files = $this->getPrivateProperty($this->_cs, '_styleSheetFiles');
+		$this->assertEquals('http://example.com/style.css', $files['mycss']);
 	}
 
 	public function testRegisterStyleSheet()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$css = '.myclass { color: red; }';
+		$this->_cs->registerStyleSheet('mycss', $css);
+		$this->assertTrue($this->_cs->isStyleSheetRegistered('mycss'));
+
+		$sheets = $this->getPrivateProperty($this->_cs, '_styleSheets');
+		$this->assertEquals($css, $sheets['mycss']);
 	}
 
 	public function testRegisterHeadScriptFile()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerHeadScriptFile('myjs', 'http://example.com/script.js');
+		$this->assertTrue($this->_cs->isHeadScriptFileRegistered('myjs'));
+	}
+
+	public function testRegisterHeadScriptFileAsync()
+	{
+		$this->_cs->registerHeadScriptFile('myjs', 'http://example.com/script.js', true);
+		$this->assertTrue($this->_cs->isHeadScriptFileRegistered('myjs'));
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_headScriptFiles');
+		$this->assertInstanceOf(TJavaScriptAsset::class, $scripts['myjs']);
+		$this->assertTrue($scripts['myjs']->getAsync());
+	}
+
+	public function testRegisterHeadScriptFileNotAsync()
+	{
+		$this->_cs->registerHeadScriptFile('myjs', 'http://example.com/script.js', false);
+		$scripts = $this->getPrivateProperty($this->_cs, '_headScriptFiles');
+		$this->assertInstanceOf(TJavaScriptAsset::class, $scripts['myjs']);
+		$this->assertFalse($scripts['myjs']->getAsync());
 	}
 
 	public function testRegisterHeadScript()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$script = 'alert("hello");';
+		$this->_cs->registerHeadScript('myjs', $script);
+		$this->assertTrue($this->_cs->isHeadScriptRegistered('myjs'));
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_headScripts');
+		$this->assertEquals($script, $scripts['myjs']);
 	}
 
 	public function testRegisterScriptFile()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerScriptFile('myjs', 'http://example.com/script.js');
+		$this->assertTrue($this->_cs->isScriptFileRegistered('myjs'));
+
+		$files = $this->getPrivateProperty($this->_cs, '_scriptFiles');
+		$this->assertEquals('http://example.com/script.js', $files['myjs']);
 	}
 
 	public function testRegisterBeginScript()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$script = 'console.log("start");';
+		$this->_cs->registerBeginScript('start', $script);
+		$this->assertTrue($this->_cs->isBeginScriptRegistered('start'));
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_beginScripts');
+		$this->assertEquals($script, $scripts['start']);
 	}
 
 	public function testRegisterEndScript()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$script = 'console.log("end");';
+		$this->_cs->registerEndScript('end', $script);
+		$this->assertTrue($this->_cs->isEndScriptRegistered('end'));
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_endScripts');
+		$this->assertEquals($script, $scripts['end']);
 	}
 
 	public function testRegisterHiddenField()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerHiddenField('field1', 'value1');
+		$this->assertTrue($this->_cs->isHiddenFieldRegistered('field1'));
+
+		$fields = $this->getPrivateProperty($this->_cs, '_hiddenFields');
+		$this->assertEquals('value1', $fields['field1']);
+	}
+
+	public function testRegisterHiddenFieldArrayValue()
+	{
+		$this->_cs->registerHiddenField('field1', ['value1', 'value2']);
+		$fields = $this->getPrivateProperty($this->_cs, '_hiddenFields');
+		$this->assertEquals(['value1', 'value2'], $fields['field1']);
 	}
 
 	public function testIsStyleSheetFileRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isStyleSheetFileRegistered('mycss'));
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style.css');
+		$this->assertTrue($this->_cs->isStyleSheetFileRegistered('mycss'));
 	}
 
 	public function testIsStyleSheetRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isStyleSheetRegistered('mycss'));
+		$this->_cs->registerStyleSheet('mycss', '.myclass { color: red; }');
+		$this->assertTrue($this->_cs->isStyleSheetRegistered('mycss'));
 	}
 
 	public function testIsHeadScriptFileRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isHeadScriptFileRegistered('myjs'));
+		$this->_cs->registerHeadScriptFile('myjs', 'http://example.com/script.js');
+		$this->assertTrue($this->_cs->isHeadScriptFileRegistered('myjs'));
 	}
 
 	public function testIsHeadScriptRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isHeadScriptRegistered('myjs'));
+		$this->_cs->registerHeadScript('myjs', 'alert("hello");');
+		$this->assertTrue($this->_cs->isHeadScriptRegistered('myjs'));
 	}
 
 	public function testIsScriptFileRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isScriptFileRegistered('myjs'));
+		$this->_cs->registerScriptFile('myjs', 'http://example.com/script.js');
+		$this->assertTrue($this->_cs->isScriptFileRegistered('myjs'));
 	}
 
 	public function testIsBeginScriptRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isBeginScriptRegistered('start'));
+		$this->_cs->registerBeginScript('start', 'console.log("start");');
+		$this->assertTrue($this->_cs->isBeginScriptRegistered('start'));
 	}
 
 	public function testIsEndScriptRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
-	}
-
-	public function testHasEndScripts()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
-	}
-
-	public function testHasBeginScripts()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isEndScriptRegistered('end'));
+		$this->_cs->registerEndScript('end', 'console.log("end");');
+		$this->assertTrue($this->_cs->isEndScriptRegistered('end'));
 	}
 
 	public function testIsHiddenFieldRegistered()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertFalse($this->_cs->isHiddenFieldRegistered('field1'));
+		$this->_cs->registerHiddenField('field1', 'value1');
+		$this->assertTrue($this->_cs->isHiddenFieldRegistered('field1'));
+	}
+
+	public function testHasEndScripts()
+	{
+		$this->assertFalse($this->_cs->hasEndScripts());
+		$this->_cs->registerEndScript('end', 'console.log("end");');
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testHasBeginScripts()
+	{
+		$this->assertFalse($this->_cs->hasBeginScripts());
+		$this->_cs->registerBeginScript('start', 'console.log("start");');
+		$this->assertTrue($this->_cs->hasBeginScripts());
+	}
+
+	public function testHasEndScriptsEmpty()
+	{
+		$this->assertFalse($this->_cs->hasEndScripts());
+	}
+
+	public function testHasBeginScriptsEmpty()
+	{
+		$this->assertFalse($this->_cs->hasBeginScripts());
+	}
+
+	public function testGetScriptUrls()
+	{
+		$this->_cs->registerHeadScriptFile('headjs', 'http://example.com/head.js');
+		$this->_cs->registerScriptFile('bodyjs', 'http://example.com/body.js');
+
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertTrue(in_array('http://example.com/head.js', $urls, true));
+		$this->assertTrue(in_array('http://example.com/body.js', $urls, true));
+	}
+
+	public function testGetScriptUrlsDuplicate()
+	{
+		$this->_cs->registerHeadScriptFile('headjs', 'http://example.com/script.js');
+		$this->_cs->registerScriptFile('bodyjs', 'http://example.com/script.js');
+
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertCount(1, $urls);
+	}
+
+	public function testGetScriptUrlsEmpty()
+	{
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertIsArray($urls);
+		$this->assertEmpty($urls);
+	}
+
+	public function testGetStyleSheetUrls()
+	{
+		$this->_cs->registerStyleSheetFile('css1', 'http://example.com/style1.css');
+		$this->_cs->registerStyleSheetFile('css2', 'http://example.com/style2.css', 'print');
+
+		$urls = $this->_cs->getStyleSheetUrls();
+		$this->assertTrue(in_array('http://example.com/style1.css', $urls, true));
+		$this->assertTrue(in_array('http://example.com/style2.css', $urls, true));
+	}
+
+	public function testGetStyleSheetUrlsEmpty()
+	{
+		$urls = $this->_cs->getStyleSheetUrls();
+		$this->assertIsArray($urls);
+	}
+
+	public function testGetStyleSheetCodes()
+	{
+		$css1 = '.myclass1 { color: red; }';
+		$css2 = '.myclass2 { color: blue; }';
+		$this->_cs->registerStyleSheet('css1', $css1);
+		$this->_cs->registerStyleSheet('css2', $css2);
+
+		$codes = $this->_cs->getStyleSheetCodes();
+		$this->assertTrue(in_array($css1, $codes, true));
+		$this->assertTrue(in_array($css2, $codes, true));
+	}
+
+	public function testGetStyleSheetCodesDuplicate()
+	{
+		$css = '.myclass { color: red; }';
+		$this->_cs->registerStyleSheet('css1', $css);
+		$this->_cs->registerStyleSheet('css2', $css);
+
+		$codes = $this->_cs->getStyleSheetCodes();
+		$this->assertCount(1, $codes);
+	}
+
+	public function testGetStyleSheetCodesEmpty()
+	{
+		$codes = $this->_cs->getStyleSheetCodes();
+		$this->assertIsArray($codes);
+		$this->assertEmpty($codes);
 	}
 
 	public function testRenderStyleSheetFiles()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerStyleSheetFile('css1', 'http://example.com/style1.css');
+		$this->_cs->registerStyleSheetFile('css2', 'http://example.com/style2.css', 'print');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderStyleSheetFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('href="http://example.com/style1.css"', $output);
+		$this->assertStringContainsString('href="http://example.com/style2.css"', $output);
+		$this->assertStringContainsString('media="print"', $output);
+	}
+
+	public function testRenderStyleSheetFilesEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderStyleSheetFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
 	}
 
 	public function testRenderStyleSheets()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$css = '.myclass { color: red; }';
+		$this->_cs->registerStyleSheet('mycss', $css);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderStyleSheets($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('<style type="text/css">', $output);
+		$this->assertStringContainsString($css, $output);
+		$this->assertStringContainsString('/*<![CDATA[*/', $output);
+		$this->assertStringContainsString('/*]]>*/', $output);
+	}
+
+	public function testRenderStyleSheetsEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderStyleSheets($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
 	}
 
 	public function testRenderHeadScriptFiles()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->_cs->registerHeadScriptFile('js1', 'http://example.com/script1.js');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHeadScriptFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('src="http://example.com/script1.js"', $output);
+	}
+
+	public function testRenderHeadScriptFilesAsync()
+	{
+		$this->_cs->registerHeadScriptFile('js1', 'http://example.com/script1.js', true);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHeadScriptFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('async ', $output);
+		$this->assertStringContainsString('src="http://example.com/script1.js"', $output);
+	}
+
+	public function testRenderHeadScriptFilesEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderHeadScriptFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
 	}
 
 	public function testRenderHeadScripts()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
-	}
+		$script = 'alert("hello");';
+		$this->_cs->registerHeadScript('myjs', $script);
 
-	public function testRenderScriptFiles()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$writer = $this->createWriter();
+		$this->_cs->renderHeadScripts($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('<script>', $output);
+		$this->assertStringContainsString($script, $output);
+		$this->assertStringContainsString('/*<![CDATA[*/', $output);
 	}
 
 	public function testRenderBeginScripts()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$script = 'console.log("start");';
+		$this->_cs->registerBeginScript('start', $script);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderBeginScripts($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('<script>', $output);
+		$this->assertStringContainsString($script, $output);
+	}
+
+	public function testRenderBeginScriptsEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderBeginScripts($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
 	}
 
 	public function testRenderEndScripts()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$script = 'console.log("end");';
+		$this->_cs->registerEndScript('end', $script);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderEndScripts($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('<script>', $output);
+		$this->assertStringContainsString($script, $output);
+	}
+
+	public function testRenderEndScriptsEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderEndScripts($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
+	}
+
+	public function testRenderBeginScriptsCallback()
+	{
+		$script = 'console.log("start");';
+		$this->_cs->registerBeginScript('start', $script);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderBeginScriptsCallback($writer);
+		$output = $writer->flush();
+
+		$this->assertStringNotContainsString('<script>', $output);
+		$this->assertStringContainsString($script, $output);
+	}
+
+	public function testRenderEndScriptsCallback()
+	{
+		$script = 'console.log("end");';
+		$this->_cs->registerEndScript('end', $script);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderEndScriptsCallback($writer);
+		$output = $writer->flush();
+
+		$this->assertStringNotContainsString('<script>', $output);
+		$this->assertStringContainsString($script, $output);
+	}
+
+	public function testRenderBeginScriptsCallbackEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderBeginScriptsCallback($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
+	}
+
+	public function testRenderEndScriptsCallbackEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderEndScriptsCallback($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
+	}
+
+	public function testRegisterCallbackControlNoOptions()
+	{
+		$control = new MockCallbackControl();
+		$control->setID('callback1');
+		$control->setPage($this->_page);
+
+		$this->_cs->registerCallbackControl('Prado.WebUI.CallbackControl', []);
+
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterCallbackControlWithOptions()
+	{
+		$control = new MockCallbackControl();
+		$control->setID('callback1');
+		$control->setPage($this->_page);
+
+		$options = ['param1' => 'value1'];
+		$this->_cs->registerCallbackControl('Prado.WebUI.CallbackControl', $options);
+
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterPostBackControlNullClass()
+	{
+		$this->_cs->registerPostBackControl(null, []);
+		$this->assertFalse($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterPostBackControlWithOptions()
+	{
+		$control = new MockButtonControl();
+		$control->setID('button1');
+		$control->setPage($this->_page);
+
+		$options = ['EventTarget' => 'button1'];
+		$this->_cs->registerPostBackControl('Prado.WebUI.PostBackControl', $options);
+
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterDefaultButtonWithPanelAndButtonIds()
+	{
+		$panelId = 'panel1';
+		$buttonId = 'button1';
+
+		$this->_cs->registerDefaultButton($panelId, $buttonId);
+
+		$this->assertTrue($this->_cs->isEndScriptRegistered('prado:' . $panelId));
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterDefaultButtonWithControlObjects()
+	{
+		$panel = new MockButtonControl();
+		$panel->setID('panel1');
+		$panel->setPage($this->_page);
+
+		$button = new MockButtonControl();
+		$button->setID('button1');
+		$button->setPage($this->_page);
+
+		$this->_cs->registerDefaultButton($panel, $button);
+
+		$this->assertTrue($this->_cs->isEndScriptRegistered('prado:' . $panel->getUniqueID()));
+		$this->assertTrue($button->getIsDefaultButton());
+	}
+
+	public function testRegisterDefaultButtonWithInvalidButton()
+	{
+		$panelId = 'panel1';
+		$button = new \stdClass();
+
+		$this->_cs->registerDefaultButton($panelId, $button);
+		$this->assertFalse($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterFocusControl()
+	{
+		$target = 'control1';
+
+		$this->_cs->registerFocusControl($target);
+
+		$this->assertTrue($this->_cs->isEndScriptRegistered('prado:focus'));
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testRegisterFocusControlWithTControl()
+	{
+		$control = new TControl();
+		$control->setID('control1');
+		$control->setPage($this->_page);
+
+		$this->_cs->registerFocusControl($control);
+
+		$this->assertTrue($this->_cs->isEndScriptRegistered('prado:focus'));
+	}
+
+	public function testRegisterFocusControlEmptyString()
+	{
+		$this->_cs->registerFocusControl('');
+		$this->assertTrue($this->_cs->isEndScriptRegistered('prado:focus'));
+		$this->assertTrue($this->_cs->hasEndScripts());
+	}
+
+	public function testMarkScriptFileAsRendered()
+	{
+		$url = 'http://example.com/script.js';
+
+		$this->_cs->markScriptFileAsRendered($url);
+
+		$rendered = $this->getPrivateProperty($this->_cs, '_renderedScriptFiles');
+		$this->assertArrayHasKey($url, $rendered);
+	}
+
+	public function testMarkScriptFileAsRenderedWithTJavaScriptAsset()
+	{
+		$asset = new TJavaScriptAsset('http://example.com/script.js');
+
+		$this->_cs->markScriptFileAsRendered($asset);
+
+		$rendered = $this->getPrivateProperty($this->_cs, '_renderedScriptFiles');
+		$this->assertArrayHasKey('http://example.com/script.js', $rendered);
+	}
+
+	public function testRenderAllPendingScriptFiles()
+	{
+		$this->_cs->registerScriptFile('js1', 'http://example.com/script1.js');
+		$this->_cs->registerScriptFile('js2', 'http://example.com/script2.js');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderAllPendingScriptFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('src="http://example.com/script1.js"', $output);
+		$this->assertStringContainsString('src="http://example.com/script2.js"', $output);
+
+		$rendered = $this->getPrivateProperty($this->_cs, '_renderedScriptFiles');
+		$this->assertArrayHasKey('http://example.com/script1.js', $rendered);
+		$this->assertArrayHasKey('http://example.com/script2.js', $rendered);
+	}
+
+	public function testRenderAllPendingScriptFilesSkipsRendered()
+	{
+		$this->_cs->registerScriptFile('js1', 'http://example.com/script1.js');
+		$this->_cs->markScriptFileAsRendered('http://example.com/script1.js');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderAllPendingScriptFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertStringNotContainsString('script1.js', $output);
+	}
+
+	public function testRenderAllPendingScriptFilesEmpty()
+	{
+		$writer = $this->createWriter();
+		$this->_cs->renderAllPendingScriptFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertEquals('', $output);
+	}
+
+	public function testRenderHiddenFieldsBegin()
+	{
+		$this->_cs->registerHiddenField('field1', 'value1');
+		$this->_cs->registerHiddenField('field2', 'value2');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHiddenFieldsBegin($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('type="text"', $output);
+		$this->assertStringContainsString('name="field1"', $output);
+		$this->assertStringContainsString('name="field2"', $output);
+		$this->assertStringContainsString('autocomplete="off"', $output);
+	}
+
+	public function testRenderHiddenFieldsBeginThenEnd()
+	{
+		$this->_cs->registerHiddenField('field1', 'value1');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHiddenFieldsBegin($writer);
+		$output1 = $writer->flush();
+		$this->assertStringContainsString('value="value1"', $output1);
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHiddenFieldsEnd($writer);
+		$output2 = $writer->flush();
+		$this->assertEquals('', $output2);
+	}
+
+	public function testRenderHiddenFieldsSkipsDuplicateNames()
+	{
+		$this->_cs->registerHiddenField('field1', 'value1');
+		$this->_cs->registerHiddenField('field1', 'value2');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHiddenFieldsBegin($writer);
+		$output1 = $writer->flush();
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHiddenFieldsEnd($writer);
+		$output2 = $writer->flush();
+
+		$this->assertStringContainsString('value="value2"', $output1);
+		$this->assertStringNotContainsString('value="value1"', $output2);
+	}
+
+	public function testGetHiddenFields()
+	{
+		$this->_cs->registerHiddenField('field1', 'value1');
+		$this->_cs->registerHiddenField('field2', 'value2');
+
+		$fields = $this->_cs->getHiddenFields();
+
+		$this->assertCount(2, $fields);
+		$this->assertEquals('value1', $fields['field1']);
+		$this->assertEquals('value2', $fields['field2']);
+	}
+
+	public function testHiddenFieldNameSpecialCharacters()
+	{
+		$this->_cs->registerHiddenField('field:name', 'value');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderHiddenFieldsBegin($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('id="field_name"', $output);
+	}
+
+	public function testRegisterScriptFileSameKeyOverwrites()
+	{
+		$this->_cs->registerScriptFile('myjs', 'http://example.com/script1.js');
+		$this->_cs->registerScriptFile('myjs', 'http://example.com/script2.js');
+
+		$files = $this->getPrivateProperty($this->_cs, '_scriptFiles');
+		$this->assertEquals('http://example.com/script2.js', $files['myjs']);
+	}
+
+	public function testRegisterStyleSheetFileSameKeyOverwrites()
+	{
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style1.css');
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style2.css');
+
+		$files = $this->getPrivateProperty($this->_cs, '_styleSheetFiles');
+		$this->assertEquals('http://example.com/style2.css', $files['mycss']);
+	}
+
+	public function testRegisterHeadScriptSameKeyOverwrites()
+	{
+		$this->_cs->registerHeadScript('myjs', 'alert("first");');
+		$this->_cs->registerHeadScript('myjs', 'alert("second");');
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_headScripts');
+		$this->assertEquals('alert("second");', $scripts['myjs']);
+	}
+
+	public function testRegisterBeginScriptSameKeyOverwrites()
+	{
+		$this->_cs->registerBeginScript('start', 'console.log("first");');
+		$this->_cs->registerBeginScript('start', 'console.log("second");');
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_beginScripts');
+		$this->assertEquals('console.log("second");', $scripts['start']);
+	}
+
+	public function testRegisterEndScriptSameKeyOverwrites()
+	{
+		$this->_cs->registerEndScript('end', 'console.log("first");');
+		$this->_cs->registerEndScript('end', 'console.log("second");');
+
+		$scripts = $this->getPrivateProperty($this->_cs, '_endScripts');
+		$this->assertEquals('console.log("second");', $scripts['end']);
+	}
+
+	public function testRegisterStyleSheetSameKeyOverwrites()
+	{
+		$this->_cs->registerStyleSheet('mycss', '.first { color: red; }');
+		$this->_cs->registerStyleSheet('mycss', '.second { color: blue; }');
+
+		$sheets = $this->getPrivateProperty($this->_cs, '_styleSheets');
+		$this->assertEquals('.second { color: blue; }', $sheets['mycss']);
+	}
+
+	public function testRegisterHiddenFieldSameKeyOverwrites()
+	{
+		$this->_cs->registerHiddenField('field1', 'value1');
+		$this->_cs->registerHiddenField('field1', 'value2');
+
+		$fields = $this->getPrivateProperty($this->_cs, '_hiddenFields');
+		$this->assertEquals('value2', $fields['field1']);
+	}
+
+	public function testRegisterHiddenFieldEmptyValue()
+	{
+		$this->_cs->registerHiddenField('field1', '');
+		$this->assertTrue($this->_cs->isHiddenFieldRegistered('field1'));
+	}
+
+	public function testRenderStyleSheetFilesWithSpecialCharactersInUrl()
+	{
+		$this->_cs->registerStyleSheetFile('mycss', 'http://example.com/style.css?foo=bar&baz=qux');
+
+		$writer = $this->createWriter();
+		$this->_cs->renderStyleSheetFiles($writer);
+		$output = $writer->flush();
+
+		$this->assertStringContainsString('href="http://example.com/style.css?foo=bar', $output);
+	}
+
+	public function testGetDefaultButtonOptions()
+	{
+		$panelId = 'panel1';
+		$buttonId = 'button1';
+
+		$options = $this->invokePrivateMethod($this->_cs, 'getDefaultButtonOptions', [$panelId, $buttonId]);
+
+		$this->assertArrayHasKey('ID', $options);
+		$this->assertArrayHasKey('Panel', $options);
+		$this->assertArrayHasKey('Target', $options);
+		$this->assertArrayHasKey('EventTarget', $options);
+		$this->assertArrayHasKey('Event', $options);
+		$this->assertEquals($buttonId, $options['EventTarget']);
+		$this->assertEquals('click', $options['Event']);
+		$this->assertEquals($panelId, $options['ID']);
+		$this->assertEquals($panelId, $options['Panel']);
+		$this->assertEquals($buttonId, $options['Target']);
+	}
+
+	public function testGetScriptPackageFolder()
+	{
+		$script = 'prado/prado.js';
+		[$base, $subPath] = $this->invokePrivateMethod($this->_cs, 'getScriptPackageFolder', [$script]);
+
+		$this->assertIsString($base);
+		$this->assertEquals('prado.js', $subPath);
+	}
+
+	public function testGetScriptPackageFolderInvalidBase()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$this->invokePrivateMethod($this->_cs, 'getScriptPackageFolder', ['invalid_base/script.js']);
+	}
+
+	public function testGetStylePackageFolder()
+	{
+		$this->_cs->registerPradoStyle('jquery-ui');
+		$style = 'jquery-ui/jquery-ui.css';
+		[$base, $subPath] = $this->invokePrivateMethod($this->_cs, 'getStylePackageFolder', [$style]);
+
+		$this->assertIsString($base);
+		$this->assertEquals('jquery-ui.css', $subPath);
+	}
+
+	public function testGetStylePackageFolderInvalidBase()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$this->invokePrivateMethod($this->_cs, 'getStylePackageFolder', ['invalid_base/style.css']);
+	}
+
+	public function testRegisterHeadScriptInRenderThrowsException()
+	{
+		$reflection = new ReflectionClass($this->_page);
+		$prop = $reflection->getProperty('_inFormRender');
+		$prop->setAccessible(true);
+		$prop->setValue($this->_page, true);
+
+		$this->expectException(\Exception::class);
+		$this->_cs->registerHeadScript('myjs', 'alert("hello");');
+	}
+
+	public function testRegisterHeadScriptFileInRenderThrowsException()
+	{
+		$reflection = new ReflectionClass($this->_page);
+		$prop = $reflection->getProperty('_inFormRender');
+		$prop->setAccessible(true);
+		$prop->setValue($this->_page, true);
+
+		$this->expectException(\Exception::class);
+		$this->_cs->registerHeadScriptFile('myjs', 'http://example.com/script.js');
+	}
+
+	public function testRegisterBeginScriptInRenderThrowsException()
+	{
+		$reflection = new ReflectionClass($this->_page);
+		$prop = $reflection->getProperty('_inFormRender');
+		$prop->setAccessible(true);
+		$prop->setValue($this->_page, true);
+
+		$this->expectException(\Exception::class);
+		$this->_cs->registerBeginScript('start', 'console.log("start");');
+	}
+
+	public function testGetRenderedScriptFiles()
+	{
+		$this->_cs->registerScriptFile('js1', 'http://example.com/script1.js');
+
+		$rendered = $this->invokePrivateMethod($this->_cs, 'getRenderedScriptFiles');
+		$this->assertIsArray($rendered);
+	}
+
+	public function testGetScriptUrlsWithHeadScriptFiles()
+	{
+		$this->_cs->registerHeadScriptFile('headjs', 'http://example.com/head.js');
+
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertTrue(in_array('http://example.com/head.js', $urls, true));
+	}
+
+	public function testGetScriptUrlsWithScriptFiles()
+	{
+		$this->_cs->registerScriptFile('bodyjs', 'http://example.com/body.js');
+
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertTrue(in_array('http://example.com/body.js', $urls, true));
+	}
+
+	public function testMultipleScriptRegistrationsSameUrl()
+	{
+		$this->_cs->registerHeadScriptFile('headjs', 'http://example.com/script.js');
+		$this->_cs->registerScriptFile('bodyjs', 'http://example.com/script.js');
+		$this->_cs->registerHeadScriptFile('headjs2', 'http://example.com/script.js');
+
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertCount(1, $urls);
+	}
+
+	public function testClearAndGetScriptUrls()
+	{
+		$this->_cs->registerScriptFile('js1', 'http://example.com/script1.js');
+		$this->_cs->registerScriptFile('js2', 'http://example.com/script2.js');
+
+		$urls = $this->_cs->getScriptUrls();
+		$this->assertCount(2, $urls);
+	}
+
+	public function testRegisterPradoScriptJquery()
+	{
+		$this->_cs->registerPradoScript('jquery');
+		$this->assertTrue($this->getPrivateProperty($this->_cs, '_registeredScripts')['jquery'] ?? false);
+	}
+
+	public function testRegisterPradoScriptPrado()
+	{
+		$this->_cs->registerPradoScript('prado');
+		$this->assertTrue($this->getPrivateProperty($this->_cs, '_registeredScripts')['prado'] ?? false);
+	}
+
+	public function testRegisterPradoScriptInvalid()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$this->_cs->registerPradoScript('invalid_script_name');
+	}
+
+	public function testRegisterPradoStyleJqueryUi()
+	{
+		$this->_cs->registerPradoStyle('jquery-ui');
+		$this->assertTrue($this->getPrivateProperty($this->_cs, '_registeredStyles')['jquery-ui'] ?? false);
+	}
+
+	public function testRegisterPradoStyleInvalid()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$this->_cs->registerPradoStyle('invalid_style_name');
+	}
+
+	public function testGetPradoScriptAssetUrl()
+	{
+		$url = $this->_cs->getPradoScriptAssetUrl('jquery');
+		$this->assertIsString($url);
+	}
+
+	public function testGetPradoScriptAssetPath()
+	{
+		$path = $this->_cs->getPradoScriptAssetPath('jquery');
+		$this->assertIsString($path);
+	}
+
+	public function testGetCallbackReference()
+	{
+		$control = new MockCallbackControl();
+		$control->setID('callback1');
+		$control->setPage($this->_page);
+
+		$options = ['onSuccess' => 'function() { }'];
+		$ref = $this->_cs->getCallbackReference($control, $options);
+
+		$this->assertIsString($ref);
+		$this->assertStringContainsString('Prado.CallbackRequest', $ref);
+		$this->assertStringContainsString($control->getUniqueID(), $ref);
+	}
+
+	public function testGetCallbackReferenceWithEmptyOptions()
+	{
+		$control = new MockCallbackControl();
+		$control->setID('callback1');
+		$control->setPage($this->_page);
+
+		$ref = $this->_cs->getCallbackReference($control);
+
+		$this->assertIsString($ref);
+		$this->assertStringContainsString('Prado.CallbackRequest', $ref);
+	}
+
+	public function testGetCallbackReferenceWithClientSideOptions()
+	{
+		$control = new MockCallbackControl();
+		$control->setID('callback1');
+		$control->setPage($this->_page);
+
+		$activeControl = $control->getActiveControl();
+		$this->assertNotNull($activeControl);
+		$this->assertInstanceOf(MockBaseActiveCallbackControl::class, $activeControl, 'instanceof ' . $activeControl::class);
+
+		$ref = $this->_cs->getCallbackReference($control);
+
+		$this->assertIsString($ref);
+		$this->assertStringContainsString('Prado.CallbackRequest', $ref);
+	}
+
+	public function testEnsurePradoJavascriptCallsFxLoadPradoJavascript()
+	{
+		TClientScriptManagerTestable::resetJavascriptCache();
+
+		$behavior = new MockFxLoadPradoJavascriptBehavior();
+		$behavior->feedForwardData = null;
+
+		$sender = TClientScriptManagerTestable::class;
+		Prado::getApplication()->attachEventHandler('fxLoadPradoJavascript', [$behavior, 'fxLoadPradoJavascript']);
+
+		try {
+			TClientScriptManagerTestable::ensurePradoJavascript();
+
+			$this->assertArrayHasKey($sender, MockFxLoadPradoJavascriptBehavior::$callCount);
+			$this->assertEquals(1, MockFxLoadPradoJavascriptBehavior::$callCount[$sender]);
+
+			$this->assertArrayHasKey($sender, MockFxLoadPradoJavascriptBehavior::$receivedData);
+			$received = MockFxLoadPradoJavascriptBehavior::$receivedData[$sender];
+			$this->assertCount(3, $received);
+
+			[$folders, $packages, $dependencies] = $received;
+			$this->assertArrayHasKey('prado', $folders);
+			$this->assertArrayHasKey('jquery', $folders);
+			$this->assertArrayHasKey('prado', $packages);
+			$this->assertArrayHasKey('jquery', $dependencies);
+		} finally {
+			Prado::getApplication()->detachEventHandler('fxLoadPradoJavascript', [$behavior, 'fxLoadPradoJavascript']);
+			TClientScriptManagerTestable::resetJavascriptCache();
+		}
+	}
+
+	public function testEnsurePradoJavascriptWithFeedForwardData()
+	{
+		TClientScriptManagerTestable::resetJavascriptCache();
+
+		$customFolders = ['custom' => 'Custom\\Js'];
+		$customPackages = ['custom' => ['custom/custom.js']];
+		$customDeps = ['custom' => ['jquery']];
+
+		$behavior = new MockFxLoadPradoJavascriptBehavior();
+		$behavior->feedForwardData = [$customFolders, $customPackages, $customDeps];
+
+		Prado::getApplication()->attachEventHandler('fxLoadPradoJavascript', [$behavior, 'fxLoadPradoJavascript']);
+
+		try {
+			TClientScriptManagerTestable::ensurePradoJavascript();
+
+			$scriptsFolders = TClientScriptManagerTestable::getPradoScriptsFolders();
+			$scriptsPackages = TClientScriptManagerTestable::getPradoPackages();
+			$scripts = TClientScriptManagerTestable::getPradoScripts();
+
+			$this->assertArrayHasKey('custom', $scriptsFolders);
+			$this->assertArrayHasKey('custom', $scriptsPackages);
+			$this->assertArrayHasKey('custom', $scripts);
+
+			$this->assertEquals('Custom\\Js', $scriptsFolders['custom']);
+			$this->assertEquals(['custom/custom.js'], $scriptsPackages['custom']);
+			$this->assertEquals(['jquery'], $scripts['custom']);
+		} finally {
+			Prado::getApplication()->detachEventHandler('fxLoadPradoJavascript', [$behavior, 'fxLoadPradoJavascript']);
+			TClientScriptManagerTestable::resetJavascriptCache();
+		}
+	}
+
+	public function testEnsurePradoJavascriptNoFeedForwardWhenEmpty()
+	{
+		TClientScriptManagerTestable::resetJavascriptCache();
+
+		$behavior = new MockFxLoadPradoJavascriptBehavior();
+		$behavior->feedForwardData = null;
+
+		Prado::getApplication()->attachEventHandler('fxLoadPradoJavascript', [$behavior, 'fxLoadPradoJavascript']);
+
+		try {
+			TClientScriptManagerTestable::ensurePradoJavascript();
+
+			$scriptsFolders = TClientScriptManagerTestable::getPradoScriptsFolders();
+			$scriptsPackages = TClientScriptManagerTestable::getPradoPackages();
+			$scripts = TClientScriptManagerTestable::getPradoScripts();
+
+			$this->assertArrayHasKey('testplugin', $scriptsFolders);
+			$this->assertArrayHasKey('testplugin', $scriptsPackages);
+			$this->assertArrayHasKey('testplugin', $scripts);
+
+			$this->assertEquals('Test\\Javascript', $scriptsFolders['testplugin']);
+			$this->assertEquals(['testplugin/test.js'], $scriptsPackages['testplugin']);
+			$this->assertEquals(['jquery', 'prado'], $scripts['testplugin']);
+		} finally {
+			Prado::getApplication()->detachEventHandler('fxLoadPradoJavascript', [$behavior, 'fxLoadPradoJavascript']);
+			TClientScriptManagerTestable::resetJavascriptCache();
+		}
+	}
+
+	private function createWriter()
+	{
+		return new THtmlWriter(new TTextWriter());
+	}
+
+	private function getPrivateProperty($object, $property)
+	{
+		$reflection = new ReflectionClass($object);
+		$prop = $reflection->getProperty($property);
+		$prop->setAccessible(true);
+		return $prop->getValue($object);
+	}
+
+	private function invokePrivateMethod($object, $method, $args = [])
+	{
+		$reflection = new ReflectionClass($object);
+		$method = $reflection->getMethod($method);
+		$method->setAccessible(true);
+		return $method->invokeArgs($object, $args);
 	}
 }

--- a/tests/unit/Web/UI/TClientScriptManagerTest.php
+++ b/tests/unit/Web/UI/TClientScriptManagerTest.php
@@ -207,11 +207,10 @@ class TClientScriptManagerTest extends PHPUnit\Framework\TestCase
 			$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 			$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0';
 
-			$_SERVER['SCRIPT_FILENAME'] = realpath(__DIR__ . '/../app/assets');
-
-			$_SERVER['SCRIPT_NAME'] = '/test/index.php';
-
-			self::$app = new TApplication(__DIR__ . '/../app');
+			
+			$_SERVER['SCRIPT_FILENAME'] = dirname(__FILE__) . '/../app/runtime/';
+			$_SERVER['SCRIPT_NAME'] = '/index.php';
+			self::$app = new TApplication(realpath(dirname(__FILE__) . '/../app'));
 			self::$app->initApplication();
 		}
 

--- a/tests/unit/Web/UI/TClientScriptManagerTest.php
+++ b/tests/unit/Web/UI/TClientScriptManagerTest.php
@@ -185,6 +185,23 @@ class MockButtonControl extends TControl implements \Prado\Web\UI\IButtonControl
 	}
 }
 
+function rrmdir($src) {
+	$dir = opendir($src);
+	while(false !== ( $file = readdir($dir)) ) {
+		if (( $file != '.' ) && ( $file != '..' )) {
+			$full = $src . '/' . $file;
+			if ( is_dir($full) ) {
+				rrmdir($full);
+			}
+			else {
+				unlink($full);
+			}
+		}
+	}
+	closedir($dir);
+	rmdir($src);
+}
+
 class TClientScriptManagerTest extends PHPUnit\Framework\TestCase
 {
 	public static $app;
@@ -208,7 +225,7 @@ class TClientScriptManagerTest extends PHPUnit\Framework\TestCase
 			$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0';
 
 			
-			$_SERVER['SCRIPT_FILENAME'] = dirname(__FILE__) . '/../app/runtime/';
+			$_SERVER['SCRIPT_FILENAME'] = dirname(__FILE__) . '/../../../FunctionalTests/features/protected/';
 			$_SERVER['SCRIPT_NAME'] = '/index.php';
 			self::$app = new TApplication(realpath(dirname(__FILE__) . '/../app'));
 			self::$app->initApplication();
@@ -228,19 +245,17 @@ class TClientScriptManagerTest extends PHPUnit\Framework\TestCase
 		if (self::$app !== null) {
 			$assetManager = self::$app->getAssetManager();
 			$basePath = $assetManager->getBasePath();
-			if ($basePath !== null && is_dir($basePath)) {
-				$iterator = new RecursiveIteratorIterator(
-					new RecursiveDirectoryIterator($basePath, RecursiveDirectoryIterator::SKIP_DOTS),
-					RecursiveIteratorIterator::CHILD_FIRST
-				);
-				foreach ($iterator as $file) {
-					if ($file->isDir()) {
-						rmdir($file->getPathname());
-					} else {
-						unlink($file->getPathname());
+			
+			$dirIterator = opendir($basePath);
+			while(false !== ( $file = readdir($dirIterator)) ) {
+				if ( $file[0] != '.' ) {
+					$full = $basePath . '/' . $file;
+					if ( is_dir($full) ) {
+						rrmdir($full);
 					}
 				}
 			}
+			closedir($dirIterator);
 		}
 	}
 

--- a/tests/unit/Web/UI/WebControls/TXmlTransformTest.php
+++ b/tests/unit/Web/UI/WebControls/TXmlTransformTest.php
@@ -77,7 +77,14 @@ class TXmlTransformTest extends PHPUnit\Framework\TestCase
 
 	public function testAddParameter()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$transform = new TXmlTransform();
+		$parameters = $transform->getParameters();
+		$parameters->add('param1', 'value1');
+		$parameters->add('param2', 'value2');
+		
+		$this->assertEquals('value1', $transform->getParameters()->itemAt('param1'));
+		$this->assertEquals('value2', $transform->getParameters()->itemAt('param2'));
+		$this->assertCount(2, $transform->getParameters());
 	}
 
 	public function testRenderWithDocumentContentAndTransformContent()
@@ -134,6 +141,27 @@ class TXmlTransformTest extends PHPUnit\Framework\TestCase
 
 	public function testRenderWithBodyAsDocumentAndTransformPath()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		// Set transform path but leave document unset so it uses body as document
+		$transform = new TXmlTransform();
+		$transform->setTransformPath($this->transformPath);
+		
+		// Create a writer and render
+		$textWriter = new TTextWriter();
+		$htmlWriter = new THtmlWriter($textWriter);
+		
+		// Test with parameters to make sure they're processed even when falling back to body
+		$transform->getParameters()->add('testParam', 'testValue');
+		$this->assertEquals('testValue', $transform->getParameters()->itemAt('testParam'));
+		
+		try {
+			$transform->render($htmlWriter);
+			$this->fail("should have thrown \ValueError");
+		} catch (\ValueError) {}
+		$actual = $textWriter->flush();
+		
+		// Since we're transforming an empty XML document with our XSL,
+		// and our XSL expects a <greeting> element, we should get an empty <b> tag
+		$this->assertEquals('', $actual);
+		ob_end_clean();
 	}
 }


### PR DESCRIPTION
- Adds removeAttribute to TCallbackClientScript.php and JS Prado.Element.
- TActiveLinkButton uses removeAttribute to remove 'href' - removed as condition from JS setAttribute.
- TActiveListBox uses removeAttribute to remove 'multiple' - removed as condition from JS setAttribute.
- TClientScriptManager:
  - _calls **`fxLoadPradoJavascript`** global event for plugins to add their own script packages._ (from ensurePradoJavascript)
  - complete docblocks.
  - static getPradoScriptsFolders; like getPradoPackages and getPradoScripts.
  - ensurePradoJavascript before use of static $_script* vars to ensure packages are loaded.
  - loadPradoJavascript to load the Prado JS packages, etc.
  - Complete and full unit tests
- TXmlTransform unit test minor update