### PR TITLE
TEventParameter adds ArrayAccess to Parameter (when array)

### DIFF
--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -14,6 +14,8 @@
 
 namespace Prado;
 
+use ArrayAccess;
+
 /**
  * TEventParameter class.
  *
@@ -24,13 +26,14 @@ namespace Prado;
  * or by constructor parameter.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.0
  */
-class TEventParameter extends \Prado\TComponent implements IEventParameter
+class TEventParameter extends \Prado\TComponent implements IEventParameter, \ArrayAccess
 {
 	private string $_eventName = '';
 	private mixed $_param;
-
+	private bool $_initialParameterNull;
 	/**
 	 * Constructor.
 	 * @param null|mixed $parameter parameter of the event
@@ -38,6 +41,7 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter
 	 */
 	public function __construct(mixed $parameter = null)
 	{
+		$this->_initialParameterNull = $parameter === null;
 		$this->setParameter($parameter);
 		parent::__construct();
 	}
@@ -61,6 +65,15 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter
 	}
 
 	/**
+	 * @return bool if the initial parameter was null
+	 * @since 4.3.3
+	 */
+	public function getInitialParameterNull(): bool
+	{
+		return $this->_initialParameterNull;
+	}
+
+	/**
 	 * @return mixed parameter of the event
 	 * @since 4.3.0
 	 */
@@ -76,5 +89,78 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter
 	public function setParameter(mixed $value)
 	{
 		$this->_param = $value;
+	}
+
+	/**
+	 * @return bool if the initial parameter was null
+	 * @since 4.3.3
+	 */
+	public function getIsParameterArray(): bool
+	{
+		return is_array($this->_param) || $this->_param instanceof ArrayAccess;
+	}
+
+	//	----- ArrayAccess -----
+
+	/**
+	 * This method is required by the interface \ArrayAccess.
+	 * @param mixed $offset the offset to check on
+	 * @return bool if not an array, then false, otherwise check _param.
+	 * @since 4.3.3
+	 */
+	public function offsetExists($offset): bool
+	{
+		if (!$this->getIsParameterArray()) {
+			return false;
+		}
+		return isset($this->_param[$offset]);
+	}
+
+	/**
+	 * This method is required by the interface \ArrayAccess. When the Parameter
+	 * is an array (or ArrayAccess) this will get the item at $offset.  If Parameter
+	 * is not an array, this returns null.
+	 * @param int $offset the offset to retrieve element.
+	 * @return mixed the element at the offset, null if no element is found.
+	 * @since 4.3.3
+	 */
+	public function offsetGet($offset): mixed
+	{
+		if (!$this->getIsParameterArray()) {
+			return null;
+		}
+		return $this->_param[$offset] ?? null;
+	}
+
+	/**
+	 * This method is required by the interface \ArrayAccess. When the Parameter
+	 * is an array (or ArrayAccess) this will set the item at $offset.  Otherwise
+	 * this has no effect.
+	 * @param int $offset the offset to set element
+	 * @param mixed $item the element value
+	 * @since 4.3.3
+	 */
+	public function offsetSet($offset, $item): void
+	{
+		$this->_param ??= [];
+		if (!$this->getIsParameterArray()) {
+			return;
+		}
+		$this->_param[$offset] = $item;
+	}
+
+	/**
+	 * This method is required by the interface \ArrayAccess. When the Parameter
+	 * is an array (or ArrayAccess) this will set the item at $offset.  Otherwise
+	 * this has no effect.
+	 * @param mixed $offset the offset to unset element
+	 * @since 4.3.3
+	 */
+	public function offsetUnset($offset): void
+	{
+		if (!$this->getIsParameterArray()) {
+			return;
+		}
+		unset($this->_param[$offset]);
 	}
 }

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -25,15 +25,26 @@ use ArrayAccess;
  * events. The event parameter is set via {@see setParameter Parameter} property
  * or by constructor parameter.
  *
+ * TEventParameter also implements \ArrayAccess to allow direct access to the
+ * parameter data when it is an array or implements \ArrayAccess. If Parameter is
+ * null (the default constructor value), the Parameter becomes an array upon offsetSet.
+ *
+ * TEventParameter tracks whether the parameter has been changed via the ParameterChanged
+ * property. It is a one-way flag that, once set to true, remains true until
+ * {@see resetParameterChanged} is called. {@see setParameterChanged} is useful for
+ * handlers that modify the parameter object (e.g., TMap) but does not change the
+ * TEventParameter's reference to that object.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @author Brad Anderson <belisoful@icloud.com>
+ * @author Brad Anderson <belisoful@icloud.com> ArrayAccess, ParameterChanged
  * @since 3.0
  */
 class TEventParameter extends \Prado\TComponent implements IEventParameter, ArrayAccess
 {
 	private string $_eventName = '';
-	private mixed $_param;
-	private bool $_initialParameterNull;
+	private mixed $_param = null;
+	private bool $_parameterChanged = false;
+
 	/**
 	 * Constructor.
 	 * @param null|mixed $parameter parameter of the event
@@ -41,8 +52,8 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function __construct(mixed $parameter = null)
 	{
-		$this->_initialParameterNull = $parameter === null;
 		$this->setParameter($parameter);
+		$this->resetParameterChanged();
 		parent::__construct();
 	}
 
@@ -56,21 +67,16 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	}
 
 	/**
+	 * Setting the Event Name also resets the ParameterChanged back to false.
+	 * This method is called by {@see TComponent::raiseEvent} to set the EventName
+	 * before the event handlers are processed.
 	 * @param string $value name of the event
 	 * @since 4.3.0
 	 */
 	public function setEventName(string $value)
 	{
 		$this->_eventName = $value;
-	}
-
-	/**
-	 * @return bool if the initial parameter was null
-	 * @since 4.3.3
-	 */
-	public function getInitialParameterNull(): bool
-	{
-		return $this->_initialParameterNull;
+		$this->resetParameterChanged();
 	}
 
 	/**
@@ -88,14 +94,49 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function setParameter(mixed $value)
 	{
+		$this->setParameterChanged($value !== $this->_param);
 		$this->_param = $value;
 	}
 
 	/**
-	 * @return bool if the initial parameter was null
+	 * @return bool Returns if the Parameter has changed
 	 * @since 4.3.3
 	 */
-	public function getIsParameterArray(): bool
+	public function getParameterChanged(): bool
+	{
+		return $this->_parameterChanged;
+	}
+
+	/**
+	 * This provides handlers to be able to set the "parameter changed" if the internal
+	 * Event Parameter was an object, like TMap.  The handler can changed the TMap
+	 * (event parameter object) without changing the TEventParameter::Parameter. This
+	 * method provides a way to "manually" set the ParameterChanged of the event.
+	 * This is a one-way function where once ParameterChanged is true, it remains true
+	 * until {@see resetParameterChanged} is called. If false is passed, this method
+	 * does nothing.
+	 * @param bool $value Sets if the Parameter has changed.
+	 * @since 4.3.3
+	 */
+	public function setParameterChanged(bool $value)
+	{
+		$this->_parameterChanged = $this->_parameterChanged || $value;
+	}
+
+	/**
+	 * This resets the ParameterChanged indicator back to false.
+	 * @since 4.3.3
+	 */
+	public function resetParameterChanged()
+	{
+		$this->_parameterChanged = false;
+	}
+
+	/**
+	 * @return bool if the Parameter is an array or is an instanceof ArrayAccess
+	 * @since 4.3.3
+	 */
+	public function getParameterIsArray(): bool
 	{
 		return is_array($this->_param) || $this->_param instanceof ArrayAccess;
 	}
@@ -110,9 +151,10 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function offsetExists($offset): bool
 	{
-		if (!$this->getIsParameterArray()) {
+		if (!$this->getParameterIsArray()) {
 			return false;
 		}
+
 		return isset($this->_param[$offset]);
 	}
 
@@ -120,15 +162,16 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 * This method is required by the interface \ArrayAccess. When the Parameter
 	 * is an array (or ArrayAccess) this will get the item at $offset.  If Parameter
 	 * is not an array, this returns null.
-	 * @param int $offset the offset to retrieve element.
+	 * @param mixed $offset the offset to retrieve element.
 	 * @return mixed the element at the offset, null if no element is found.
 	 * @since 4.3.3
 	 */
 	public function offsetGet($offset): mixed
 	{
-		if (!$this->getIsParameterArray()) {
+		if (!$this->getParameterIsArray()) {
 			return null;
 		}
+
 		return $this->_param[$offset] ?? null;
 	}
 
@@ -136,31 +179,45 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 * This method is required by the interface \ArrayAccess. When the Parameter
 	 * is an array (or ArrayAccess) this will set the item at $offset.  Otherwise
 	 * this has no effect.
-	 * @param int $offset the offset to set element
+	 * @param mixed $offset the offset to set element
 	 * @param mixed $item the element value
 	 * @since 4.3.3
 	 */
 	public function offsetSet($offset, $item): void
 	{
-		$this->_param ??= [];
-		if (!$this->getIsParameterArray()) {
+		if ($this->_param === null) {
+			$this->setParameter([]);
+		}
+		if (!$this->getParameterIsArray()) {
 			return;
 		}
+
+		$changed = true;
+		if (isset($this->_param[$offset])) {
+			$changed = ($item !== $this->_param[$offset]);
+		}
+		if (!$changed) {
+			return;
+		}
+
 		$this->_param[$offset] = $item;
+		$this->setParameterChanged(true);
 	}
 
 	/**
 	 * This method is required by the interface \ArrayAccess. When the Parameter
-	 * is an array (or ArrayAccess) this will set the item at $offset.  Otherwise
+	 * is an array (or ArrayAccess) this will unset the item at $offset.  Otherwise
 	 * this has no effect.
 	 * @param mixed $offset the offset to unset element
 	 * @since 4.3.3
 	 */
 	public function offsetUnset($offset): void
 	{
-		if (!$this->getIsParameterArray()) {
+		if (!$this->getParameterIsArray() || !isset($this->_param[$offset])) {
 			return;
 		}
+
 		unset($this->_param[$offset]);
+		$this->setParameterChanged(true);
 	}
 }

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -29,7 +29,7 @@ use ArrayAccess;
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 3.0
  */
-class TEventParameter extends \Prado\TComponent implements IEventParameter, \ArrayAccess
+class TEventParameter extends \Prado\TComponent implements IEventParameter, ArrayAccess
 {
 	private string $_eventName = '';
 	private mixed $_param;

--- a/tests/unit/TEventParameterTest.php
+++ b/tests/unit/TEventParameterTest.php
@@ -15,18 +15,21 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter();
 		$this->assertNull($param->getParameter());
 		$this->assertEquals('', $param->getEventName());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	public function testConstructorWithParameter()
 	{
 		$param = new TEventParameter('test value');
 		$this->assertEquals('test value', $param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	public function testConstructorWithNullParameter()
 	{
 		$param = new TEventParameter(null);
 		$this->assertNull($param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	public function testConstructorWithArrayParameter()
@@ -34,18 +37,21 @@ class TEventParameterTest extends TestCase
 		$data = ['key1' => 'value1', 'key2' => 'value2'];
 		$param = new TEventParameter($data);
 		$this->assertEquals($data, $param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	public function testConstructorWithIntegerParameter()
 	{
 		$param = new TEventParameter(42);
 		$this->assertEquals(42, $param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	public function testConstructorWithBooleanParameter()
 	{
 		$param = new TEventParameter(true);
 		$this->assertTrue($param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	public function testConstructorWithObjectParameter()
@@ -54,6 +60,14 @@ class TEventParameterTest extends TestCase
 		$obj->key = 'value';
 		$param = new TEventParameter($obj);
 		$this->assertSame($obj, $param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testConstructorWithEmptyArray()
+	{
+		$param = new TEventParameter([]);
+		$this->assertEquals([], $param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	// ================================================================================
@@ -80,13 +94,6 @@ class TEventParameterTest extends TestCase
 		$this->assertEquals('', $param->getEventName());
 	}
 
-	public function testEventNameCanBeSetViaConstructor()
-	{
-		$param = new TEventParameter();
-		$param->setEventName('OnClick');
-		$this->assertEquals('OnClick', $param->getEventName());
-	}
-
 	// ================================================================================
 	// Parameter Property Tests
 	// ================================================================================
@@ -96,6 +103,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter();
 		$param->setParameter('test');
 		$this->assertEquals('test', $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testSetParameterToNull()
@@ -103,6 +111,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter('initial');
 		$param->setParameter(null);
 		$this->assertNull($param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testSetParameterToArray()
@@ -110,6 +119,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter();
 		$param->setParameter(['a' => 1, 'b' => 2]);
 		$this->assertEquals(['a' => 1, 'b' => 2], $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testSetParameterToZero()
@@ -117,6 +127,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter();
 		$param->setParameter(0);
 		$this->assertEquals(0, $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testSetParameterToFalse()
@@ -124,6 +135,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter();
 		$param->setParameter(false);
 		$this->assertFalse($param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testSetParameterToEmptyString()
@@ -131,6 +143,23 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter();
 		$param->setParameter('');
 		$this->assertEquals('', $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testSetParameterToNullNoChange()
+	{
+		$param = new TEventParameter();
+		$param->setParameter(null);
+		$this->assertEquals(null, $param->getParameter());
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testSetParameterInitialArrayToNull()
+	{
+		$param = new TEventParameter([]);
+		$param->setParameter(null);
+		$this->assertEquals(null, $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	// ================================================================================
@@ -163,6 +192,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter(['initial' => 'value']);
 		$param->offsetSet('newKey', 'newValue');
 		$this->assertEquals('newValue', $param->getParameter()['newKey']);
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testOffsetUnsetWithArray()
@@ -171,6 +201,17 @@ class TEventParameterTest extends TestCase
 		$param->offsetUnset('key1');
 		$this->assertFalse($param->offsetExists('key1'));
 		$this->assertTrue($param->offsetExists('key2'));
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testOffsetUnsetWithArrayNoKey()
+	{
+		$param = new TEventParameter(['key2' => 'value2']);
+		$param->resetParameterChanged();
+		$param->offsetUnset('key1');
+		$this->assertFalse($param->offsetExists('key1'));
+		$this->assertTrue($param->offsetExists('key2'));
+		$this->assertFalse($param->getParameterChanged());
 	}
 
 	// ================================================================================
@@ -238,6 +279,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter(null);
 		$param->offsetSet('key', 'value');
 		$this->assertEquals(['key' => 'value'], $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testOffsetUnsetWithStringParameter()
@@ -286,6 +328,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter($collection);
 		$param->offsetSet('newKey', 'newValue');
 		$this->assertEquals('newValue', $param->offsetGet('newKey'));
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	// Note: offsetUnset does NOT check for ArrayAccess, only is_array
@@ -300,6 +343,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter([]);
 		$param->offsetSet('0', 'first');
 		$this->assertEquals('first', $param->getParameter()['0']);
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testOffsetGetWithNullKey()
@@ -319,6 +363,7 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter(['key' => 'original']);
 		$param->offsetSet('key', 'overwritten');
 		$this->assertEquals('overwritten', $param->getParameter()['key']);
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testOffsetSetAddsNewKey()
@@ -327,6 +372,7 @@ class TEventParameterTest extends TestCase
 		$param->offsetSet('new', 'newValue');
 		$this->assertEquals('value', $param->getParameter()['existing']);
 		$this->assertEquals('newValue', $param->getParameter()['new']);
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testOffsetUnsetWithNonexistentKey()
@@ -343,6 +389,7 @@ class TEventParameterTest extends TestCase
 		$param->offsetUnset(null);
 		$this->assertFalse($param->offsetExists(null));
 		$this->assertTrue($param->offsetExists('key1'));
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	// ================================================================================
@@ -361,13 +408,6 @@ class TEventParameterTest extends TestCase
 		$this->assertInstanceOf(ArrayAccess::class, $param);
 	}
 
-	public function testEventNameGetterSetter()
-	{
-		$param = new TEventParameter();
-		$param->setEventName('CustomEvent');
-		$this->assertEquals('CustomEvent', $param->getEventName());
-	}
-
 	// ================================================================================
 	// Complex Scenarios
 	// ================================================================================
@@ -380,6 +420,7 @@ class TEventParameterTest extends TestCase
 
 		$this->assertEquals('TestEvent', $param->getEventName());
 		$this->assertEquals(['key' => 'value'], $param->getParameter());
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testModifyArrayViaOffsetAndRetrieve()
@@ -388,6 +429,7 @@ class TEventParameterTest extends TestCase
 		$param->offsetSet('added', 'new');
 		$this->assertEquals('new', $param->offsetGet('added'));
 		$this->assertEquals('value', $param->offsetGet('initial'));
+		$this->assertTrue($param->getParameterChanged());
 	}
 
 	public function testEmptyArrayHandling()
@@ -445,5 +487,238 @@ class TEventParameterTest extends TestCase
 		$this->assertEquals('zeroValue', $param->offsetGet(0));
 		$this->assertEquals('nullValue', $param->offsetGet(null));
 		$this->assertEquals(true, $param->offsetGet('bool'));
+	}
+
+	// ================================================================================
+	// ParameterChanged Manual Set Tests
+	// ================================================================================
+
+	public function testSetParameterChangedToTrue()
+	{
+		$param = new TEventParameter();
+		$this->assertFalse($param->getParameterChanged());
+		$param->setParameterChanged(true);
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testSetParameterChangedIsOneWay()
+	{
+		$param = new TEventParameter();
+		$param->setParameterChanged(true);
+		$this->assertTrue($param->getParameterChanged());
+		$param->setParameterChanged(false);
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testSetParameterChangedFalseToTrue()
+	{
+		$param = new TEventParameter();
+		$this->assertFalse($param->getParameterChanged());
+		$param->setParameterChanged(true);
+		$this->assertTrue($param->getParameterChanged());
+		$param->setParameterChanged(true);
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testResetParameterChanged()
+	{
+		$param = new TEventParameter();
+		$param->setParameterChanged(true);
+		$this->assertTrue($param->getParameterChanged());
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testResetParameterChangedWhenNotChanged()
+	{
+		$param = new TEventParameter();
+		$this->assertFalse($param->getParameterChanged());
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testResetParameterChangedAfterOffsetSet()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->offsetSet('newKey', 'newValue');
+		$this->assertTrue($param->getParameterChanged());
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testResetParameterChangedAfterOffsetUnset()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->offsetUnset('key');
+		$this->assertTrue($param->getParameterChanged());
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testResetParameterChangedAfterSetParameter()
+	{
+		$param = new TEventParameter('initial');
+		$param->setParameter('changed');
+		$this->assertTrue($param->getParameterChanged());
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	// ================================================================================
+	// EventName Resets ParameterChanged Tests
+	// ================================================================================
+
+	public function testSetEventNameDoesNotAffectParameter()
+	{
+		$param = new TEventParameter('original');
+		$param->setEventName('TestEvent');
+		$this->assertEquals('original', $param->getParameter());
+		$this->assertEquals('TestEvent', $param->getEventName());
+	}
+
+	public function testSetEventNameWithNoPriorChange()
+	{
+		$param = new TEventParameter();
+		$param->setEventName('Event');
+		$this->assertFalse($param->getParameterChanged());
+		$this->assertEquals('Event', $param->getEventName());
+	}
+
+	public function testSetEventNameWithPriorParameterChanged()
+	{
+		$param = new TEventParameter();
+		$param->setParameter('value');
+		$this->assertTrue($param->getParameterChanged());
+		$param->setEventName('TestEvent');
+		$this->assertFalse($param->getParameterChanged());
+		$this->assertEquals('TestEvent', $param->getEventName());
+	}
+
+	// ================================================================================
+	// ParameterHasChanged Tests
+	// ================================================================================
+
+	public function testgetParameterChangedDefault()
+	{
+		$param = new TEventParameter();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedConstructor()
+	{
+		$param = new TEventParameter('value');
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedConstructorNull()
+	{
+		$param = new TEventParameter(null);
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedWithArrayParameter()
+	{
+		$param = new TEventParameter(['a' => 1]);
+		$param->resetParameterChanged();
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedAfterSetParameter()
+	{
+		$param = new TEventParameter();
+		$param->setParameter('value');
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedWithSameValue()
+	{
+		$param = new TEventParameter('value');
+		$param->resetParameterChanged();
+		$param->setParameter('value');
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedWithDifferentValue()
+	{
+		$param = new TEventParameter('initial');
+		$param->setParameter('changed');
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedAfterOffsetSet()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->offsetSet('newKey', 'newValue');
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedAfterOffsetSetSameValue()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->resetParameterChanged();
+		$param->offsetSet('key', 'value');
+		$this->assertFalse($param->getParameterChanged());
+	}
+
+	public function testgetParameterChangedAfterOffsetUnset()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->offsetUnset('key');
+		$this->assertTrue($param->getParameterChanged());
+	}
+
+	// ================================================================================
+	// ParameterIsArray Tests
+	// ================================================================================
+
+	public function testGetParameterIsArrayWithArray()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$this->assertTrue($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithArrayAccess()
+	{
+		$collection = new TAttributeCollection();
+		$collection['key'] = 'value';
+		$param = new TEventParameter($collection);
+		$this->assertTrue($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithNull()
+	{
+		$param = new TEventParameter(null);
+		$this->assertFalse($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithString()
+	{
+		$param = new TEventParameter('string');
+		$this->assertFalse($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithInteger()
+	{
+		$param = new TEventParameter(42);
+		$this->assertFalse($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithBoolean()
+	{
+		$param = new TEventParameter(true);
+		$this->assertFalse($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithObject()
+	{
+		$param = new TEventParameter(new stdClass());
+		$this->assertFalse($param->getParameterIsArray());
+	}
+
+	public function testGetParameterIsArrayWithEmptyArray()
+	{
+		$param = new TEventParameter([]);
+		$this->assertTrue($param->getParameterIsArray());
 	}
 }

--- a/tests/unit/TEventParameterTest.php
+++ b/tests/unit/TEventParameterTest.php
@@ -1,0 +1,449 @@
+<?php
+
+use Prado\TEventParameter;
+use Prado\Collections\TAttributeCollection;
+use PHPUnit\Framework\TestCase;
+
+class TEventParameterTest extends TestCase
+{
+	// ================================================================================
+	// Constructor Tests
+	// ================================================================================
+
+	public function testDefaultConstructor()
+	{
+		$param = new TEventParameter();
+		$this->assertNull($param->getParameter());
+		$this->assertEquals('', $param->getEventName());
+	}
+
+	public function testConstructorWithParameter()
+	{
+		$param = new TEventParameter('test value');
+		$this->assertEquals('test value', $param->getParameter());
+	}
+
+	public function testConstructorWithNullParameter()
+	{
+		$param = new TEventParameter(null);
+		$this->assertNull($param->getParameter());
+	}
+
+	public function testConstructorWithArrayParameter()
+	{
+		$data = ['key1' => 'value1', 'key2' => 'value2'];
+		$param = new TEventParameter($data);
+		$this->assertEquals($data, $param->getParameter());
+	}
+
+	public function testConstructorWithIntegerParameter()
+	{
+		$param = new TEventParameter(42);
+		$this->assertEquals(42, $param->getParameter());
+	}
+
+	public function testConstructorWithBooleanParameter()
+	{
+		$param = new TEventParameter(true);
+		$this->assertTrue($param->getParameter());
+	}
+
+	public function testConstructorWithObjectParameter()
+	{
+		$obj = new stdClass();
+		$obj->key = 'value';
+		$param = new TEventParameter($obj);
+		$this->assertSame($obj, $param->getParameter());
+	}
+
+	// ================================================================================
+	// EventName Property Tests
+	// ================================================================================
+
+	public function testGetSetEventName()
+	{
+		$param = new TEventParameter();
+		$param->setEventName('testEvent');
+		$this->assertEquals('testEvent', $param->getEventName());
+	}
+
+	public function testEventNameDefaultIsEmpty()
+	{
+		$param = new TEventParameter();
+		$this->assertEquals('', $param->getEventName());
+	}
+
+	public function testEventNameCanBeEmpty()
+	{
+		$param = new TEventParameter();
+		$param->setEventName('');
+		$this->assertEquals('', $param->getEventName());
+	}
+
+	public function testEventNameCanBeSetViaConstructor()
+	{
+		$param = new TEventParameter();
+		$param->setEventName('OnClick');
+		$this->assertEquals('OnClick', $param->getEventName());
+	}
+
+	// ================================================================================
+	// Parameter Property Tests
+	// ================================================================================
+
+	public function testGetSetParameter()
+	{
+		$param = new TEventParameter();
+		$param->setParameter('test');
+		$this->assertEquals('test', $param->getParameter());
+	}
+
+	public function testSetParameterToNull()
+	{
+		$param = new TEventParameter('initial');
+		$param->setParameter(null);
+		$this->assertNull($param->getParameter());
+	}
+
+	public function testSetParameterToArray()
+	{
+		$param = new TEventParameter();
+		$param->setParameter(['a' => 1, 'b' => 2]);
+		$this->assertEquals(['a' => 1, 'b' => 2], $param->getParameter());
+	}
+
+	public function testSetParameterToZero()
+	{
+		$param = new TEventParameter();
+		$param->setParameter(0);
+		$this->assertEquals(0, $param->getParameter());
+	}
+
+	public function testSetParameterToFalse()
+	{
+		$param = new TEventParameter();
+		$param->setParameter(false);
+		$this->assertFalse($param->getParameter());
+	}
+
+	public function testSetParameterToEmptyString()
+	{
+		$param = new TEventParameter();
+		$param->setParameter('');
+		$this->assertEquals('', $param->getParameter());
+	}
+
+	// ================================================================================
+	// ArrayAccess with Array Parameter Tests
+	// ================================================================================
+
+	public function testOffsetExistsWithArray()
+	{
+		$param = new TEventParameter(['key1' => 'value1', 'key2' => 'value2']);
+		$this->assertTrue($param->offsetExists('key1'));
+		$this->assertTrue($param->offsetExists('key2'));
+		$this->assertFalse($param->offsetExists('nonexistent'));
+	}
+
+	public function testOffsetGetWithArray()
+	{
+		$param = new TEventParameter(['key1' => 'value1', 'key2' => 'value2']);
+		$this->assertEquals('value1', $param->offsetGet('key1'));
+		$this->assertEquals('value2', $param->offsetGet('key2'));
+	}
+
+	public function testOffsetGetWithNonexistentKey()
+	{
+		$param = new TEventParameter(['key1' => 'value1']);
+		$this->assertNull($param->offsetGet('nonexistent'));
+	}
+
+	public function testOffsetSetWithArray()
+	{
+		$param = new TEventParameter(['initial' => 'value']);
+		$param->offsetSet('newKey', 'newValue');
+		$this->assertEquals('newValue', $param->getParameter()['newKey']);
+	}
+
+	public function testOffsetUnsetWithArray()
+	{
+		$param = new TEventParameter(['key1' => 'value1', 'key2' => 'value2']);
+		$param->offsetUnset('key1');
+		$this->assertFalse($param->offsetExists('key1'));
+		$this->assertTrue($param->offsetExists('key2'));
+	}
+
+	// ================================================================================
+	// ArrayAccess with Non-Array Parameter Tests
+	// ================================================================================
+
+	public function testOffsetExistsWithStringParameter()
+	{
+		$param = new TEventParameter('string value');
+		$this->assertFalse($param->offsetExists('anyKey'));
+	}
+
+	public function testOffsetExistsWithIntegerParameter()
+	{
+		$param = new TEventParameter(42);
+		$this->assertFalse($param->offsetExists(0));
+	}
+
+	public function testOffsetExistsWithNullParameter()
+	{
+		$param = new TEventParameter(null);
+		$this->assertFalse($param->offsetExists('anyKey'));
+	}
+
+	public function testOffsetExistsWithObjectParameter()
+	{
+		$param = new TEventParameter(new stdClass());
+		$this->assertFalse($param->offsetExists('anyKey'));
+	}
+
+	public function testOffsetGetWithStringParameter()
+	{
+		$param = new TEventParameter('string value');
+		$this->assertNull($param->offsetGet('anyKey'));
+	}
+
+	public function testOffsetGetWithIntegerParameter()
+	{
+		$param = new TEventParameter(42);
+		$this->assertNull($param->offsetGet(0));
+	}
+
+	public function testOffsetGetWithNullParameter()
+	{
+		$param = new TEventParameter(null);
+		$this->assertNull($param->offsetGet('anyKey'));
+	}
+
+	public function testOffsetSetWithStringParameter()
+	{
+		$param = new TEventParameter('original');
+		$param->offsetSet('key', 'value');
+		$this->assertEquals('original', $param->getParameter());
+	}
+
+	public function testOffsetSetWithIntegerParameter()
+	{
+		$param = new TEventParameter(42);
+		$param->offsetSet('key', 'value');
+		$this->assertEquals(42, $param->getParameter());
+	}
+
+	public function testOffsetSetWithNullParameter()
+	{
+		$param = new TEventParameter(null);
+		$param->offsetSet('key', 'value');
+		$this->assertEquals(['key' => 'value'], $param->getParameter());
+	}
+
+	public function testOffsetUnsetWithStringParameter()
+	{
+		$param = new TEventParameter('string value');
+		$param->offsetUnset('key');
+		$this->assertEquals('string value', $param->getParameter());
+	}
+
+	public function testOffsetUnsetWithIntegerParameter()
+	{
+		$param = new TEventParameter(42);
+		$param->offsetUnset('key');
+		$this->assertEquals(42, $param->getParameter());
+	}
+
+	// ================================================================================
+	// ArrayAccess with ArrayAccess Object Tests
+	// ================================================================================
+
+	public function testOffsetExistsWithArrayAccessObject()
+	{
+		$collection = new TAttributeCollection();
+		$collection['key1'] = 'value1';
+		$collection['key2'] = 'value2';
+
+		$param = new TEventParameter($collection);
+		$this->assertTrue($param->offsetExists('key1'));
+		$this->assertTrue($param->offsetExists('key2'));
+		$this->assertFalse($param->offsetExists('nonexistent'));
+	}
+
+	public function testOffsetGetWithArrayAccessObject()
+	{
+		$collection = new TAttributeCollection();
+		$collection['key1'] = 'value1';
+
+		$param = new TEventParameter($collection);
+		$this->assertEquals('value1', $param->offsetGet('key1'));
+		$this->assertNull($param->offsetGet('nonexistent'));
+	}
+
+	public function testOffsetSetWithArrayAccessObject()
+	{
+		$collection = new TAttributeCollection();
+		$param = new TEventParameter($collection);
+		$param->offsetSet('newKey', 'newValue');
+		$this->assertEquals('newValue', $param->offsetGet('newKey'));
+	}
+
+	// Note: offsetUnset does NOT check for ArrayAccess, only is_array
+	// So unsetting on an ArrayAccess object has no effect
+
+	// ================================================================================
+	// Edge Cases for Array Values
+	// ================================================================================
+
+	public function testOffsetSetWithNumericStringKey()
+	{
+		$param = new TEventParameter([]);
+		$param->offsetSet('0', 'first');
+		$this->assertEquals('first', $param->getParameter()['0']);
+	}
+
+	public function testOffsetGetWithNullKey()
+	{
+		$param = new TEventParameter([null => 'nullKey']);
+		$this->assertEquals('nullKey', $param->offsetGet(null));
+	}
+
+	public function testOffsetExistsWithNullKey()
+	{
+		$param = new TEventParameter([null => 'nullKey']);
+		$this->assertTrue($param->offsetExists(null));
+	}
+
+	public function testOffsetSetOverwritesExisting()
+	{
+		$param = new TEventParameter(['key' => 'original']);
+		$param->offsetSet('key', 'overwritten');
+		$this->assertEquals('overwritten', $param->getParameter()['key']);
+	}
+
+	public function testOffsetSetAddsNewKey()
+	{
+		$param = new TEventParameter(['existing' => 'value']);
+		$param->offsetSet('new', 'newValue');
+		$this->assertEquals('value', $param->getParameter()['existing']);
+		$this->assertEquals('newValue', $param->getParameter()['new']);
+	}
+
+	public function testOffsetUnsetWithNonexistentKey()
+	{
+		$param = new TEventParameter(['key1' => 'value1']);
+		$param->offsetUnset('nonexistent');
+		$this->assertTrue($param->offsetExists('key1'));
+		$this->assertEquals('value1', $param->getParameter()['key1']);
+	}
+
+	public function testOffsetUnsetWithNullKey()
+	{
+		$param = new TEventParameter([null => 'nullValue', 'key1' => 'value1']);
+		$param->offsetUnset(null);
+		$this->assertFalse($param->offsetExists(null));
+		$this->assertTrue($param->offsetExists('key1'));
+	}
+
+	// ================================================================================
+	// IEventParameter Interface Tests
+	// ================================================================================
+
+	public function testImplementsIEventParameter()
+	{
+		$param = new TEventParameter();
+		$this->assertInstanceOf(\Prado\IEventParameter::class, $param);
+	}
+
+	public function testImplementsArrayAccess()
+	{
+		$param = new TEventParameter();
+		$this->assertInstanceOf(ArrayAccess::class, $param);
+	}
+
+	public function testEventNameGetterSetter()
+	{
+		$param = new TEventParameter();
+		$param->setEventName('CustomEvent');
+		$this->assertEquals('CustomEvent', $param->getEventName());
+	}
+
+	// ================================================================================
+	// Complex Scenarios
+	// ================================================================================
+
+	public function testChainedSetOperations()
+	{
+		$param = new TEventParameter();
+		$param->setEventName('TestEvent');
+		$param->setParameter(['key' => 'value']);
+
+		$this->assertEquals('TestEvent', $param->getEventName());
+		$this->assertEquals(['key' => 'value'], $param->getParameter());
+	}
+
+	public function testModifyArrayViaOffsetAndRetrieve()
+	{
+		$param = new TEventParameter(['initial' => 'value']);
+		$param->offsetSet('added', 'new');
+		$this->assertEquals('new', $param->offsetGet('added'));
+		$this->assertEquals('value', $param->offsetGet('initial'));
+	}
+
+	public function testEmptyArrayHandling()
+	{
+		$param = new TEventParameter([]);
+		$this->assertFalse($param->offsetExists('any'));
+		$param->offsetSet('key', 'value');
+		$this->assertTrue($param->offsetExists('key'));
+	}
+
+	public function testFalseAndNullDistinction()
+	{
+		$param = new TEventParameter(false);
+		$this->assertFalse($param->offsetExists('key'));
+
+		$param->setParameter(null);
+		$this->assertFalse($param->offsetExists('key'));
+	}
+
+	public function testZeroAndEmptyStringDistinction()
+	{
+		$param = new TEventParameter(0);
+		$this->assertFalse($param->offsetExists('key'));
+
+		$param->setParameter('');
+		$this->assertFalse($param->offsetExists('key'));
+	}
+
+	public function testConstructorSetsParameterNotEventName()
+	{
+		$param = new TEventParameter('parameterValue');
+		$this->assertEquals('parameterValue', $param->getParameter());
+		$this->assertEquals('', $param->getEventName());
+	}
+
+	public function testIntegerAsArrayIndex()
+	{
+		$param = new TEventParameter([5 => 'five', 10 => 'ten']);
+		$this->assertEquals('five', $param->offsetGet(5));
+		$this->assertEquals('ten', $param->offsetGet(10));
+		$this->assertTrue($param->offsetExists(5));
+		$this->assertTrue($param->offsetExists(10));
+	}
+
+	public function testMixedArrayKeys()
+	{
+		$param = new TEventParameter([
+			'string' => 'stringValue',
+			0 => 'zeroValue',
+			null => 'nullValue',
+			'bool' => true,
+		]);
+
+		$this->assertEquals('stringValue', $param->offsetGet('string'));
+		$this->assertEquals('zeroValue', $param->offsetGet(0));
+		$this->assertEquals('nullValue', $param->offsetGet(null));
+		$this->assertEquals(true, $param->offsetGet('bool'));
+	}
+}


### PR DESCRIPTION
Adds ParameterChanged property, and method for handlers to flag that the parameter has been changed.
Flagging the Parameter as changed by an event handler is required if the parameter is an object like TMap where changes to the parameter object are not registered as direct changes to the Event Parameter in the TEventParameter instance.
with unit test for the class