### PR TITLE
Adds composer scripts for devtools install and a full test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,12 +96,22 @@
 		"docs" : "http://www.pradoframework.net/site/documentation"
 	},
     "scripts": {
+		"devtools": [
+			"composer require --dev friendsofphp/php-cs-fixer",
+			"composer require --dev phpstan/phpstan",
+			"composer require --dev phpunit/phpunit"
+		],
         "gendoc": "phpdoc --template=./vendor/pradosoft/prado-phpdoc-template",
         "unittest": "phpunit --testsuite unit",
         "functionaltest": [
         	"Composer\\Config::disableProcessTimeout",
         	"phpunit --testsuite functional"
-        ]
+        ],
+		"fulltest": [
+			"php-cs-fixer fix",
+			"phpstan analyse --memory-limit=512M",
+			"phpunit --testsuite unit"
+		]
     },
 	"bin" : [
 		"bin/prado-cli"


### PR DESCRIPTION
Adds `devtools` to scripts for easy installation of PRADO Dev Tools.
Adds `fulltest` to run php-cs-fixer, phpstan, and phpunit in series.

Faster setup of PRADO for dev.
Easier to ensure all tests pass with one command before commit/push