### PR TITLE
Better integration of PRADO with PHPStan

### DIFF
--- a/agents/framework/PHPStan/INDEX.md
+++ b/agents/framework/PHPStan/INDEX.md
@@ -1,11 +1,11 @@
 # PHPStan/INDEX.md
 
 ### Directories
-[framework](./INDEX.md) / **`PHPStan/INDEX.md`**
+[framework](../INDEX.md) / **`PHPStan/INDEX.md`**
 
 ## Purpose
 
-PHPStan static analysis extensions that teach PHPStan about Prado's dynamic method system (`dy*` / `fx*` methods) and the [TComponent](../../TComponent.md::TComponent::isa()) type-narrowing helper.
+PHPStan static analysis extensions that teach PHPStan about Prado's dynamic method system (`dy*` / `fx*` methods), virtual property system (`get{X}()` / `set{X}()`), and TComponent type-narrowing helpers (`isa()`, `hasMethod()`, `canGetProperty()`, `canSetProperty()`, `Prado::method_visible()`).
 
 ## Classes
 
@@ -18,26 +18,53 @@ PHPStan static analysis extensions that teach PHPStan about Prado's dynamic meth
   - Parameters: variadic (accepts any arguments)
   - Side effects: `TrinaryLogic::createMaybe()`
 
+- **TComponentPropertiesReflectionExtension** — PHPStan `PropertiesClassReflectionExtension`. Maps every `get{X}()` / `set{X}()` method pair on any `TComponent` subclass to a virtual property `X`, enabling `$obj->X` access without "undefined property" errors. The readable type is derived from the getter's return type; the writable type from the setter's first parameter type. The `getjs{X}()` / `setjs{X}()` JS-aware variants are also recognised.
+
+- **TComponentPropertyReflection** — Implements PHPStan's `PropertyReflection` for PRADO virtual properties. Stores optional getter and setter `MethodReflection` references. `isReadable()` is true when a getter exists; `isWritable()` is true when a setter exists. `canChangeTypeAfterAssignment()` returns `false` (method-hook semantics).
+
+- **TComponentHasMethodTypeSpecifyingExtension** — PHPStan `MethodTypeSpecifyingExtension` for `TComponent::hasMethod()`. When `$obj->hasMethod('foo')` is true inside an `if`-block, narrows the type of `$obj` to `OriginalType & HasMethodType('foo')`, making the guarded call `$obj->foo()` valid. Mirrors the behaviour of PHPStan's built-in `method_exists()` narrowing.
+
+- **TComponentCanGetPropertyTypeSpecifyingExtension** — `MethodTypeSpecifyingExtension` for `TComponent::canGetProperty()`. When `$obj->canGetProperty('Foo')` is true, narrows `$obj` to have `HasMethodType('getFoo')`, allowing `$obj->getFoo()` inside the guarded block without errors.
+
+- **TComponentCanSetPropertyTypeSpecifyingExtension** — `MethodTypeSpecifyingExtension` for `TComponent::canSetProperty()`. When `$obj->canSetProperty('Foo')` is true, narrows `$obj` to have `HasMethodType('setFoo')`, allowing `$obj->setFoo(...)` inside the guarded block without errors.
+
 - **[TComponentIsaTypeSpecifyingExtension](./TComponentIsaTypeSpecifyingExtension.md)** — PHPStan type-specifying extension for `TComponent::isa()`. Narrows the type of the subject when `isa()` returns `true`, similar to `instanceof`.
+
+- **PradoMethodVisibleStaticMethodTypeSpecifyingExtension** — PHPStan `StaticMethodTypeSpecifyingExtension` for `Prado::method_visible()`. When `Prado::method_visible($obj, 'foo')` is true, narrows the type of `$obj` to have `HasMethodType('foo')`, making the guarded call `$obj->foo()` valid. Mirrors the behaviour of PHPStan's built-in `method_exists()` narrowing.
 
 ## Configuration
 
-These extensions are wired in `phpstan.neon.dist`:
-```neon
-services:
-  -
-    class: Prado\PHPStan\DynamicMethodsClassReflectionExtension
-    tags:
-      - phpstan.broker.methodsClassReflectionExtension
-```
+All extensions are wired in `phpstan.neon.dist`. Tags used:
+- `phpstan.broker.methodsClassReflectionExtension` — for dynamic method extensions
+- `phpstan.broker.propertiesClassReflectionExtension` — for virtual property extensions
+- `phpstan.typeSpecifier.methodTypeSpecifyingExtension` — for instance-method type narrowing
+- `phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension` — for static-method type narrowing
+
+## Tests
+
+PHPUnit tests live in `tests/unit/PHPStan/PHPStanExtensionsTest.php`. Each extension has a pair of tests:
+1. **Without extension** (`phpstan-no-extensions.neon`) — verifies the fixture file DOES produce PHPStan errors.
+2. **With extension** (`phpstan.neon.dist`) — verifies the fixture file produces ZERO errors.
+
+Fixture files are in `tests/unit/PHPStan/fixtures/`:
+- `HasMethodFixture.php` — `TComponent::hasMethod()` guard patterns
+- `MethodVisibleFixture.php` — `Prado::method_visible()` guard patterns
+- `DynamicMethodsFixture.php` — `dy*` / `fx*` dynamic method calls
+- `IsaFixture.php` — `TComponent::isa()` type-narrowing patterns
+- `CanGetPropertyFixture.php` — `canGetProperty()` guard patterns
+- `CanSetPropertyFixture.php` — `canSetProperty()` guard patterns
+- `PropertiesReflectionFixture.php` — virtual property access via `$obj->Prop`
 
 ## When to Update
 
 - **Adding new dynamic accessor prefixes** beyond `dy`/`fx` → update `DynamicMethodsClassReflectionExtension`.
-- **Adding new type-narrowing helpers** similar to `isa()` → add a new type-specifying extension following the pattern in `TComponentIsaTypeSpecifyingExtension`.
+- **Adding new type-narrowing helpers** similar to `isa()` → add a new type-specifying extension following the existing patterns.
+- **Adding new property-checking methods** similar to `canGetProperty()` → follow the `TComponentCanGetPropertyTypeSpecifyingExtension` pattern.
 - These extensions affect static analysis only — not runtime behaviour.
 
 ## Gotchas
 
-- The `dy`/`fx` prefix check is **case-insensitive** (`strncasecmp`).
-- All dynamic methods report `MixedType` return — no return type refinement is possible without explicit PHPDoc on the call site.
+- The `dy`/`fx` prefix check in `DynamicMethodsClassReflectionExtension` is **case-insensitive** (`strncasecmp`).
+- `TComponentHasMethodTypeSpecifyingExtension` only narrows when exactly **one** constant string is passed as the method name argument. Dynamic (variable) method names cannot be narrowed.
+- `TComponentPropertiesReflectionExtension` uses `hasMethod('get' . $name)` which is case-insensitive in PHP — `getText` and `gettext` are the same method. PHPStan will ask for whatever case appears in source code (`$obj->Text` → `hasProperty('Text')` → `hasMethod('getText')`).
+- Virtual properties use `canChangeTypeAfterAssignment() = false` because the setter/getter may apply custom logic, preventing type narrowing after writes.

--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,7 @@
         	"Composer\\Config::disableProcessTimeout",
         	"phpunit --testsuite functional"
         ],
+		"stantest": "vendor/bin/phpunit --testsuite phpstan",
 		"fulltest": [
 			"php-cs-fixer fix",
 			"phpstan analyse --memory-limit=512M",

--- a/framework/PHPStan/INDEX.md
+++ b/framework/PHPStan/INDEX.md
@@ -1,0 +1,113 @@
+# framework/PHPStan Extensions for PRADO
+
+## Purpose
+
+PHPStan static analysis extensions that teach PHPStan about Prado's dynamic method system (`dy*` / `fx*` methods), virtual property system (`get{X}()` / `set{X}()`), and TComponent type-narrowing helpers (`isa()`, `hasMethod()`, `canGetProperty()`, `canSetProperty()`, `Prado::method_visible()`).
+
+## Classes
+
+- **[DynamicMethodsClassReflectionExtension](./DynamicMethodsClassReflectionExtension.php)** — PHPStan `MethodsClassReflectionExtension`. Applies only to `TComponent` subclasses. Recognises any method name starting with `dy` or `fx` (case-insensitive) and reports it as a valid public, non-static method with `MixedType` return and variadic parameters. Prevents false "undefined method" PHPStan errors for dynamic behavior events.
+
+- **[DynamicMethodReflection](./DynamicMethodReflection.php)** — Implements PHPStan's `MethodReflection`. Returns:
+  - Visibility: public, non-static
+  - No doc comment
+  - Return type: `MixedType`
+  - Parameters: variadic (accepts any arguments)
+  - Side effects: `TrinaryLogic::createMaybe()`
+
+- **[TComponentPropertiesReflectionExtension](./TComponentPropertiesReflectionExtension.php)** — PHPStan `PropertiesClassReflectionExtension`. Maps every `get{X}()` / `set{X}()` method pair on any `TComponent` subclass to a virtual property `X`, enabling `$obj->X` access without "undefined property" errors. The readable type is derived from the getter's return type; the writable type from the setter's first parameter type. The `getjs{X}()` / `setjs{X}()` JS-aware variants are also recognised.
+
+- **[TComponentPropertyReflection](./TComponentPropertyReflection.php)** — Implements PHPStan's `PropertyReflection` for PRADO virtual properties. Stores optional getter and setter `MethodReflection` references. `isReadable()` is true when a getter exists; `isWritable()` is true when a setter exists. `canChangeTypeAfterAssignment()` returns `false` (method-hook semantics).
+
+- **[TComponentHasMethodTypeSpecifyingExtension](./TComponentHasMethodTypeSpecifyingExtension.php)** — PHPStan `MethodTypeSpecifyingExtension` for `TComponent::hasMethod()`. When `$obj->hasMethod('foo')` is true inside an `if`-block, narrows the type of `$obj` to `OriginalType & HasMethodType('foo')`, making the guarded call `$obj->foo()` valid. Mirrors the behaviour of PHPStan's built-in `method_exists()` narrowing.
+
+- **[TComponentCanGetPropertyTypeSpecifyingExtension](./TComponentCanGetPropertyTypeSpecifyingExtension.php)** — `MethodTypeSpecifyingExtension` for `TComponent::canGetProperty()`. When `$obj->canGetProperty('Foo')` is true, narrows `$obj` to have `HasMethodType('getFoo')`, allowing `$obj->getFoo()` inside the guarded block without errors.
+
+- **[TComponentCanSetPropertyTypeSpecifyingExtension](./TComponentCanSetPropertyTypeSpecifyingExtension.php)** — `MethodTypeSpecifyingExtension` for `TComponent::canSetProperty()`. When `$obj->canSetProperty('Foo')` is true, narrows `$obj` to have `HasMethodType('setFoo')`, allowing `$obj->setFoo(...)` inside the guarded block without errors.
+
+- **[TComponentIsaTypeSpecifyingExtension](./TComponentIsaTypeSpecifyingExtension.php)** — PHPStan type-specifying extension for `TComponent::isa()`. Narrows the type of the subject when `isa()` returns `true`, similar to `instanceof`.
+
+- **[PradoMethodVisibleStaticMethodTypeSpecifyingExtension](./PradoMethodVisibleStaticMethodTypeSpecifyingExtension.php)** — PHPStan `StaticMethodTypeSpecifyingExtension` for `Prado::method_visible()`. When `Prado::method_visible($obj, 'foo')` is true, narrows the type of `$obj` to have `HasMethodType('foo')`, making the guarded call `$obj->foo()` valid. Mirrors the behaviour of PHPStan's built-in `method_exists()` narrowing.
+
+## Configuration
+
+All extensions are wired in `phpstan.neon.dist`. Tags used:
+- `phpstan.broker.methodsClassReflectionExtension` — for dynamic method extensions
+- `phpstan.broker.propertiesClassReflectionExtension` — for virtual property extensions
+- `phpstan.typeSpecifier.methodTypeSpecifyingExtension` — for instance-method type narrowing
+- `phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension` — for static-method type narrowing
+
+Examples of configuration are provided below in the ## PHPStan Configuration section.
+
+## Tests
+
+PHPUnit tests live in `tests/unit/PHPStan/PHPStanExtensionsTest.php`. Each extension has a pair of tests:
+1. **Without extension** (`phpstan-no-extensions.neon`) — verifies the fixture file DOES produce PHPStan errors.
+2. **With extension** (`phpstan.neon.dist`) — verifies the fixture file produces ZERO errors.
+
+Fixture files are in `tests/unit/PHPStan/fixtures/`:
+- `HasMethodFixture.php` — `TComponent::hasMethod()` guard patterns
+- `MethodVisibleFixture.php` — `Prado::method_visible()` guard patterns
+- `DynamicMethodsFixture.php` — `dy*` / `fx*` dynamic method calls
+- `IsaFixture.php` — `TComponent::isa()` type-narrowing patterns
+- `CanGetPropertyFixture.php` — `canGetProperty()` guard patterns
+- `CanSetPropertyFixture.php` — `canSetProperty()` guard patterns
+- `PropertiesReflectionFixture.php` — virtual property access via `$obj->Prop`
+
+## When to Update
+
+- **Adding new dynamic accessor prefixes** beyond `dy`/`fx` → update `DynamicMethodsClassReflectionExtension`.
+- **Adding new type-narrowing helpers** similar to `isa()` → add a new type-specifying extension following the existing patterns.
+- **Adding new property-checking methods** similar to `canGetProperty()` → follow the `TComponentCanGetPropertyTypeSpecifyingExtension` pattern.
+- These extensions affect static analysis only — not runtime behaviour.
+
+## Gotchas
+
+- The `dy`/`fx` prefix check in `DynamicMethodsClassReflectionExtension` is **case-insensitive** (`strncasecmp`).
+- `TComponentHasMethodTypeSpecifyingExtension` only narrows when exactly **one** constant string is passed as the method name argument. Dynamic (variable) method names cannot be narrowed.
+- `TComponentPropertiesReflectionExtension` uses `hasMethod('get' . $name)` which is case-insensitive in PHP — `getText` and `gettext` are the same method. PHPStan will ask for whatever case appears in source code (`$obj->Text` → `hasProperty('Text')` → `hasMethod('getText')`).
+- Virtual properties use `canChangeTypeAfterAssignment() = false` because the setter/getter may apply custom logic, preventing type narrowing after writes.
+
+---
+
+## PHPStan Configuration
+
+To use these extensions in a PRADO Application, add the following to your `phpstan.neon`:
+
+```neon
+services:
+	-
+		class: Prado\PHPStan\TComponentPropertiesReflectionExtension
+		tags:
+			- phpstan.broker.propertiesClassReflectionExtension
+
+	-
+		class: Prado\PHPStan\TComponentCanSetPropertyTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+
+	-
+		class: Prado\PHPStan\TComponentCanGetPropertyTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+
+	-
+		class: Prado\PHPStan\TComponentHasMethodTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+
+	-
+		class: Prado\PHPStan\TComponentIsaTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+
+	-
+		class: Prado\PHPStan\PradoMethodVisibleStaticMethodTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
+
+	-
+		class: Prado\PHPStan\DynamicMethodsClassReflectionExtension
+		tags:
+			- phpstan.broker.methodsClassReflectionExtension
+```

--- a/framework/PHPStan/PradoMethodVisibleStaticMethodTypeSpecifyingExtension.php
+++ b/framework/PHPStan/PradoMethodVisibleStaticMethodTypeSpecifyingExtension.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * PradoMethodVisibleStaticMethodTypeSpecifyingExtension class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/teamdigitale/licenses/blob/master/CC0-1.0
+ */
+
+declare(strict_types=1);
+
+namespace Prado\PHPStan;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\HasMethodType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+use Prado\Prado;
+
+/**
+ * PradoMethodVisibleStaticMethodTypeSpecifyingExtension class.
+ *
+ * This is a PHPStan Extension which tells PHPStan that:
+ * ```php
+ *		if (Prado::method_visible($this, 'someMethod')) {
+ *			$this->someMethod();
+ *		}
+ * ```
+ * has the same effect as:
+ * ```php
+ *		if (method_exists($this, 'someMethod')) {
+ *			$this->someMethod();
+ *		}
+ * ```
+ *
+ * When the condition is true (inside the if block), PHPStan will know that the
+ * method exists and is publicly callable on the object and will not throw an
+ * error for calling it.
+ *
+ * {@see Prado::method_visible()} extends {@see method_exists()} with PHP visibility
+ * checks — a method must both exist and be accessible from the calling context.
+ * From PHPStan's perspective this narrows the subject type exactly as
+ * method_exists() would: the method is present on the object.
+ *
+ * This class helps PHPStan understand the "method_visible" PRADO feature and
+ * validate PRADO projects.
+ * To use this class, add the following PHPStan configuration to a project:
+ * ```neon
+ * services:
+ *		-
+ *			class: Prado\PHPStan\PradoMethodVisibleStaticMethodTypeSpecifyingExtension
+ *			tags:
+ *				- phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+final class PradoMethodVisibleStaticMethodTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+	private TypeSpecifier $typeSpecifier;
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+	{
+		return Prado::class;
+	}
+
+	public function isStaticMethodSupported(
+		MethodReflection $staticMethodReflection,
+		StaticCall $node,
+		TypeSpecifierContext $context
+	): bool {
+		return $staticMethodReflection->getName() === 'method_visible'
+			&& isset($node->args[0], $node->args[1])
+			&& $context->true();
+	}
+
+	public function specifyTypes(
+		MethodReflection $staticMethodReflection,
+		StaticCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes {
+		$objectArg = $node->args[0]->value;
+		$objectType = $scope->getType($objectArg);
+
+		if (!$objectType->isObject()->yes()) {
+			return new SpecifiedTypes();
+		}
+
+		$methodArgType = $scope->getType($node->args[1]->value);
+		$constantStrings = $methodArgType->getConstantStrings();
+
+		if (count($constantStrings) !== 1) {
+			return new SpecifiedTypes();
+		}
+
+		$methodName = $constantStrings[0]->getValue();
+
+		// Narrow the object type to include HasMethodType so PHPStan knows the
+		// method is visible and callable when the condition is true.
+		return $this->typeSpecifier->create(
+			$objectArg,
+			new IntersectionType([$objectType, new HasMethodType($methodName)]),
+			$context,
+			$scope
+		);
+	}
+}

--- a/framework/PHPStan/TComponentCanGetPropertyTypeSpecifyingExtension.php
+++ b/framework/PHPStan/TComponentCanGetPropertyTypeSpecifyingExtension.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * TComponentCanGetPropertyTypeSpecifyingExtension class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/teamdigitale/licenses/blob/master/CC0-1.0
+ */
+
+declare(strict_types=1);
+
+namespace Prado\PHPStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\HasMethodType;
+use PHPStan\Type\Accessory\HasPropertyType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use Prado\TComponent;
+
+/**
+ * TComponentCanGetPropertyTypeSpecifyingExtension class.
+ *
+ * This is a PHPStan Extension which tells PHPStan that:
+ * ```php
+ *		if ($this->canGetProperty('Foo')) {
+ *			$value = $this->getFoo(); // method call form
+ *			$value = $this->foo;      // virtual property form
+ *		}
+ * ```
+ * narrows the type of `$this` inside the if-block to indicate that both the
+ * getter method `getFoo()` exists and the virtual property `foo` is readable.
+ *
+ * In PRADO, {@see TComponent::canGetProperty()} returns true when a `get{Name}()`
+ * or `getjs{Name}()` method is publicly visible on the object or one of its
+ * enabled behaviors.  This extension teaches PHPStan about both the `get{Name}()`
+ * method and the `lcfirst($name)` virtual property so that neither the direct
+ * getter call nor the `$obj->prop` access produces a false PHPStan error inside
+ * the guarded branch.
+ *
+ * This class helps PHPStan understand the "canGetProperty" PRADO feature and
+ * validate PRADO projects.
+ * To use this class, add the following PHPStan configuration to a project:
+ * ```neon
+ * services:
+ *		-
+ *			class: Prado\PHPStan\TComponentCanGetPropertyTypeSpecifyingExtension
+ *			tags:
+ *				- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+final class TComponentCanGetPropertyTypeSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+	private TypeSpecifier $typeSpecifier;
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+	{
+		return TComponent::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context
+	): bool {
+		return $methodReflection->getName() === 'canGetProperty'
+			&& isset($node->args[0])
+			&& $context->true();
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes {
+		$calledOnType = $scope->getType($node->var);
+
+		if (!$calledOnType->isObject()->yes()) {
+			return new SpecifiedTypes();
+		}
+
+		$argType = $scope->getType($node->args[0]->value);
+		$constantStrings = $argType->getConstantStrings();
+
+		if (count($constantStrings) !== 1) {
+			return new SpecifiedTypes();
+		}
+
+		$propertyName = $constantStrings[0]->getValue();
+
+		// Narrow the object type so PHPStan knows:
+		//   1. The getter method get{Name}() exists (covers $obj->getName() calls).
+		//   2. The virtual property lcfirst($name) is readable (covers $obj->name access).
+		// HasPropertyType uses the lowercase-first form because PHPStan passes the
+		// property name exactly as written in source, and PRADO properties are
+		// conventionally accessed with a lowercase-first name (e.g. $obj->title).
+		return $this->typeSpecifier->create(
+			$node->var,
+			new IntersectionType([
+				$calledOnType,
+				new HasMethodType('get' . $propertyName),
+				new HasPropertyType(lcfirst($propertyName)),
+			]),
+			$context,
+			$scope
+		);
+	}
+}

--- a/framework/PHPStan/TComponentCanSetPropertyTypeSpecifyingExtension.php
+++ b/framework/PHPStan/TComponentCanSetPropertyTypeSpecifyingExtension.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * TComponentCanSetPropertyTypeSpecifyingExtension class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/teamdigitale/licenses/blob/master/CC0-1.0
+ */
+
+declare(strict_types=1);
+
+namespace Prado\PHPStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\HasMethodType;
+use PHPStan\Type\Accessory\HasPropertyType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use Prado\TComponent;
+
+/**
+ * TComponentCanSetPropertyTypeSpecifyingExtension class.
+ *
+ * This is a PHPStan Extension which tells PHPStan that:
+ * ```php
+ *		if ($this->canSetProperty('Foo')) {
+ *			$this->setFoo($value); // method call form
+ *			$this->foo = $value;   // virtual property form
+ *		}
+ * ```
+ * narrows the type of `$this` inside the if-block to indicate that both the
+ * setter method `setFoo()` exists and the virtual property `foo` is writable.
+ *
+ * In PRADO, {@see TComponent::canSetProperty()} returns true when a `set{Name}()`
+ * or `setjs{Name}()` method is publicly visible on the object or one of its
+ * enabled behaviors.  This extension teaches PHPStan about both the `set{Name}()`
+ * method and the `lcfirst($name)` virtual property so that neither the direct
+ * setter call nor the `$obj->prop = $value` assignment produces a false PHPStan
+ * error inside the guarded branch.
+ *
+ * This class helps PHPStan understand the "canSetProperty" PRADO feature and
+ * validate PRADO projects.
+ * To use this class, add the following PHPStan configuration to a project:
+ * ```neon
+ * services:
+ *		-
+ *			class: Prado\PHPStan\TComponentCanSetPropertyTypeSpecifyingExtension
+ *			tags:
+ *				- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+final class TComponentCanSetPropertyTypeSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+	private TypeSpecifier $typeSpecifier;
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+	{
+		return TComponent::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context
+	): bool {
+		return $methodReflection->getName() === 'canSetProperty'
+			&& isset($node->args[0])
+			&& $context->true();
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes {
+		$calledOnType = $scope->getType($node->var);
+
+		if (!$calledOnType->isObject()->yes()) {
+			return new SpecifiedTypes();
+		}
+
+		$argType = $scope->getType($node->args[0]->value);
+		$constantStrings = $argType->getConstantStrings();
+
+		if (count($constantStrings) !== 1) {
+			return new SpecifiedTypes();
+		}
+
+		$propertyName = $constantStrings[0]->getValue();
+
+		// Narrow the object type so PHPStan knows:
+		//   1. The setter method set{Name}() exists (covers $obj->setName() calls).
+		//   2. The virtual property lcfirst($name) is writable (covers $obj->name = $v).
+		// HasPropertyType uses the lowercase-first form because PHPStan passes the
+		// property name exactly as written in source, and PRADO properties are
+		// conventionally accessed with a lowercase-first name (e.g. $obj->title = 'x').
+		return $this->typeSpecifier->create(
+			$node->var,
+			new IntersectionType([
+				$calledOnType,
+				new HasMethodType('set' . $propertyName),
+				new HasPropertyType(lcfirst($propertyName)),
+			]),
+			$context,
+			$scope
+		);
+	}
+}

--- a/framework/PHPStan/TComponentHasMethodTypeSpecifyingExtension.php
+++ b/framework/PHPStan/TComponentHasMethodTypeSpecifyingExtension.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * TComponentHasMethodTypeSpecifyingExtension class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/teamdigitale/licenses/blob/master/CC0-1.0
+ */
+
+declare(strict_types=1);
+
+namespace Prado\PHPStan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\HasMethodType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use Prado\TComponent;
+
+/**
+ * TComponentHasMethodTypeSpecifyingExtension class.
+ *
+ * This is a PHPStan Extension which tells PHPStan that:
+ * ```php
+ *		if ($this->hasMethod('someMethod')) {
+ *			$this->someMethod();
+ *		}
+ * ```
+ * has the same effect as:
+ * ```php
+ *		if (method_exists($this, 'someMethod')) {
+ *			$this->someMethod();
+ *		}
+ * ```
+ *
+ * When the condition is true (inside the if block), PHPStan will know that the
+ * method exists on the object and will not throw an error for calling it.
+ *
+ * This class helps PHPStan understand the "hasMethod" PRADO feature and validate
+ * PRADO projects.
+ * To use this class, add the following PHPStan configuration to a project:
+ * ```neon
+ * services:
+ *		-
+ *			class: Prado\PHPStan\TComponentHasMethodTypeSpecifyingExtension
+ *			tags:
+ *				- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+final class TComponentHasMethodTypeSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+	private TypeSpecifier $typeSpecifier;
+
+	public function __construct(
+	) {
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+	{
+		return TComponent::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context
+	): bool {
+		return $methodReflection->getName() === 'hasMethod'
+			&& isset($node->args[0])
+			&& $context->true();
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes {
+		$calledOnType = $scope->getType($node->var);
+
+		if (!$calledOnType->isObject()->yes()) {
+			return new SpecifiedTypes();
+		}
+
+		$argType = $scope->getType($node->args[0]->value);
+		$constantStrings = $argType->getConstantStrings();
+
+		if (count($constantStrings) !== 1) {
+			return new SpecifiedTypes();
+		}
+
+		$methodName = $constantStrings[0]->getValue();
+
+		// Intersect the object type with HasMethodType so PHPStan understands
+		// that the method exists on the object inside the if-block, matching
+		// the same narrowing behaviour as method_exists().
+		return $this->typeSpecifier->create(
+			$node->var,
+			new IntersectionType([$calledOnType, new HasMethodType($methodName)]),
+			$context,
+			$scope
+		);
+	}
+}

--- a/framework/PHPStan/TComponentHasMethodTypeSpecifyingExtension.php
+++ b/framework/PHPStan/TComponentHasMethodTypeSpecifyingExtension.php
@@ -20,6 +20,7 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Accessory\HasMethodType;
+use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
 use Prado\TComponent;
@@ -106,12 +107,31 @@ final class TComponentHasMethodTypeSpecifyingExtension implements MethodTypeSpec
 
 		$methodName = $constantStrings[0]->getValue();
 
-		// Intersect the object type with HasMethodType so PHPStan understands
+		// Always narrow the object type with HasMethodType so PHPStan understands
 		// that the method exists on the object inside the if-block, matching
 		// the same narrowing behaviour as method_exists().
+		$types = [$calledOnType, new HasMethodType($methodName)];
+
+		// If the method follows the PRADO virtual-property convention
+		// (get{Name} / set{Name} / getjs{Name} / setjs{Name}), also narrow the
+		// virtual property so that $obj->name access inside the guard is accepted
+		// without a false "Access to an undefined property" error.
+		$lowerMethod = strtolower($methodName);
+		if (str_starts_with($lowerMethod, 'getjs') || str_starts_with($lowerMethod, 'setjs')) {
+			$propPart = substr($methodName, 5);
+			if ($propPart !== '') {
+				$types[] = new HasPropertyType(lcfirst($propPart));
+			}
+		} elseif (str_starts_with($lowerMethod, 'get') || str_starts_with($lowerMethod, 'set')) {
+			$propPart = substr($methodName, 3);
+			if ($propPart !== '') {
+				$types[] = new HasPropertyType(lcfirst($propPart));
+			}
+		}
+
 		return $this->typeSpecifier->create(
 			$node->var,
-			new IntersectionType([$calledOnType, new HasMethodType($methodName)]),
+			new IntersectionType($types),
 			$context,
 			$scope
 		);

--- a/framework/PHPStan/TComponentPropertiesReflectionExtension.php
+++ b/framework/PHPStan/TComponentPropertiesReflectionExtension.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * TComponentPropertiesReflectionExtension class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ */
+
+declare(strict_types=1);
+
+namespace Prado\PHPStan;
+
+use PHPStan\Analyser\OutOfClassScope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+use Prado\TComponent;
+
+/**
+ * TComponentPropertiesReflectionExtension class.
+ *
+ * This is a PHPStan Extension that teaches PHPStan about PRADO's virtual property
+ * system.  In PRADO, any pair of `get{Name}()` / `set{Name}()` methods on a
+ * {@see TComponent} subclass defines a virtual property that can be read or written
+ * via PHP's magic `__get` / `__set`:
+ *
+ * ```php
+ *		$component->Text       // calls $component->getText()
+ *		$component->Text = 'x' // calls $component->setText('x')
+ * ```
+ *
+ * Without this extension PHPStan reports "Access to an undefined property" for
+ * every such access.  With it, PHPStan resolves the getter return type and setter
+ * parameter type automatically, giving full type-checked property access.
+ *
+ * The `getjs` / `setjs` variants used for JavaScript-aware properties are also
+ * recognised.
+ *
+ * This class helps PHPStan understand PRADO's virtual property convention and
+ * validate PRADO projects.
+ * To use this class, add the following PHPStan configuration to a project:
+ * ```neon
+ * services:
+ *		-
+ *			class: Prado\PHPStan\TComponentPropertiesReflectionExtension
+ *			tags:
+ *				- phpstan.broker.propertiesClassReflectionExtension
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+class TComponentPropertiesReflectionExtension implements PropertiesClassReflectionExtension
+{
+	/**
+	 * Returns true when the given class is a TComponent subclass that exposes a
+	 * virtual property named $propertyName via a getter or setter method.
+	 *
+	 * Both the standard `get{Name}` / `set{Name}` convention and the JavaScript
+	 * `getjs{Name}` / `setjs{Name}` variant are checked.  Method lookup is
+	 * case-insensitive (matching PHP's own method resolution).
+	 * @param ClassReflection $classReflection
+	 * @param string $propertyName
+	 */
+	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+	{
+		if (!$classReflection->is(TComponent::class)) {
+			return false;
+		}
+		return $classReflection->hasMethod('get' . $propertyName)
+			|| $classReflection->hasMethod('set' . $propertyName)
+			|| $classReflection->hasMethod('getjs' . $propertyName)
+			|| $classReflection->hasMethod('setjs' . $propertyName);
+	}
+
+	/**
+	 * Returns a {@see TComponentPropertyReflection} that describes the virtual
+	 * property.  The getter is preferred over its JS variant for the readable
+	 * type; the setter is preferred over its JS variant for the writable type.
+	 * @param ClassReflection $classReflection
+	 * @param string $propertyName
+	 */
+	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		$getter = null;
+		$setter = null;
+
+		if ($classReflection->hasMethod('get' . $propertyName)) {
+			$getter = $classReflection->getMethod('get' . $propertyName, new OutOfClassScope());
+		} elseif ($classReflection->hasMethod('getjs' . $propertyName)) {
+			$getter = $classReflection->getMethod('getjs' . $propertyName, new OutOfClassScope());
+		}
+
+		if ($classReflection->hasMethod('set' . $propertyName)) {
+			$setter = $classReflection->getMethod('set' . $propertyName, new OutOfClassScope());
+		} elseif ($classReflection->hasMethod('setjs' . $propertyName)) {
+			$setter = $classReflection->getMethod('setjs' . $propertyName, new OutOfClassScope());
+		}
+
+		return new TComponentPropertyReflection($classReflection, $getter, $setter);
+	}
+}

--- a/framework/PHPStan/TComponentPropertyReflection.php
+++ b/framework/PHPStan/TComponentPropertyReflection.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * TComponentPropertyReflection class
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ */
+
+declare(strict_types=1);
+
+namespace Prado\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+
+/**
+ * TComponentPropertyReflection class.
+ *
+ * This class implements PHPStan's {@see PropertyReflection} interface for PRADO
+ * virtual properties — properties that are backed by `get{Name}()` / `set{Name}()`
+ * method pairs rather than a real PHP property declaration.
+ *
+ * A virtual property is readable when a getter method exists and writable when a
+ * setter method exists.  The readable type is derived from the getter's declared
+ * return type; the writable type is derived from the setter's first parameter
+ * type.  When no type information is available, {@see MixedType} is used.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+class TComponentPropertyReflection implements PropertyReflection
+{
+	public function __construct(
+		private ClassReflection $declaringClass,
+		private ?MethodReflection $getter,
+		private ?MethodReflection $setter
+	) {
+	}
+
+	public function getDeclaringClass(): ClassReflection
+	{
+		return $this->declaringClass;
+	}
+
+	public function isStatic(): bool
+	{
+		return false;
+	}
+
+	public function isPrivate(): bool
+	{
+		return false;
+	}
+
+	public function isPublic(): bool
+	{
+		return true;
+	}
+
+	public function getDocComment(): ?string
+	{
+		if ($this->getter !== null) {
+			return $this->getter->getDocComment();
+		}
+		if ($this->setter !== null) {
+			return $this->setter->getDocComment();
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the readable type of the property.
+	 * Derived from the getter's return type when available.
+	 */
+	public function getReadableType(): Type
+	{
+		if ($this->getter !== null) {
+			$variants = $this->getter->getVariants();
+			if ($variants !== []) {
+				return $variants[0]->getReturnType();
+			}
+		}
+		return new MixedType();
+	}
+
+	/**
+	 * Returns the writable type of the property.
+	 * Derived from the setter's first parameter type when available.
+	 */
+	public function getWritableType(): Type
+	{
+		if ($this->setter !== null) {
+			$variants = $this->setter->getVariants();
+			if ($variants !== []) {
+				$params = $variants[0]->getParameters();
+				if ($params !== []) {
+					return $params[0]->getType();
+				}
+			}
+		}
+		return new MixedType();
+	}
+
+	/**
+	 * Virtual properties backed by get/set method pairs use different logic
+	 * for reading and writing (method hooks), so type narrowing via assignment
+	 * is not safe.
+	 */
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return false;
+	}
+
+	public function isReadable(): bool
+	{
+		return $this->getter !== null;
+	}
+
+	public function isWritable(): bool
+	{
+		return $this->setter !== null;
+	}
+
+	public function isDeprecated(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+	public function getDeprecatedDescription(): ?string
+	{
+		return null;
+	}
+
+	public function isInternal(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,26 @@ services:
         tags:
             - phpstan.broker.methodsClassReflectionExtension
     -
+        class: Prado\PHPStan\TComponentPropertiesReflectionExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+    -
+        class: Prado\PHPStan\TComponentHasMethodTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
+        class: Prado\PHPStan\TComponentCanGetPropertyTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
+        class: Prado\PHPStan\TComponentCanSetPropertyTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
         class: Prado\PHPStan\TComponentIsaTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
+        class: Prado\PHPStan\PradoMethodVisibleStaticMethodTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,10 @@
   <testsuites>
     <testsuite name="unit">
       <directory suffix="Test.php">./tests/unit</directory>
+      <exclude>./tests/unit/PHPStan</exclude>
+    </testsuite>
+    <testsuite name="phpstan">
+      <directory suffix="Test.php">./tests/unit/PHPStan</directory>
     </testsuite>
     <testsuite name="functional">
       <directory suffix="TestCase.php">./tests/FunctionalTests</directory>

--- a/tests/unit/PHPStan/PHPStanExtensionsTest.php
+++ b/tests/unit/PHPStan/PHPStanExtensionsTest.php
@@ -1,0 +1,381 @@
+<?php
+
+/**
+ * PHPStanExtensionsTest
+ *
+ * Unit tests that verify every PHPStan extension wired into phpstan.neon.dist
+ * actually changes PHPStan's output for the corresponding fixture file.
+ *
+ * Strategy
+ * --------
+ * Each extension is tested in two passes:
+ *   1. WITHOUT the extension active – PHPStan must report at least one error on
+ *      the fixture.  This confirms the fixture is a genuine test case and that
+ *      the extension is actually doing work, not just silently passing.
+ *   2. WITH the extension active (via the project's phpstan.neon.dist) – PHPStan
+ *      must report zero errors on the same fixture.
+ *
+ * PHPStan is invoked as a subprocess so the tests remain independent of the
+ * PHPStan phar's internal API and work with any compatible PHPStan version.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires function exec
+ */
+class PHPStanExtensionsTest extends TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/** Absolute path to the project root (one level above tests/). */
+	private string $projectRoot;
+
+	protected function setUp(): void
+	{
+		$this->projectRoot = dirname(__DIR__, 3);
+
+		$phpstan = $this->projectRoot . '/vendor/bin/phpstan';
+		if (!is_file($phpstan)) {
+			$this->markTestSkipped('PHPStan binary not found at ' . $phpstan);
+		}
+
+		if (!function_exists('exec')) {
+			$this->markTestSkipped('exec() function is not available.');
+		}
+	}
+
+	/**
+	 * Run PHPStan on a fixture file and return the JSON-decoded result.
+	 *
+	 * @param string $fixtureFile  Basename of a file under tests/unit/PHPStan/fixtures/
+	 * @param string|null $config  Path to a neon config (null → phpstan.neon.dist)
+	 * @return array{totals: array{errors: int, file_errors: int}, files: array<string,mixed>}
+	 */
+	private function runPhpStan(string $fixtureFile, ?string $config = null): array
+	{
+		$fixture = __DIR__ . '/fixtures/' . $fixtureFile;
+		$phpstan = $this->projectRoot . '/vendor/bin/phpstan';
+		$configArg = $config !== null
+			? '--configuration=' . escapeshellarg($config)
+			: '--configuration=' . escapeshellarg($this->projectRoot . '/phpstan.neon.dist');
+
+		$cmd = escapeshellarg($phpstan)
+			. ' analyse'
+			. ' --no-progress'
+			. ' --error-format=json'
+			. ' ' . $configArg
+			. ' ' . escapeshellarg($fixture)
+			. ' 2>/dev/null';
+
+		$output = [];
+		exec($cmd, $output);
+		$json = implode("\n", $output);
+		$decoded = json_decode($json, true);
+
+		if (!is_array($decoded)) {
+			// PHPStan sometimes writes non-JSON lines first; strip them.
+			foreach ($output as $line) {
+				$candidate = json_decode($line, true);
+				if (is_array($candidate)) {
+					$decoded = $candidate;
+					break;
+				}
+			}
+		}
+
+		return $decoded ?? ['totals' => ['errors' => 0, 'file_errors' => 0], 'files' => []];
+	}
+
+	/**
+	 * Count errors reported for a given fixture file path inside the PHPStan JSON result.
+	 *
+	 * @param array<string,mixed> $result  Return value of runPhpStan()
+	 * @param string $fixtureFile          Basename of the fixture file
+	 */
+	private function countFileErrors(array $result, string $fixtureFile): int
+	{
+		$fixturePath = realpath(__DIR__ . '/fixtures/' . $fixtureFile) ?: (__DIR__ . '/fixtures/' . $fixtureFile);
+		foreach ($result['files'] ?? [] as $path => $data) {
+			// PHPStan may use relative or absolute paths; match by realpath or basename.
+			$realPath = realpath($path) ?: $path;
+			if ($realPath === $fixturePath || basename($path) === $fixtureFile) {
+				return (int) ($data['errors'] ?? 0);
+			}
+		}
+		return 0;
+	}
+
+	/** Path to the "no extensions" config used for the negative pass. */
+	private function noExtensionsConfig(): string
+	{
+		return __DIR__ . '/phpstan-no-extensions.neon';
+	}
+
+	// -------------------------------------------------------------------------
+	// DynamicMethodsClassReflectionExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension PHPStan reports "Call to an undefined method" for
+	 * every dy* or fx* call on a TComponent subclass.
+	 *
+	 * @group phpstan
+	 */
+	public function testDynamicMethodsExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('DynamicMethodsFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'DynamicMethodsFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan to report errors for dy*/fx* calls without DynamicMethodsClassReflectionExtension.'
+		);
+	}
+
+	/**
+	 * With the extension active, all dy* or fx* calls are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testDynamicMethodsExtension_PassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('DynamicMethodsFixture.php');
+		$errors = $this->countFileErrors($result, 'DynamicMethodsFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for dy*/fx* calls with DynamicMethodsClassReflectionExtension.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// TComponentHasMethodTypeSpecifyingExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension, guarded method calls produce "undefined method" errors.
+	 *
+	 * @group phpstan
+	 */
+	public function testHasMethodExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('HasMethodFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'HasMethodFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan errors for method calls guarded by hasMethod() without the extension.'
+		);
+	}
+
+	/**
+	 * With the extension active, hasMethod() guards correctly narrow the type and
+	 * all guarded method calls are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testHasMethodExtensionPassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('HasMethodFixture.php');
+		$errors = $this->countFileErrors($result, 'HasMethodFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for hasMethod()-guarded method calls with the extension.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// PradoMethodVisibleStaticMethodTypeSpecifyingExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension, Prado::method_visible() guards do not narrow the type.
+	 *
+	 * @group phpstan
+	 */
+	public function testMethodVisibleExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('MethodVisibleFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'MethodVisibleFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan errors for method calls guarded by Prado::method_visible() without the extension.'
+		);
+	}
+
+	/**
+	 * With the extension active, Prado::method_visible() guards narrow the type and
+	 * all guarded method calls are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testMethodVisibleExtension_PassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('MethodVisibleFixture.php');
+		$errors = $this->countFileErrors($result, 'MethodVisibleFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for Prado::method_visible()-guarded method calls with the extension.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// TComponentIsaTypeSpecifyingExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension, isa() guards do not narrow the type.
+	 *
+	 * @group phpstan
+	 */
+	public function testIsaExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('IsaFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'IsaFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan errors for subclass-specific calls inside isa() guards without the extension.'
+		);
+	}
+
+	/**
+	 * With the extension active, isa() guards narrow the type to the specified
+	 * subclass and all guarded method calls are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testIsaExtension_PassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('IsaFixture.php');
+		$errors = $this->countFileErrors($result, 'IsaFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for isa()-guarded subclass calls with the extension.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// TComponentCanGetPropertyTypeSpecifyingExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension, canGetProperty() guards do not narrow the type.
+	 *
+	 * @group phpstan
+	 */
+	public function testCanGetPropertyExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('CanGetPropertyFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'CanGetPropertyFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan errors for getter calls inside canGetProperty() guards without the extension.'
+		);
+	}
+
+	/**
+	 * With the extension active, canGetProperty() guards narrow the type so that
+	 * getter calls inside the block are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testCanGetPropertyExtension_PassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('CanGetPropertyFixture.php');
+		$errors = $this->countFileErrors($result, 'CanGetPropertyFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for canGetProperty()-guarded getter calls with the extension.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// TComponentCanSetPropertyTypeSpecifyingExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension, canSetProperty() guards do not narrow the type.
+	 *
+	 * @group phpstan
+	 */
+	public function testCanSetPropertyExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('CanSetPropertyFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'CanSetPropertyFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan errors for setter calls inside canSetProperty() guards without the extension.'
+		);
+	}
+
+	/**
+	 * With the extension active, canSetProperty() guards narrow the type so that
+	 * setter calls inside the block are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testCanSetPropertyExtension_PassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('CanSetPropertyFixture.php');
+		$errors = $this->countFileErrors($result, 'CanSetPropertyFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for canSetProperty()-guarded setter calls with the extension.'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// TComponentPropertiesReflectionExtension
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Without the extension, magic property access ($obj->PropName) produces
+	 * "Access to an undefined property" errors.
+	 *
+	 * @group phpstan
+	 */
+	public function testPropertiesReflectionExtension_FailsWithoutExtension(): void
+	{
+		$result = $this->runPhpStan('PropertiesReflectionFixture.php', $this->noExtensionsConfig());
+		$errors = $this->countFileErrors($result, 'PropertiesReflectionFixture.php');
+		$this->assertGreaterThan(
+			0,
+			$errors,
+			'Expected PHPStan errors for magic property access without TComponentPropertiesReflectionExtension.'
+		);
+	}
+
+	/**
+	 * With the extension active, PRADO virtual properties are resolved to their
+	 * getter/setter methods and all property accesses are accepted without error.
+	 *
+	 * @group phpstan
+	 */
+	public function testPropertiesReflectionExtension_PassesWithExtension(): void
+	{
+		$result = $this->runPhpStan('PropertiesReflectionFixture.php');
+		$errors = $this->countFileErrors($result, 'PropertiesReflectionFixture.php');
+		$this->assertSame(
+			0,
+			$errors,
+			'Expected zero PHPStan errors for virtual property access with TComponentPropertiesReflectionExtension.'
+		);
+	}
+}

--- a/tests/unit/PHPStan/PHPStanExtensionsTest.php
+++ b/tests/unit/PHPStan/PHPStanExtensionsTest.php
@@ -113,6 +113,38 @@ class PHPStanExtensionsTest extends TestCase
 		return 0;
 	}
 
+	/**
+	 * Build a human-readable list of PHPStan errors for a fixture file.
+	 *
+	 * Appended to assertion failure messages so you can see exactly which
+	 * errors remain rather than just a bare count.
+	 *
+	 * @param array<string,mixed> $result  Return value of runPhpStan()
+	 * @param string $fixtureFile          Basename of the fixture file
+	 */
+	private function describeErrors(array $result, string $fixtureFile): string
+	{
+		$fixturePath = realpath(__DIR__ . '/fixtures/' . $fixtureFile) ?: (__DIR__ . '/fixtures/' . $fixtureFile);
+		foreach ($result['files'] ?? [] as $path => $data) {
+			$realPath = realpath($path) ?: $path;
+			if ($realPath !== $fixturePath && basename($path) !== $fixtureFile) {
+				continue;
+			}
+			$messages = $data['messages'] ?? [];
+			if (empty($messages)) {
+				return '';
+			}
+			$lines = ["\nPHPStan errors in {$fixtureFile}:"];
+			foreach ($messages as $msg) {
+				$line = $msg['line'] ?? '?';
+				$text = $msg['message'] ?? '(no message)';
+				$lines[] = "  line {$line}: {$text}";
+			}
+			return implode("\n", $lines);
+		}
+		return '';
+	}
+
 	/** Path to the "no extensions" config used for the negative pass. */
 	private function noExtensionsConfig(): string
 	{
@@ -153,6 +185,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for dy*/fx* calls with DynamicMethodsClassReflectionExtension.'
+				. $this->describeErrors($result, 'DynamicMethodsFixture.php')
 		);
 	}
 
@@ -190,6 +223,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for hasMethod()-guarded method calls with the extension.'
+				. $this->describeErrors($result, 'HasMethodFixture.php')
 		);
 	}
 
@@ -227,6 +261,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for Prado::method_visible()-guarded method calls with the extension.'
+				. $this->describeErrors($result, 'MethodVisibleFixture.php')
 		);
 	}
 
@@ -264,6 +299,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for isa()-guarded subclass calls with the extension.'
+				. $this->describeErrors($result, 'IsaFixture.php')
 		);
 	}
 
@@ -301,6 +337,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for canGetProperty()-guarded getter calls with the extension.'
+				. $this->describeErrors($result, 'CanGetPropertyFixture.php')
 		);
 	}
 
@@ -338,6 +375,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for canSetProperty()-guarded setter calls with the extension.'
+				. $this->describeErrors($result, 'CanSetPropertyFixture.php')
 		);
 	}
 
@@ -376,6 +414,7 @@ class PHPStanExtensionsTest extends TestCase
 			0,
 			$errors,
 			'Expected zero PHPStan errors for virtual property access with TComponentPropertiesReflectionExtension.'
+				. $this->describeErrors($result, 'PropertiesReflectionFixture.php')
 		);
 	}
 }

--- a/tests/unit/PHPStan/fixtures/CanGetPropertyFixture.php
+++ b/tests/unit/PHPStan/fixtures/CanGetPropertyFixture.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Fixture for TComponentCanGetPropertyTypeSpecifyingExtension tests.
+ *
+ * PHPStan should not report errors on this file when the extension is active.
+ * When the extension is disabled, PHPStan cannot prove the getter exists inside
+ * a canGetProperty() guard and will report "Call to an undefined method".
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\TComponent;
+
+/**
+ * Exposes Title and Count as virtual properties.
+ */
+class CanGetPropertyFixtureComponent extends TComponent
+{
+	private string $_title = '';
+	private int $_count = 0;
+
+	public function getTitle(): string
+	{
+		return $this->_title;
+	}
+
+	public function setTitle(string $value): void
+	{
+		$this->_title = $value;
+	}
+
+	public function getCount(): int
+	{
+		return $this->_count;
+	}
+}
+
+class CanGetPropertyCaller extends TComponent
+{
+	/**
+	 * Guard on an external component's property getter.
+	 */
+	public function testCanGetPropertyGuard(CanGetPropertyFixtureComponent $component): void
+	{
+		if ($component->canGetProperty('Title')) {
+			// With extension: PHPStan knows getTitle() exists
+			$value = $component->getTitle();
+			\assert(\is_string($value));
+			
+			$value = $component->title;
+			\assert(\is_string($value));
+		}
+	}
+
+	/**
+	 * A read-only property: getter exists but no setter.
+	 */
+	public function testCanGetReadOnlyProperty(CanGetPropertyFixtureComponent $component): void
+	{
+		if ($component->canGetProperty('Count')) {
+			$count = $component->getCount();
+			\assert(\is_int($count));
+			
+			$count = $component->count;
+			\assert(\is_int($count));
+		}
+	}
+
+	/**
+	 * Self-based guard pattern used inside TComponent subclasses.
+	 */
+	public function testCanGetPropertyOnSelf(): void
+	{
+		if ($this->canGetProperty('Title')) {
+			$this->getTitle();
+			$this->title;
+		}
+	}
+}

--- a/tests/unit/PHPStan/fixtures/CanSetPropertyFixture.php
+++ b/tests/unit/PHPStan/fixtures/CanSetPropertyFixture.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Fixture for TComponentCanSetPropertyTypeSpecifyingExtension tests.
+ *
+ * PHPStan should not report errors on this file when the extension is active.
+ * When the extension is disabled, PHPStan cannot prove the setter exists inside
+ * a canSetProperty() guard and will report "Call to an undefined method".
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\TComponent;
+
+/**
+ * Exposes Label and Priority as virtual properties with setters.
+ */
+class CanSetPropertyFixtureComponent extends TComponent
+{
+	private string $_label = '';
+	private int $_priority = 0;
+	private int $_readOnly = 0;
+
+	public function getLabel(): string
+	{
+		return $this->_label;
+	}
+
+	public function setLabel(string $value): void
+	{
+		$this->_label = $value;
+	}
+
+	public function getPriority(): int
+	{
+		return $this->_priority;
+	}
+
+	public function setPriority(int $value): void
+	{
+		$this->_priority = $value;
+	}
+
+	public function getReadOnly(): int
+	{
+		return $this->_readOnly;
+	}
+}
+
+class CanSetPropertyCaller extends TComponent
+{
+	/**
+	 * Guard on an external component's property setter.
+	 */
+	public function testCanSetPropertyGuard(CanSetPropertyFixtureComponent $component): void
+	{
+		if ($component->canSetProperty('Label')) {
+			// With extension: PHPStan knows setLabel() exists
+			$component->setLabel('hello');
+			$component->label = 'hello';
+		}
+	}
+
+	/**
+	 * A second writable property.
+	 */
+	public function testCanSetPriorityGuard(CanSetPropertyFixtureComponent $component): void
+	{
+		if ($component->canSetProperty('Priority')) {
+			$component->setPriority(10);
+			$component->priority = 10;
+		}
+	}
+
+	/**
+	 * Self-based pattern.
+	 */
+	public function testCanSetPropertyOnSelf(): void
+	{
+		if ($this->canSetProperty('Label')) {
+			$this->setLabel('world');
+			$this->label = 'world';
+		}
+	}
+}

--- a/tests/unit/PHPStan/fixtures/DynamicMethodsFixture.php
+++ b/tests/unit/PHPStan/fixtures/DynamicMethodsFixture.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Fixture for DynamicMethodsClassReflectionExtension tests.
+ *
+ * PHPStan must never report "Call to an undefined method" for any method whose
+ * name starts with 'dy' or 'fx' on a TComponent subclass.  This is true whether
+ * or not the method is actually declared on the class.
+ *
+ * NOTE: Do not use fxAttachClassBehavior or fxDetachClassBehavior here — those
+ * ARE real declared methods on TComponent (with specific signatures) so PHPStan
+ * type-checks them normally and they do not exercise the dynamic extension.
+ * Use invented names that do not exist on TComponent.
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\TComponent;
+
+class DynamicMethodsFixtureComponent extends TComponent
+{
+}
+
+class DynamicMethodsCaller
+{
+	/**
+	 * Dynamic behavior events (dy prefix) must be accepted unconditionally.
+	 * PHPStan must not report "Call to an undefined method" for invented dy names.
+	 */
+	public function testDyPrefixMethods(DynamicMethodsFixtureComponent $component): void
+	{
+		// All of these are valid regardless of whether the method is declared.
+		$component->dyCustomMethod();
+		$component->dyInitialize('arg');
+		$component->dyValidate('value', true);
+	}
+
+	/**
+	 * Global events (fx prefix) must be accepted unconditionally.
+	 * PHPStan must not report "Call to an undefined method" for invented fx names.
+	 */
+	public function testFxPrefixMethods(DynamicMethodsFixtureComponent $component): void
+	{
+		// Invented fx names — not declared on TComponent.
+		$component->fxCustomBroadcast('payload');
+		$component->fxNotifySubscribers(42);
+		$component->fxBuildIndex();
+	}
+
+	/**
+	 * Additional dy/fx calls on the same component instance.
+	 */
+	public function testMoreDynamicMethods(DynamicMethodsFixtureComponent $component): void
+	{
+		$component->dyBeforeSave();
+		$component->dyAfterLoad('result');
+		$component->fxDispatchEvent('name', []);
+	}
+}

--- a/tests/unit/PHPStan/fixtures/HasMethodFixture.php
+++ b/tests/unit/PHPStan/fixtures/HasMethodFixture.php
@@ -45,6 +45,12 @@ class HasMethodCaller extends TComponent
 		if ($component->hasMethod('dynamicMethod')) {
 			$component->dynamicMethod('someValue');
 		}
+		if ($component->hasMethod('getTitle')) {
+			$value = $component->title; // only get property should validate
+		}
+		if ($component->hasMethod('setTitle')) {
+			$component->title = 'value'; // only get property should validate
+		}
 	}
 
 	/**
@@ -56,6 +62,12 @@ class HasMethodCaller extends TComponent
 		if ($this->hasMethod('dynamicMethod')) {
 			$this->dynamicMethod('Property');
 		}
+		if ($this->hasMethod('getTitle')) {
+			$value = $this->title; // only get property should validate
+		}
+		if ($this->hasMethod('setTitle')) {
+			$this->title = 'value'; // only get property should validate
+		}
 	}
 
 	/**
@@ -66,6 +78,12 @@ class HasMethodCaller extends TComponent
 	{
 		if ($component->hasMethod('validate')) {
 			$component->validate('someValue');
+		}
+		if ($component->hasMethod('getValue')) {
+			$value = $component->value; // only get property should validate
+		}
+		if ($component->hasMethod('setValue')) {
+			$component->value = 'value'; // only get property should validate
 		}
 	}
 }

--- a/tests/unit/PHPStan/fixtures/HasMethodFixture.php
+++ b/tests/unit/PHPStan/fixtures/HasMethodFixture.php
@@ -45,10 +45,18 @@ class HasMethodCaller extends TComponent
 		if ($component->hasMethod('dynamicMethod')) {
 			$component->dynamicMethod('someValue');
 		}
+		
 		if ($component->hasMethod('getTitle')) {
 			$value = $component->title; // only get property should validate
 		}
 		if ($component->hasMethod('setTitle')) {
+			$component->title = 'value'; // only get property should validate
+		}
+		
+		if ($component->hasMethod('getjsTitle')) {
+			$value = $component->title; // only get property should validate
+		}
+		if ($component->hasMethod('setjsTitle')) {
 			$component->title = 'value'; // only get property should validate
 		}
 	}
@@ -62,10 +70,18 @@ class HasMethodCaller extends TComponent
 		if ($this->hasMethod('dynamicMethod')) {
 			$this->dynamicMethod('Property');
 		}
+		
 		if ($this->hasMethod('getTitle')) {
 			$value = $this->title; // only get property should validate
 		}
 		if ($this->hasMethod('setTitle')) {
+			$this->title = 'value'; // only get property should validate
+		}
+		
+		if ($this->hasMethod('getjsTitle')) {
+			$value = $this->title; // only get property should validate
+		}
+		if ($this->hasMethod('setjsTitle')) {
 			$this->title = 'value'; // only get property should validate
 		}
 	}
@@ -79,10 +95,18 @@ class HasMethodCaller extends TComponent
 		if ($component->hasMethod('validate')) {
 			$component->validate('someValue');
 		}
+		
 		if ($component->hasMethod('getValue')) {
 			$value = $component->value; // only get property should validate
 		}
 		if ($component->hasMethod('setValue')) {
+			$component->value = 'value'; // only get property should validate
+		}
+		
+		if ($component->hasMethod('getjsValue')) {
+			$value = $component->value; // only get property should validate
+		}
+		if ($component->hasMethod('setjsValue')) {
 			$component->value = 'value'; // only get property should validate
 		}
 	}

--- a/tests/unit/PHPStan/fixtures/HasMethodFixture.php
+++ b/tests/unit/PHPStan/fixtures/HasMethodFixture.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Fixture for TComponentHasMethodTypeSpecifyingExtension tests.
+ *
+ * PHPStan should not report any errors on this file when the extension is active.
+ * When the extension is disabled, PHPStan should report "Call to an undefined
+ * method" for every guarded method call inside an if ($this->hasMethod(...)) block.
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\TComponent;
+
+/**
+ * A concrete subclass that declares assertUninitialized() – this is the method
+ * the tests try to call after the hasMethod guard.
+ */
+class HasMethodFixtureComponent extends TComponent
+{
+	public function assertUninitialized(string $connectionId): void
+	{
+	}
+
+	public function validate(mixed $value): bool
+	{
+		return true;
+	}
+}
+
+/**
+ * Caller that uses hasMethod() guards before invoking methods.
+ * Without the extension, PHPStan cannot prove the methods exist and emits errors.
+ */
+class HasMethodCaller extends TComponent
+{
+	/**
+	 * The canonical motivating example from the bug report.
+	 * hasMethod guard for a method declared on a sibling subclass.
+	 */
+	public function testHasMethodGuard(HasMethodFixtureComponent $component): void
+	{
+		if ($component->hasMethod('dynamicMethod')) {
+			$component->dynamicMethod('someValue');
+		}
+	}
+
+	/**
+	 * $this-based guard: the real-world pattern where a framework class checks
+	 * for an optional lifecycle method on itself.
+	 */
+	public function testSelfHasMethodGuard(): void
+	{
+		if ($this->hasMethod('dynamicMethod')) {
+			$this->dynamicMethod('Property');
+		}
+	}
+
+	/**
+	 * A second method name to confirm the extension handles any constant string,
+	 * not just 'assertUninitialized'.
+	 */
+	public function testAlternativeMethodGuard(HasMethodFixtureComponent $component): void
+	{
+		if ($component->hasMethod('validate')) {
+			$component->validate('someValue');
+		}
+	}
+}

--- a/tests/unit/PHPStan/fixtures/IsaFixture.php
+++ b/tests/unit/PHPStan/fixtures/IsaFixture.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Fixture for TComponentIsaTypeSpecifyingExtension tests.
+ *
+ * PHPStan should not report errors on this file when the extension is active.
+ * When the extension is disabled, PHPStan cannot narrow the type inside the
+ * isa() guard and will report "Call to an undefined method" for the narrowed call.
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\TComponent;
+
+/**
+ * A concrete subclass with its own method, used as the narrowing target.
+ */
+class IsaFixtureSubComponent extends TComponent
+{
+	public function subclassSpecificMethod(): string
+	{
+		return 'specific';
+	}
+}
+
+/**
+ * Another distinct subclass so we can verify narrowing applies to the right type.
+ */
+class IsaFixtureOtherComponent extends TComponent
+{
+	public function otherSpecificMethod(): int
+	{
+		return 42;
+	}
+}
+
+class IsaCaller
+{
+	/**
+	 * Canonical isa() guard: $component is TComponent but the guard narrows it
+	 * to IsaFixtureSubComponent, enabling the subclass-specific call.
+	 */
+	public function testIsaGuard(TComponent $component): void
+	{
+		if ($component->isa(IsaFixtureSubComponent::class)) {
+			// With extension: $component is narrowed to IsaFixtureSubComponent
+			$component->subclassSpecificMethod();
+		}
+	}
+
+	/**
+	 * A second narrowing target to confirm the extension handles any subclass.
+	 */
+	public function testIsaGuardOther(TComponent $component): void
+	{
+		if ($component->isa(IsaFixtureOtherComponent::class)) {
+			$component->otherSpecificMethod();
+		}
+	}
+}

--- a/tests/unit/PHPStan/fixtures/MethodVisibleFixture.php
+++ b/tests/unit/PHPStan/fixtures/MethodVisibleFixture.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Fixture for PradoMethodVisibleStaticMethodTypeSpecifyingExtension tests.
+ *
+ * PHPStan should not report any errors on this file when the extension is active.
+ * When the extension is disabled, PHPStan should report "Call to an undefined
+ * method" for every guarded call inside a Prado::method_visible() block.
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\Prado;
+use Prado\TComponent;
+
+/**
+ * Declares two optional methods that callers check via method_visible().
+ */
+class MethodVisibleFixtureComponent extends TComponent
+{
+	public function initialize(string $id): void
+	{
+	}
+
+	public function configure(array $options): void
+	{
+	}
+}
+
+/**
+ * Caller that uses Prado::method_visible() guards.
+ * Mirrors the pattern used extensively inside TComponent itself.
+ */
+class MethodVisibleCaller extends TComponent
+{
+	/**
+	 * Guard on an external object.
+	 */
+	public function testMethodVisibleOnObject(MethodVisibleFixtureComponent $component): void
+	{
+		if (Prado::method_visible($component, 'initialize')) {
+			$component->initialize('myId');
+		}
+	}
+
+	/**
+	 * Guard on $this — used in TComponent::__get / __set and similar lifecycle code.
+	 */
+	public function testMethodVisibleOnSelf(): void
+	{
+		if (Prado::method_visible($this, 'initialize')) {
+			$this->initialize('myId');
+		}
+	}
+
+	/**
+	 * A second method name to confirm generality.
+	 */
+	public function testMethodVisibleConfigure(MethodVisibleFixtureComponent $component): void
+	{
+		if (Prado::method_visible($component, 'configure')) {
+			$component->configure([]);
+		}
+	}
+}

--- a/tests/unit/PHPStan/fixtures/MethodVisibleFixture.php
+++ b/tests/unit/PHPStan/fixtures/MethodVisibleFixture.php
@@ -43,6 +43,20 @@ class MethodVisibleCaller extends TComponent
 		if (Prado::method_visible($component, 'initialize')) {
 			$component->initialize('myId');
 		}
+		
+		if ($component->hasMethod('getTitle')) {
+			$value = $component->title; // only get property should validate
+		}
+		if ($component->hasMethod('setTitle')) {
+			$component->title = 'value'; // only get property should validate
+		}
+		
+		if ($component->hasMethod('getjsTitle')) {
+			$value = $component->title; // only get property should validate
+		}
+		if ($component->hasMethod('setjsTitle')) {
+			$component->title = 'value'; // only get property should validate
+		}
 	}
 
 	/**
@@ -53,6 +67,20 @@ class MethodVisibleCaller extends TComponent
 		if (Prado::method_visible($this, 'initialize')) {
 			$this->initialize('myId');
 		}
+		
+		if ($this->hasMethod('getTitle')) {
+			$value = $this->title; // only get property should validate
+		}
+		if ($this->hasMethod('setTitle')) {
+			$this->title = 'value'; // only get property should validate
+		}
+		
+		if ($this->hasMethod('getjsTitle')) {
+			$value = $this->title; // only get property should validate
+		}
+		if ($this->hasMethod('setjsTitle')) {
+			$this->title = 'value'; // only get property should validate
+		}
 	}
 
 	/**
@@ -62,6 +90,20 @@ class MethodVisibleCaller extends TComponent
 	{
 		if (Prado::method_visible($component, 'configure')) {
 			$component->configure([]);
+		}
+		
+		if ($component->hasMethod('getValue')) {
+			$value = $component->value; // only get property should validate
+		}
+		if ($component->hasMethod('setValue')) {
+			$component->value = 'value'; // only get property should validate
+		}
+		
+		if ($component->hasMethod('getjsValue')) {
+			$value = $component->value; // only get property should validate
+		}
+		if ($component->hasMethod('setjsValue')) {
+			$component->value = 'value'; // only get property should validate
 		}
 	}
 }

--- a/tests/unit/PHPStan/fixtures/PropertiesReflectionFixture.php
+++ b/tests/unit/PHPStan/fixtures/PropertiesReflectionFixture.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Fixture for TComponentPropertiesReflectionExtension tests.
+ *
+ * PHPStan should not report errors on this file when the extension is active.
+ * When the extension is disabled, PHPStan reports "Access to an undefined property"
+ * for every magic $component->PropertyName access.
+ */
+
+declare(strict_types=1);
+
+namespace PradoTests\PHPStan\Fixtures;
+
+use Prado\TComponent;
+
+/**
+ * A component with typical PRADO virtual property pairs.
+ */
+class PropertiesFixtureComponent extends TComponent
+{
+	private string $_name = '';
+	private int $_age = 0;
+	private bool $_active = false;
+
+	// Standard get/set pair → readable and writable property 'Name'
+	public function getName(): string
+	{
+		return $this->_name;
+	}
+
+	public function setName(string $value): void
+	{
+		$this->_name = $value;
+	}
+
+	// Read-only virtual property 'Age' (getter only)
+	public function getAge(): int
+	{
+		return $this->_age;
+	}
+
+	// Write-only virtual property 'Active' (setter only)
+	public function setActive(bool $value): void
+	{
+		$this->_active = $value;
+	}
+}
+
+class PropertiesReflectionCaller
+{
+	/**
+	 * Read and write a standard get/set property via magic access.
+	 * Without the extension PHPStan would flag both lines.
+	 */
+	public function testReadWriteProperty(PropertiesFixtureComponent $component): void
+	{
+		// Write
+		$component->Name = 'Alice';
+		// Read
+		$name = $component->Name;
+		\assert(\is_string($name));
+	}
+
+	/**
+	 * Read a read-only virtual property.
+	 */
+	public function testReadOnlyProperty(PropertiesFixtureComponent $component): void
+	{
+		$age = $component->Age;
+		\assert(\is_int($age));
+	}
+
+	/**
+	 * Write a write-only virtual property.
+	 */
+	public function testWriteOnlyProperty(PropertiesFixtureComponent $component): void
+	{
+		$component->Active = true;
+	}
+}

--- a/tests/unit/PHPStan/phpstan-no-extensions.neon
+++ b/tests/unit/PHPStan/phpstan-no-extensions.neon
@@ -1,0 +1,6 @@
+## PHPStan configuration with all PRADO extensions disabled.
+## Used to verify that the fixture files DO produce errors without the extensions,
+## confirming the extensions are actually doing useful work.
+parameters:
+    phpVersion: 80300
+    level: 2


### PR DESCRIPTION
unit tests for the PRADO PHPStan extensions via fixture
Adds the following PHPStan extensions:
- Prado::method_visible indicates the method it's checking.
- TComponent::hasMethod() indicates the method, and property when (get/set; js aware)
- TComponent:: canSetProperty() indicates a set property.
- TComponent:: canGetProperty() indicates a get property.
- MethodReflection isReadable/isWritable properties for reflection
- get/set methods are PRADO Property magic; JS aware (getjs/setjs).
