### PR TITLE
TModuleView & TControl::createControlChildren parent chain (for attached behaviors)

### DIFF
--- a/framework/Web/UI/ActiveControls/TActiveFileUpload.php
+++ b/framework/Web/UI/ActiveControls/TActiveFileUpload.php
@@ -345,6 +345,8 @@ class TActiveFileUpload extends TFileUpload implements IActiveControl, ICallback
 		$this->_target->setFrameUrl('about:blank');
 		$this->_target->setStyle("width:0px; height:0px; border:none");
 		$this->getControls()->add($this->_target);
+
+		parent::createChildControls();
 	}
 
 	/**

--- a/framework/Web/UI/TControl.php
+++ b/framework/Web/UI/TControl.php
@@ -1024,9 +1024,11 @@ class TControl extends \Prado\TApplicationComponent implements IRenderable, IBin
 	 * This method can be overridden for controls who want to have their controls.
 	 * Do not call this method directly. Instead, call {@see ensureChildControls}
 	 * to ensure child controls are created only once.
+	 * @method dyCreateChildControls() for the behaviors to process children.
 	 */
 	public function createChildControls()
 	{
+		$this->dyCreateChildControls();
 	}
 
 	/**
@@ -1211,6 +1213,8 @@ class TControl extends \Prado\TApplicationComponent implements IRenderable, IBin
 	}
 
 	/**
+	 * @todo v4.4 param $inTemplate for whether or not its for template or for creating control
+	 *					This can be used by TModuleView.
 	 * @return bool whether body contents are allowed for this control. Defaults to true.
 	 */
 	public function getAllowChildControls()

--- a/framework/Web/UI/TEventContent.php
+++ b/framework/Web/UI/TEventContent.php
@@ -36,6 +36,7 @@ class TEventContent extends TCompositeControl
 		if ($event = $this->getBroadcastEvent()) {
 			$this->raiseEvent($event, $this, new TEventParameter($this->getControls()));
 		}
+		parent::createChildControls();
 	}
 
 	/**

--- a/framework/Web/UI/TModuleView.php
+++ b/framework/Web/UI/TModuleView.php
@@ -18,12 +18,12 @@ use Prado\TPropertyValue;
  * TModuleView class.
  *
  * TModuleView disables its children controls when a module is not present.  In their
- * place the optional {@see getNotFoundTemplate NotFoundTemplate} is instantiated.
+ * place the optional {@see getFallbackTemplate FallbackTemplate} is instantiated.
  *
  * Properties:
  * - <b>ModuleId</b>, string — the application module ID to check the presence of.
  * - <b>Condition</b>, bool — the condition to display module specific children controls.
- * - <b>NotFoundTemplate</b>, ITemplate — template rendered when the module is absent.
+ * - <b>FallbackTemplate</b>, ITemplate — template rendered when the module is absent.
  *
  * By leaving out the ModuleId, it becomes like a {@see TConditional}, except this
  * does not create the children when the condition is not met.
@@ -39,7 +39,7 @@ class TModuleView extends TCompositeControl
 	private $_condition = '';
 
 	/** @var ?ITemplate Template rendered when the module is not found. */
-	private $_notfoundtemplate;
+	private $_fallbacktemplate;
 
 	/**
 	 * Creates child controls.
@@ -51,8 +51,8 @@ class TModuleView extends TCompositeControl
 	{
 		if (!$this->getIsActive()) {
 			$this->getControls()->clear();
-			if ($this->_notfoundtemplate) {
-				$this->_notfoundtemplate->instantiateIn($this);
+			if ($this->_fallbacktemplate) {
+				$this->_fallbacktemplate->instantiateIn($this);
 			}
 		}
 		parent::createChildControls();
@@ -71,7 +71,7 @@ class TModuleView extends TCompositeControl
 	/**
 	 * Whether or not the control is active with the module and the condition expression
 	 * evaluating to true.
-	 * @return bool is the Module View active otherwise the NotFoundTemplate is showing.
+	 * @return bool is the Module View active otherwise the FallbackTemplate is showing.
 	 */
 	public function getIsActive(): bool
 	{
@@ -179,17 +179,17 @@ class TModuleView extends TCompositeControl
 	/**
 	 * @return ?ITemplate the template rendered when the module is not found
 	 */
-	public function getNotFoundTemplate()
+	public function getFallbackTemplate()
 	{
-		return $this->_notfoundtemplate;
+		return $this->_fallbacktemplate;
 	}
 
 	/**
 	 * @param ITemplate $template the template rendered when the module is not found
 	 */
-	public function setNotFoundTemplate($template)
+	public function setFallbackTemplate($template)
 	{
-		$this->_notfoundtemplate = $template;
+		$this->_fallbacktemplate = $template;
 	}
 
 	//  --- TControl Overrides

--- a/framework/Web/UI/TModuleView.php
+++ b/framework/Web/UI/TModuleView.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * TModuleView class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Web\UI;
+
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Prado;
+use Prado\TPropertyValue;
+
+/**
+ * TModuleView class.
+ *
+ * TModuleView disables its children controls when a module is not present.  In their
+ * place the optional {@see getNotFoundTemplate NotFoundTemplate} is instantiated.
+ *
+ * Properties:
+ * - <b>ModuleId</b>, string — the application module ID to check the presence of.
+ * - <b>Condition</b>, bool — the condition to display module specific children controls.
+ * - <b>NotFoundTemplate</b>, ITemplate — template rendered when the module is absent.
+ *
+ * By leaving out the ModuleId, it becomes like a {@see TConditional}, except this
+ * does not create the children when the condition is not met.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ */
+class TModuleView extends TCompositeControl
+{
+	private $_isActive;
+	private $_mod;
+	private $_moduleId = '';
+	private $_condition = '';
+
+	/** @var ?ITemplate Template rendered when the module is not found. */
+	private $_notfoundtemplate;
+
+	/**
+	 * Creates child controls.
+	 * This method overrides the parent implementation. It evaluates {@see getCondition Condition}
+	 * and instantiate the corresponding template.
+	 * @return void
+	 */
+	public function createChildControls()
+	{
+		if (!$this->getIsActive()) {
+			$this->getControls()->clear();
+			if ($this->_notfoundtemplate) {
+				$this->_notfoundtemplate->instantiateIn($this);
+			}
+		}
+		parent::createChildControls();
+	}
+
+	/**
+	 * Override parent to always return a control collection not dependent upon
+	 * {@see getAllowChildControls}.
+	 * @return TControlCollection control collection
+	 */
+	protected function createControlCollection()
+	{
+		return new TControlCollection($this);
+	}
+
+	/**
+	 * Whether or not the control is active with the module and the condition expression
+	 * evaluating to true.
+	 * @return bool is the Module View active otherwise the NotFoundTemplate is showing.
+	 */
+	public function getIsActive(): bool
+	{
+		if ($this->_isActive === null) {
+			$this->_isActive = $this->getModuleAvailable() && $this->getConditionEvaluation();
+		}
+		return $this->_isActive;
+	}
+
+	/**
+	 * Internal reset of the isActive property.
+	 */
+	protected function resetIsActive(): void
+	{
+		$this->_isActive = null;
+	}
+
+	/**
+	 * @return bool whether the module specified by {@see getModuleId ModuleId} is registered
+	 */
+	public function getModuleAvailable(): bool
+	{
+		return $this->getModule() !== null;
+	}
+
+	/**
+	 * @return ?mixed the module instance, or null if not found
+	 */
+	public function getModule(): mixed
+	{
+		if ($this->_mod === null) {
+			$moduleId = $this->getModuleId();
+			if (!empty($moduleId) && ($app = $this->getApplication())) {
+				$this->_mod = $app->getModule($moduleId);
+			}
+		}
+		return $this->_mod;
+	}
+
+	/**
+	 * @return string the application module ID to check for
+	 */
+	public function getModuleId()
+	{
+		return $this->_moduleId;
+	}
+
+	/**
+	 * @param string $value the application module ID to check for
+	 */
+	public function setModuleId($value)
+	{
+		$value = TPropertyValue::ensureString($value);
+		if ($this->_moduleId !== $value) {
+			$this->_mod = null;
+			$this->_moduleId = $value;
+			$this->resetIsActive();
+		}
+	}
+
+	/**
+	 * @return string the evaluated condition for turning on or off the children
+	 */
+	public function getCondition()
+	{
+		return empty($this->_condition) ? 'true' : $this->_condition;
+	}
+
+	/**
+	 * @param string $value the evaluated condition for turning on or off the children
+	 */
+	public function setCondition($value)
+	{
+		$value = TPropertyValue::ensureString($value);
+		if ($this->_condition !== $value) {
+			$value = TPropertyValue::ensureString($value);
+			$value = html_entity_decode($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+			$this->_condition = $value;
+			$this->resetIsActive();
+		}
+	}
+
+	/**
+	 * Creates child controls.
+	 * This method overrides the parent implementation. It evaluates {@see getCondition Condition}
+	 * and instantiate the corresponding template.
+	 * @return bool if the expression evaluates to true
+	 */
+	protected function getConditionEvaluation(): bool
+	{
+		$result = true;
+		$condition = $this->getCondition();
+		$tplControl = $this->getTemplateControl();
+		if (!$tplControl) {
+			return false;
+		}
+		try {
+			$result = $tplControl->evaluateExpression($condition);
+		} catch (\Exception $e) {
+			throw new TInvalidDataValueException('conditional_condition_invalid', $condition, $e->getMessage());
+		}
+		return $result;
+	}
+
+	/**
+	 * @return ?ITemplate the template rendered when the module is not found
+	 */
+	public function getNotFoundTemplate()
+	{
+		return $this->_notfoundtemplate;
+	}
+
+	/**
+	 * @param ITemplate $template the template rendered when the module is not found
+	 */
+	public function setNotFoundTemplate($template)
+	{
+		$this->_notfoundtemplate = $template;
+	}
+
+	//  --- TControl Overrides
+
+	/**
+	 * This specifically tells the template Whether or not to allow children controls.
+	 * @return bool true if child controls should be instantiated
+	 */
+	public function getAllowChildControls()
+	{
+		return $this->getModuleAvailable();
+	}
+}

--- a/framework/Web/UI/TTemplateControl.php
+++ b/framework/Web/UI/TTemplateControl.php
@@ -146,6 +146,7 @@ class TTemplateControl extends TCompositeControl
 			}
 			$tpl->instantiateIn($this);
 		}
+		parent::createChildControls();
 	}
 
 	/**

--- a/framework/Web/UI/TTemplateControlInheritable.php
+++ b/framework/Web/UI/TTemplateControlInheritable.php
@@ -53,6 +53,7 @@ class TTemplateControlInheritable extends TTemplateControl
 		}
 
 		$_template->instantiateIn($this);
+		parent::createChildControls();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TConditional.php
+++ b/framework/Web/UI/WebControls/TConditional.php
@@ -74,11 +74,17 @@ class TConditional extends \Prado\Web\UI\TControl
 	public function createChildControls()
 	{
 		$this->_creatingChildren = true;
+		$this->getControls()->clear();
 		$result = true;
+		$condition = $this->getCondition();
+		$tplControl = $this->getTemplateControl();
+		if (!$tplControl) {
+			return;
+		}
 		try {
-			$result = $this->getTemplateControl()->evaluateExpression($this->_condition);
+			$result = $tplControl->evaluateExpression($condition);
 		} catch (\Exception $e) {
-			throw new TInvalidDataValueException('conditional_condition_invalid', $this->_condition, $e->getMessage());
+			throw new TInvalidDataValueException('conditional_condition_invalid', $condition, $e->getMessage());
 		}
 		if ($result) {
 			if ($this->_trueTemplate) {
@@ -88,6 +94,7 @@ class TConditional extends \Prado\Web\UI\TControl
 			$this->_falseTemplate->instantiateIn($this->getTemplateControl(), $this);
 		}
 		$this->_creatingChildren = false;
+		parent::createChildControls();
 	}
 
 	/**
@@ -95,7 +102,7 @@ class TConditional extends \Prado\Web\UI\TControl
 	 */
 	public function getCondition()
 	{
-		return $this->_condition;
+		return empty($this->_condition) ? 'true' : $this->_condition;
 	}
 
 	/**
@@ -105,7 +112,9 @@ class TConditional extends \Prado\Web\UI\TControl
 	 */
 	public function setCondition($value)
 	{
-		$this->_condition = TPropertyValue::ensureString($value);
+		$value = TPropertyValue::ensureString($value);
+		$value = html_entity_decode($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+		$this->_condition = $value;
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TConditional.php
+++ b/framework/Web/UI/WebControls/TConditional.php
@@ -102,7 +102,10 @@ class TConditional extends \Prado\Web\UI\TControl
 	 */
 	public function getCondition()
 	{
-		return empty($this->_condition) ? 'true' : $this->_condition;
+		if (empty($this->_condition)) {
+			return 'true';
+		}
+		return $this->_condition;
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TDataSize.php
+++ b/framework/Web/UI/WebControls/TDataSize.php
@@ -11,10 +11,11 @@
 namespace Prado\Web\UI\WebControls;
 
 use Prado\Exceptions\TInvalidDataValueException;
-use Prado\Prado;
-use Prado\TPropertyValue;
 use Prado\I18N\core\CultureInfo;
 use Prado\I18N\core\CultureInfoUnits;
+use Prado\I18N\TI18NControlTrait;
+use Prado\Prado;
+use Prado\TPropertyValue;
 
 /**
  * TDataSize class
@@ -50,6 +51,8 @@ use Prado\I18N\core\CultureInfoUnits;
  */
 class TDataSize extends TLabel
 {
+	use TI18NControlTrait;
+
 	/**
 	 * renders the size in the closes base, bytes, kilobytes, megabytes,
 	 * gigabytes, terabytes, petabytes, exabytes, zettabytes, yottabytes, ronnabyte,
@@ -70,12 +73,12 @@ class TDataSize extends TLabel
 
 		$sf = ($size >= 1000) ? 3 : 2;
 		$size = round($size, (int) ceil($sf - ($size == 0 ? 0 : log10($size))));
-		$culture = $this->getLocalizedInfo();
+		$cultureInfo = $this->getCultureInfo();
 
 		$contents = null;
 		if ($abbr) {
-			if ($culture) {
-				$sizeString = $culture->formatNumber($size);
+			if ($cultureInfo) {
+				$sizeString = $cultureInfo->formatNumber($size);
 			} else {
 				$sizeString = number_format($size, 2, '.', ',');
 			}
@@ -89,15 +92,16 @@ class TDataSize extends TLabel
 				$contents = $sizeString . ' ' . Prado::localize($binary[$orderOfMagnitude]);
 			}
 		} else {
-			if ($culture && $marketingSize) {
+			if ($cultureInfo && $marketingSize) {
 				$unitType = $this->unitFromMagnitude($orderOfMagnitude);
 				if ($unitType) {
-					$contents = $culture->formatUnit($size, $unitType);
+					$sizeUnitStr = $cultureInfo->formatUnit($size, $unitType);
+					$contents = $this->convertToCharset($sizeUnitStr);
 				}
 			}
 			if (!$contents) {
-				if ($culture) {
-					$sizeString = $culture->formatNumber($size);
+				if ($cultureInfo) {
+					$sizeString = $cultureInfo->formatNumber($size);
 				} else {
 					$sizeString = number_format($size, 2, '.', ',');
 				}
@@ -172,49 +176,6 @@ class TDataSize extends TLabel
 	}
 
 	/**
-	 * @return string the current culture, falls back to application if culture is not set.
-	 * @since 4.3.3
-	 */
-	protected function getCurrentCulture()
-	{
-		$app = $this->getApplication()->getGlobalization(false);
-		return $this->getCulture() == '' ?
-				($app ? $app->getCulture() : 'en') : $this->getCulture();
-	}
-
-	/**
-	 * @return \Prado\I18N\core\CultureInfo date time format information for the current culture.
-	 * @since 4.3.3
-	 */
-	protected function getLocalizedInfo()
-	{
-		//expensive operations
-		$culture = $this->getCurrentCulture();
-		$info = new CultureInfo($culture);
-		return $info;
-	}
-
-	/**
-	 * Gets the current culture.
-	 * @return string current culture, e.g. en_AU.
-	 * @since 4.3.3
-	 */
-	public function getCulture()
-	{
-		return $this->getViewState('Culture', '');
-	}
-
-	/**
-	 * Sets the culture/language for the date picker.
-	 * @param string $value a culture string, e.g. en_AU.
-	 * @since 4.3.3
-	 */
-	public function setCulture($value)
-	{
-		$this->setViewState('Culture', $value, '');
-	}
-
-	/**
 	 * For the Decimal (marketing) versions of TDataSize,
 	 * this takes the number magnitude and returns the ICU unit.
 	 * @param int $magnitude the magnitude of the unit (per 1000, decimal).
@@ -252,6 +213,4 @@ class TDataSize extends TLabel
 		}
 		return null;
 	}
-
-
 }

--- a/framework/Web/UI/WebControls/TExpression.php
+++ b/framework/Web/UI/WebControls/TExpression.php
@@ -58,7 +58,7 @@ class TExpression extends \Prado\Web\UI\TControl
 	public function render($writer)
 	{
 		$expression = $this->getExpression();
-		if ($expression !== '') {
+		if (!empty($expression)) {
 			$writer->write($this->evaluateExpression($expression));
 		}
 	}

--- a/framework/Web/UI/WebControls/TExpression.php
+++ b/framework/Web/UI/WebControls/TExpression.php
@@ -10,6 +10,8 @@
 
 namespace Prado\Web\UI\WebControls;
 
+use Prado\TPropertyValue;
+
 /**
  * TExpression class
  *
@@ -44,6 +46,8 @@ class TExpression extends \Prado\Web\UI\TControl
 	 */
 	public function setExpression($value)
 	{
+		$value = TPropertyValue::ensureString($value);
+		$value = html_entity_decode($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
 		$this->_exp = $value;
 	}
 
@@ -53,8 +57,9 @@ class TExpression extends \Prado\Web\UI\TControl
 	 */
 	public function render($writer)
 	{
-		if ($this->_exp !== '') {
-			$writer->write($this->evaluateExpression($this->_exp));
+		$expression = $this->getExpression();
+		if ($expression !== '') {
+			$writer->write($this->evaluateExpression($expression));
 		}
 	}
 }

--- a/framework/Web/UI/WebControls/TTemplatedWizardStep.php
+++ b/framework/Web/UI/WebControls/TTemplatedWizardStep.php
@@ -49,6 +49,7 @@ class TTemplatedWizardStep extends TWizardStep implements \Prado\Web\UI\INamingC
 		if ($this->_contentTemplate) {
 			$this->_contentTemplate->instantiateIn($this);
 		}
+		parent::createChildControls();
 	}
 
 	/**

--- a/framework/Web/UI/WebControls/TWizard.php
+++ b/framework/Web/UI/WebControls/TWizard.php
@@ -1048,6 +1048,7 @@ class TWizard extends \Prado\Web\UI\WebControls\TWebControl implements \Prado\We
 		$this->createHeader();
 		$this->createStepContent();
 		$this->createNavigation();
+		parent::createChildControls();
 	}
 
 	/**

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -530,6 +530,7 @@ return [
 'TEventContent' => 'Prado\Web\UI\TEventContent',
 'TForm' => 'Prado\Web\UI\TForm',
 'THtmlWriter' => 'Prado\Web\UI\THtmlWriter',
+'TModuleView' => 'Prado\Web\UI\TModuleView',
 'TPage' => 'Prado\Web\UI\TPage',
 'TPageStateFormatter' => 'Prado\Web\UI\TPageStateFormatter',
 'TPageStatePersister' => 'Prado\Web\UI\TPageStatePersister',

--- a/tests/unit/Web/UI/TClientScriptManagerTest.php
+++ b/tests/unit/Web/UI/TClientScriptManagerTest.php
@@ -224,10 +224,10 @@ class TClientScriptManagerTest extends PHPUnit\Framework\TestCase
 			$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 			$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0';
 
-			
 			$_SERVER['SCRIPT_FILENAME'] = dirname(__FILE__) . '/../../../FunctionalTests/features/protected/';
 			$_SERVER['SCRIPT_NAME'] = '/index.php';
 			self::$app = new TApplication(realpath(dirname(__FILE__) . '/../app'));
+
 			self::$app->initApplication();
 		}
 

--- a/tests/unit/Web/UI/TModuleViewTest.php
+++ b/tests/unit/Web/UI/TModuleViewTest.php
@@ -117,27 +117,27 @@ class TModuleViewTest extends TestCase
 		$this->assertFalse($control->getAllowChildControls());
 	}
 
-	public function testNotFoundTemplateDefaultNull()
+	public function testFallbackTemplateDefaultNull()
 	{
 		$control = new TModuleView();
-		$this->assertNull($control->getNotFoundTemplate());
+		$this->assertNull($control->getFallbackTemplate());
 	}
 
-	public function testSetNotFoundTemplate()
+	public function testSetFallbackTemplate()
 	{
 		$control = new TModuleView();
 		$template = $this->createMock(\Prado\Web\UI\ITemplate::class);
-		$control->setNotFoundTemplate($template);
-		$this->assertSame($template, $control->getNotFoundTemplate());
+		$control->setFallbackTemplate($template);
+		$this->assertSame($template, $control->getFallbackTemplate());
 	}
 
-	public function testSetNotFoundTemplateNull()
+	public function testSetFallbackTemplateNull()
 	{
 		$control = new TModuleView();
 		$template = $this->createMock(\Prado\Web\UI\ITemplate::class);
-		$control->setNotFoundTemplate($template);
-		$control->setNotFoundTemplate(null);
-		$this->assertNull($control->getNotFoundTemplate());
+		$control->setFallbackTemplate($template);
+		$control->setFallbackTemplate(null);
+		$this->assertNull($control->getFallbackTemplate());
 	}
 
 	public function testConditionDefaultTrue()
@@ -222,7 +222,7 @@ class TModuleViewTest extends TestCase
 		$this->assertFalse($control->getIsActive());
 	}
 
-	public function testCreateChildControlsClearsControlsWhenInactive_NoNotFoundTemplate()
+	public function testCreateChildControlsClearsControlsWhenInactive_NoFallbackTemplate()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView1');
@@ -254,14 +254,14 @@ class TModuleViewTest extends TestCase
 		$this->assertTrue($moduleView->getControls()->contains($childLabel));
 	}
 
-	public function testNotFoundTemplateInstantiatedWhenInactive()
+	public function testFallbackTemplateInstantiatedWhenInactive()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView3');
 		$moduleView->setModuleId('test-module-l');
 		$moduleView->setCondition('false');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$childLabel = new TLabel();
 		$childLabel->setID('ChildLabel');
 		$moduleView->getControls()->add($childLabel);
@@ -274,14 +274,14 @@ class TModuleViewTest extends TestCase
 		$this->assertNull($moduleView->findControl('ChildLabel'));
 	}
 
-	public function testNotFoundTemplateNotUsedWhenActive()
+	public function testFallbackTemplateNotUsedWhenActive()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView4');
 		$moduleView->setModuleId('test-module-m');
 		$moduleView->setCondition('true');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$childLabel = new TLabel();
 		$childLabel->setID('ChildLabel');
 		$moduleView->getControls()->add($childLabel);
@@ -294,14 +294,14 @@ class TModuleViewTest extends TestCase
 		$this->assertNull($moduleView->findControl('NotFoundLabel'));
 	}
 
-	public function testModulePresentConditionFalse_NotFoundTemplate()
+	public function testModulePresentConditionFalse_FallbackTemplate()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView5');
 		$moduleView->setModuleId('test-module-n');
 		$moduleView->setCondition('false');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$this->_page->getControls()->add($moduleView);
 		$this->setupModuleView($moduleView);
 		$this->setModuleAvailable('test-module-n', true);
@@ -311,14 +311,14 @@ class TModuleViewTest extends TestCase
 		$this->assertEquals(1, $moduleView->getControls()->count());
 	}
 
-	public function testModuleNotPresentConditionTrue_NotFoundTemplate()
+	public function testModuleNotPresentConditionTrue_FallbackTemplate()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView6');
 		$moduleView->setModuleId('test-module-o');
 		$moduleView->setCondition('true');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$moduleView->getControls()->add(new TLabel());
 		$this->_page->getControls()->add($moduleView);
 		$this->setupModuleView($moduleView);
@@ -329,14 +329,14 @@ class TModuleViewTest extends TestCase
 		$this->assertNull($moduleView->findControl('ChildLabel'));
 	}
 
-	public function testModuleNotPresentConditionFalse_NotFoundTemplate()
+	public function testModuleNotPresentConditionFalse_FallbackTemplate()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView7');
 		$moduleView->setModuleId('test-module-p');
 		$moduleView->setCondition('false');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$moduleView->getControls()->add(new TLabel());
 		$this->_page->getControls()->add($moduleView);
 		$this->setupModuleView($moduleView);
@@ -347,14 +347,14 @@ class TModuleViewTest extends TestCase
 		$this->assertNull($moduleView->findControl('ChildLabel'));
 	}
 
-	public function testClearControlsHappensBeforeNotFoundTemplate()
+	public function testClearControlsHappensBeforeFallbackTemplate()
 	{
 		$moduleView = new TModuleView();
 		$moduleView->setID('ModuleView8');
 		$moduleView->setModuleId('test-module-q');
 		$moduleView->setCondition('false');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel1" /><com:TLabel ID="NotFoundLabel2" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$moduleView->getControls()->add(new TLabel());
 		$this->_page->getControls()->add($moduleView);
 		$this->setupModuleView($moduleView);
@@ -388,7 +388,7 @@ class TModuleViewTest extends TestCase
 		$moduleView->setModuleId('test-module-r');
 		$moduleView->setCondition('1 == 0');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$childLabel = new TLabel();
 		$childLabel->setID('ChildLabel');
 		$moduleView->getControls()->add($childLabel);
@@ -408,7 +408,7 @@ class TModuleViewTest extends TestCase
 		$moduleView->setModuleId('test-module-s');
 		$moduleView->setCondition('1 == 1');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$childLabel = new TLabel();
 		$childLabel->setID('ChildLabel');
 		$moduleView->getControls()->add($childLabel);
@@ -451,7 +451,7 @@ class TModuleViewTest extends TestCase
 		$moduleView->setModuleId('test-module-v');
 		$moduleView->setCondition('false');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$this->_page->getControls()->add($moduleView);
 		$this->setupModuleView($moduleView);
 		$this->setModuleAvailable('test-module-v', true);
@@ -467,7 +467,7 @@ class TModuleViewTest extends TestCase
 		$moduleView->setModuleId('test-module-w');
 		$moduleView->setCondition('true');
 		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
-		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->setFallbackTemplate($notFoundTpl);
 		$childLabel = new TLabel();
 		$childLabel->setID('ChildLabel');
 		$moduleView->getControls()->add($childLabel);
@@ -504,7 +504,7 @@ class TModuleViewTest extends TestCase
 		$this->assertNotNull($moduleView->findControl('ChildLabel'));
 	}
 
-	public function testTemplate_ModulePresentConditionFalse_NotFoundTemplate()
+	public function testTemplate_ModulePresentConditionFalse_FallbackTemplate()
 	{
 		$this->setModuleAvailable('test-tpl-module-2', true);
 		$template = '<com:TModuleView ID="MV2" ModuleId="test-tpl-module-2" Condition="false">
@@ -520,7 +520,7 @@ class TModuleViewTest extends TestCase
 		$this->assertNotNull($page->findControl('NotFoundLabel'));
 	}
 
-	public function testTemplate_ModuleNotPresentConditionTrue_NotFoundTemplate()
+	public function testTemplate_ModuleNotPresentConditionTrue_FallbackTemplate()
 	{
 		$this->setModuleAvailable('test-tpl-module-3', false);
 		$template = '<com:TModuleView ID="MV3" ModuleId="test-tpl-module-3" Condition="true">
@@ -536,7 +536,7 @@ class TModuleViewTest extends TestCase
 		$this->assertNotNull($page->findControl('NotFoundLabel'));
 	}
 
-	public function testTemplate_ModuleNotPresentConditionFalse_NotFoundTemplate()
+	public function testTemplate_ModuleNotPresentConditionFalse_FallbackTemplate()
 	{
 		$this->setModuleAvailable('test-tpl-module-4', false);
 		$template = '<com:TModuleView ID="MV4" ModuleId="test-tpl-module-4" Condition="false">
@@ -562,7 +562,7 @@ class TModuleViewTest extends TestCase
 		$this->assertEquals(0, $moduleView->getControls()->count());
 	}
 
-	public function testTemplate_ModuleNotPresentConditionTrue_NoChildren_NoNotFoundTemplate()
+	public function testTemplate_ModuleNotPresentConditionTrue_NoChildren_NoFallbackTemplate()
 	{
 		$this->setModuleAvailable('test-tpl-module-6', false);
 		$template = '<com:TModuleView ID="MV6" ModuleId="test-tpl-module-6" Condition="true">
@@ -574,7 +574,7 @@ class TModuleViewTest extends TestCase
 		$this->assertNull($moduleView->findControl('ChildLabel'));
 	}
 
-	public function testTemplate_ModulePresentConditionFalse_NoNotFoundTemplate()
+	public function testTemplate_ModulePresentConditionFalse_NoFallbackTemplate()
 	{
 		$this->setModuleAvailable('test-tpl-module-7', true);
 		$template = '<com:TModuleView ID="MV7" ModuleId="test-tpl-module-7" Condition="false">
@@ -589,7 +589,7 @@ class TModuleViewTest extends TestCase
 		$this->assertEquals(0, $moduleView->getControls()->count());
 	}
 
-	public function testTemplate_ModuleNotPresentConditionFalse_NoNotFoundTemplate()
+	public function testTemplate_ModuleNotPresentConditionFalse_NoFallbackTemplate()
 	{
 		$this->setModuleAvailable('test-tpl-module-8', false);
 		$template = '<com:TModuleView ID="MV8" ModuleId="test-tpl-module-8" Condition="false">

--- a/tests/unit/Web/UI/TModuleViewTest.php
+++ b/tests/unit/Web/UI/TModuleViewTest.php
@@ -1,0 +1,703 @@
+<?php
+
+use Prado\Web\UI\TModuleView;
+use Prado\Web\UI\TCompositeControl;
+use Prado\Web\UI\TTemplate;
+use Prado\Web\UI\TPage;
+use Prado\Web\UI\WebControls\TLabel;
+use Prado\Prado;
+use Prado\TApplication;
+use Prado\TModule;
+use PHPUnit\Framework\TestCase;
+
+class TTestModule extends TModule
+{
+}
+
+class TModuleViewTest extends TestCase
+{
+	private $_app;
+	private $_contextPath;
+	private $_page;
+
+	protected function setUp(): void
+	{
+		$this->_contextPath = sys_get_temp_dir();
+		$this->_app = Prado::getApplication();
+		$this->_page = new TPage();
+		$this->_page->setID('TestPage');
+	}
+
+	protected function tearDown(): void
+	{
+		$this->_contextPath = null;
+		$this->_app = null;
+		$this->_page = null;
+	}
+
+	private function newTemplate($template): TTemplate
+	{
+		return new TTemplate($template, $this->_contextPath, null, 0, true);
+	}
+
+	private function setupModuleView(TModuleView $moduleView): void
+	{
+		$moduleView->setTemplateControl($this->_page);
+		$moduleView->setPage($this->_page);
+	}
+
+	private function setModuleAvailable(string $moduleId, bool $available): void
+	{
+		$ref = new \ReflectionProperty(TApplication::class, '_modules');
+		$ref->setAccessible(true);
+		$modules = $ref->getValue($this->_app);
+		if ($available) {
+			if (!isset($modules[$moduleId]) || $modules[$moduleId] === null) {
+				$module = new TTestModule();
+				$module->setID($moduleId);
+				$modules[$moduleId] = $module;
+			}
+		} else {
+			unset($modules[$moduleId]);
+		}
+		$ref->setValue($this->_app, $modules);
+	}
+
+	public function testExtendsCompositeControl()
+	{
+		$control = new TModuleView();
+		$this->assertInstanceOf(TCompositeControl::class, $control);
+	}
+
+	public function testModuleIdDefaultEmpty()
+	{
+		$control = new TModuleView();
+		$this->assertEquals('', $control->getModuleId());
+	}
+
+	public function testSetModuleId()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('cache');
+		$this->assertEquals('cache', $control->getModuleId());
+	}
+
+	public function testSetModuleIdEmpty()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('cache');
+		$control->setModuleId('');
+		$this->assertEquals('', $control->getModuleId());
+	}
+
+	public function testGetModuleReturnsNullForUnknownId()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('nonexistent-module-xyz');
+		$this->assertNull($control->getModule());
+	}
+
+	public function testGetModuleAvailableReturnsFalseForUnknownId()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('nonexistent-module-xyz');
+		$this->assertFalse($control->getModuleAvailable());
+	}
+
+	public function testGetModuleAvailableReturnsFalseWhenNoModuleIdSet()
+	{
+		$control = new TModuleView();
+		$this->assertFalse($control->getModuleAvailable());
+	}
+
+	public function testGetAllowChildControlsReturnsFalseWhenModuleUnavailable()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('nonexistent-module-xyz');
+		$this->assertFalse($control->getAllowChildControls());
+	}
+
+	public function testNotFoundTemplateDefaultNull()
+	{
+		$control = new TModuleView();
+		$this->assertNull($control->getNotFoundTemplate());
+	}
+
+	public function testSetNotFoundTemplate()
+	{
+		$control = new TModuleView();
+		$template = $this->createMock(\Prado\Web\UI\ITemplate::class);
+		$control->setNotFoundTemplate($template);
+		$this->assertSame($template, $control->getNotFoundTemplate());
+	}
+
+	public function testSetNotFoundTemplateNull()
+	{
+		$control = new TModuleView();
+		$template = $this->createMock(\Prado\Web\UI\ITemplate::class);
+		$control->setNotFoundTemplate($template);
+		$control->setNotFoundTemplate(null);
+		$this->assertNull($control->getNotFoundTemplate());
+	}
+
+	public function testConditionDefaultTrue()
+	{
+		$control = new TModuleView();
+		$this->assertEquals('true', $control->getCondition());
+	}
+
+	public function testConditionEmptyStringBecomesTrue()
+	{
+		$control = new TModuleView();
+		$control->setCondition('');
+		$this->assertEquals('true', $control->getCondition());
+	}
+
+	public function testConditionIsCaseInsensitive()
+	{
+		$control = new TModuleView();
+		$control->setCondition('TRUE');
+		$this->assertEquals('TRUE', $control->getCondition());
+		$control->setCondition('FALSE');
+		$this->assertEquals('FALSE', $control->getCondition());
+	}
+
+	public function testConditionWithSingleQuotes()
+	{
+		$control = new TModuleView();
+		$control->setCondition('value&#039;s'); // HTML entity for single quote
+		$this->assertEquals("value's", $control->getCondition());
+	}
+
+	public function testConditionWithDoubleQuotes()
+	{
+		$control = new TModuleView();
+		$control->setCondition('value&quot;s'); // HTML entity for double quote
+		$this->assertEquals('value"s', $control->getCondition());
+	}
+
+	public function testgetIsActiveResetsOnModuleIdChange()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('test-module-a');
+		$this->_page->getControls()->add($control);
+		$this->setupModuleView($control);
+		$this->assertFalse($control->getIsActive());
+		$this->setModuleAvailable('test-module-a', true);
+		$control->setModuleId('test-module-b'); // trigger reset of module presence
+		$control->setModuleId('test-module-a');
+		$this->assertTrue($control->getIsActive());
+	}
+
+	public function testGetAllowChildControlsTrueWhenModuleAvailable()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('test-module-c');
+		$this->setModuleAvailable('test-module-c', true);
+		$this->assertTrue($control->getAllowChildControls());
+	}
+
+	public function testGetAllowChildControlsFalseWhenModuleUnavailable()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('test-module-d');
+		$this->setModuleAvailable('test-module-d', false);
+		$this->assertFalse($control->getAllowChildControls());
+	}
+
+	public function testGetAllowChildControlsBasedOnModuleIdNotCondition()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('test-module-e');
+		$control->setCondition('false');
+		$this->setModuleAvailable('test-module-e', true);
+		$this->assertTrue($control->getAllowChildControls());
+	}
+
+	public function testNoModuleIdMeansModuleUnavailable()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('');
+		$this->assertFalse($control->getModuleAvailable());
+		$this->assertFalse($control->getIsActive());
+	}
+
+	public function testCreateChildControlsClearsControlsWhenInactive_NoNotFoundTemplate()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView1');
+		$moduleView->setModuleId('test-module-j');
+		$moduleView->setCondition('false');
+		$moduleView->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-j', false);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertEquals(0, $moduleView->getControls()->count());
+	}
+
+	public function testCreateChildControlsKeepsControlsWhenActive()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView2');
+		$moduleView->setModuleId('test-module-k');
+		$moduleView->setCondition('true');
+		$childLabel = new TLabel();
+		$childLabel->setID('ChildLabel');
+		$moduleView->getControls()->add($childLabel);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-k', true);
+		$moduleView->createChildControls();
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertTrue($moduleView->getControls()->contains($childLabel));
+	}
+
+	public function testNotFoundTemplateInstantiatedWhenInactive()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView3');
+		$moduleView->setModuleId('test-module-l');
+		$moduleView->setCondition('false');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$childLabel = new TLabel();
+		$childLabel->setID('ChildLabel');
+		$moduleView->getControls()->add($childLabel);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-l', false);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testNotFoundTemplateNotUsedWhenActive()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView4');
+		$moduleView->setModuleId('test-module-m');
+		$moduleView->setCondition('true');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$childLabel = new TLabel();
+		$childLabel->setID('ChildLabel');
+		$moduleView->getControls()->add($childLabel);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-m', true);
+		$moduleView->createChildControls();
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertTrue($moduleView->getControls()->contains($childLabel));
+		$this->assertNull($moduleView->findControl('NotFoundLabel'));
+	}
+
+	public function testModulePresentConditionFalse_NotFoundTemplate()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView5');
+		$moduleView->setModuleId('test-module-n');
+		$moduleView->setCondition('false');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-n', true);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+		$this->assertEquals(1, $moduleView->getControls()->count());
+	}
+
+	public function testModuleNotPresentConditionTrue_NotFoundTemplate()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView6');
+		$moduleView->setModuleId('test-module-o');
+		$moduleView->setCondition('true');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-o', false);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testModuleNotPresentConditionFalse_NotFoundTemplate()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView7');
+		$moduleView->setModuleId('test-module-p');
+		$moduleView->setCondition('false');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-p', false);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testClearControlsHappensBeforeNotFoundTemplate()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView8');
+		$moduleView->setModuleId('test-module-q');
+		$moduleView->setCondition('false');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel1" /><com:TLabel ID="NotFoundLabel2" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$moduleView->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-q', false);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel1'));
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel2'));
+		$this->assertEquals(2, $moduleView->getControls()->count());
+	}
+
+	public function testNoModuleId_NoChildrenWhenInactive()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView9');
+		$moduleView->setModuleId('');
+		$moduleView->setCondition('false');
+		$moduleView->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertEquals(0, $moduleView->getControls()->count());
+	}
+
+	public function testCreateChildControls_ConditionFalseExpression()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView10');
+		$moduleView->setModuleId('test-module-r');
+		$moduleView->setCondition('1 == 0');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$childLabel = new TLabel();
+		$childLabel->setID('ChildLabel');
+		$moduleView->getControls()->add($childLabel);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-r', true);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+	}
+
+	public function testCreateChildControls_ConditionTrueExpression()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView11');
+		$moduleView->setModuleId('test-module-s');
+		$moduleView->setCondition('1 == 1');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$childLabel = new TLabel();
+		$childLabel->setID('ChildLabel');
+		$moduleView->getControls()->add($childLabel);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-s', true);
+		$moduleView->createChildControls();
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertTrue($moduleView->getControls()->contains($childLabel));
+		$this->assertNull($moduleView->findControl('NotFoundLabel'));
+	}
+
+	public function testCreateControlCollectionAlways()
+	{
+		$moduleView = new TModuleView();
+		$collection = $moduleView->getControls();
+		$this->assertInstanceOf(\Prado\Web\UI\TControlCollection::class, $collection);
+	}
+
+	public function testGetModuleAvailableReturnsTrueWhenModulePresent()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('test-module-t');
+		$this->setModuleAvailable('test-module-t', true);
+		$this->assertTrue($control->getModuleAvailable());
+	}
+
+	public function testGetModuleAvailableReturnsFalseWhenModuleNotPresent()
+	{
+		$control = new TModuleView();
+		$control->setModuleId('test-module-u');
+		$this->setModuleAvailable('test-module-u', false);
+		$this->assertFalse($control->getModuleAvailable());
+	}
+
+	public function testgetIsActive_WhenConditionFalseModulePresent()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView12');
+		$moduleView->setModuleId('test-module-v');
+		$moduleView->setCondition('false');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-v', true);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+	}
+
+	public function testgetIsActive_WhenConditionTrueModuleNotPresent()
+	{
+		$moduleView = new TModuleView();
+		$moduleView->setID('ModuleView13');
+		$moduleView->setModuleId('test-module-w');
+		$moduleView->setCondition('true');
+		$notFoundTpl = $this->newTemplate('<com:TLabel ID="NotFoundLabel" />');
+		$moduleView->setNotFoundTemplate($notFoundTpl);
+		$childLabel = new TLabel();
+		$childLabel->setID('ChildLabel');
+		$moduleView->getControls()->add($childLabel);
+		$this->_page->getControls()->add($moduleView);
+		$this->setupModuleView($moduleView);
+		$this->setModuleAvailable('test-module-w', false);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertNotNull($moduleView->findControl('NotFoundLabel'));
+	}
+
+	// Template-based integration tests using <com:TModuleView ... /> syntax
+	// These test the actual template parsing and instantiation in real-world use
+
+	private function createPageWithTModuleView(string $template): array
+	{
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		return [$page, $tpl];
+	}
+
+	public function testTemplate_ModulePresentConditionTrue_ShowsChildren()
+	{
+		$this->setModuleAvailable('test-tpl-module-1', true);
+		$template = '<com:TModuleView ID="MV1" ModuleId="test-tpl-module-1" Condition="true">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV1');
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testTemplate_ModulePresentConditionFalse_NotFoundTemplate()
+	{
+		$this->setModuleAvailable('test-tpl-module-2', true);
+		$template = '<com:TModuleView ID="MV2" ModuleId="test-tpl-module-2" Condition="false">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>
+		<com:TLabel ID="NotFoundLabel" Text="Not Found" />';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV2');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertNotNull($page->findControl('NotFoundLabel'));
+	}
+
+	public function testTemplate_ModuleNotPresentConditionTrue_NotFoundTemplate()
+	{
+		$this->setModuleAvailable('test-tpl-module-3', false);
+		$template = '<com:TModuleView ID="MV3" ModuleId="test-tpl-module-3" Condition="true">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>
+		<com:TLabel ID="NotFoundLabel" Text="Not Found" />';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV3');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertNotNull($page->findControl('NotFoundLabel'));
+	}
+
+	public function testTemplate_ModuleNotPresentConditionFalse_NotFoundTemplate()
+	{
+		$this->setModuleAvailable('test-tpl-module-4', false);
+		$template = '<com:TModuleView ID="MV4" ModuleId="test-tpl-module-4" Condition="false">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>
+		<com:TLabel ID="NotFoundLabel" Text="Not Found" />';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV4');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertNotNull($page->findControl('NotFoundLabel'));
+	}
+
+	public function testTemplate_ModulePresentConditionTrue_NoChildren()
+	{
+		$this->setModuleAvailable('test-tpl-module-5', true);
+		$template = '<com:TModuleView ID="MV5" ModuleId="test-tpl-module-5" Condition="true" />';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV5');
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertEquals(0, $moduleView->getControls()->count());
+	}
+
+	public function testTemplate_ModuleNotPresentConditionTrue_NoChildren_NoNotFoundTemplate()
+	{
+		$this->setModuleAvailable('test-tpl-module-6', false);
+		$template = '<com:TModuleView ID="MV6" ModuleId="test-tpl-module-6" Condition="true">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV6');
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testTemplate_ModulePresentConditionFalse_NoNotFoundTemplate()
+	{
+		$this->setModuleAvailable('test-tpl-module-7', true);
+		$template = '<com:TModuleView ID="MV7" ModuleId="test-tpl-module-7" Condition="false">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV7');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertEquals(0, $moduleView->getControls()->count());
+	}
+
+	public function testTemplate_ModuleNotPresentConditionFalse_NoNotFoundTemplate()
+	{
+		$this->setModuleAvailable('test-tpl-module-8', false);
+		$template = '<com:TModuleView ID="MV8" ModuleId="test-tpl-module-8" Condition="false">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV8');
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertEquals(0, $moduleView->getControls()->count());
+	}
+
+	public function testTemplate_ConditionExpression_True()
+	{
+		$this->setModuleAvailable('test-tpl-module-9', true);
+		$template = '<com:TModuleView ID="MV9" ModuleId="test-tpl-module-9" Condition="1 == 1">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV9');
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testTemplate_ConditionExpression_False()
+	{
+		$this->setModuleAvailable('test-tpl-module-10', true);
+		$template = '<com:TModuleView ID="MV10" ModuleId="test-tpl-module-10" Condition="1 == 0">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV10');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testTemplate_NoModuleId_ConditionFalse()
+	{
+		$template = '<com:TModuleView ID="MV11" Condition="false">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV11');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+		$this->assertEquals(0, $moduleView->getControls()->count());
+	}
+
+	public function testTemplate_NoModuleId_ConditionTrue()
+	{
+		$template = '<com:TModuleView ID="MV12" Condition="true">
+			<com:TLabel ID="ChildLabel" Text="Module Content" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV12');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('ChildLabel'));
+	}
+
+	public function testTemplate_NestedChildren_PresentAndActive()
+	{
+		$this->setModuleAvailable('test-tpl-module-16', true);
+		$template = '<com:TModuleView ID="MV16" ModuleId="test-tpl-module-16" Condition="true">
+			<com:TLabel ID="Label1" Text="Label 1" />
+			<com:TLabel ID="Label2" Text="Label 2" />
+			<com:TLabel ID="Label3" Text="Label 3" />
+		</com:TModuleView>';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV16');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertTrue($moduleView->getIsActive());
+		$this->assertNotNull($moduleView->findControl('Label1'));
+		$this->assertNotNull($moduleView->findControl('Label2'));
+		$this->assertNotNull($moduleView->findControl('Label3'));
+		$labelCount = 0;
+		foreach ($moduleView->getControls() as $control) {
+			if ($control instanceof TLabel) {
+				$labelCount++;
+			}
+		}
+		$this->assertEquals(3, $labelCount);
+	}
+
+	public function testTemplate_NestedChildren_NotPresent()
+	{
+		$this->setModuleAvailable('test-tpl-module-17', false);
+		$template = '<com:TModuleView ID="MV17" ModuleId="test-tpl-module-17" Condition="true">
+			<com:TLabel ID="Label1" Text="Label 1" />
+			<com:TLabel ID="Label2" Text="Label 2" />
+			<com:TLabel ID="Label3" Text="Label 3" />
+		</com:TModuleView>
+		<com:TLabel ID="OuterLabel" Text="Outer" />';
+		[$page, $tpl] = $this->createPageWithTModuleView($template);
+		$moduleView = $page->findControl('MV17');
+		$this->setupModuleView($moduleView);
+		$moduleView->createChildControls();
+		$this->assertFalse($moduleView->getIsActive());
+		$this->assertNull($moduleView->findControl('Label1'));
+		$this->assertNull($moduleView->findControl('Label2'));
+		$this->assertNull($moduleView->findControl('Label3'));
+		$this->assertEquals(0, $moduleView->getControls()->count());
+		$this->assertNotNull($page->findControl('OuterLabel'));
+	}
+}

--- a/tests/unit/Web/UI/WebControls/TConditionalTest.php
+++ b/tests/unit/Web/UI/WebControls/TConditionalTest.php
@@ -1,0 +1,470 @@
+<?php
+
+use Prado\Web\UI\WebControls\TConditional;
+use Prado\Web\UI\TTemplate;
+use Prado\Web\UI\TPage;
+use Prado\Web\UI\WebControls\TLabel;
+use Prado\Prado;
+use PHPUnit\Framework\TestCase;
+
+class TConditionalTest extends TestCase
+{
+	private $_page;
+	private $_contextPath;
+
+	protected function setUp(): void
+	{
+		$this->_contextPath = sys_get_temp_dir();
+		$this->_page = new TPage();
+		$this->_page->setID('TestPage');
+	}
+
+	protected function tearDown(): void
+	{
+		$this->_page = null;
+		$this->_contextPath = null;
+	}
+
+	private function newTemplate($template): TTemplate
+	{
+		return new TTemplate($template, $this->_contextPath, null, 0, true);
+	}
+
+	private function setupConditional(TConditional $conditional): void
+	{
+		$conditional->setTemplateControl($this->_page);
+		$conditional->setPage($this->_page);
+	}
+
+	public function testExtendsTControl()
+	{
+		$control = new TConditional();
+		$this->assertInstanceOf(\Prado\Web\UI\TControl::class, $control);
+	}
+
+	public function testConditionDefaultTrue()
+	{
+		$control = new TConditional();
+		$this->assertEquals('true', $control->getCondition());
+	}
+
+	public function testConditionEmptyStringBecomesTrue()
+	{
+		$control = new TConditional();
+		$control->setCondition('');
+		$this->assertEquals('true', $control->getCondition());
+	}
+
+	public function testConditionIsCasePreserved()
+	{
+		$control = new TConditional();
+		$control->setCondition('TRUE');
+		$this->assertEquals('TRUE', $control->getCondition());
+		$control->setCondition('FALSE');
+		$this->assertEquals('FALSE', $control->getCondition());
+	}
+
+	public function testConditionWithSingleQuotes()
+	{
+		$control = new TConditional();
+		$control->setCondition('value&#039;s');
+		$this->assertEquals("value's", $control->getCondition());
+	}
+
+	public function testConditionWithDoubleQuotes()
+	{
+		$control = new TConditional();
+		$control->setCondition('value&quot;s');
+		$this->assertEquals('value"s', $control->getCondition());
+	}
+
+	public function testConditionWithMixedQuotes()
+	{
+		$control = new TConditional();
+		$control->setCondition('He said &#039;Hello &quot;World&quot;&#039;');
+		$this->assertEquals('He said \'Hello "World"\'', $control->getCondition());
+	}
+
+	public function testTrueTemplateDefaultNull()
+	{
+		$control = new TConditional();
+		$this->assertNull($control->getTrueTemplate());
+	}
+
+	public function testFalseTemplateDefaultNull()
+	{
+		$control = new TConditional();
+		$this->assertNull($control->getFalseTemplate());
+	}
+
+	public function testCreateChildControls_ConditionFalseExpression()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional1');
+		$conditional->setCondition('1 == 0');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+		$this->assertEquals('False Branch', $conditional->findControl('FalseLabel')->getText());
+	}
+
+	public function testCreateChildControls_ConditionTrueExpression()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional2');
+		$conditional->setCondition('1 == 1');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+		$this->assertEquals('True Branch', $conditional->findControl('TrueLabel')->getText());
+	}
+	
+	public function testCreateChildControls_NoTemplateControl()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional2');
+		$conditional->setCondition('1 == 1');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		{	// $this->setupConditional($conditional);
+			//$conditional->setTemplateControl($this->_page);
+			$conditional->setPage($this->_page);
+		}
+		$conditional->createChildControls();
+		$this->assertNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(0, $conditional->getControls()->count());
+	}
+	
+	public function testCreateChildControls_NoPage()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional2');
+		$conditional->setCondition('1 == 1');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		{	// $this->setupConditional($conditional);
+			$conditional->setTemplateControl($this->_page);
+			//$conditional->setPage($this->_page);
+		}
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+	}
+	
+	public function testCreateChildControls_NoPageNoTemplateControl()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional2');
+		$conditional->setCondition('1 == 1');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		{	// $this->setupConditional($conditional);
+			//$conditional->setTemplateControl($this->_page);
+			//$conditional->setPage($this->_page);
+		}
+		$conditional->createChildControls();
+		$this->assertNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(0, $conditional->getControls()->count());
+	}
+
+	public function testCreateChildControls_BothTemplatesTrueCondition()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional3');
+		$conditional->setCondition('true');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+	}
+
+	public function testCreateChildControls_BothTemplatesFalseCondition()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional4');
+		$conditional->setCondition('false');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNull($conditional->findControl('TrueLabel'));
+		$this->assertNotNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+	}
+
+	public function testCreateChildControls_NoTemplates()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional5');
+		$conditional->setCondition('true');
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		if ($conditional->getControls()->count()) {
+			$this->assertNull($conditional->getControls()[0], 'Control should have no children after createChildrenControls');
+		}
+		$this->assertEquals(0, $conditional->getControls()->count(), 'There should be no controls');
+	}
+
+	private function createPageWithTConditional(string $template): array
+	{
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		return [$page, $tpl];
+	}
+
+	public function testTemplate_ConditionTrue_ShowsTrueTemplate()
+	{
+		$template = '<com:TConditional ID="Cond1" Condition="true">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="True Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond1');
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals('True Content', $conditional->findControl('TrueLabel')->getText());
+	}
+
+	public function testTemplate_ConditionFalse_ShowsFalseTemplate()
+	{
+		$template = '<com:TConditional ID="Cond2" Condition="false">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="True Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond2');
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('FalseLabel'));
+		$this->assertNull($conditional->findControl('TrueLabel'));
+		$this->assertEquals('False Content', $conditional->findControl('FalseLabel')->getText());
+	}
+
+	public function testTemplate_ConditionExpression_True()
+	{
+		$template = '<com:TConditional ID="Cond3" Condition="1 == 1">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="True Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond3');
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+	}
+
+	public function testTemplate_ConditionExpression_False()
+	{
+		$template = '<com:TConditional ID="Cond4" Condition="1 == 0">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="True Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond4');
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('FalseLabel'));
+		$this->assertNull($conditional->findControl('TrueLabel'));
+	}
+
+	public function testTemplate_ConditionWithSingleQuotes()
+	{
+		$template = "<com:TConditional ID=\"Cond5\" Condition='&#039;value&#039; === &#039;value&#039;'>
+			<prop:TrueTemplate>
+				<com:TLabel ID=\"TrueLabel\" Text=\"Single Quote Content\" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID=\"FalseLabel\" Text=\"False Content\" />
+			</prop:FalseTemplate>
+		</com:TConditional>";
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond5');
+		$this->assertEquals("'value' === 'value'", $conditional->getCondition());
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+	}
+	
+	public function testTemplate_ConditionWithSingleQuotes_DoubleWithin()
+	{
+		$template = "<com:TConditional ID=\"Cond5\" Condition='\"value\" === \"value\"'>
+			<prop:TrueTemplate>
+				<com:TLabel ID=\"TrueLabel\" Text=\"Single Quote Content\" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID=\"FalseLabel\" Text=\"False Content\" />
+			</prop:FalseTemplate>
+		</com:TConditional>";
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond5');
+		$this->assertEquals('"value" === "value"', $conditional->getCondition());
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+	}
+
+	public function testTemplate_ConditionWithDoubleQuotes()
+	{
+		$template = '<com:TConditional ID="Cond6" Condition="&quot;value&quot; === &quot;value&quot;">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="Double Quote Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond6');
+		$this->assertEquals('"value" === "value"', $conditional->getCondition());
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+	}
+	
+	public function testTemplate_ConditionWithDoubleQuotes_SingleWithin()
+	{
+		$template = '<com:TConditional ID="Cond6" Condition="\'value\' === \'value\'">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="Double Quote Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond6');
+		$this->assertEquals("'value' === 'value'", $conditional->getCondition());
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+	}
+
+	public function testTemplate_ConditionWithMixedQuotes()
+	{
+		$template = '<com:TConditional ID="Cond7" Condition="He said &#039;Hello &quot;World&quot;&#039;">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="Mixed Quote Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond7');
+		$this->assertEquals('He said \'Hello "World"\'', $conditional->getCondition());
+		$this->setupConditional($conditional);
+	}
+
+	public function testTemplate_EmptyConditionDefaultsToTrue()
+	{
+		$template = '<com:TConditional ID="Cond8" Condition="">
+			<prop:TrueTemplate>
+				<com:TLabel ID="TrueLabel" Text="Empty Condition Content" />
+			</prop:TrueTemplate>
+			<prop:FalseTemplate>
+				<com:TLabel ID="FalseLabel" Text="False Content" />
+			</prop:FalseTemplate>
+		</com:TConditional>';
+		[$page, $tpl] = $this->createPageWithTConditional($template);
+		$conditional = $page->findControl('Cond8');
+		$this->assertEquals('true', $conditional->getCondition());
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertNull($conditional->findControl('FalseLabel'));
+	}
+
+	public function testCreateChildControls_EmptyConditionTrue()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional6');
+		$conditional->setCondition('');
+		$trueTemplate = $this->newTemplate('<com:TLabel ID="TrueLabel" Text="True Branch" />');
+		$conditional->setTrueTemplate($trueTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertEquals('true', $conditional->getCondition());
+		$this->assertNotNull($conditional->findControl('TrueLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+	}
+
+	public function testCreateChildControls_NoTrueTemplateWhenConditionFalse()
+	{
+		$conditional = new TConditional();
+		$conditional->setID('Conditional7');
+		$conditional->setCondition('false');
+		$falseTemplate = $this->newTemplate('<com:TLabel ID="FalseLabel" Text="False Branch" />');
+		$conditional->setFalseTemplate($falseTemplate);
+		$conditional->getControls()->add(new TLabel());
+		$this->_page->getControls()->add($conditional);
+		$this->setupConditional($conditional);
+		$conditional->createChildControls();
+		$this->assertNotNull($conditional->findControl('FalseLabel'));
+		$this->assertEquals(1, $conditional->getControls()->count());
+	}
+}

--- a/tests/unit/Web/UI/WebControls/TExpressionTest.php
+++ b/tests/unit/Web/UI/WebControls/TExpressionTest.php
@@ -1,0 +1,366 @@
+<?php
+
+use Prado\Web\UI\WebControls\TExpression;
+use Prado\Web\UI\TTemplate;
+use Prado\Web\UI\TPage;
+use Prado\Web\UI\THtmlWriter;
+use Prado\IO\TTextWriter;
+use PHPUnit\Framework\TestCase;
+
+class TExpressionTest extends TestCase
+{
+	private $_page;
+	private $_contextPath;
+
+	protected function setUp(): void
+	{
+		$this->_contextPath = sys_get_temp_dir();
+		$this->_page = new TPage();
+		$this->_page->setID('TestPage');
+	}
+
+	protected function tearDown(): void
+	{
+		$this->_page = null;
+		$this->_contextPath = null;
+	}
+
+	private function newTemplate($template): TTemplate
+	{
+		return new TTemplate($template, $this->_contextPath, null, 0, true);
+	}
+
+	private function render($control)
+	{
+		$tw = new TTextWriter();
+		$writer = new THtmlWriter($tw);
+		$control->render($writer);
+		return $tw->flush();
+	}
+
+	public function testExtendsTControl()
+	{
+		$control = new TExpression();
+		$this->assertInstanceOf(\Prado\Web\UI\TControl::class, $control);
+	}
+
+	public function testExpressionDefaultEmptyString()
+	{
+		$control = new TExpression();
+		$this->assertEquals('', $control->getExpression());
+	}
+
+	public function testExpressionSetter()
+	{
+		$control = new TExpression();
+		$control->setExpression('test');
+		$this->assertEquals('test', $control->getExpression());
+	}
+
+	public function testExpressionWithSingleQuotes()
+	{
+		$control = new TExpression();
+		$control->setExpression('value&#039;s');
+		$this->assertEquals("value's", $control->getExpression());
+	}
+
+	public function testExpressionWithDoubleQuotes()
+	{
+		$control = new TExpression();
+		$control->setExpression('value&quot;s');
+		$this->assertEquals('value"s', $control->getExpression());
+	}
+
+	public function testExpressionWithMixedQuotes()
+	{
+		$control = new TExpression();
+		$control->setExpression('He said &#039;Hello &quot;World&quot;&#039;');
+		$this->assertEquals('He said \'Hello "World"\'', $control->getExpression());
+	}
+
+	public function testExpressionEvaluationSimpleValue()
+	{
+		$control = new TExpression();
+		$control->setExpression('123');
+		$result = $control->evaluateExpression('123');
+		$this->assertEquals('123', $result);
+	}
+
+	public function testExpressionEvaluationString()
+	{
+		$control = new TExpression();
+		$control->setExpression('"Hello World"');
+		$result = $control->evaluateExpression('"Hello World"');
+		$this->assertEquals('Hello World', $result);
+	}
+
+	public function testExpressionEvaluationFunction()
+	{
+		$control = new TExpression();
+		$control->setExpression('count(["a", "b", "c"])');
+		$result = $control->evaluateExpression('count(["a", "b", "c"])');
+		$this->assertEquals('3', $result);
+	}
+
+	public function testExpressionEvaluationEmptyExpression()
+	{
+		$control = new TExpression();
+		$control->setExpression('');
+		$result = $control->evaluateExpression('');
+		$this->assertEquals('', $result);
+	}
+
+	public function testExpressionEvaluationInvalidExpression()
+	{
+		$control = new TExpression();
+		$control->setExpression('invalid syntax');
+		
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$result = $control->evaluateExpression('invalid syntax');
+	}
+
+	public function testTemplate_ExpressionEvaluation()
+	{
+		$template = '<com:TExpression ID="Expr1" Expression="123" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr1');
+		$result = $expression->evaluateExpression('123');
+		$this->assertEquals('123', $result);
+	}
+
+	public function testTemplate_EmptyExpression()
+	{
+		$template = '<com:TExpression ID="Expr3" Expression="" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr3');
+		$result = $expression->evaluateExpression('');
+		$this->assertEquals('', $result);
+	}
+
+	public function testRenderSimpleValue()
+	{
+		$expression = new TExpression();
+		$expression->setExpression('123');
+		$expression->setID('Expression1');
+		$this->_page->getControls()->add($expression);
+		
+		$output = $this->render($expression);
+		$this->assertEquals('123', $output);
+	}
+
+	public function testRenderStringExpression()
+	{
+		$expression = new TExpression();
+		$expression->setExpression('"Hello World"');
+		$expression->setID('Expression2');
+		$this->_page->getControls()->add($expression);
+		
+		$output = $this->render($expression);
+		$this->assertEquals('Hello World', $output);
+	}
+
+	public function testRenderFunctionExpression()
+	{
+		$expression = new TExpression();
+		$expression->setExpression('count(["a", "b", "c"])');
+		$expression->setID('Expression3');
+		$this->_page->getControls()->add($expression);
+		
+		$output = $this->render($expression);
+		$this->assertEquals('3', $output);
+	}
+
+	public function testRenderEmptyExpression()
+	{
+		$expression = new TExpression();
+		$expression->setExpression('');
+		$expression->setID('Expression4');
+		$this->_page->getControls()->add($expression);
+		
+		$output = $this->render($expression);
+		$this->assertEquals('', $output);
+	}
+
+	public function testRenderTemplateExpression()
+	{
+		$template = '<com:TExpression ID="Expr5" Expression="123" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr5');
+		$output = $this->render($expression);
+		$this->assertEquals('123', $output);
+	}
+
+	public function testRenderTemplateEmptyExpression()
+	{
+		$template = '<com:TExpression ID="Expr6" Expression="" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr6');
+		$output = $this->render($expression);
+		$this->assertEquals('', $output);
+	}
+
+	public function testRenderWithSingleQuoteString()
+	{
+		$expression = new TExpression();
+		$expression->setExpression("'value\'s'");
+		$expression->setID('Expression7');
+		$this->_page->getControls()->add($expression);
+		
+		$output = $this->render($expression);
+		$this->assertEquals("value's", $output);
+	}
+
+	public function testRenderWithDoubleQuoteString()
+	{
+		$expression = new TExpression();
+		$expression->setExpression('"value\"s"');
+		$expression->setID('Expression8');
+		$this->_page->getControls()->add($expression);
+		
+		$output = $this->render($expression);
+		$this->assertEquals('value"s', $output);
+	}
+
+	public function testPropertyHandlingWithSingleQuotes()
+	{
+		$control = new TExpression();
+		$control->setExpression('value&#039;s');
+		$this->assertEquals("value's", $control->getExpression());
+	}
+
+	public function testPropertyHandlingWithDoubleQuotes()
+	{
+		$control = new TExpression();
+		$control->setExpression('value&quot;s');
+		$this->assertEquals('value"s', $control->getExpression());
+	}
+
+	public function testPropertyHandlingWithMixedQuotes()
+	{
+		$control = new TExpression();
+		$control->setExpression('He said &#039;Hello &quot;World&quot;&#039;');
+		$this->assertEquals('He said \'Hello "World"\'', $control->getExpression());
+	}
+
+	public function testTemplatePropertyHandlingWithSingleQuotes()
+	{
+		$template = '<com:TExpression ID="Expr7" Expression="value&#039;s" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr7');
+		$this->assertEquals("value's", $expression->getExpression());
+	}
+
+	public function testTemplatePropertyHandlingWithDoubleQuotes()
+	{
+		$template = '<com:TExpression ID="Expr8" Expression="value&quot;s" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr8');
+		$this->assertEquals('value"s', $expression->getExpression());
+	}
+
+	public function testTemplatePropertyHandlingWithMixedQuotes()
+	{
+		$template = '<com:TExpression ID="Expr9" Expression="He said &#039;Hello &quot;World&quot;&#039;" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr9');
+		$this->assertEquals('He said \'Hello "World"\'', $expression->getExpression());
+	}
+
+	public function testRenderWithHtmlEntitySingleQuotes()
+	{
+		// Test that HTML entity encoded single quotes are properly decoded and rendered
+		// Expression uses double quotes, so decoded &#039; (') is valid inside
+		$expression = new TExpression();
+		$expression->setExpression('"it&#039;s working"');
+		$expression->setID('Expression10');
+		$this->_page->getControls()->add($expression);
+		
+		// Verify the expression property has the decoded value
+		$this->assertEquals('"it\'s working"', $expression->getExpression());
+		
+		// Now render - the expression should evaluate to the string "it's working"
+		$output = $this->render($expression);
+		$this->assertEquals("it's working", $output);
+	}
+
+	public function testRenderWithHtmlEntityDoubleQuotes()
+	{
+		// Test that HTML entity encoded double quotes are properly decoded and rendered
+		// Expression uses single quotes, so decoded &quot; (") is valid inside
+		$expression = new TExpression();
+		$expression->setExpression("'she said &quot;hello&quot;'");
+		$expression->setID('Expression11');
+		$this->_page->getControls()->add($expression);
+		
+		// Verify the expression property has the decoded value
+		$this->assertEquals("'she said \"hello\"'", $expression->getExpression());
+		
+		// Now render - the expression should evaluate to the string 'she said "hello"'
+		$output = $this->render($expression);
+		$this->assertEquals('she said "hello"', $output);
+	}
+
+	public function testTemplateRenderWithHtmlEntitySingleQuotes()
+	{
+		// Test template with HTML entity that becomes valid PHP string with single quotes
+		// &#039; decodes to ' which is valid inside double-quoted PHP string
+		$template = '<com:TExpression ID="Expr10" Expression="&quot;hello&#039;s&quot;" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr10');
+		// The expression property should have the decoded value: "hello's"
+		$this->assertEquals('"hello\'s"', $expression->getExpression());
+		
+		$output = $this->render($expression);
+		$this->assertEquals("hello's", $output);
+	}
+
+	public function testTemplateRenderWithHtmlEntityDoubleQuotes()
+	{
+		// Test template with HTML entity that becomes valid PHP string with double quotes
+		// &quot; decodes to " which is valid inside single-quoted PHP string
+		$template = '<com:TExpression ID="Expr11" Expression="&#039;say &quot;hi&quot;&#039;" />';
+		$page = new TPage();
+		$page->setID('TestPage');
+		$tpl = $this->newTemplate($template);
+		$tpl->instantiateIn($page);
+		
+		$expression = $page->findControl('Expr11');
+		// The expression property should have the decoded value: 'say "hi"'
+		$this->assertEquals("'say \"hi\"'", $expression->getExpression());
+		
+		$output = $this->render($expression);
+		$this->assertEquals('say "hi"', $output);
+	}
+}

--- a/tests/unit/Web/UI/WebControls/TI18NWebControlTest.php
+++ b/tests/unit/Web/UI/WebControls/TI18NWebControlTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Prado\Web\UI\WebControls\TI18NWebControl;
+use Prado\Web\UI\WebControls\TWebControl;
+use Prado\I18N\TI18NControlTrait;
+use Prado\Web\UI\THtmlWriter;
+use Prado\IO\TTextWriter;
+use PHPUnit\Framework\TestCase;
+
+class TI18NWebControlTest extends TestCase
+{
+	private function render($control)
+	{
+		$tw = new TTextWriter();
+		$writer = new THtmlWriter($tw);
+		$control->render($writer);
+		return $tw->flush();
+	}
+
+	public function testExtendsWebControl()
+	{
+		$control = new TI18NWebControl();
+		$this->assertInstanceOf(TWebControl::class, $control);
+	}
+
+	public function testUsesTrait()
+	{
+		$traits = class_uses(TI18NWebControl::class);
+		$this->assertArrayHasKey(TI18NControlTrait::class, $traits);
+	}
+
+	public function testCultureDefaultEmpty()
+	{
+		$control = new TI18NWebControl();
+		// When no globalization module, getCulture() falls back via dy event or returns ''
+		$this->assertIsString($control->getCulture());
+	}
+
+	public function testSetCulture()
+	{
+		$control = new TI18NWebControl();
+		$control->setCulture('fr_FR');
+		$this->assertEquals('fr_FR', $control->getCulture());
+	}
+
+	public function testSetCultureEmpty()
+	{
+		$control = new TI18NWebControl();
+		$control->setCulture('en_US');
+		$control->setCulture('');
+		// When cleared, falls back to application/default
+		$this->assertIsString($control->getCulture());
+	}
+
+	public function testCharsetDefault()
+	{
+		$control = new TI18NWebControl();
+		// Without globalization, falls back to UTF-8 via dy event
+		$charset = $control->getCharset();
+		$this->assertIsString($charset);
+	}
+
+	public function testSetCharset()
+	{
+		$control = new TI18NWebControl();
+		$control->setCharset('UTF-8');
+		$this->assertEquals('UTF-8', $control->getCharset());
+	}
+
+	public function testSetCharsetEmpty()
+	{
+		$control = new TI18NWebControl();
+		$control->setCharset('ISO-8859-1');
+		$control->setCharset('');
+		// Falls back to app or UTF-8
+		$this->assertIsString($control->getCharset());
+	}
+
+	public function testRendersTag()
+	{
+		$control = new TI18NWebControl();
+		// TI18NWebControl inherits TWebControl's default tag (span or div)
+		$output = $this->render($control);
+		$this->assertNotEmpty($output);
+		$this->assertStringContainsString('<', $output);
+	}
+}


### PR DESCRIPTION
TModuleView - only instancing children on presence of module, fallback template
TControl::createControlChildren has a parent chain for triggering attached behavior actions on the same
TDataSize uses TI18NControlTrait

Use case 1 for TModuleView.  Developer installs a PRADO 4 extension plugin that implements several template controls that are used, but the developer doesn't want the page to break if the extension is un-installed.

Use case2 for TModuleView: Plugin Developers can code their own pages and (template) controls to key on other installed modules/controls; recursive plugin behavior for plugins.
