### PR TITLE
TSecurityManager adds EncryptionKeyAlgorithm

### DIFF
--- a/framework/Security/TSecurityManager.php
+++ b/framework/Security/TSecurityManager.php
@@ -36,7 +36,10 @@ use Prado\TPropertyValue;
  *
  * To encrypt and decrypt data, call {@see encrypt()} and {@see decrypt()}
  * respectively. The encryption algorithm can be set by {@see setCryptAlgorithm CryptAlgorithm}.
- * The algorithm used to hash the encryption key can be set by {@see setEncryptionKeyAlgorithm EncryptionKeyAlgorithm}.
+ * The algorithm used to hash the encryption key can be set by
+ * {@see setEncryptionKeyAlgorithm EncryptionKeyAlgorithm}. By default this is `md5` for
+ * backward compatibility. It is highly recommended that EncryptionKeyAlgorithm be set to,
+ * at least, `sha1` or `sha256`.
  *
  * Note, to use encryption, the PHP OpenSSL extension must be loaded. This was introduced in
  * Prado4, older versions used the deprecated mcrypt extension with rijndael-256 cipher as

--- a/framework/Security/TSecurityManager.php
+++ b/framework/Security/TSecurityManager.php
@@ -36,6 +36,7 @@ use Prado\TPropertyValue;
  *
  * To encrypt and decrypt data, call {@see encrypt()} and {@see decrypt()}
  * respectively. The encryption algorithm can be set by {@see setCryptAlgorithm CryptAlgorithm}.
+ * The algorithm used to hash the encryption key can be set by {@see setEncryptionKeyAlgorithm EncryptionKeyAlgorithm}.
  *
  * Note, to use encryption, the PHP OpenSSL extension must be loaded. This was introduced in
  * Prado4, older versions used the deprecated mcrypt extension with rijndael-256 cipher as
@@ -55,6 +56,7 @@ class TSecurityManager extends \Prado\TModule
 	private $_encryptionKey;
 	private $_hashAlgorithm = 'sha256';
 	private $_cryptAlgorithm = 'aes-256-cbc';
+	private $_encryptionKeyAlgorithm = 'md5';
 	private $_mbstring;
 
 	/**
@@ -118,9 +120,10 @@ class TSecurityManager extends \Prado\TModule
 	public function getEncryptionKey()
 	{
 		if (null === $this->_encryptionKey) {
-			if (null === ($this->_encryptionKey = $this->getApplication()->getGlobalState(self::STATE_ENCRYPTION_KEY))) {
+			$application = $this->getApplication();
+			if (null === ($this->_encryptionKey = $application->getGlobalState(self::STATE_ENCRYPTION_KEY))) {
 				$this->_encryptionKey = $this->generateRandomKey();
-				$this->getApplication()->setGlobalState(self::STATE_ENCRYPTION_KEY, $this->_encryptionKey, null, true);
+				$application->setGlobalState(self::STATE_ENCRYPTION_KEY, $this->_encryptionKey, null, true);
 			}
 		}
 		return $this->_encryptionKey;
@@ -140,7 +143,7 @@ class TSecurityManager extends \Prado\TModule
 	}
 
 	/**
-	 * @return string hashing algorithm used to generate HMAC. Defaults to 'sha256'.
+	 * @return string Hashing algorithm used to generate HMAC. Defaults to 'sha256'.
 	 */
 	public function getHashAlgorithm()
 	{
@@ -148,20 +151,45 @@ class TSecurityManager extends \Prado\TModule
 	}
 
 	/**
-	 * This method accepts all hash algorithms returned by hash_algos().
-	 * @param string $value hashing algorithm used to generate HMAC.
-	 * @throws TInvalidDataValueException if the hash algorithm is not supported.
+	 * This method accepts all hash algorithms returned by {@see supportedHashAlgorithms()}.
+	 * @param string $value Hashing algorithm used to generate HMAC.
+	 * @throws TInvalidDataValueException If the hash algorithm is not supported.
 	 */
 	public function setHashAlgorithm($value)
 	{
-		$this->_hashAlgorithm = TPropertyValue::ensureString($value);
-		if (!in_array($this->_hashAlgorithm, function_exists('hash_hmac_algos') ? hash_hmac_algos() : hash_algos())) {
+		$value = TPropertyValue::ensureString($value);
+		if (!in_array($value, $this->supportedHashAlgorithms())) {
 			throw new TInvalidDataValueException('securitymanager_hash_algorithm_invalid');
 		}
+		$this->_hashAlgorithm = $value;
 	}
 
 	/**
-	 * @return mixed the algorithm used to encrypt/decrypt data. Defaults to the string 'aes-256-cbc'.
+	 * @return string Hashing algorithm used to hash {@see getEncryptionKey} during {@see encrypt()} and {@see decrypt()}. Defaults to 'md5'.
+	 * @since 4.3.3
+	 */
+	public function getEncryptionKeyAlgorithm()
+	{
+		return $this->_encryptionKeyAlgorithm;
+	}
+
+	/**
+	 * This method accepts all hash algorithms returned by {@see supportedHashAlgorithms()}.
+	 * @param string $value Hashing algorithm used to hash {@see getEncryptionKey} during {@see encrypt()} and {@see decrypt()}.
+	 * @throws TInvalidDataValueException if the hash algorithm is not supported.
+	 * @since 4.3.3
+	 */
+	public function setEncryptionKeyAlgorithm($value)
+	{
+		$value = TPropertyValue::ensureString($value);
+		if (!in_array($value, $this->supportedHashAlgorithms())) {
+			throw new TInvalidDataValueException('securitymanager_hash_algorithm_invalid');
+		}
+		$this->_encryptionKeyAlgorithm = $value;
+	}
+
+	/**
+	 * @return string the algorithm used to encrypt/decrypt data. Defaults to the string 'aes-256-cbc'.
 	 */
 	public function getCryptAlgorithm()
 	{
@@ -170,14 +198,15 @@ class TSecurityManager extends \Prado\TModule
 
 	/**
 	 * Sets the crypt algorithm (also known as cipher or cypher) that will be used for {@see encrypt} and {@see decrypt}.
-	 * @param mixed $value either a string containing the cipther name.
+	 * @param string $value either a string containing the cipher name.
 	 */
 	public function setCryptAlgorithm($value)
 	{
-		$this->_cryptAlgorithm = TPropertyValue::ensureString($value);
-		if (!in_array($this->_cryptAlgorithm, openssl_get_cipher_methods())) {
+		$value = TPropertyValue::ensureString($value);
+		if (!in_array($value, $this->supportedCipherAlgorithms())) {
 			throw new TInvalidDataValueException('securitymanager_crypt_algorithm_invalid');
 		}
+		$this->_cryptAlgorithm = $value;
 	}
 
 	/**
@@ -189,9 +218,10 @@ class TSecurityManager extends \Prado\TModule
 	public function encrypt($data)
 	{
 		if (extension_loaded('openssl')) {
-			$key = md5($this->getEncryptionKey());
-			$iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length($this->_cryptAlgorithm));
-			return $iv . openssl_encrypt($data, $this->_cryptAlgorithm, $key, 0, $iv);
+			$key = hash($this->getEncryptionKeyAlgorithm(), $this->getEncryptionKey());
+			$cryptAlgorithm = $this->getCryptAlgorithm();
+			$iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length($cryptAlgorithm));
+			return $iv . openssl_encrypt($data, $cryptAlgorithm, $key, 0, $iv);
 		} else {
 			throw new TNotSupportedException('securitymanager_openssl_required');
 		}
@@ -206,9 +236,10 @@ class TSecurityManager extends \Prado\TModule
 	public function decrypt($data)
 	{
 		if (extension_loaded('openssl')) {
-			$key = md5($this->getEncryptionKey());
-			$iv = $this->substr($data, 0, openssl_cipher_iv_length($this->_cryptAlgorithm));
-			return openssl_decrypt($this->substr($data, $this->strlen($iv), $this->strlen($data)), $this->_cryptAlgorithm, $key, 0, $iv);
+			$key = hash($this->getEncryptionKeyAlgorithm(), $this->getEncryptionKey());
+			$cryptAlgorithm = $this->getCryptAlgorithm();
+			$iv = $this->substr($data, 0, openssl_cipher_iv_length($cryptAlgorithm));
+			return openssl_decrypt($this->substr($data, $this->strlen($iv), $this->strlen($data)), $cryptAlgorithm, $key, 0, $iv);
 		} else {
 			throw new TNotSupportedException('securitymanager_openssl_required');
 		}
@@ -252,7 +283,28 @@ class TSecurityManager extends \Prado\TModule
 	 */
 	protected function computeHMAC($data)
 	{
-		return hash_hmac($this->_hashAlgorithm, $data, $this->getValidationKey());
+		return hash_hmac($this->getHashAlgorithm(), $data, $this->getValidationKey());
+	}
+
+	/**
+	 * When `hash_hmac_algos` exists it is called and results returned.
+	 * Otherwise, this calls `hash_algos` and its results are returned.
+	 * @return array Array of supported hash methods, eg md5, sha1, sha256
+	 * @since 4.3.3
+	 */
+	public function supportedHashAlgorithms()
+	{
+		return function_exists('hash_hmac_algos') ? hash_hmac_algos() : hash_algos();
+	}
+
+	/**
+	 * When `openssl_get_cipher_methods` exists it is called and results returned.
+	 * @return array Array of supported cipher methods, e.g. aes-256-cbc, aes-256-gcm
+	 * @since 4.3.3
+	 */
+	public function supportedCipherAlgorithms()
+	{
+		return function_exists('openssl_get_cipher_methods') ? openssl_get_cipher_methods() : [];
 	}
 
 	/**

--- a/tests/unit/Security/TSecurityManagerTest.php
+++ b/tests/unit/Security/TSecurityManagerTest.php
@@ -100,13 +100,15 @@ class TSecurityManagerTest extends PHPUnit\Framework\TestCase
 	{
 		$sec = new TSecurityManager();
 		$sec->init(null);
+		$defaultAlgo = $sec->getCryptAlgorithm();
 		try {
 			$sec->setCryptAlgorithm('NotExisting');
-			$foo = $sec->encrypt('dummy');
-			self::fail('Expected TNotSupportedException not thrown');
+			self::fail('Expected TInvalidDataValueException not thrown');
 		} catch (\Prado\Exceptions\TInvalidDataValueException $e) {
-			self::assertEquals('NotExisting', $sec->getCryptAlgorithm());
+			self::assertEquals($defaultAlgo, $sec->getCryptAlgorithm());
 		}
+		$sec->setCryptAlgorithm('aes-256-cbc');
+		self::assertEquals('aes-256-cbc', $sec->getCryptAlgorithm());
 	}
 
 	public function testEncryptDecrypt()
@@ -169,5 +171,558 @@ class TSecurityManagerTest extends PHPUnit\Framework\TestCase
 		self::assertFalse($sec->validateData($hashed));
 		// and a test without tampered data
 		self::assertFalse($sec->validateData('bad'));
+	}
+	
+	public function testSupportedHashAlgorithms()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$algos = $sec->supportedHashAlgorithms();
+		self::assertIsArray($algos);
+		self::assertNotEmpty($algos);
+		self::assertContains('md5', $algos);
+		self::assertContains('sha256', $algos);
+	}
+	
+	public function testSupportedCipherAlgorithms()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$algos = $sec->supportedCipherAlgorithms();
+		self::assertIsArray($algos);
+		self::assertContains('aes-192-cbc', $algos);
+		self::assertContains('aes-256-cbc', $algos);
+	}
+
+	public function testEncryptionKeyAlgorithm()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		self::assertEquals('md5', $sec->getEncryptionKeyAlgorithm());
+
+		$sec->setEncryptionKeyAlgorithm('sha1');
+		self::assertEquals('sha1', $sec->getEncryptionKeyAlgorithm());
+
+		$sec->setEncryptionKeyAlgorithm('sha256');
+		self::assertEquals('sha256', $sec->getEncryptionKeyAlgorithm());
+
+		try {
+			$sec->setEncryptionKeyAlgorithm('BADALGO');
+			self::fail('Expected TInvalidDataValueException not thrown');
+		} catch (TInvalidDataValueException $e) {
+		}
+	}
+
+	public function testEncryptionKeyAlgorithmWithEncryptDecrypt()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('testEncryptionKey');
+
+		foreach (['md5', 'sha1', 'sha256'] as $algo) {
+			$sec->setEncryptionKeyAlgorithm($algo);
+			self::assertEquals($algo, $sec->getEncryptionKeyAlgorithm());
+
+			$plainText = 'Test data for encryption with ' . $algo;
+			$encrypted = $sec->encrypt($plainText);
+			$decrypted = $sec->decrypt($encrypted);
+			self::assertEquals($plainText, $decrypted, "Failed with algorithm: $algo");
+		}
+	}
+
+	public function testDifferentEncryptionKeyAlgorithmsProduceDifferentResults()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('sameKey');
+
+		$plainText = 'Same plaintext';
+
+		$sec->setEncryptionKeyAlgorithm('md5');
+		$encryptedMd5 = $sec->encrypt($plainText);
+		$decryptedMd5 = $sec->decrypt($encryptedMd5);
+		self::assertEquals($plainText, $decryptedMd5);
+
+		$sec->setEncryptionKeyAlgorithm('sha1');
+		$encryptedSha1 = $sec->encrypt($plainText);
+		$decryptedSha1 = $sec->decrypt($encryptedSha1);
+		self::assertEquals($plainText, $decryptedSha1);
+
+		$sec->setEncryptionKeyAlgorithm('sha256');
+		$encryptedSha256 = $sec->encrypt($plainText);
+		$decryptedSha256 = $sec->decrypt($encryptedSha256);
+		self::assertEquals($plainText, $decryptedSha256);
+
+		self::assertNotEquals($encryptedMd5, $encryptedSha1);
+		self::assertNotEquals($encryptedSha1, $encryptedSha256);
+		self::assertNotEquals($encryptedMd5, $encryptedSha256);
+
+		$sec->setEncryptionKeyAlgorithm('sha1');
+		$wrongDecrypt = $sec->decrypt($encryptedMd5);
+		self::assertNotEquals($plainText, $wrongDecrypt);
+	}
+
+	public function testEncryptDecryptWithEmptyString()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$encrypted = $sec->encrypt('');
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals('', $decrypted);
+	}
+
+	public function testEncryptDecryptWithBinaryData()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$binaryData = "\x00\x01\x02\xff\xfe\xfd" . bin2hex(random_bytes(16));
+		$encrypted = $sec->encrypt($binaryData);
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals($binaryData, $decrypted);
+	}
+
+	public function testEncryptDecryptWithSpecialCharacters()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$specialChars = "!@#$%^&*()_+-=[]{}|;':\",./<>?\n\r\t\\";
+		$encrypted = $sec->encrypt($specialChars);
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals($specialChars, $decrypted);
+	}
+
+	public function testEncryptDecryptWithLongData()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$longData = str_repeat('A very long string to test encryption and decryption. ', 100);
+		$encrypted = $sec->encrypt($longData);
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals($longData, $decrypted);
+	}
+
+	public function testEncryptDecryptWithDifferentKeysSameAlgorithm()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$plainText = 'Same plaintext, different keys';
+
+		$sec->setEncryptionKey('key1');
+		$encrypted1 = $sec->encrypt($plainText);
+		$decrypted1 = $sec->decrypt($encrypted1);
+		self::assertEquals($plainText, $decrypted1);
+
+		$sec->setEncryptionKey('key2');
+		$encrypted2 = $sec->encrypt($plainText);
+		$decrypted2 = $sec->decrypt($encrypted2);
+		self::assertEquals($plainText, $decrypted2);
+
+		self::assertNotEquals($encrypted1, $encrypted2);
+
+		$sec->setEncryptionKey('key1');
+		self::assertFalse($sec->decrypt($encrypted2));
+	}
+
+	public function testEncryptDecryptWithUtf8Data()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$utf8Data = 'Unicode data: 你好世界 🌍 éèê ñ';
+		$encrypted = $sec->encrypt($utf8Data);
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals($utf8Data, $decrypted);
+	}
+
+	public function testEncryptDecryptCipherMismatchFails()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+		$sec->setCryptAlgorithm('aes-256-cbc');
+
+		$plainText = 'Test data';
+		$encrypted = $sec->encrypt($plainText);
+
+		$sec->setCryptAlgorithm('aes-256-ecb');
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertNotEquals($plainText, $decrypted);
+	}
+
+	public function testValidationKeyEmptyStringThrowsException()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$this->expectException(TInvalidDataValueException::class);
+		$sec->setValidationKey('');
+	}
+
+	public function testEncryptionKeyEmptyStringThrowsException()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$this->expectException(TInvalidDataValueException::class);
+		$sec->setEncryptionKey('');
+	}
+
+	public function testHashAlgorithmInvalidThrowsException()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$this->expectException(TInvalidDataValueException::class);
+		$sec->setHashAlgorithm('invalid_hash_algo');
+	}
+
+	public function testCryptAlgorithmInvalidThrowsException()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$this->expectException(TInvalidDataValueException::class);
+		$sec->setCryptAlgorithm('invalid_crypt_algo');
+	}
+
+	public function testEncryptionKeyAlgorithmInvalidThrowsException()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$this->expectException(TInvalidDataValueException::class);
+		$sec->setEncryptionKeyAlgorithm('invalid_hash_algo');
+	}
+
+	public function testValidateDataWithTamperedData()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setValidationKey('aKey');
+		$sec->setHashAlgorithm('sha256');
+
+		$hashed = $sec->hashData('Test data');
+		$originalChar = $hashed[10];
+		$hashed[10] = chr(ord($originalChar) + 1);
+		self::assertFalse($sec->validateData($hashed));
+	}
+
+	public function testValidateDataWithShortData()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setValidationKey('aKey');
+		$sec->setHashAlgorithm('sha256');
+
+		self::assertFalse($sec->validateData('short'));
+	}
+
+	public function testHashDataValidationKeyPersistence()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setHashAlgorithm('sha256');
+
+		$sec->setValidationKey('key1');
+		$hashed1 = $sec->hashData('Test data');
+
+		$sec->setValidationKey('key2');
+		$hashed2 = $sec->hashData('Test data');
+
+		self::assertNotEquals($hashed1, $hashed2);
+	}
+
+	public function testEncryptProducesDifferentOutputEachTime()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$plainText = 'Same plaintext';
+
+		$encrypted1 = $sec->encrypt($plainText);
+		$encrypted2 = $sec->encrypt($plainText);
+
+		self::assertNotEquals($encrypted1, $encrypted2);
+		self::assertEquals($plainText, $sec->decrypt($encrypted1));
+		self::assertEquals($plainText, $sec->decrypt($encrypted2));
+	}
+
+	public function testEncryptionKeyAlgorithmAffectsKeyDerivation()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('sharedkey');
+
+		$plainText = 'Data to verify key derivation';
+
+		$sec->setEncryptionKeyAlgorithm('md5');
+		$encrypted1 = $sec->encrypt($plainText);
+
+		$sec->setEncryptionKeyAlgorithm('sha1');
+		$encrypted2 = $sec->encrypt($plainText);
+
+		$sec->setEncryptionKeyAlgorithm('sha256');
+		$encrypted3 = $sec->encrypt($plainText);
+
+		self::assertNotEquals($encrypted1, $encrypted2);
+		self::assertNotEquals($encrypted2, $encrypted3);
+		self::assertNotEquals($encrypted1, $encrypted3);
+
+		$sec->setEncryptionKeyAlgorithm('md5');
+		self::assertEquals($plainText, $sec->decrypt($encrypted1));
+		$sec->setEncryptionKeyAlgorithm('sha1');
+		self::assertEquals($plainText, $sec->decrypt($encrypted2));
+		$sec->setEncryptionKeyAlgorithm('sha256');
+		self::assertEquals($plainText, $sec->decrypt($encrypted3));
+	}
+
+	public function testSingleByteEncryptionDecryption()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		for ($i = 0; $i < 256; $i++) {
+			$char = chr($i);
+			$encrypted = $sec->encrypt($char);
+			$decrypted = $sec->decrypt($encrypted);
+			self::assertEquals($char, $decrypted, "Failed for byte: $i");
+		}
+	}
+
+	public function testGenerateRandomKeyUniqueness()
+	{
+		$sec = new TCustomTestSecurityManager();
+		$sec->init(null);
+
+		$keys = [];
+		for ($i = 0; $i < 10; $i++) {
+			$keys[] = $sec->publicGenerateRandomKey();
+		}
+
+		$uniqueKeys = array_unique($keys);
+		self::assertCount(10, $uniqueKeys, 'Random keys should be unique');
+	}
+
+	public function testValidationKeyGlobalStatePersistence()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$key1 = $sec->getValidationKey();
+		$key2 = $sec->getValidationKey();
+
+		self::assertEquals($key1, $key2);
+		self::assertEquals($key1, self::$app->getGlobalState(TSecurityManager::STATE_VALIDATION_KEY));
+	}
+
+	public function testEncryptionKeyGlobalStatePersistence()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+
+		$key1 = $sec->getEncryptionKey();
+		$key2 = $sec->getEncryptionKey();
+
+		self::assertEquals($key1, $key2);
+		self::assertEquals($key1, self::$app->getGlobalState(TSecurityManager::STATE_ENCRYPTION_KEY));
+	}
+
+	public function testEncryptDecryptAllSupportedAlgorithms()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('testKey');
+		$plainText = 'Testing all hash algorithms as encryption key algorithm';
+
+		$hashAlgos = $sec->supportedHashAlgorithms();
+		$testAlgos = array_intersect(['md5', 'sha1', 'sha256', 'sha512'], $hashAlgos);
+
+		foreach ($testAlgos as $algo) {
+			$sec->setEncryptionKeyAlgorithm($algo);
+			$encrypted = $sec->encrypt($plainText);
+			$decrypted = $sec->decrypt($encrypted);
+			self::assertEquals($plainText, $decrypted, "Failed for hash algorithm: $algo");
+		}
+	}
+
+	public function testEncryptDecryptWithChangedEncryptionKeyAlgorithmMidProcess()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('testKey');
+		$sec->setEncryptionKeyAlgorithm('sha256');
+
+		$plainText = 'Test data';
+		$encrypted = $sec->encrypt($plainText);
+
+		$sec->setEncryptionKeyAlgorithm('md5');
+		$decryptedWrong = $sec->decrypt($encrypted);
+		self::assertNotEquals($plainText, $decryptedWrong);
+
+		$sec->setEncryptionKeyAlgorithm('sha256');
+		$decryptedCorrect = $sec->decrypt($encrypted);
+		self::assertEquals($plainText, $decryptedCorrect);
+	}
+
+	public function testHashDataAndValidateDataRoundTrip()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setValidationKey('testKey');
+		$sec->setHashAlgorithm('sha256');
+
+		$original = 'Data to hash and validate';
+		$hashed = $sec->hashData($original);
+		$validated = $sec->validateData($hashed);
+
+		self::assertEquals($original, $validated);
+	}
+
+	public function testValidateDataWithDifferentHashAlgorithms()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setValidationKey('testKey');
+
+		$testData = 'Testing data with different hash algorithms';
+
+		foreach (['md5', 'sha1', 'sha256'] as $algo) {
+			if (!in_array($algo, $sec->supportedHashAlgorithms())) {
+				continue;
+			}
+			$sec->setHashAlgorithm($algo);
+			$hashed = $sec->hashData($testData);
+			$validated = $sec->validateData($hashed);
+			self::assertEquals($testData, $validated, "Failed for hash algorithm: $algo");
+		}
+	}
+
+	public function testEncryptDecryptZeroLengthData()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey('aKey');
+
+		$encrypted = $sec->encrypt('');
+		self::assertNotEmpty($encrypted, 'Encrypted empty string should not be empty');
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals('', $decrypted);
+	}
+
+	public function testHashDataEmptyString()
+	{
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setValidationKey('aKey');
+		$sec->setHashAlgorithm('sha256');
+
+		$hashed = $sec->hashData('');
+		self::assertNotEmpty($hashed);
+		self::assertEquals('', $sec->validateData($hashed));
+	}
+
+	public function testEncryptKeyWithVeryLongEncryptionKey()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey(str_repeat('a', 1000));
+
+		$plainText = 'Test with very long key';
+		$encrypted = $sec->encrypt($plainText);
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals($plainText, $decrypted);
+	}
+
+	public function testEncryptKeyWithSpecialCharactersInKey()
+	{
+		if (!extension_loaded('openssl')) {
+			self::markTestSkipped('openssl extension not loaded');
+		}
+
+		$sec = new TSecurityManager();
+		$sec->init(null);
+		$sec->setEncryptionKey("special!@#$%^&*()_+-=[]{}|;':\",./<>?");
+
+		$plainText = 'Test with special characters in key';
+		$encrypted = $sec->encrypt($plainText);
+		$decrypted = $sec->decrypt($encrypted);
+		self::assertEquals($plainText, $decrypted);
 	}
 }


### PR DESCRIPTION
TSecurityManager provides for encrypt/decrypt.  It uses md5 to hash the EncryptionKey for the secret key in encrypt/decrypt. That may not be the easiest attack vulnerability, it's certainly far from perfect.

I'd like to change out the EncryptionKey hash algorithm for something stronger, but we need backward compatibility.

Adds methods for getting supportedHashAlgorithms and supportedCipherAlgorithms.  no more guessing about the internal black box of what algorithms are supported.

 lots of new unit tests for encrypt/decrypt.