### PR TITLE
TTemplate & TTheme (skins) refactor

### DIFF
--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -10,122 +10,131 @@
 
 namespace Prado\Web\UI;
 
-use Prado\Prado;
-use Prado\TComponent;
-use Prado\Web\Javascripts\TJavaScriptLiteral;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TException;
 use Prado\Exceptions\TTemplateException;
+use Prado\Prado;
+use Prado\TComponent;
+use Prado\Web\Javascripts\TJavaScriptLiteral;
+use Prado\Web\Services\TPageService;
 
 /**
+ * TTemplate class
+ *
  * TTemplate implements PRADO template parsing logic.
  * A TTemplate object represents a parsed PRADO control template.
  * It can instantiate the template as child controls of a specified control.
  * The template format is like HTML, with the following special tags introduced,
  * - component tags: a component tag represents the configuration of a component.
- * The tag name is in the format of com:ComponentType, where ComponentType is the component
- * class name. Component tags must be well-formed. Attributes of the component tag
- * are treated as either property initial values, event handler attachment, or regular
- * tag attributes.
+ *   The tag name is in the format of com:ComponentType, where ComponentType is
+ *   the component class name. Component tags must be well-formed. Attributes of
+ *   the component tag are treated as either property initial values, event handler
+ *   attachment, or regular tag attributes.
  * - property tags: property tags are used to set large block of attribute values.
- * The property tag name is in the format of <prop:AttributeName> where AttributeName
- * can be a property name, an event name or a regular tag attribute name.
+ *   The property tag name is in the format of <prop:AttributeName> where AttributeName
+ *   can be a property name, an event name or a regular tag attribute name.
  * - group subproperty tags: subproperties of a common property can be configured using
- * <prop:MainProperty SubProperty1="Value1" SubProperty2="Value2" .../>
+ *   <prop:MainProperty SubProperty1="Value1" SubProperty2="Value2" .../>
  * - directive: directive specifies the property values for the template owner.
- * It is in the format of <%@ property name-value pairs %>;
- * - expressions: They are in the format of <%= PHP expression %> and <%% PHP statements %>
- * - comments: There are two kinds of comments, regular HTML comments and special template comments.
- * The former is in the format of <!-- comments -->, which will be treated as text strings.
- * The latter is in the format of <!-- comments --!>, which will be stripped out.
+ *   It is in the format of <%@ property name-value pairs %>;
+ * - expressions: They are in the format of <%= PHP expression %> and
+ *   <%% PHP statements %>
+ * - Template comments are formatted as  <!--- comments --->, which will be entirely
+ *     stripped from the output.
  *
  * Tags other than the above are not required to be well-formed.
  *
- * A TTemplate object represents a parsed PRADO template. To instantiate the template
- * for a particular control, call {@see instantiateIn($control)}, which
- * will create and intialize all components specified in the template and
+ * A TTemplate object represents a parsed PRADO template. To instantiate the
+ * template for a particular control, call {@see instantiateIn($control)}, which
+ * will create and initialize all components specified in the template and
  * set their parent as $control.
  *
+ * Attribute Name Transformations:
+ * - Hyphens (dashes) in attribute names are converted to underscores for PHP method lookup.
+ *   For example, `--webkit-toggle="modal"` becomes `set__webkit_toggle("modal")` or sets
+ *   the `data_toggle` property via `__set()`. This allows HTML5 data attributes to map
+ *   to PHP setter methods with underscores.
+ * - Property and attribute names are matched case-insensitively for lookup, but the
+ *   original case is preserved when calling setters or magic `__set()`. For subproperties
+ *   like `Style.ForeColor`, the dot notation accesses the subproperty directly.
+ *
+ * @note AGENTS: For visibility on screen, the code blocks below must remain dense.
  * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Brad Anderson <belisoful@icloud.com> dash-andCaseSupport.
  * @since 3.0
- * @method \Prado\Web\Services\TPageService getService()
+ * @ method \Prado\Web\Services\TPageService getService()
+ * @phpstan-consistent-constructor
  */
 class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 {
+	private const PARSE_COMMENTS = '<!---.*?---!?>';
+
+	private const PARSE_SINGLE_QUOTED_VALUE = '\'.*?\'';
+	private const PARSE_DOUBLE_QUOTED_VALUE = '".*?"';
+	private const PARSE_EXPRESSION_VALUE = '.*?';
+
+	private const PARSE_CONTROL_NAME = '[\w\.\\\]+';
+	private const PARSE_PROP_NAME = '[\w\.\-]+';
+	private const PARSE_EQUALS = '\s*=\s*';
+
 	/**
-	 *  '<!--.*?--!>' - template comments
-	 *  '<!--.*?-->'  - HTML comments
-	 *	'<\/?com:([\w\.\\\]+)((?:\s*[\w\.]+\s*=\s*\'.*?\'|\s*[\w\.]+\s*=\s*".*?"|\s*[\w\.]+\s*=\s*<%.*?%>)*)\s*\/?>' - component tags
-	 *	'<\/?prop:([\w\.\-]+)\s*>'  - property tags
+	 *  '<!---.*?---!?>' - template comments (stripped during parse)
+	 *	'<\/?com:([\w\.\\\]+)((?:\s*[\w\.\-]+\s*=\s*\'.*?\'|\s*[\w\.\-]+\s*=\s*".*?"|\s*[\w\.\-]+\s*=\s*<%.*?%>)*)\s*\/?>' - component tags & attributes
 	 *	'<%@\s*((?:\s*[\w\.]+\s*=\s*\'.*?\'|\s*[\w\.]+\s*=\s*".*?")*)\s*%>'  - directives
 	 *	'<%[%#~\/\\$=\\[](.*?)%>'  - expressions
-	 *  '<prop:([\w\.\-]+)((?:\s*[\w\.\-]+=\'.*?\'|\s*[\w\.\-]+=".*?"|\s*[\w\.\-]+=<%.*?%>)*)\s*\/>' - group subproperty tags
+	 *  '<prop:([\w\.\-]+)((?:\s*[\w\.\-]+=\'.*?\'|\s*[\w\.\-]+=".*?"|\s*[\w\.\-]+=<%.*?%>)*)\s*\/>' - closed group subproperty tag
+	 *	'<\/?prop:([\w\.\-]+)\s*>'  - open (and end) group subproperty tag
 	 */
-	public const REGEX_RULES = '/<!--.*?--!>|<!---.*?--->|<\/?com:([\w\.\\\]+)((?:\s*[\w\.]+\s*=\s*\'.*?\'|\s*[\w\.]+\s*=\s*".*?"|\s*[\w\.]+\s*=\s*<%.*?%>)*)\s*\/?>|<\/?prop:([\w\.\-]+)\s*>|<%@\s*((?:\s*[\w\.]+\s*=\s*\'.*?\'|\s*[\w\.]+\s*=\s*".*?")*)\s*%>|<%[%#~\/\\$=\\[](.*?)%>|<prop:([\w\.\-]+)((?:\s*[\w\.\-]+\s*=\s*\'.*?\'|\s*[\w\.\-]+\s*=\s*".*?"|\s*[\w\.\-]+\s*=\s*<%.*?%>)*)\s*\/>/msS';
+	public const REGEX_RULES = '/<!---.*?---!?>|<\/?com:([\w\.\\\]+)((?:\s*[\w\.\-]+\s*=\s*\'.*?\'|\s*[\w\.\-]+\s*=\s*".*?"|\s*[\w\.\-]+\s*=\s*<%.*?%>)*)\s*\/?>|<\/?prop:([\w\.\-]+)\s*>|<%@\s*((?:\s*[\w\.]+\s*=\s*\'.*?\'|\s*[\w\.]+\s*=\s*".*?")*)\s*%>|<%[%#~\/\\$=\\[](.*?)%>|<prop:([\w\.\-]+)((?:\s*[\w\.\-]+\s*=\s*\'.*?\'|\s*[\w\.\-]+\s*=\s*".*?"|\s*[\w\.\-]+\s*=\s*<%.*?%>)*)\s*\/>/msS';
 
 	/**
 	 * Different configurations of component property/event/attribute
 	 */
-	public const CONFIG_DATABIND = 0;
-	public const CONFIG_EXPRESSION = 1;
-	public const CONFIG_ASSET = 2;
-	public const CONFIG_PARAMETER = 3;
-	public const CONFIG_LOCALIZATION = 4;
-	public const CONFIG_TEMPLATE = 5;
+	public const CONFIG_VALUE = 1;
+	public const CONFIG_DATABIND = 2;
+	public const CONFIG_EXPRESSION = 3;
+	public const CONFIG_ASSET = 4;
+	public const CONFIG_PARAMETER = 5;
+	public const CONFIG_LOCALIZATION = 6;
+	public const CONFIG_TEMPLATE = 7;
 
-	/**
-	 * @var array list of component tags and strings
-	 */
+	/** Template Info Keys */
+	public const TPL_PARENT_INDEX = 0;
+	public const TPL_TYPE = 1;
+	public const TPL_PROPS = 2;
+
+	/** Property Info Keys */
+	public const PROP_TYPE = 0;
+	public const PROP_NAME = 1;
+	public const PROP_VALUE = 2;
+
+	/** @var array list of component tags and strings */
 	private $_tpl = [];
-	/**
-	 * @var array list of directive settings
-	 */
+	/** @var array list of directive settings */
 	private $_directive = [];
-	/**
-	 * @var string context path
-	 */
+	/** @var string context path */
 	private $_contextPath;
-	/**
-	 * @var string template file path (if available)
-	 */
+	/** @var string template file path (if available) */
 	private $_tplFile;
-	/**
-	 * @var int the line number that parsing starts from (internal use)
-	 */
+	/** @var int the line number that parsing starts from (internal use) */
 	private $_startingLine = 0;
-	/**
-	 * @var string template content to be parsed
-	 */
+	/** @var string template content to be parsed */
 	private $_content;
-	/**
-	 * @var bool tells whether the class and attributes should be validated before moving on	 */
+	/** @var bool tells whether the class and attributes should be validated before moving on	 */
 	private $_attributevalidation = true;
-	/**
-	 * @var bool whether this template is a source template
-	 */
+	/** @var bool whether this template is a source template */
 	private $_sourceTemplate = true;
-	/**
-	 * @var string hash code of the template
-	 */
+	/** @var string hash code of the template */
 	private $_hashCode = '';
 
-	/**
-	 * @var \Prado\Web\UI\TControl
-	 */
+	/** @var \Prado\Web\UI\TControl */
 	private $_tplControl;
-	/**
-	 * @var array<string>
-	 */
+	/** @var array<string> */
 	private $_includedFiles = [];
-	/**
-	 * @var array<int>
-	 */
+	/** @var array<int> */
 	private $_includeAtLine = [];
-	/**
-	 * @var array<int>
-	 */
+	/** @var array<int> */
 	private $_includeLines = [];
-
 
 	/**
 	 * Constructor.
@@ -223,6 +232,8 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	 * and passed to the specified parent control.
 	 * @param \Prado\Web\UI\TControl $tplControl the control who owns the template
 	 * @param null|TControl $parentControl the control who will become the root parent of the controls on the template. If null, it uses the template control.
+	 * @see \Prado\Web\Services\TPageService getService() - when the $tplControl has
+	 *			no page, this asks the service for the requested page; for applying style sheets
 	 */
 	public function instantiateIn($tplControl, $parentControl = null)
 	{
@@ -230,83 +241,84 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 		if ($parentControl === null) {
 			$parentControl = $tplControl;
 		}
-		if (($page = $tplControl->getPage()) === null) {
-			$page = $this->getService()->getRequestedPage();
+		if (($page = $tplControl->getPage()) === null && ($service = $this->getService()) !== null && $service->isa(TPageService::class)) {
+			$page = $service->getRequestedPage();
 		}
 		$controls = [];
 		$directChildren = [];
-		foreach ($this->_tpl as $key => $object) {
-			if ($object[0] === -1) {
+		$appParameters = $this->getApplication()->getParameters();
+		foreach ($this->_tpl as $tplKey => $tplInfo) {
+			if ($tplInfo[self::TPL_PARENT_INDEX] === -1) {
 				$parent = $parentControl;
-			} elseif (isset($controls[$object[0]])) {
-				$parent = $controls[$object[0]];
+			} elseif (isset($controls[$tplInfo[self::TPL_PARENT_INDEX]])) {
+				$parent = $controls[$tplInfo[self::TPL_PARENT_INDEX]];
 			} else {
 				continue;
 			}
-			if (isset($object[2])) {	// component
-				$component = Prado::createComponent($object[1]);
-				$properties = &$object[2];
+			if (isset($tplInfo[self::TPL_PROPS])) {	// is a component or control, b/c it has properties
+				$component = Prado::createComponent($tplInfo[self::TPL_TYPE]);
+				$properties = &$tplInfo[self::TPL_PROPS];
 				if ($component instanceof TControl) {
 					if ($component instanceof \Prado\Web\UI\WebControls\TOutputCache) {
-						$component->setCacheKeyPrefix($this->_hashCode . $key);
+						$component->setCacheKeyPrefix($this->_hashCode . $tplKey);
 					}
 					$component->setTemplateControl($tplControl);
 					if (isset($properties['id'])) {
-						if (is_array($properties['id'])) {
-							if ($properties['id'][0] === self::CONFIG_PARAMETER) {
-								$properties['id'] = $this->getApplication()->getParameters()->itemAt($properties['id'][1]);
-							} else {
-								$properties['id'] = $component->evaluateExpression($properties['id'][1]);
-							}
+						switch ($properties['id'][self::PROP_TYPE]) {
+							case self::CONFIG_VALUE:break;
+							case self::CONFIG_PARAMETER:
+								$properties['id'][self::PROP_VALUE] = $appParameters->itemAt($properties['id'][self::PROP_VALUE]);
+								break;
+							default:
+								$properties['id'][self::PROP_VALUE] = $component->evaluateExpression($properties['id'][self::PROP_VALUE]);
 						}
-						$tplControl->registerObject($properties['id'], $component);
+						$tplControl->registerObject($properties['id'][self::PROP_VALUE], $component);
 					}
 					if (isset($properties['skinid'])) {
-						if (is_array($properties['skinid'])) {
-							if ($properties['skinid'][0] === self::CONFIG_PARAMETER) {
-								$properties['skinid'] = $this->getApplication()->getParameters()->itemAt($properties['skinid'][1]);
-							} else {
-								$properties['skinid'] = $component->evaluateExpression($properties['skinid'][1]);
-							}
+						switch ($properties['skinid'][self::PROP_TYPE]) {
+							case self::CONFIG_VALUE:break;
+							case self::CONFIG_PARAMETER:
+								$properties['skinid'][self::PROP_VALUE] = $appParameters->itemAt($properties['skinid'][self::PROP_VALUE]);
+								break;
+							default:
+								$properties['skinid'][self::PROP_VALUE] = $component->evaluateExpression($properties['skinid'][self::PROP_VALUE]);
 						}
-						$component->setSkinID($properties['skinid']);
+						$component->setSkinID($properties['skinid'][self::PROP_VALUE]);
 						unset($properties['skinid']);
 					}
-
 					$component->trackViewState(false);
-
 					$component->applyStyleSheetSkin($page);
-					foreach ($properties as $name => $value) {
-						$this->configureControl($component, $name, $value);
+					foreach ($properties as $attrKey => $propInfo) {
+						$this->configureControl($component, $attrKey, $propInfo);
 					}
-
 					$component->trackViewState(true);
-
 					if ($parent === $parentControl) {
 						$directChildren[] = $component;
 					} else {
 						$component->createdOnTemplate($parent);
 					}
 					if ($component->getAllowChildControls()) {
-						$controls[$key] = $component;
+						$controls[$tplKey] = $component;
 					}
 				} elseif ($component instanceof TComponent) {
-					$controls[$key] = $component;
+					$controls[$tplKey] = $component;
 					if (isset($properties['id'])) {
-						if (is_array($properties['id'])) {
-							if ($properties['id'][0] === self::CONFIG_PARAMETER) {
-								$properties['id'] = $this->getApplication()->getParameters()->itemAt($properties['id'][1]);
-							} else {
-								$properties['id'] = $component->evaluateExpression($properties['id'][1]);
-							}
-						}
-						$tplControl->registerObject($properties['id'], $component);
 						if (!$component->hasProperty('id')) {
 							unset($properties['id']);
+						} else {
+							switch ($properties['id'][self::PROP_TYPE]) {
+								case self::CONFIG_VALUE:break;
+								case self::CONFIG_PARAMETER:
+									$properties['id'][self::PROP_VALUE] = $appParameters->itemAt($properties['id'][self::PROP_VALUE]);
+									break;
+								default:
+									$properties['id'][self::PROP_VALUE] = $component->evaluateExpression($properties['id'][self::PROP_VALUE]);
+							}
+							$tplControl->registerObject($properties['id'][self::PROP_VALUE], $component);
 						}
 					}
-					foreach ($properties as $name => $value) {
-						$this->configureComponent($component, $name, $value);
+					foreach ($properties as $attrKey => $propInfo) {
+						$this->configureComponent($component, $attrKey, $propInfo);
 					}
 					if ($parent === $parentControl) {
 						$directChildren[] = $component;
@@ -315,9 +327,9 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 					}
 				}
 			} else {
-				if ($object[1] instanceof TCompositeLiteral) {
+				if ($tplInfo[self::TPL_TYPE] instanceof TCompositeLiteral) {
 					// need to clone a new object because the one in template is reused
-					$o = clone $object[1];
+					$o = clone $tplInfo[self::TPL_TYPE];
 					$o->setContainer($tplControl);
 					if ($parent === $parentControl) {
 						$directChildren[] = $o;
@@ -326,9 +338,9 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 					}
 				} else {
 					if ($parent === $parentControl) {
-						$directChildren[] = $object[1];
+						$directChildren[] = $tplInfo[self::TPL_TYPE];
 					} else {
-						$parent->addParsedObject($object[1]);
+						$parent->addParsedObject($tplInfo[self::TPL_TYPE]);
 					}
 				}
 			}
@@ -348,144 +360,106 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	/**
 	 * Configures a property/event of a control.
 	 * @param \Prado\Web\UI\TControl $control control to be configured
-	 * @param string $name property name
-	 * @param mixed $value property initial value
+	 * @param string $attrKey property name
+	 * @param mixed $propInfo property initial value
 	 */
-	protected function configureControl($control, $name, $value)
+	protected function configureControl($control, $attrKey, $propInfo)
 	{
-		if (strncasecmp($name, 'on', 2) === 0) {		// is an event
-			$this->configureEvent($control, $name, $value, $control);
-		} elseif (($pos = strrpos($name, '.')) === false) {	// is a simple property or custom attribute
-			$this->configureProperty($control, $name, $value);
-		} else {	// is a subproperty
-			$this->configureSubProperty($control, $name, $value);
+		if (strncasecmp($attrKey, 'on', 2) === 0) {		// is an event
+			$this->configureEvent($control, $attrKey, $propInfo, $control);
+		} else {
+			$this->configureProperty($control, $attrKey, $propInfo);
 		}
 	}
 
 	/**
 	 * Configures a property of a non-control component.
 	 * @param \Prado\TComponent $component component to be configured
-	 * @param string $name property name
-	 * @param mixed $value property initial value
+	 * @param string $attrKey property name
+	 * @param mixed $propInfo property initial value
 	 */
-	protected function configureComponent($component, $name, $value)
+	protected function configureComponent($component, $attrKey, $propInfo)
 	{
-		if (strpos($name, '.') === false) {	// is a simple property or custom attribute
-			$this->configureProperty($component, $name, $value);
-		} else {	// is a subproperty
-			$this->configureSubProperty($component, $name, $value);
-		}
+		$this->configureProperty($component, $attrKey, $propInfo);
 	}
 
 	/**
 	 * Configures an event for a control.
 	 * @param \Prado\Web\UI\TControl $control control to be configured
-	 * @param string $name event name
-	 * @param string $value event handler
+	 * @param string $attrKey event name
+	 * @param string $propInfo event handler
 	 * @param \Prado\Web\UI\TControl $contextControl context control
 	 */
-	protected function configureEvent($control, $name, $value, $contextControl)
+	protected function configureEvent($control, $attrKey, $propInfo, $contextControl)
 	{
-		if (strpos($value, '.') === false) {
-			$control->attachEventHandler($name, [$contextControl, 'TemplateControl.' . $value]);
+		if (strpos($propInfo[self::PROP_VALUE], '.') === false) {
+			$control->attachEventHandler($attrKey, [$contextControl, 'TemplateControl.' . $propInfo[self::PROP_VALUE]]);
 		} else {
-			$control->attachEventHandler($name, [$contextControl, $value]);
+
+			$control->attachEventHandler($attrKey, [$contextControl, $propInfo[self::PROP_VALUE]]);
 		}
 	}
 
 	/**
 	 * Configures a simple property for a component.
+	 * Note: setSubProperty does set the Property on the component if there is no `.`.
 	 * @param \Prado\Web\UI\TControl $component component to be configured
-	 * @param string $name property name
-	 * @param mixed $value property initial value
+	 * @param string $attrKey property name
+	 * @param array $propInfo [type, property value, full name]
 	 */
-	protected function configureProperty($component, $name, $value)
+	protected function configureProperty($component, $attrKey, $propInfo)
 	{
-		if (is_array($value)) {
-			switch ($value[0]) {
-				case self::CONFIG_DATABIND:
-					$component->bindProperty($name, $value[1]);
-					break;
-				case self::CONFIG_EXPRESSION:
-					if ($component instanceof TControl) {
-						$component->autoBindProperty($name, $value[1]);
-					} else {
-						$setter = 'set' . $name;
-						$component->$setter($this->_tplControl->evaluateExpression($value[1]));
+		$propName = $this->attributeToMethodName($propInfo[self::PROP_NAME]);
+		switch ($propInfo[self::PROP_TYPE]) {
+			case self::CONFIG_VALUE:
+				$pos = strrpos($propName, '.');
+				$prop = substr($propName, $pos !== false ? $pos + 1 : 0);
+				if (strncasecmp($prop, 'js', 2) === 0) {
+					$jsValue = $propInfo[self::PROP_VALUE];
+					if ($jsValue && !($jsValue instanceof TJavaScriptLiteral)) {
+						$jsValue = new TJavaScriptLiteral($jsValue);
 					}
-					break;
-				case self::CONFIG_TEMPLATE:
-					$setter = 'set' . $name;
-					$component->$setter($value[1]);
-					break;
-				case self::CONFIG_ASSET:		// asset URL
-					$setter = 'set' . $name;
-					$url = $this->publishFilePath($this->_contextPath . DIRECTORY_SEPARATOR . $value[1]);
-					$component->$setter($url);
-					break;
-				case self::CONFIG_PARAMETER:		// application parameter
-					$setter = 'set' . $name;
-					$component->$setter($this->getApplication()->getParameters()->itemAt($value[1]));
-					break;
-				case self::CONFIG_LOCALIZATION:
-					$setter = 'set' . $name;
-					$component->$setter(Prado::localize($value[1]));
-					break;
-				default:	// an error if reaching here
-					throw new TConfigurationException('template_tag_unexpected', $name, $value[1]);
-					break;
-			}
-		} else {
-			if (substr($name, 0, 2) == 'js') {
-				if ($value && !($value instanceof TJavaScriptLiteral)) {
-					$value = new TJavaScriptLiteral($value);
 				}
-			}
-			$setter = 'set' . $name;
-			$component->$setter($value);
+				$component->setSubProperty($propName, $propInfo[self::PROP_VALUE]);
+				break;
+			case self::CONFIG_DATABIND:		// databinding
+				$component->bindProperty($propName, $propInfo[self::PROP_VALUE]);
+				break;
+			case self::CONFIG_EXPRESSION:		// expression
+				if ($component instanceof TControl) {
+					$component->autoBindProperty($propName, $propInfo[self::PROP_VALUE]);
+				} else {
+					$component->setSubProperty($propName, $this->_tplControl->evaluateExpression($propInfo[self::PROP_VALUE]));
+				}
+				break;
+			case self::CONFIG_TEMPLATE:
+				$component->setSubProperty($propName, $propInfo[self::PROP_VALUE]);
+				break;
+			case self::CONFIG_ASSET:		// asset URL
+				$url = $this->publishFilePath($this->_contextPath . DIRECTORY_SEPARATOR . $propInfo[self::PROP_VALUE]);
+				$component->setSubProperty($propName, $url);
+				break;
+			case self::CONFIG_PARAMETER:		// application parameter
+				$component->setSubProperty($propName, $this->getApplication()->getParameters()->itemAt($propInfo[self::PROP_VALUE]));
+				break;
+			case self::CONFIG_LOCALIZATION:
+				$component->setSubProperty($propName, Prado::localize($propInfo[self::PROP_VALUE]));
+				break;
+			default:
+				$propType = $propInfo[self::PROP_TYPE];
+				throw new TConfigurationException('template_tag_unexpected', $propName . " (tag-type: {$propType})", $propInfo[self::PROP_VALUE]);
 		}
 	}
 
 	/**
-	 * Configures a subproperty for a component.
-	 * @param \Prado\Web\UI\TControl $component component to be configured
-	 * @param string $name subproperty name
-	 * @param mixed $value subproperty initial value
+	 * Converts attribute names with dashes to method name format.
+	 * @param string $propName property name with possible dashes
+	 * @return string property name with dashes replaced by underscores
+	 * @since 4.3.3
 	 */
-	protected function configureSubProperty($component, $name, $value)
+	protected function attributeToMethodName($propName)
 	{
-		if (is_array($value)) {
-			switch ($value[0]) {
-				case self::CONFIG_DATABIND:		// databinding
-					$component->bindProperty($name, $value[1]);
-					break;
-				case self::CONFIG_EXPRESSION:		// expression
-					if ($component instanceof TControl) {
-						$component->autoBindProperty($name, $value[1]);
-					} else {
-						$component->setSubProperty($name, $this->_tplControl->evaluateExpression($value[1]));
-					}
-					break;
-				case self::CONFIG_TEMPLATE:
-					$component->setSubProperty($name, $value[1]);
-					break;
-				case self::CONFIG_ASSET:		// asset URL
-					$url = $this->publishFilePath($this->_contextPath . DIRECTORY_SEPARATOR . $value[1]);
-					$component->setSubProperty($name, $url);
-					break;
-				case self::CONFIG_PARAMETER:		// application parameter
-					$component->setSubProperty($name, $this->getApplication()->getParameters()->itemAt($value[1]));
-					break;
-				case self::CONFIG_LOCALIZATION:
-					$component->setSubProperty($name, Prado::localize($value[1]));
-					break;
-				default:	// an error if reaching here
-					throw new TConfigurationException('template_tag_unexpected', $name, $value[1]);
-					break;
-			}
-		} else {
-			$component->setSubProperty($name, $value);
-		}
+		return str_replace('-', '_', $propName);
 	}
 
 	/**
@@ -516,7 +490,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 		$n = preg_match_all(self::REGEX_RULES, $input, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
 		$expectPropEnd = false;
 		$textStart = 0;
-		$stack = [];
+		$tagStack = [];
 		$container = -1;
 		$matchEnd = 0;
 		$c = 0;
@@ -527,164 +501,148 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 				$str = $match[0][0];
 				$matchStart = $match[0][1];
 				$matchEnd = $matchStart + strlen($str) - 1;
-				if (strpos($str, '<com:') === 0) {	// opening component tag
+				if (strncasecmp($str, '<com:', 5) === 0) {	// opening component tag
 					if ($expectPropEnd) {
 						continue;
 					}
 					if ($matchStart > $textStart) {
-						$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+						$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart, $matchStart - $textStart));
 					}
 					$textStart = $matchEnd + 1;
-					$type = $match[1][0];
+					$tag = $match[1][0];
 					$attributes = $this->parseAttributes($match[2][0], $match[2][1]);
-					$class = $this->validateAttributes($type, $attributes);
-					$tpl[$c++] = [$container, $class, $attributes];
-					if ($str[strlen($str) - 2] !== '/') {  // open tag
-						$stack[] = $type;
+					$class = $this->validateAttributes($tag, $attributes);
+					$tpl[$c++] = $this->packTemplate($container, $class, $attributes);
+					if ($str[strlen($str) - 2] !== '/') {  // open tag, stack the tag w/ case
+						$tagStack[] = $tag;
 						$container = $c - 1;
 					}
-				} elseif (strpos($str, '</com:') === 0) {	// closing component tag
+				} elseif (strncasecmp($str, '</com:', 6) === 0) {	// closing component tag
 					if ($expectPropEnd) {
 						continue;
 					}
 					if ($matchStart > $textStart) {
-						$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+						$tag = substr($input, $textStart, $matchStart - $textStart);
+						$tpl[$c++] = $this->packTemplate($container, $tag);
 					}
 					$textStart = $matchEnd + 1;
-					$type = $match[1][0];
-
-					if (empty($stack)) {
-						throw new TConfigurationException('template_closingtag_unexpected', "</com:$type>");
+					$tag = $match[1][0];
+					if (empty($tagStack)) {
+						throw new TConfigurationException('template_closingtag_unexpected', "</com:$tag>");
 					}
-
-					$name = array_pop($stack);
-					if ($name !== $type) {
-						$tag = $name[0] === '@' ? '</prop:' . substr($name, 1) . '>' : "</com:$name>";
-						throw new TConfigurationException('template_closingtag_expected', $tag, "</com:$type>");
+					$openTag = array_pop($tagStack);
+					if ($openTag !== $tag) {
+						$expected = $openTag[0] === '@' ? '</prop:' . substr($openTag, 1) . '>' : "</com:$openTag>";
+						throw new TConfigurationException('template_closingtag_expected', $expected, "</com:$tag>");
 					}
-					$container = $tpl[$container][0];
-				} elseif (strpos($str, '<%@') === 0) {	// directive
+					$container = $tpl[$container][self::TPL_PARENT_INDEX];
+				} elseif (strncasecmp($str, '<%@', 3) === 0) {	// directive
 					if ($expectPropEnd) {
 						continue;
 					}
 					if ($matchStart > $textStart) {
-						$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+						$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart, $matchStart - $textStart));
 					}
 					$textStart = $matchEnd + 1;
-					if (isset($tpl[0]) || $this->_directive !== null) {
+					if (isset($tpl[0]) || $this->_directive !== null) { // requires: no parsed template, no directives
 						throw new TConfigurationException('template_directive_nonunique');
 					}
-					$this->_directive = $this->parseAttributes($match[4][0], $match[4][1]);
-				} elseif (strpos($str, '<%') === 0) {	// expression
+					$this->_directive = $this->parseAttributes($match[4][0], $match[4][1], true);
+				} elseif (strncasecmp($str, '<%', 2) === 0) {	// expression
 					if ($expectPropEnd) {
 						continue;
 					}
 					if ($matchStart > $textStart) {
-						$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+						$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart, $matchStart - $textStart));
 					}
 					$textStart = $matchEnd + 1;
-					$literal = trim($match[5][0]);
-					if ($str[2] === '=') {	// expression
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_EXPRESSION, $literal]];
-					} elseif ($str[2] === '%') {  // statements
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_STATEMENTS, $literal]];
-					} elseif ($str[2] === '#') {
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_DATABINDING, $literal]];
-					} elseif ($str[2] === '$') {
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_EXPRESSION, "\$this->getApplication()->getParameters()->itemAt('$literal')"]];
-					} elseif ($str[2] === '~') {
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_EXPRESSION, "\$this->publishFilePath('$this->_contextPath/$literal')"]];
-					} elseif ($str[2] === '/') {
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_EXPRESSION, "rtrim(dirname(\$this->getApplication()->getRequest()->getApplicationUrl()), '\/').'/$literal'"]];
-					} elseif ($str[2] === '[') {
-						$literal = strtr(trim(substr($literal, 0, strlen($literal) - 1)), ["'" => "\'", "\\" => "\\\\"]);
-						$tpl[$c++] = [$container, [TCompositeLiteral::TYPE_EXPRESSION, "Prado::localize('$literal')"]];
-					}
-				} elseif (strpos($str, '<prop:') === 0) {	// opening property
-					if (strrpos($str, '/>') === strlen($str) - 2) {  //subproperties
+					$expressionInfo = $this->parseExpression($str[2], trim($match[5][0]));
+					$tpl[$c++] = $this->packTemplate($container, $expressionInfo);
+				} elseif (strncasecmp($str, '<prop:', 6) === 0) {	// opening property
+					if (str_ends_with($str, '/>')) {  //subproperties
 						if ($expectPropEnd) {
 							continue;
 						}
 						if ($matchStart > $textStart) {
-							$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+							$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart, $matchStart - $textStart));
 						}
 						$textStart = $matchEnd + 1;
-						$prop = strtolower($match[6][0]);
+						//$propName = strtolower($match[6][0]);
+						$propName = ($match[6][0]);
+						$propKey = strtolower($propName);
 						$attrs = $this->parseAttributes($match[7][0], $match[7][1]);
 						$attributes = [];
-						foreach ($attrs as $name => $value) {
-							$attributes[$prop . '.' . $name] = $value;
+						foreach ($attrs as $attrKey => $value) {
+							$value[self::PROP_NAME] = $propName . '.' . $value[self::PROP_NAME];
+							$attributes[$propKey . '.' . $attrKey] = $value;
 						}
-						$type = $tpl[$container][1];
-						$this->validateAttributes($type, $attributes);
-						foreach ($attributes as $name => $value) {
-							if (isset($tpl[$container][2][$name])) {
-								throw new TConfigurationException('template_property_duplicated', $name);
+						$this->validateAttributes($tpl[$container][self::TPL_TYPE], $attributes);
+						foreach ($attributes as $attrKey => $propInfo) {
+							if (isset($tpl[$container][self::TPL_PROPS][$attrKey])) {
+								throw new TConfigurationException('template_property_duplicated', $attrKey);
 							}
-							$tpl[$container][2][$name] = $value;
+							$tpl[$container][self::TPL_PROPS][$attrKey] = $propInfo;
 						}
-					} else {  // regular property
-						$prop = strtolower($match[3][0]);
-						$stack[] = '@' . $prop;
+					} else {  // regular opening property
+						$propName = $match[3][0]; // Preserve case, match on other side
+						$tagStack[] = '@' . $propName;
 						if (!$expectPropEnd) {
 							if ($matchStart > $textStart) {
-								$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+								$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart, $matchStart - $textStart));
 							}
 							$textStart = $matchEnd + 1;
 							$expectPropEnd = true;
 						}
 					}
-				} elseif (strpos($str, '</prop:') === 0) {	// closing property
-					$prop = strtolower($match[3][0]);
-					if (empty($stack)) {
-						throw new TConfigurationException('template_closingtag_unexpected', "</prop:$prop>");
+				} elseif (strncasecmp($str, '</prop:', 7) === 0) {	// closing property
+					$propName = $match[3][0];
+					$propKey = strtolower($propName);
+					if (empty($tagStack)) {
+						throw new TConfigurationException('template_closingtag_unexpected', "</prop:$propName>");
 					}
-					$name = array_pop($stack);
-					if ($name !== '@' . $prop) {
-						$tag = $name[0] === '@' ? '</prop:' . substr($name, 1) . '>' : "</com:$name>";
-						throw new TConfigurationException('template_closingtag_expected', $tag, "</prop:$prop>");
+					$openName = array_pop($tagStack);
+					if ($openName !== '@' . $propName) {
+						$tag = $openName[0] === '@' ? '</prop:' . substr($openName, 1) . '>' : "</com:$openName>";
+						throw new TConfigurationException('template_closingtag_expected', $tag, "</prop:$propName>");
 					}
-					if (($last = count($stack)) < 1 || $stack[$last - 1][0] !== '@') {
+					if (($last = count($tagStack)) < 1 || $tagStack[$last - 1][0] !== '@') {
 						if ($matchStart > $textStart) {
 							$value = substr($input, $textStart, $matchStart - $textStart);
-							if (substr($prop, -8, 8) === 'template') {
-								$value = $this->parseTemplateProperty($value, $textStart);
+							if (str_ends_with($propKey, 'template')) {
+								//if (strncasecmp(substr($propName, -8, 8), 'template', 8) === 0) {
+								$propInfo = $this->parseTemplateProperty($propName, $value, $textStart);
 							} else {
-								$value = $this->parseAttribute($value);
+								$propInfo = $this->parseAttribute($propName, $value);
 							}
 							if ($container >= 0) {
-								$type = $tpl[$container][1];
-								$this->validateAttributes($type, [$prop => $value]);
-								if (isset($tpl[$container][2][$prop])) {
-									throw new TConfigurationException('template_property_duplicated', $prop);
+								$this->validateAttributes($tpl[$container][self::TPL_TYPE], [$propName => $propInfo]);
+								if (isset($tpl[$container][self::TPL_PROPS][$propKey])) {
+									throw new TConfigurationException('template_property_duplicated', $propKey);
 								}
-								$tpl[$container][2][$prop] = $value;
+								$tpl[$container][self::TPL_PROPS][$propKey] = $propInfo;
 							} else {	// a property for the template control
-								$this->_directive[$prop] = $value;
+								$this->_directive[$propName] = $propInfo[self::PROP_VALUE];
 							}
 							$textStart = $matchEnd + 1;
 						}
 						$expectPropEnd = false;
 					}
-				} elseif (strpos($str, '<!--') === 0) {	// comments
-					if ($expectPropEnd) {
-						throw new TConfigurationException('template_comments_forbidden');
-					}
+				} elseif (strncmp($str, '<!---', 5) === 0) {	// skip template comments
 					if ($matchStart > $textStart) {
-						$tpl[$c++] = [$container, substr($input, $textStart, $matchStart - $textStart)];
+						$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart, $matchStart - $textStart));
 					}
 					$textStart = $matchEnd + 1;
 				} else {
 					throw new TConfigurationException('template_matching_unexpected', $match);
 				}
 			}
-			if (!empty($stack)) {
-				$name = array_pop($stack);
-				$tag = $name[0] === '@' ? '</prop:' . substr($name, 1) . '>' : "</com:$name>";
+			if (!empty($tagStack)) {
+				$openName = array_pop($tagStack);
+				$tag = $openName[0] === '@' ? '</prop:' . substr($openName, 1) . '>' : "</com:$openName>";
 				throw new TConfigurationException('template_closingtag_expected', $tag, "nothing");
 			}
 			if ($textStart < strlen($input)) {
-				$tpl[$c++] = [$container, substr($input, $textStart)];
+				$tpl[$c++] = $this->packTemplate($container, substr($input, $textStart));
 			}
 		} catch (\Exception $e) {
 			if (($e instanceof TException) && ($e instanceof TTemplateException)) {
@@ -693,7 +651,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 			if ($matchEnd === 0) {
 				$line = $this->_startingLine + 1;
 			} else {
-				$line = $this->_startingLine + count(explode("\n", substr($input, 0, $matchEnd + 1)));
+				$line = $this->_startingLine + substr_count($input, "\n", 0, $matchEnd + 1) + 1;
 			}
 			$this->handleException($e, $line, $input);
 		}
@@ -702,94 +660,105 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 			$this->_directive = [];
 		}
 
-		// optimization by merging consecutive strings, expressions, statements and bindings
-		$objects = [];
-		$parent = null;
-		$id = null;
-		$merged = [];
-		foreach ($tpl as $id => $object) {
-			if (isset($object[2]) || $object[0] !== $parent) {
-				if ($parent !== null) {
-					if (count($merged[1]) === 1 && is_string($merged[1][0])) {
-						$objects[$id - 1] = [$merged[0], $merged[1][0]];
-					} else {
-						$objects[$id - 1] = [$merged[0], new TCompositeLiteral($merged[1])];
-					}
-				}
-				if (isset($object[2])) {
-					$parent = null;
-					$objects[$id] = $object;
-				} else {
-					$parent = $object[0];
-					$merged = [$parent, [$object[1]]];
-				}
-			} else {
-				$merged[1][] = $object[1];
-			}
-		}
-		if ($parent !== null && $id !== null) {
-			if (count($merged[1]) === 1 && is_string($merged[1][0])) {
-				$objects[$id] = [$merged[0], $merged[1][0]];
-			} else {
-				$objects[$id] = [$merged[0], new TCompositeLiteral($merged[1])];
-			}
-		}
-		$tpl = $objects;
-		return $objects;
+		return $this->optimizeTemplate();
 	}
 
 	/**
-	 * Parses the attributes of a tag from a string.
-	 * @param string $str the string to be parsed.
-	 * @param mixed $offset
-	 * @return array attribute values indexed by names.
+	 * Creates a template item array with named keys.
+	 * $type can be:
+	 *		- a string literal to output (no self::TPL_PROPS).
+	 * 		- a class name to instance, (self::TPL_PROPS exists).
+	 * 		- an array from {@see parseExpression}.
+	 *		- a TTemplate
+	 * @param int $parentIndex parent container index
+	 * @param array|string|TTemplate $type template data or component type
+	 * @param null|array $attributes parsed attributes for components
+	 * @return array template item with TPL_PARENT_INDEX, TPL_TYPE, and optionally TPL_PROPS
+	 * @since 4.3.3
 	 */
-	protected function parseAttributes($str, $offset)
+	protected function packTemplate(int $parentIndex, string|array|TTemplate $type, ?array $attributes = null)
+	{
+		if ($attributes === null) {
+			return [self::TPL_PARENT_INDEX => $parentIndex, self::TPL_TYPE => $type];
+		} else {
+			return [self::TPL_PARENT_INDEX => $parentIndex, self::TPL_TYPE => $type, self::TPL_PROPS => $attributes];
+		}
+	}
+
+	/**
+	 * Parses a template property value as a nested TTemplate.
+	 * @param string $propName property name being parsed
+	 * @param string $content template content between tags
+	 * @param int $offset character offset in source for line calculation
+	 * @return array packed property with CONFIG_TEMPLATE type
+	 */
+	protected function parseTemplateProperty(string $propName, string $content, int $offset)
+	{
+		$line = $this->_startingLine + substr_count($this->_content, "\n", 0, $offset); // -1, unlike other substr_count here
+		$template = new static($content, $this->_contextPath, $this->_tplFile, $line, false);
+		return $this->packProperty(self::CONFIG_TEMPLATE, $propName, $template);
+	}
+
+	/**
+	 * Parses attributes from a tag string.
+	 * @param string $str attribute string like `attr="value" another='value'`
+	 * @param int $offset character offset for line tracking
+	 * @param bool $directive if true, preserves case and returns direct values
+	 * @return array attribute values indexed by lowercased names
+	 */
+	protected function parseAttributes(string $str, int $offset, bool $directive = false)
 	{
 		if ($str === '') {
 			return [];
 		}
-		$pattern = '/([\w\.\-]+)\s*=\s*(\'.*?\'|".*?"|<%.*?%>)/msS';
+		$pattern = '/([\w\.\-]+)\s*=\s*(' . self::PARSE_SINGLE_QUOTED_VALUE . '|' .
+											self::PARSE_DOUBLE_QUOTED_VALUE . '|' .
+											'<%' . self::PARSE_EXPRESSION_VALUE . '%>)/msS';
 		$attributes = [];
 		$n = preg_match_all($pattern, $str, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
 		for ($i = 0; $i < $n; ++$i) {
 			$match = &$matches[$i];
-			$name = strtolower($match[1][0]);
-			if (isset($attributes[$name])) {
-				throw new TConfigurationException('template_property_duplicated', $name);
+			$propName = $match[1][0];
+			$attrKey = strtolower($propName);
+			if (isset($attributes[$attrKey])) {
+				throw new TConfigurationException('template_property_duplicated', $attrKey);
 			}
 			$value = $match[2][0];
-			if (substr($name, -8, 8) === 'template') {
+			if (str_ends_with($attrKey, 'template')) {
 				if ($value[0] === '\'' || $value[0] === '"') {
-					$attributes[$name] = $this->parseTemplateProperty(substr($value, 1, strlen($value) - 2), $match[2][1] + 1);
+					$parseValue = $this->parseTemplateProperty($propName, substr($value, 1, strlen($value) - 2), $match[2][1] + 1);
 				} else {
-					$attributes[$name] = $this->parseTemplateProperty($value, $match[2][1]);
+					$parseValue = $this->parseTemplateProperty($propName, $value, $match[2][1]);
 				}
 			} else {
 				if ($value[0] === '\'' || $value[0] === '"') {
-					$attributes[$name] = $this->parseAttribute(substr($value, 1, strlen($value) - 2));
+					$parseValue = $this->parseAttribute($propName, substr($value, 1, strlen($value) - 2));
 				} else {
-					$attributes[$name] = $this->parseAttribute($value);
+					$parseValue = $this->parseAttribute($propName, $value);
 				}
+			}
+			$attributes[$attrKey] = $parseValue;
+		}
+		if ($directive) { //directives have cased names and direct values
+			$directiveAttr = $attributes;
+			$attributes = [];
+			foreach ($directiveAttr as $attrKey => &$propInfo) {
+				$propName = $this->attributeToMethodName($propInfo[self::PROP_NAME]);
+				$attributes[$propName] = $propInfo[self::PROP_VALUE];
 			}
 		}
 		return $attributes;
 	}
 
-	protected function parseTemplateProperty($content, $offset)
-	{
-		$line = $this->_startingLine + count(explode("\n", substr($this->_content, 0, $offset))) - 1;
-		return [self::CONFIG_TEMPLATE, new TTemplate($content, $this->_contextPath, $this->_tplFile, $line, false)];
-	}
-
 	/**
-	 * Parses a single attribute.
-	 * @param string $value the string to be parsed.
-	 * @return array attribute initialization
+	 * Parses a single attribute value to determine its type.
+	 * @param string $propName property name from template
+	 * @param string $value raw attribute value to parse
+	 * @return array [PROP_TYPE, PROP_VALUE, PROP_NAME] packed property info
 	 */
-	protected function parseAttribute($value)
+	protected function parseAttribute($propName, $value)
 	{
-		if (($n = preg_match_all('/<%[#=].*?%>/msS', $value, $matches, PREG_OFFSET_CAPTURE)) > 0) {
+		if (($n = preg_match_all('/<%[#=]' . self::PARSE_EXPRESSION_VALUE . '%>/msS', $value, $matches, PREG_OFFSET_CAPTURE)) > 0) {
 			$isDataBind = false;
 			$textStart = 0;
 			$expr = '';
@@ -811,27 +780,90 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 			if ($length > $textStart) {
 				$expr .= ".'" . strtr(substr($value, $textStart, $length - $textStart), ["'" => "\\'", "\\" => "\\\\"]) . "'";
 			}
-			if ($isDataBind) {
-				return [self::CONFIG_DATABIND, ltrim($expr, '.')];
-			} else {
-				return [self::CONFIG_EXPRESSION, ltrim($expr, '.')];
+			return $this->packProperty($isDataBind ? self::CONFIG_DATABIND : self::CONFIG_EXPRESSION, $propName, ltrim($expr, '.'));
+		} elseif (preg_match('/\\s*(<%~' . self::PARSE_EXPRESSION_VALUE . '%>|' .
+								   '<%\\$' . self::PARSE_EXPRESSION_VALUE . '%>|' .
+								   '<%\\[' . self::PARSE_EXPRESSION_VALUE . '\\]%>|' .
+								   '<%\/' . self::PARSE_EXPRESSION_VALUE . '%>)\\s*/msS', $value, $matches) && $matches[0] === $value) {
+			$strValue = $matches[1];
+			$propType = $this->propertyExpressionCharToType($strValue, $propName);
+			$endOffset = ($propType === self::CONFIG_LOCALIZATION) ? -1 : 0;
+			$strValue = trim(substr($strValue, 3, strlen($strValue) - 5 + $endOffset));
+			if ($propType === self::CONFIG_EXPRESSION) {
+				$strValue = "rtrim(dirname(\$this->getApplication()->getRequest()->getApplicationUrl()), '\/').'/$strValue'";
 			}
-		} elseif (preg_match('/\\s*(<%~.*?%>|<%\\$.*?%>|<%\\[.*?\\]%>|<%\/.*?%>)\\s*/msS', $value, $matches) && $matches[0] === $value) {
-			$value = $matches[1];
-			if ($value[2] === '~') {
-				return [self::CONFIG_ASSET, trim(substr($value, 3, strlen($value) - 5))];
-			} elseif ($value[2] === '[') {
-				return [self::CONFIG_LOCALIZATION, trim(substr($value, 3, strlen($value) - 6))];
-			} elseif ($value[2] === '$') {
-				return [self::CONFIG_PARAMETER, trim(substr($value, 3, strlen($value) - 5))];
-			} elseif ($value[2] === '/') {
-				$literal = trim(substr($value, 3, strlen($value) - 5));
-				return [self::CONFIG_EXPRESSION, "rtrim(dirname(\$this->getApplication()->getRequest()->getApplicationUrl()), '\/').'/$literal'"];
-			}
+			return $this->packProperty($propType, $propName, $strValue);
 		}
-		return $value;
+		return $this->packProperty(self::CONFIG_VALUE, $propName, $value);
 	}
 
+	/**
+	 * Creates a property info array with named keys.
+	 * @param int $type CONFIG_* constant for property type
+	 * @param string $propName original property name from template
+	 * @param mixed $value parsed property value
+	 * @return array property info with PROP_TYPE, PROP_NAME, PROP_VALUE keys
+	 * @since 4.3.3
+	 */
+	protected function packProperty($type, $propName, $value)
+	{
+		return [self::PROP_TYPE => $type, self::PROP_NAME => $propName, self::PROP_VALUE => $value];
+	}
+
+	/**
+	 * Maps expression character to CONFIG type.
+	 * @param string $strValue full expression string like <%~path%>
+	 * @param string $propName property name for error messages
+	 * @throws TConfigurationException if character is not recognized
+	 * @return int CONFIG_* constant
+	 * @since 4.3.3
+	 */
+	protected function propertyExpressionCharToType($strValue, $propName)
+	{
+		switch ($strValue[2]) {
+			case '=': return self::CONFIG_EXPRESSION;
+			case '#': return self::CONFIG_DATABIND;
+			case '~': return self::CONFIG_ASSET;
+			case '[': return self::CONFIG_LOCALIZATION;
+			case '$': return self::CONFIG_PARAMETER;
+			case '/': return self::CONFIG_EXPRESSION;
+			default:
+				throw new TConfigurationException('template_tag_unexpected', $propName . " (tag-type: {$strValue[2]})", $strValue);
+		}
+	}
+
+	/**
+	 * Parses template expressions like <%= %>, <%% %>, <%# %> etc.
+	 * @param string $tplType expression type character (=, %, #, $, ~, /, [)
+	 * @param string $literal expression content
+	 * @throws TConfigurationException for invalid expression types
+	 * @return array [TCompositeLiteral::TYPE_*, expression string]
+	 * @since 4.3.3
+	 */
+	protected function parseExpression($tplType, $literal)
+	{
+		switch ($tplType) {
+			case '=': return [TCompositeLiteral::TYPE_EXPRESSION, $literal];
+			case '%': return [TCompositeLiteral::TYPE_STATEMENTS, $literal];
+			case '#': return [TCompositeLiteral::TYPE_DATABINDING, $literal];
+			case '$': return [TCompositeLiteral::TYPE_EXPRESSION, "\$this->getApplication()->getParameters()->itemAt('$literal')"];
+			case '~': return [TCompositeLiteral::TYPE_EXPRESSION, "\$this->publishFilePath('$this->_contextPath/$literal')"];
+			case '/': return [TCompositeLiteral::TYPE_EXPRESSION, "rtrim(dirname(\$this->getApplication()->getRequest()->getApplicationUrl()), '\/').'/$literal'"];
+			case '[':
+				$literal = strtr(trim(substr($literal, 0, strlen($literal) - 1)), ["'" => "\'", "\\" => "\\\\"]);
+				return [TCompositeLiteral::TYPE_EXPRESSION, "Prado::localize('$literal')"];
+			default:
+				throw new TConfigurationException('template_tag_unexpected', " (expression-type: {$tplType})", $literal);
+		}
+	}
+
+	/**
+	 * Validates component attributes against class definitions using reflection.
+	 * @param string $type fully qualified component type name
+	 * @param array $attributes attribute key-value pairs to validate
+	 * @throws TConfigurationException if validation fails
+	 * @return string class name from reflection
+	 */
 	protected function validateAttributes($type, $attributes)
 	{
 		Prado::using($type);
@@ -842,60 +874,55 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 		}
 		$class = new \ReflectionClass($className);
 		if (!$this->_attributevalidation) {
-			return $class->getName();
+			return $class->getName();	//	Skins don't validate.
 		}
 		if (is_subclass_of($className, TControl::class) || $className === TControl::class) {
-			foreach ($attributes as $name => $att) {
-				if (($pos = strpos($name, '.')) !== false) {
-					// a subproperty, so the first segment must be readable
-					$subname = substr($name, 0, $pos);
+			foreach ($attributes as $attrKey => $propInfo) {
+				if (($pos = strpos($attrKey, '.')) !== false) {	// a subproperty, first segment is readable
+					$subname = substr($attrKey, 0, $pos);
 					if (!$class->hasMethod('get' . $subname)) {
 						throw new TConfigurationException('template_property_unknown', $type, $subname);
 					}
-				} elseif (strncasecmp($name, 'on', 2) === 0) {
-					// an event
-					if (!$class->hasMethod($name)) {
-						throw new TConfigurationException('template_event_unknown', $type, $name);
-					} elseif (!is_string($att)) {
-						throw new TConfigurationException('template_eventhandler_invalid', $type, $name);
+				} elseif (strncasecmp($attrKey, 'on', 2) === 0) {	// an event
+					if (!$class->hasMethod($attrKey)) {
+						throw new TConfigurationException('template_event_unknown', $type, $attrKey);
+					} elseif ($propInfo[self::PROP_TYPE] !== self::CONFIG_VALUE || !is_string($propInfo[self::PROP_VALUE])) {
+						throw new TConfigurationException('template_eventhandler_invalid', $type, $attrKey);
 					}
-				} else {
-					// a simple property
-					if (!($class->hasMethod('set' . $name) || $class->hasMethod('setjs' . $name) || $this->isClassBehaviorMethod($class, 'set' . $name))) {
-						if ($class->hasMethod('get' . $name) || $class->hasMethod('getjs' . $name)) {
-							throw new TConfigurationException('template_property_readonly', $type, $name);
+				} else {	// a simple property
+					if (!($class->hasMethod('set' . $attrKey) || $class->hasMethod('setjs' . $attrKey) || $this->isClassBehaviorMethod($class, 'set' . $attrKey))) {
+						if ($class->hasMethod('get' . $attrKey) || $class->hasMethod('getjs' . $attrKey)) {
+							throw new TConfigurationException('template_property_readonly', $type, $attrKey);
 						} else {
-							throw new TConfigurationException('template_property_unknown', $type, $name);
+							throw new TConfigurationException('template_property_unknown', $type, $attrKey);
 						}
-					} elseif (is_array($att) && $att[0] !== self::CONFIG_EXPRESSION && $att[0] !== self::CONFIG_PARAMETER) {
-						if (strcasecmp($name, 'id') === 0) {
+					} elseif ($propInfo[self::PROP_TYPE] !== self::CONFIG_EXPRESSION && $propInfo[self::PROP_TYPE] !== self::CONFIG_PARAMETER && $propInfo[self::PROP_TYPE] !== self::CONFIG_VALUE) {
+						if (strcasecmp($attrKey, 'id') === 0) {
 							throw new TConfigurationException('template_controlid_invalid', $type);
-						} elseif (strcasecmp($name, 'skinid') === 0) {
+						} elseif (strcasecmp($attrKey, 'skinid') === 0) {
 							throw new TConfigurationException('template_controlskinid_invalid', $type);
 						}
 					}
 				}
 			}
 		} elseif (is_subclass_of($className, TComponent::class) || $className === TComponent::class) {
-			foreach ($attributes as $name => $att) {
-				if (is_array($att) && ($att[0] === self::CONFIG_DATABIND)) {
-					throw new TConfigurationException('template_databind_forbidden', $type, $name);
+			foreach ($attributes as $attrKey => $propInfo) {
+				if ($propInfo[self::PROP_TYPE] === self::CONFIG_DATABIND) {
+					throw new TConfigurationException('template_databind_forbidden', $type, $attrKey);
 				}
-				if (($pos = strpos($name, '.')) !== false) {
-					// a subproperty, so the first segment must be readable
-					$subname = substr($name, 0, $pos);
+				if (($pos = strpos($attrKey, '.')) !== false) {	// a subproperty, first segment is readable
+					$subname = substr($attrKey, 0, $pos);
 					if (!$class->hasMethod('get' . $subname)) {
 						throw new TConfigurationException('template_property_unknown', $type, $subname);
 					}
-				} elseif (strncasecmp($name, 'on', 2) === 0) {
-					throw new TConfigurationException('template_event_forbidden', $type, $name);
-				} else {
-					// id is still allowed for TComponent, even if id property doesn't exist
-					if (strcasecmp($name, 'id') !== 0 && !($class->hasMethod('set' . $name) || $this->isClassBehaviorMethod($class, 'set' . $name))) {
-						if ($class->hasMethod('get' . $name)) {
-							throw new TConfigurationException('template_property_readonly', $type, $name);
+				} elseif (strncasecmp($attrKey, 'on', 2) === 0) {
+					throw new TConfigurationException('template_event_forbidden', $type, $attrKey);
+				} else {	// id is still allowed for TComponent, even if id property doesn't exist
+					if (strcasecmp($attrKey, 'id') !== 0 && !($class->hasMethod('set' . $attrKey) || $this->isClassBehaviorMethod($class, 'set' . $attrKey))) {
+						if ($class->hasMethod('get' . $attrKey)) {
+							throw new TConfigurationException('template_property_readonly', $type, $attrKey);
 						} else {
-							throw new TConfigurationException('template_property_unknown', $type, $name);
+							throw new TConfigurationException('template_property_unknown', $type, $attrKey);
 						}
 					}
 				}
@@ -907,11 +934,56 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	}
 
 	/**
-	 * @return array list of included external template files
+	 * @return array<string> list of included external template file paths
 	 */
 	public function getIncludedFiles()
 	{
 		return $this->_includedFiles;
+	}
+
+	/**
+	 * Merges consecutive string and literal items to reduce template size.
+	 * Consecutive strings, expressions, statements, and bindings with the same
+	 * parent are combined into TCompositeLiteral objects for efficiency.
+	 * @return array optimized template array
+	 * @since 4.3.3
+	 */
+	protected function optimizeTemplate()
+	{
+		$tpl = &$this->_tpl;
+		$mergedTemplates = [];
+		$parent = null;
+		$tplKey = null;
+		$merged = [];
+		foreach ($tpl as $tplKey => $tplInfo) {
+			if (isset($tplInfo[self::TPL_PROPS]) || $tplInfo[self::TPL_PARENT_INDEX] !== $parent) {
+				if ($parent !== null) {
+					if (count($merged[self::TPL_TYPE]) === 1 && is_string($merged[self::TPL_TYPE][0])) {
+						$mergedTemplates[$tplKey - 1] = [self::TPL_PARENT_INDEX => $merged[self::TPL_PARENT_INDEX], self::TPL_TYPE => $merged[self::TPL_TYPE][0]];
+					} else {
+						$mergedTemplates[$tplKey - 1] = [self::TPL_PARENT_INDEX => $merged[self::TPL_PARENT_INDEX], self::TPL_TYPE => new TCompositeLiteral($merged[self::TPL_TYPE])];
+					}
+				}
+				if (isset($tplInfo[self::TPL_PROPS])) {
+					$parent = null;
+					$mergedTemplates[$tplKey] = $tplInfo;
+				} else {
+					$parent = $tplInfo[self::TPL_PARENT_INDEX];
+					$merged = [self::TPL_PARENT_INDEX => $parent, self::TPL_TYPE => [$tplInfo[self::TPL_TYPE]]];
+				}
+			} else {
+				$merged[self::TPL_TYPE][] = $tplInfo[self::TPL_TYPE];
+			}
+		}
+		if ($parent !== null && $tplKey !== null) {
+			if (count($merged[self::TPL_TYPE]) === 1 && is_string($merged[self::TPL_TYPE][0])) {
+				$mergedTemplates[$tplKey] = [self::TPL_PARENT_INDEX => $merged[self::TPL_PARENT_INDEX], self::TPL_TYPE => $merged[self::TPL_TYPE][0]];
+			} else {
+				$mergedTemplates[$tplKey] = [self::TPL_PARENT_INDEX => $merged[self::TPL_PARENT_INDEX], self::TPL_TYPE => new TCompositeLiteral($merged[self::TPL_TYPE])];
+			}
+		}
+		$tpl = $mergedTemplates;
+		return $mergedTemplates;
 	}
 
 	/**
@@ -962,7 +1034,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 				if ($filePath !== null && is_file($filePath)) {
 					$this->_includedFiles[] = $filePath;
 				} else {
-					$errorLine = count(explode("\n", substr($input, 0, $matches[$i][0][1] + 1)));
+					$errorLine = substr_count($input, "\n", 0, $matches[$i][0][1] + 1) + 1;
 					$this->handleException(new TConfigurationException('template_include_invalid', trim($matches[$i][1][0])), $errorLine, $input);
 				}
 			}
@@ -971,8 +1043,8 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 				$ext = file_get_contents($this->_includedFiles[$i]);
 				$length = strlen($matches[$i][0][0]);
 				$offset = $base + $matches[$i][0][1];
-				$this->_includeAtLine[$i] = count(explode("\n", substr($input, 0, $offset)));
-				$this->_includeLines[$i] = count(explode("\n", $ext));
+				$this->_includeAtLine[$i] = substr_count($input, "\n", 0, $offset) + 1;
+				$this->_includeLines[$i] = substr_count($ext, "\n") + 1;
 				$input = substr_replace($input, $ext, $offset, $length);
 				$base += strlen($ext) - $length;
 			}

--- a/framework/Web/UI/TTheme.php
+++ b/framework/Web/UI/TTheme.php
@@ -149,14 +149,14 @@ class TTheme extends \Prado\TApplicationComponent implements ITheme
 				} elseif (basename($file, self::SKIN_FILE_EXT) !== $file) {
 					$template = new TSkinTemplate(file_get_contents($themePath . DIRECTORY_SEPARATOR . $file), $themePath, $themePath . DIRECTORY_SEPARATOR . $file);
 					foreach ($template->getItems() as $skin) {
-						if (!isset($skin[2])) {  // a text string, ignored
+						if (!isset($skin[TTemplate::TPL_PROPS])) {  // a text string, ignored
 							continue;
-						} elseif ($skin[0] !== -1) {
+						} elseif ($skin[TTemplate::TPL_PARENT_INDEX] !== -1) {
 							throw new TConfigurationException('theme_control_nested', $skin[1], dirname($themePath));
 						}
-						$type = $skin[1];
-						$id = $skin[2]['skinid'] ?? 0;
-						unset($skin[2]['skinid']);
+						$type = $skin[TTemplate::TPL_TYPE];
+						$id = $skin[TTemplate::TPL_PROPS]['skinid'] ?? 0;
+						unset($skin[TTemplate::TPL_PROPS]['skinid']);
 						if (isset($this->_skins[$type][$id])) {
 							throw new TConfigurationException('theme_skinid_duplicated', $type, $id, dirname($themePath));
 						}
@@ -167,7 +167,7 @@ class TTheme extends \Prado\TApplicationComponent implements ITheme
 								throw new TConfigurationException('theme_databind_forbidden',dirname($themePath),$type,$id);
 						}
 						*/
-						$this->_skins[$type][$id] = $skin[2];
+						$this->_skins[$type][$id] = $skin[TTemplate::TPL_PROPS];
 					}
 				}
 			}
@@ -263,47 +263,45 @@ class TTheme extends \Prado\TApplicationComponent implements ITheme
 		}
 		if (isset($this->_skins[$type][$id])) {
 			foreach ($this->_skins[$type][$id] as $name => $value) {
-				Prado::trace("Applying skin $name to $type", \Prado\Web\UI\TThemeManager::class);
-				if (is_array($value)) {
-					switch ($value[0]) {
-						case TTemplate::CONFIG_EXPRESSION:
-							$value = $this->evaluateExpression($value[1]);
-							break;
-						case TTemplate::CONFIG_ASSET:
-							$value = $this->_themeUrl . '/' . ltrim($value[1], '/');
-							break;
-						case TTemplate::CONFIG_DATABIND:
-							$control->bindProperty($name, $value[1]);
-							break;
-						case TTemplate::CONFIG_PARAMETER:
-							$control->setSubProperty($name, $this->getApplication()->getParameters()->itemAt($value[1]));
-							break;
-						case TTemplate::CONFIG_TEMPLATE:
-							$control->setSubProperty($name, $value[1]);
-							break;
-						case TTemplate::CONFIG_LOCALIZATION:
-							$control->setSubProperty($name, Prado::localize($value[1]));
-							break;
-						default:
-							throw new TConfigurationException('theme_tag_unexpected', $name, $value[0]);
-							break;
-					}
-				}
-				if (!is_array($value)) {
-					if (strpos($name, '.') === false) {	// is simple property or custom attribute
-						if ($control->hasProperty($name)) {
-							if ($control->canSetProperty($name)) {
-								$setter = 'set' . $name;
-								$control->$setter($value);
+				$propName = $value[TTemplate::PROP_NAME];
+				Prado::trace("Applying skin $propName to $type", \Prado\Web\UI\TThemeManager::class);
+				switch ($value[TTemplate::PROP_TYPE]) {
+					case TTemplate::CONFIG_VALUE:
+						if (strpos($name, '.') === false) {	// is simple property or custom attribute
+							if ($control->hasProperty($name)) {
+								if ($control->canSetProperty($name)) {
+									$control->$propName = $value[TTemplate::PROP_VALUE];
+								} else {
+									throw new TConfigurationException('theme_property_readonly', $type, $propName);
+								}
 							} else {
-								throw new TConfigurationException('theme_property_readonly', $type, $name);
+								throw new TConfigurationException('theme_property_undefined', $type, $propName);
 							}
-						} else {
-							throw new TConfigurationException('theme_property_undefined', $type, $name);
+						} else {	// complex property
+							$control->setSubProperty($propName, $value[TTemplate::PROP_VALUE]);
 						}
-					} else {	// complex property
-						$control->setSubProperty($name, $value);
-					}
+						break;
+					case TTemplate::CONFIG_EXPRESSION:
+						$value = $this->evaluateExpression($value[TTemplate::PROP_VALUE]);
+						break;
+					case TTemplate::CONFIG_ASSET:
+						$value = $this->_themeUrl . '/' . ltrim($value[TTemplate::PROP_VALUE], '/');
+						break;
+					case TTemplate::CONFIG_DATABIND:
+						$control->bindProperty($propName, $value[TTemplate::PROP_VALUE]);
+						break;
+					case TTemplate::CONFIG_PARAMETER:
+						$control->setSubProperty($propName, $this->getApplication()->getParameters()->itemAt($value[TTemplate::PROP_VALUE]));
+						break;
+					case TTemplate::CONFIG_TEMPLATE:
+						$control->setSubProperty($propName, $value[TTemplate::PROP_VALUE]);
+						break;
+					case TTemplate::CONFIG_LOCALIZATION:
+						$control->setSubProperty($propName, Prado::localize($value[TTemplate::PROP_VALUE]));
+						break;
+					default:
+						throw new TConfigurationException('theme_tag_unexpected', $propName, $value[TTemplate::PROP_TYPE]);
+						break;
 				}
 			}
 			return true;

--- a/tests/unit/Web/UI/TTemplateInstantiateInTest.php
+++ b/tests/unit/Web/UI/TTemplateInstantiateInTest.php
@@ -1,0 +1,1649 @@
+<?php
+
+use Prado\TComponent;
+use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Web\Javascripts\TJavaScriptLiteral;
+use Prado\Web\UI\TCompositeLiteral;
+use Prado\Web\UI\TControl;
+use Prado\Web\UI\TPage;
+use Prado\Web\UI\TTemplate;
+use Prado\Web\UI\WebControls\TButton;
+use Prado\Web\UI\WebControls\TLabel;
+use Prado\Web\UI\WebControls\TOutputCache;
+use Prado\Web\UI\WebControls\TPanel;
+
+class TTemplateMagicComponent extends TComponent
+{
+	public $receivedProperties = [];
+
+	public function __set($name, $value)
+	{
+		$this->receivedProperties[$name] = $value;
+		return true;
+	}
+
+	public function hasProperty($name)
+	{
+		return true;
+	}
+}
+
+class TTemplateMagicControl extends TControl
+{
+	public $receivedProperties = [];
+
+	public function __set($name, $value)
+	{
+		$this->receivedProperties[$name] = $value;
+		return true;
+	}
+
+	public function hasProperty($name)
+	{
+		return parent::hasProperty($name) || true;
+	}
+}
+
+class TTemplateDashComponent extends TComponent
+{
+	private $_data = [];
+
+	public function setDataToggle($value)
+	{
+		$this->_data['dataToggle'] = $value;
+	}
+	public function getDataToggle()
+	{
+		return $this->_data['dataToggle'] ?? null;
+	}
+	public function setForeColor($value)
+	{
+		$this->_data['foreColor'] = $value;
+	}
+	public function getForeColor()
+	{
+		return $this->_data['foreColor'] ?? null;
+	}
+	public function setSubProp()
+	{
+	}
+	public function getSubProp()
+	{
+		return $this;
+	}
+	public function setText($value)
+	{
+		$this->_data['text'] = $value;
+	}
+	public function getText()
+	{
+		return $this->_data['text'] ?? null;
+	}
+	public function setId($value)
+	{
+		$this->_data['id'] = $value;
+	}
+	public function getId()
+	{
+		return $this->_data['id'] ?? null;
+	}
+}
+
+class TTemplateDashControl extends TControl
+{
+	private $_data = [];
+
+	public function setDataToggle($value)
+	{
+		$this->_data['dataToggle'] = $value;
+	}
+	public function getDataToggle()
+	{
+		return $this->_data['dataToggle'] ?? null;
+	}
+	public function setForeColor($value)
+	{
+		$this->_data['foreColor'] = $value;
+	}
+	public function getForeColor()
+	{
+		return $this->_data['foreColor'] ?? null;
+	}
+	public function setText($value)
+	{
+		$this->_data['text'] = $value;
+	}
+	public function getText()
+	{
+		return $this->_data['text'] ?? null;
+	}
+}
+
+class TTemplateInstantiateInTestComponent extends TComponent
+{
+	private $_customProp;
+
+	public function setCustomProp($v)
+	{
+		$this->_customProp = $v;
+	}
+	public function getCustomProp()
+	{
+		return $this->_customProp;
+	}
+}
+
+class TTemplateInstantiateInJsControl extends TControl
+{
+	private $_jsClick;
+
+	public function setJsClick($v)
+	{
+		$this->_jsClick = $v;
+	}
+	public function getJsClick()
+	{
+		return $this->_jsClick;
+	}
+}
+
+class TTemplateInstantiateInNoAllowChildControl extends TControl
+{
+	public function getAllowChildControls()
+	{
+		return false;
+	}
+}
+
+class TTemplateInstantiateInAcceptingControl extends TControl
+{
+	public array $parsedObjects = [];
+
+	public function addParsedObject($object)
+	{
+		$this->parsedObjects[] = $object;
+		if ($object instanceof TControl) {
+			$this->getControls()->add($object);
+		}
+	}
+}
+
+/**
+ * TControl with an ItemTemplate property that accepts a TTemplate instance.
+ * Used to verify CONFIG_TEMPLATE instantiation sets a nested TTemplate on the property.
+ */
+class TTemplateInstantiateInTemplateControl extends TControl
+{
+	private $_itemTemplate;
+
+	public function setItemTemplate($tpl)
+	{
+		$this->_itemTemplate = $tpl;
+	}
+	public function getItemTemplate()
+	{
+		return $this->_itemTemplate;
+	}
+}
+
+// Test helper: a render-capable accepting control for end-to-end instantiateIn + render tests
+class TTemplateInstantiateInRenderAcceptingControl extends TTemplateInstantiateInAcceptingControl
+{
+	public function renderAll(): string
+	{
+		// Lightweight in-test writer compatible with TCompositeLiteral::render
+		$writer = new class () implements \Prado\IO\ITextWriter {
+			public $buffer = '';
+			public function write($str)
+			{
+				$this->buffer .= $str;
+			}
+			public function writeLine($str = '')
+			{
+				$this->buffer .= $str . PHP_EOL;
+			}
+			public function flush()
+			{
+				$out = $this->buffer;
+				$this->buffer = '';
+				return $out;
+			}
+		};
+		foreach ($this->parsedObjects as $obj) {
+			if (is_string($obj)) {
+				$writer->write($obj);
+			} elseif ($obj instanceof TCompositeLiteral) {
+				$obj->evaluateDynamicContent();
+				$obj->render($writer);
+			} elseif (method_exists($obj, 'render')) {
+				$obj->render($writer);
+			}
+		}
+		return $writer->buffer;
+	}
+}
+
+class TTemplateInstantiateInTest extends PHPUnit\Framework\TestCase
+{
+	private $_contextPath;
+
+	protected function setUp(): void
+	{
+		$this->_contextPath = sys_get_temp_dir();
+	}
+
+	protected function tearDown(): void
+	{
+		$this->_contextPath = null;
+	}
+
+	private function newTemplate($template, $contextPath = null, $tplFile = null, $startingLine = 0, $sourceTemplate = true)
+	{
+		return new TTemplate($template, $contextPath ?? $this->_contextPath, $tplFile, $startingLine, $sourceTemplate);
+	}
+
+	private function newTemplateUnvalidated($template)
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$props = [
+			'_sourceTemplate' => true,
+			'_contextPath' => $this->_contextPath,
+			'_tplFile' => null,
+			'_startingLine' => 0,
+			'_content' => $template,
+			'_attributevalidation' => false,
+			'_hashCode' => md5($template),
+		];
+		foreach ($props as $name => $val) {
+			$p = $ref->getProperty($name);
+			$p->setAccessible(true);
+			$p->setValue($tplObj, $val);
+		}
+		$ref->getParentClass()->getParentClass()->getConstructor()->invoke($tplObj);
+		$parse = $ref->getMethod('parse');
+		$parse->setAccessible(true);
+		$parse->invoke($tplObj, $template);
+		$c = $ref->getProperty('_content');
+		$c->setAccessible(true);
+		$c->setValue($tplObj, null);
+		return $tplObj;
+	}
+
+	private function createPage()
+	{
+		$page = new TPage();
+		$page->setID('TestPage');
+		return $page;
+	}
+
+	private function createControlWithPage()
+	{
+		$page = $this->createPage();
+		$control = new TControl();
+		$control->setID('tplControl');
+		$page->getControls()->add($control);
+		return $control;
+	}
+
+	private function createAcceptingControlWithPage()
+	{
+		$page = $this->createPage();
+		$control = new TTemplateInstantiateInAcceptingControl();
+		$control->setID('tplControl');
+		$page->getControls()->add($control);
+		return $control;
+	}
+
+	// -----------------------------------------------------------------------
+	// Plain text and basic instantiation
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInPlainText()
+	{
+		$tpl = $this->newTemplate('Hello World');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$this->assertEquals('Hello World', $parent->getControls()[0]);
+	}
+
+	public function testInstantiateInEmptyTemplate()
+	{
+		$tpl = $this->newTemplate('');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(0, $parent->getControls());
+	}
+
+	public function testInstantiateInWhitespaceOnly()
+	{
+		$tpl = $this->newTemplate('   ');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$this->assertEquals('   ', $parent->getControls()[0]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Separate parent control
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInSeparateParentControl()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$tplControl = $this->createControlWithPage();
+		$parentControl = new TControl();
+		$parentControl->setID('parent');
+		$tplControl->getPage()->getControls()->add($parentControl);
+		$tpl->instantiateIn($tplControl, $parentControl);
+		$this->assertCount(1, $parentControl->getControls());
+		$this->assertCount(0, $tplControl->getControls());
+		$label = $parentControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+		$this->assertEquals('Hello', $label->getText());
+		$this->assertSame($tplControl, $label->getTemplateControl());
+	}
+
+	public function testInstantiateInSeparateParentControlWithText()
+	{
+		$tpl = $this->newTemplate('Hello');
+		$tplControl = $this->createControlWithPage();
+		$parentControl = new TControl();
+		$parentControl->setID('parent');
+		$tplControl->getPage()->getControls()->add($parentControl);
+		$tpl->instantiateIn($tplControl, $parentControl);
+		$this->assertCount(1, $parentControl->getControls());
+		$this->assertEquals('Hello', $parentControl->getControls()[0]);
+		$this->assertCount(0, $tplControl->getControls());
+	}
+
+	public function testInstantiateInSeparateParentCompositeLiteral()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1">a<%= $this->X %>b</com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$parentControl = new TControl();
+		$parentControl->setID('parent');
+		$tplControl->getPage()->getControls()->add($parentControl);
+		$tpl->instantiateIn($tplControl, $parentControl);
+		$this->assertCount(1, $parentControl->getControls());
+		$label = $parentControl->getControls()[0];
+		$this->assertCount(1, $label->getControls());
+		$this->assertInstanceOf(TCompositeLiteral::class, $label->getControls()[0]);
+	}
+
+	// -----------------------------------------------------------------------
+	// TControl component instantiation
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInTControlComponent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$label = $parent->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+		$this->assertInstanceOf(TControl::class, $label);
+		$this->assertEquals('Hello', $label->getText());
+		$this->assertEquals('lbl1', $label->getID());
+		$this->assertCount(0, $label->getControls());
+		$this->assertSame($parent, $label->getParent());
+	}
+
+	// -----------------------------------------------------------------------
+	// TComponent (non-control) instantiation
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInTComponentNonControlViaAcceptingParent()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+		$this->assertNotInstanceOf(TControl::class, $comp);
+	}
+
+	public function testInstantiateInTComponentDirectChildFailsInTControlCollection()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" />');
+		$tplControl = $this->createControlWithPage();
+		$this->expectException(TInvalidDataTypeException::class);
+		$tpl->instantiateIn($tplControl);
+	}
+
+	// -----------------------------------------------------------------------
+	// Comment rendering (valid and invalid comment forms)
+	// -----------------------------------------------------------------------
+
+	// Valid PRADO HTML comments - testing "<!-- --!>"
+
+	public function testInstantiateIn_Valid_PradoHtmlComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!-- --!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!-- --!>after', $rendered);
+	}
+
+	public function testInstantiateIn_Valid_PradoHtmlCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--PRADO HTML Comment--!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!--PRADO HTML Comment--!>after', $rendered);
+	}
+
+	// Valid HTML comments - testing "<!-- -->"
+
+	public function testInstantiateIn_Valid_HtmlComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!-- -->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!-- -->after', $rendered);
+	}
+
+	public function testInstantiateIn_Valid_HtmlCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--HTML Comments-->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!--HTML Comments-->after', $rendered);
+	}
+
+	// Valid PRADO Template comments - testing "<!--- ---!>"
+
+	public function testInstantiateIn_Valid_PradoTemplateComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--- ---!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('beforeafter', $rendered);
+		$this->assertStringNotContainsString('<!---', $rendered);
+		$this->assertStringNotContainsString('---!>', $rendered);
+	}
+
+	public function testInstantiateIn_Valid_PradoTemplateCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!---Template Comments---!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('beforeafter', $rendered);
+		$this->assertStringNotContainsString('<!---', $rendered);
+		$this->assertStringNotContainsString('---!>', $rendered);
+	}
+
+	// Valid PRADO Template comments like HTML Comments - testing "<!--- --->"
+
+	public function testInstantiateIn_Valid_TemplateComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--- --->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender2');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('beforeafter', $rendered);
+		$this->assertStringNotContainsString('<!---', $rendered);
+		$this->assertStringNotContainsString('--->', $rendered);
+	}
+
+	public function testInstantiateIn_Valid_TemplateCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!---Template Comments--->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender2');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('beforeafter', $rendered);
+		$this->assertStringNotContainsString('<!---', $rendered);
+		$this->assertStringNotContainsString('--->', $rendered);
+	}
+
+	// Invalid mismatch comments must pass through unmodified
+
+	public function testInstantiateIn_Invalid_PradoHtmlComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!-- ---!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!-- ---!>after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_PradoHtmlCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--PRADO HTML Comment---!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!--PRADO HTML Comment---!>after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_HtmlComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!-- --->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!-- --->after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_HtmlCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--HTML Comments--->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!--HTML Comments--->after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_PradoTemplateComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--- --!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!--- --!>after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_PradoTemplateCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!---Template Comments--!>after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!---Template Comments--!>after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_TemplateComment()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!--- -->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender2');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!--- -->after', $rendered);
+	}
+
+	public function testInstantiateIn_Invalid_TemplateCommentText()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!---Template Comments-->after');
+		$tplCtl = new TTemplateInstantiateInRenderAcceptingControl();
+		$page = $this->createPage();
+		$tplCtl->setID('tplRender2');
+		$page->getControls()->add($tplCtl);
+		$tpl->instantiateIn($tplCtl);
+		$rendered = $tplCtl->renderAll();
+		$this->assertEquals('before<!---Template Comments-->after', $rendered);
+	}
+
+	// -----------------------------------------------------------------------
+	// Template-control relationship, ID registration, and view state
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInSetsTemplateControlOnTControl()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertSame($tplControl, $label->getTemplateControl());
+		$this->assertSame($tplControl, $label->getParent());
+	}
+
+	public function testInstantiateInRegistersIdOnTControl()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="myLabel" Text="test" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertTrue($tplControl->isObjectRegistered('myLabel'));
+		$registered = $tplControl->getRegisteredObject('myLabel');
+		$this->assertInstanceOf(TLabel::class, $registered);
+		$this->assertEquals('myLabel', $registered->getID());
+	}
+
+	public function testInstantiateInRegistersIdOnTComponentWithIdProperty()
+	{
+		Prado::using('TTemplateDashComponent');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateDashComponent ID="c1" ForeColor="red" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateDashComponent::class, $comp);
+		$this->assertEquals('c1', $comp->getID());
+		$this->assertTrue($tplControl->isObjectRegistered('c1'));
+		$this->assertEquals('red', $comp->getForeColor());
+	}
+
+	public function testInstantiateInTComponentNoIdPropertyUnsetsId()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+		$this->assertFalse($comp->hasProperty('id'));
+		$this->assertFalse($tplControl->isObjectRegistered('c1'));
+	}
+
+	public function testInstantiateInTComponentIdNoIdPropertyWithCustomProp()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="val" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+		$this->assertEquals('val', $comp->getCustomProp());
+		$this->assertFalse($tplControl->isObjectRegistered('c1'));
+	}
+
+	public function testInstantiateInTComponentNestedInAcceptingControl()
+	{
+		Prado::using('TTemplateInstantiateInAcceptingControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInAcceptingControl ID="pnl1"><com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="val" /></com:TTemplateInstantiateInAcceptingControl>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$panel = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateInstantiateInAcceptingControl::class, $panel);
+		$this->assertCount(1, $panel->parsedObjects);
+		$comp = $panel->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+		$this->assertEquals('val', $comp->getCustomProp());
+	}
+
+	// -----------------------------------------------------------------------
+	// SkinID handling
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInSkinIdConfigValue()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" SkinID="default" Text="Hello" />');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$label = $parent->getControls()[0];
+		$this->assertEquals('default', $label->getSkinID());
+		$this->assertEquals('Hello', $label->getText());
+	}
+
+	public function testInstantiateInSkinidRemovedFromPropertiesAfterSet()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" SkinID="default" Text="Hello" Font.Size="12" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$label = $tplControl->getControls()[0];
+		$this->assertEquals('default', $label->getSkinID());
+		$this->assertEquals('Hello', $label->getText());
+		$this->assertEquals('12', $label->getFont()->getSize());
+	}
+
+	public function testInstantiateInSkinidExpressionEvaluates()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" SkinID="<%= "custom" %>" Text="Hello" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInSkinidParameterEvaluates()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" SkinID="<%$ SkinParam %>" Text="Hello" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	// -----------------------------------------------------------------------
+	// Orphaned child items (parent index not in controls map)
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInOrphanedChildIndexSkipped()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" Text="Hello" />');
+		$itemsProp = $ref->getProperty('_tpl');
+		$itemsProp->setAccessible(true);
+		$items = $itemsProp->getValue($tplObj);
+		$items[99] = [TTemplate::TPL_PARENT_INDEX => 50, TTemplate::TPL_TYPE => 'Prado\\Web\\UI\\WebControls\\TLabel', TTemplate::TPL_PROPS => ['id' => [TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE, TTemplate::PROP_NAME => 'ID', TTemplate::PROP_VALUE => 'orphan']]];
+		$itemsProp->setValue($tplObj, $items);
+		$tplControl = $this->createControlWithPage();
+		$tplObj->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$this->assertEquals('Hello', $tplControl->getControls()[0]->getText());
+	}
+
+	// -----------------------------------------------------------------------
+	// TCompositeLiteral cloning and container
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInCompositeLiteralCloned()
+	{
+		$tpl = $this->newTemplate('before<%= $this->Name %>after');
+		$parent1 = $this->createControlWithPage();
+		$parent2 = $this->createControlWithPage();
+		$tpl->instantiateIn($parent1);
+		$tpl->instantiateIn($parent2);
+		$this->assertCount(1, $parent1->getControls());
+		$this->assertCount(1, $parent2->getControls());
+		$this->assertNotSame($parent1->getControls()[0], $parent2->getControls()[0]);
+	}
+
+	public function testInstantiateInCompositeLiteralSetsContainer()
+	{
+		$tpl = $this->newTemplate('<%= $this->Name %>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$literal = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $literal);
+		$this->assertSame($tplControl, $literal->getContainer());
+	}
+
+	public function testInstantiateInCompositeLiteralDirectChild()
+	{
+		$tpl = $this->newTemplate('text<%= $this->Name %>more');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$literal = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $literal);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$itemsProp = $ref->getProperty('_items');
+		$itemsProp->setAccessible(true);
+		$items = $itemsProp->getValue($literal);
+		$this->assertCount(3, $items);
+	}
+
+	public function testInstantiateInCompositeLiteralNestedChild()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><%= $this->Name %></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$label = $tplControl->getControls()[0];
+		$this->assertCount(1, $label->getControls());
+		$literal = $label->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $literal);
+		$this->assertSame($tplControl, $literal->getContainer());
+	}
+
+	public function testInstantiateInCompositeLiteralNestedViaAddParsedObject()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1">a<%= $this->X %>b</com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$label = $tplControl->getControls()[0];
+		$this->assertCount(1, $label->getControls());
+		$this->assertInstanceOf(TCompositeLiteral::class, $label->getControls()[0]);
+	}
+
+	public function testInstantiateInCompositeLiteralClonePreservesExpressions()
+	{
+		$tpl = $this->newTemplate('a<%= $this->X %>b');
+		$parent1 = $this->createControlWithPage();
+		$tpl->instantiateIn($parent1);
+		$lit1 = $parent1->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $lit1);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$exprs1 = $exprProp->getValue($lit1);
+		$this->assertCount(1, $exprs1);
+	}
+
+	// -----------------------------------------------------------------------
+	// Property configuration: CONFIG_VALUE
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInConfigureControlValue()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$label = $parent->getControls()[0];
+		$this->assertEquals('Hello', $label->getText());
+	}
+
+	public function testInstantiateInConfigureComponentValueViaAcceptingParent()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="val" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+		$this->assertEquals('val', $comp->getCustomProp());
+	}
+
+	// -----------------------------------------------------------------------
+	// Property configuration: CONFIG_EXPRESSION
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInExpressionOnTControlAutoBinds()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%= $this->Title %>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInConfigureComponentExpressionViaAcceptingParent()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="<%= "hello" %>" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+	}
+
+	public function testInstantiateInExpressionOnTComponentEvaluatesImmediately()
+	{
+		// Use single-quoted string inside the expression to avoid breaking the attribute parser's
+		// double-quote boundary detection ("..." stops at the first inner double quote).
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="<%= \'hello\' %>" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		// For TComponent (non-control), CONFIG_EXPRESSION is evaluated immediately via
+		// $this->_tplControl->evaluateExpression($propInfo[PROP_VALUE]).
+		$this->assertInstanceOf(TTemplateInstantiateInTestComponent::class, $comp);
+		$this->assertEquals('hello', $comp->getCustomProp());
+	}
+
+	// -----------------------------------------------------------------------
+	// Property configuration: CONFIG_DATABIND
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInDatabindOnTControlBindsProperty()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%# $this->Data %>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInDatabindOnTComponentNotAllowed()
+	{
+		$this->expectException(TConfigurationException::class);
+		$tpl = $this->newTemplate('<com:TComponent Text="<%# $this->Data %>" />');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+	}
+
+	// -----------------------------------------------------------------------
+	// Property configuration: CONFIG_PARAMETER, CONFIG_LOCALIZATION, CONFIG_ASSET
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInParameterExpressionRetrievesParam()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%$ SomeParam %>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInConfigureComponentParameterViaAcceptingParent()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="<%$ SomeParam %>" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+	}
+
+	public function testInstantiateInLocalizationExpressionLocalizes()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%[ Hello World ]%>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInConfigureComponentLocalizationViaAcceptingParent()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="<%[ Hello ]%>" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+	}
+
+	public function testInstantiateInConfigureComponentAssetParsedCorrectly()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" CustomProp="<%~ assets/img.png %>" />');
+		$items = $tpl->getItems();
+		$component = null;
+		foreach ($items as $item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				$component = $item;
+			}
+		}
+		$this->assertNotNull($component);
+		$this->assertCount(2, $component[TTemplate::TPL_PROPS]);
+		$this->assertEquals(TTemplate::CONFIG_ASSET, $component[TTemplate::TPL_PROPS]['customprop'][TTemplate::PROP_TYPE]);
+		$this->assertEquals('assets/img.png', $component[TTemplate::TPL_PROPS]['customprop'][TTemplate::PROP_VALUE]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Property configuration: CONFIG_TEMPLATE
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInConfigureComponentTemplateParsedCorrectly()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTestComponent ID="c1" Template="content" />');
+		$items = $tpl->getItems();
+		$component = null;
+		foreach ($items as $item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				$component = $item;
+			}
+		}
+		$this->assertNotNull($component);
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $component[TTemplate::TPL_PROPS]['template'][TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $component[TTemplate::TPL_PROPS]['template'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testInstantiateInConfigureControlTemplateSetsNestedTemplate()
+	{
+		Prado::using('TTemplateInstantiateInTemplateControl');
+		// 'itemtemplate' (all lowercase) triggers CONFIG_TEMPLATE on instantiation
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInTemplateControl ID="c1" Itemtemplate="inner content" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateInstantiateInTemplateControl::class, $control);
+		$this->assertInstanceOf(TTemplate::class, $control->getItemTemplate());
+	}
+
+	// -----------------------------------------------------------------------
+	// Unexpected property type triggers exception
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInConfigurePropertyUnexpectedTypeThrows()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" Text="Hello" />');
+		$itemsProp = $ref->getProperty('_tpl');
+		$itemsProp->setAccessible(true);
+		$items = $itemsProp->getValue($tplObj);
+		foreach ($items as &$item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				$item[TTemplate::TPL_PROPS]['badprop'] = [TTemplate::PROP_TYPE => 99, TTemplate::PROP_NAME => 'BadProp', TTemplate::PROP_VALUE => 'x'];
+			}
+		}
+		$itemsProp->setValue($tplObj, $items);
+		$parent = $this->createControlWithPage();
+		$this->expectException(TConfigurationException::class);
+		$tplObj->instantiateIn($parent);
+	}
+
+	// -----------------------------------------------------------------------
+	// Events
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInConfigureEventWithoutDot()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TButton ID="btn1" OnClick="handleClick" Text="Click" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$button = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TButton::class, $button);
+		$this->assertEquals('Click', $button->getText());
+		// Verify the event handler was actually attached to the OnClick event
+		$this->assertTrue($button->hasEventHandler('onClick'));
+	}
+
+	public function testInstantiateInConfigureEventWithDot()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TButton ID="btn1" OnClick="MyObj.handleClick" Text="Click" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$button = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TButton::class, $button);
+		// Dot-handler passes the literal handler string directly
+		$this->assertTrue($button->hasEventHandler('onClick'));
+	}
+
+	public function testInstantiateInEventOnTControlNotAllowed()
+	{
+		$this->expectException(TConfigurationException::class);
+		$tpl = $this->newTemplate('<com:TControl onClick="handler" />');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+	}
+
+	// -----------------------------------------------------------------------
+	// Subproperty configuration
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInSubPropertyConfigValue()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Font.Size="12" />');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$label = $parent->getControls()[0];
+		$this->assertEquals('12', $label->getFont()->getSize());
+	}
+
+	public function testInstantiateInSubPropertySetsNestedProperty()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Font.Size="12" Font.Bold="true" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertEquals('12', $label->getFont()->getSize());
+		$this->assertTrue($label->getFont()->getBold());
+	}
+
+	public function testInstantiateInSubPropertyWithExpression()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" Font.Size="<%= 12 %>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInSubPropertyWithDatabind()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" Font.Size="<%# 12 %>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInSubPropertyWithParameter()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" Font.Size="<%$ FontSizeParam %>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInSubPropertyWithLocalization()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="lbl1" Font.Size="<%[ size ]%>" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	// -----------------------------------------------------------------------
+	// Property tag (block-style) configuration
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInGroupSubPropertyTag()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Font Size="14" Bold="true" /></com:TLabel>');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$label = $parent->getControls()[0];
+		$this->assertEquals('14', $label->getFont()->getSize());
+		$this->assertTrue($label->getFont()->getBold());
+	}
+
+	public function testInstantiateInGroupSubPropertyWithDash()
+	{
+		Prado::using('TTemplateDashComponent');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateDashComponent ID="c1"><prop:SubProp ForeColor="green" /></com:TTemplateDashComponent>');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateDashComponent::class, $comp);
+		$this->assertEquals('green', $comp->getForeColor());
+	}
+
+	public function testInstantiateInPropertyTag()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text>Hello World</prop:Text></com:TLabel>');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(1, $parent->getControls());
+		$label = $parent->getControls()[0];
+		$this->assertEquals('Hello World', $label->getText());
+	}
+
+	public function testInstantiateInPropertyTagWithExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%= $this->Name %></prop:Text></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInPropertyTagWithDatabind()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%# $this->Data %></prop:Text></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInPropertyTagWithParameter()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%$ AppParam %></prop:Text></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	public function testInstantiateInPropertyTagWithLocalization()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%[ Hello ]%></prop:Text></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+	}
+
+	// -----------------------------------------------------------------------
+	// Dash-to-underscore attribute name conversion
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInPropertyTagWithDashInMagicComponent()
+	{
+		Prado::using('TTemplateMagicComponent');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicComponent ID="c1"><prop:Custom-Prop>value from tag</prop:Custom-Prop></com:TTemplateMagicComponent>');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateMagicComponent::class, $comp);
+		$this->assertArrayHasKey('Custom_Prop', $comp->receivedProperties);
+		$this->assertEquals('value from tag', $comp->receivedProperties['Custom_Prop']);
+	}
+
+	public function testInstantiateInPropertyTagWithDashInMagicControl()
+	{
+		Prado::using('TTemplateMagicControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicControl ID="c1"><prop:data-value>123</prop:data-value></com:TTemplateMagicControl>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateMagicControl::class, $control);
+		$this->assertArrayHasKey('data_value', $control->receivedProperties);
+		$this->assertEquals('123', $control->receivedProperties['data_value']);
+	}
+
+	public function testInstantiateInAttributeDashToUnderscoreOnMagicControl()
+	{
+		Prado::using('TTemplateMagicControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicControl ID="c1" data-toggle="dropdown" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateMagicControl::class, $control);
+		$this->assertArrayHasKey('data_toggle', $control->receivedProperties);
+		$this->assertEquals('dropdown', $control->receivedProperties['data_toggle']);
+	}
+
+	public function testInstantiateInCasePreservedPropertyOnDashControl()
+	{
+		Prado::using('TTemplateDashControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateDashControl ID="c1" ForeColor="blue" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateDashControl::class, $control);
+		$this->assertEquals('blue', $control->getForeColor());
+	}
+
+	public function testInstantiateInPropertyWithDashSetViaMagic()
+	{
+		Prado::using('TTemplateMagicControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicControl ID="c1" Custom-Prop="value" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateMagicControl::class, $control);
+		$this->assertArrayHasKey('Custom_Prop', $control->receivedProperties);
+		$this->assertEquals('value', $control->receivedProperties['Custom_Prop']);
+	}
+
+	public function testInstantiateInMagicComponentReceivesDashProperty()
+	{
+		Prado::using('TTemplateMagicComponent');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicComponent ID="c1" data-toggle="dropdown" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateMagicComponent::class, $comp);
+		$this->assertArrayHasKey('data_toggle', $comp->receivedProperties);
+		$this->assertEquals('dropdown', $comp->receivedProperties['data_toggle']);
+	}
+
+	public function testInstantiateInMagicComponentReceivesCasePreservedProperty()
+	{
+		Prado::using('TTemplateMagicComponent');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicComponent ID="c1" ThemeColor="blue" />');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->parsedObjects);
+		$comp = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateMagicComponent::class, $comp);
+		$this->assertArrayHasKey('ThemeColor', $comp->receivedProperties);
+		$this->assertEquals('blue', $comp->receivedProperties['ThemeColor']);
+	}
+
+	public function testInstantiateInMagicControlReceivesDashProperty()
+	{
+		Prado::using('TTemplateMagicControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicControl ID="c1" data-toggle="modal" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateMagicControl::class, $control);
+		$this->assertArrayHasKey('data_toggle', $control->receivedProperties);
+		$this->assertEquals('modal', $control->receivedProperties['data_toggle']);
+	}
+
+	public function testInstantiateInMagicControlReceivesCasePreservedProperty()
+	{
+		Prado::using('TTemplateMagicControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateMagicControl ID="c1" ThemeColor="purple" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateMagicControl::class, $control);
+		$this->assertArrayHasKey('ThemeColor', $control->receivedProperties);
+		$this->assertEquals('purple', $control->receivedProperties['ThemeColor']);
+	}
+
+	// -----------------------------------------------------------------------
+	// JS property prefix
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInJsPropertyPrefixOnControl()
+	{
+		Prado::using('TTemplateInstantiateInJsControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInJsControl ID="c1" JsClick="alert(1)" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateInstantiateInJsControl::class, $control);
+		$this->assertInstanceOf(TJavaScriptLiteral::class, $control->getJsClick());
+	}
+
+	public function testInstantiateInJsPropertyPrefixEmptyValue()
+	{
+		Prado::using('TTemplateInstantiateInJsControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInJsControl ID="c1" JsClick="" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$control = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateInstantiateInJsControl::class, $control);
+		$this->assertEquals('', $control->getJsClick());
+	}
+
+	// -----------------------------------------------------------------------
+	// Multiple components, nesting, mixed content
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInMultipleComponents()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="a" Text="A" /><com:TLabel ID="b" Text="B" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(2, $tplControl->getControls());
+		$this->assertEquals('A', $tplControl->getControls()[0]->getText());
+		$this->assertEquals('B', $tplControl->getControls()[1]->getText());
+		$this->assertSame($tplControl, $tplControl->getControls()[0]->getParent());
+		$this->assertSame($tplControl, $tplControl->getControls()[1]->getParent());
+	}
+
+	public function testInstantiateInNestedComponents()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="outer"><com:TLabel ID="inner" Text="World" /></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$outer = $tplControl->getControls()[0];
+		$this->assertEquals('outer', $outer->getID());
+		$this->assertCount(1, $outer->getControls());
+		$inner = $outer->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $inner);
+		$this->assertEquals('World', $inner->getText());
+		$this->assertSame($outer, $inner->getParent());
+	}
+
+	public function testInstantiateInNestedTextUsesAddParsedObject()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="outer">inner text</com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$outer = $tplControl->getControls()[0];
+		$this->assertCount(1, $outer->getControls());
+		$this->assertEquals('inner text', $outer->getControls()[0]);
+	}
+
+	public function testInstantiateInDeeplyNestedComponents()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="l1"><com:TLabel ID="l2"><com:TLabel ID="l3" Text="Deep" /></com:TLabel></com:TLabel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$l1 = $tplControl->getControls()[0];
+		$this->assertEquals('l1', $l1->getID());
+		$this->assertCount(1, $l1->getControls());
+		$l2 = $l1->getControls()[0];
+		$this->assertEquals('l2', $l2->getID());
+		$this->assertCount(1, $l2->getControls());
+		$l3 = $l2->getControls()[0];
+		$this->assertEquals('l3', $l3->getID());
+		$this->assertEquals('Deep', $l3->getText());
+	}
+
+	public function testInstantiateInMultipleTextsAndComponents()
+	{
+		$tpl = $this->newTemplate('before<com:TLabel ID="lbl1" Text="Hello" />after');
+		$parent = $this->createControlWithPage();
+		$tpl->instantiateIn($parent);
+		$this->assertCount(3, $parent->getControls());
+		$this->assertEquals('before', $parent->getControls()[0]);
+		$this->assertInstanceOf(TLabel::class, $parent->getControls()[1]);
+		$this->assertEquals('Hello', $parent->getControls()[1]->getText());
+		$this->assertEquals('after', $parent->getControls()[2]);
+	}
+
+	public function testInstantiateInMultipleNestedLevelsSameParent()
+	{
+		$tpl = $this->newTemplate('<com:TPanel ID="p1"><com:TLabel ID="l1" Text="A" /><com:TLabel ID="l2" Text="B" /></com:TPanel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$panel = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TPanel::class, $panel);
+		$this->assertCount(2, $panel->getControls());
+		$this->assertEquals('A', $panel->getControls()[0]->getText());
+		$this->assertEquals('B', $panel->getControls()[1]->getText());
+	}
+
+	public function testInstantiateInComponentWithNoAttributes()
+	{
+		$tpl = $this->newTemplate('<com:TLabel />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+		$this->assertCount(0, $label->getControls());
+	}
+
+	public function testInstantiateInAllowChildControlsFalse()
+	{
+		Prado::using('TTemplateInstantiateInNoAllowChildControl');
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInNoAllowChildControl ID="outer"><com:TLabel ID="inner" Text="Hello" /></com:TTemplateInstantiateInNoAllowChildControl>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$outer = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TTemplateInstantiateInNoAllowChildControl::class, $outer);
+		$this->assertCount(0, $outer->getControls());
+	}
+
+	public function testInstantiateInTComponentNestedAddsToControlsArray()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TTemplateInstantiateInAcceptingControl ID="pnl1"><com:TTemplateDashComponent ID="c1" ForeColor="red" /></com:TTemplateInstantiateInAcceptingControl>');
+		$tplControl = $this->createAcceptingControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$outer = $tplControl->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateInstantiateInAcceptingControl::class, $outer);
+		$this->assertCount(1, $outer->parsedObjects);
+		$comp = $outer->parsedObjects[0];
+		$this->assertInstanceOf(TTemplateDashComponent::class, $comp);
+		$this->assertEquals('red', $comp->getForeColor());
+	}
+
+	public function testInstantiateInPanelWithChildren()
+	{
+		$tpl = $this->newTemplate('<com:TPanel ID="pnl1"><com:TLabel ID="lbl1" Text="Inside" /></com:TPanel>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$panel = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TPanel::class, $panel);
+		$this->assertCount(1, $panel->getControls());
+		$label = $panel->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+		$this->assertEquals('Inside', $label->getText());
+	}
+
+	// -----------------------------------------------------------------------
+	// Reusing a template across multiple controls
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInTemplateReusedMultipleTimes()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$parent1 = $this->createControlWithPage();
+		$parent2 = $this->createControlWithPage();
+		$tpl->instantiateIn($parent1);
+		$tpl->instantiateIn($parent2);
+		$label1 = $parent1->getControls()[0];
+		$label2 = $parent2->getControls()[0];
+		$this->assertNotSame($label1, $label2);
+		$this->assertEquals('lbl1', $label1->getID());
+		$this->assertEquals('lbl1', $label2->getID());
+		$this->assertEquals('Hello', $label1->getText());
+		$this->assertEquals('Hello', $label2->getText());
+	}
+
+	public function testInstantiateInMultipleTemplatesSequentially()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$tpl2 = $this->newTemplate('<com:TLabel ID="lbl2" Text="World" />');
+		$tpl2->instantiateIn($tplControl);
+		$this->assertCount(2, $tplControl->getControls());
+		$this->assertEquals('Hello', $tplControl->getControls()[0]->getText());
+		$this->assertEquals('World', $tplControl->getControls()[1]->getText());
+	}
+
+	// -----------------------------------------------------------------------
+	// TOutputCache cache key prefix
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInOutputCacheSetsCacheKeyPrefix()
+	{
+		$templateStr = '<com:TOutputCache ID="cache1" Duration="60"><com:TLabel ID="lbl1" Text="Cached" /></com:TOutputCache>';
+		$tpl = $this->newTemplateUnvalidated($templateStr);
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$cache = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TOutputCache::class, $cache);
+		$this->assertCount(1, $cache->getControls());
+		$label = $cache->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+		$this->assertEquals('Cached', $label->getText());
+		// TOutputCache has setCacheKeyPrefix() but no getter; read via reflection.
+		$refProp = (new \ReflectionClass(TOutputCache::class))->getProperty('_keyPrefix');
+		$refProp->setAccessible(true);
+		$prefix = $refProp->getValue($cache);
+		$this->assertNotEmpty($prefix);
+		// TTemplate sets the prefix to $this->_hashCode . $tplKey; hashCode = md5 of the template string.
+		$this->assertStringStartsWith(md5($templateStr), $prefix);
+	}
+
+	// -----------------------------------------------------------------------
+	// Component namespace, inline expressions, and directive-level tags
+	// -----------------------------------------------------------------------
+
+	public function testInstantiateInComponentNamespaceHandling()
+	{
+		$tpl = $this->newTemplate('<com:Prado\\Web\\UI\\WebControls\\TLabel ID="lbl1" Text="Hello" />');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$label = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TLabel::class, $label);
+		$this->assertEquals('Hello', $label->getText());
+	}
+
+	public function testInstantiateInMixedExpressionAndStaticText()
+	{
+		$tpl = $this->newTemplate('prefix<%= $this->Name %>suffix');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$literal = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $literal);
+	}
+
+	public function testInstantiateInStatementExpression()
+	{
+		$tpl = $this->newTemplate('<%% echo "hello"; %>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$literal = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $literal);
+	}
+
+	public function testInstantiateInlineDatabindExpression()
+	{
+		$tpl = $this->newTemplate('<%# $this->Data %>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(1, $tplControl->getControls());
+		$literal = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $literal);
+	}
+
+	public function testInstantiateInDirectiveLevelPropertyTagNotInstantiated()
+	{
+		$tpl = $this->newTemplate('<prop:Title>My Page</prop:Title>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(0, $tplControl->getControls());
+	}
+
+	public function testInstantiateInMultipleCompositeLiteralsNotMerged()
+	{
+		$tpl = $this->newTemplate('<com:TPanel ID="p1"><%= $a %></com:TPanel><%= $b %>');
+		$tplControl = $this->createControlWithPage();
+		$tpl->instantiateIn($tplControl);
+		$this->assertCount(2, $tplControl->getControls());
+		$panel = $tplControl->getControls()[0];
+		$this->assertInstanceOf(TPanel::class, $panel);
+		$this->assertCount(1, $panel->getControls());
+		$this->assertInstanceOf(TCompositeLiteral::class, $panel->getControls()[0]);
+		$outer = $tplControl->getControls()[1];
+		$this->assertInstanceOf(TCompositeLiteral::class, $outer);
+	}
+
+	public function testInstantiateInIdParameterExpressionParsedCorrectly()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TLabel ID="<%$ LabelIdParam %>" Text="Hello" />');
+		$items = $tpl->getItems();
+		$component = null;
+		foreach ($items as $item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				$component = $item;
+			}
+		}
+		$this->assertNotNull($component);
+		$this->assertCount(2, $component[TTemplate::TPL_PROPS]);
+		$this->assertEquals(TTemplate::CONFIG_PARAMETER, $component[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_TYPE]);
+		$this->assertEquals('LabelIdParam', $component[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE]);
+	}
+}

--- a/tests/unit/Web/UI/TTemplateTest.php
+++ b/tests/unit/Web/UI/TTemplateTest.php
@@ -1,79 +1,1803 @@
 <?php
 
+use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\TTemplateException;
+use Prado\TComponent;
+use Prado\Web\UI\TCompositeLiteral;
+use Prado\Web\UI\TTemplate;
 
+/**
+ * Helper: TComponent subclass that has only a getter — no setter — to test readonly validation.
+ */
+class TTemplateTestReadonlyComponent extends TComponent
+{
+	public function getReadonlyProp()
+	{
+		return 'value';
+	}
+}
 
 class TTemplateTest extends PHPUnit\Framework\TestCase
 {
+	private $_contextPath;
 	protected $obj;
-	
-	private $_baseClass;
+
+	protected function getTestClass()
+	{
+		return TTemplate::class;
+	}
 
 	protected function setUp(): void
 	{
-		$this->_baseClass = $this->getTestClass();
-		$this->obj = new $this->_baseClass('', '');
+		$this->_contextPath = sys_get_temp_dir();
+		$class = $this->getTestClass();
+		$this->obj = new $class('', $this->_contextPath);
 	}
 
 	protected function tearDown(): void
 	{
+		$this->_contextPath = null;
 		$this->obj = null;
 	}
-	
-	protected function getTestClass()
+
+	private function newTemplate($template, $contextPath = null, $tplFile = null, $startingLine = 0, $sourceTemplate = true)
 	{
-		return \Prado\Web\UI\TTemplate::class;
+		return new TTemplate($template, $contextPath ?? $this->_contextPath, $tplFile, $startingLine, $sourceTemplate);
 	}
-	
+
+	private function newTemplateUnvalidated($template)
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$props = [
+			'_sourceTemplate' => true,
+			'_contextPath' => $this->_contextPath,
+			'_tplFile' => null,
+			'_startingLine' => 0,
+			'_content' => $template,
+			'_attributevalidation' => false,
+			'_hashCode' => md5($template),
+		];
+		foreach ($props as $name => $val) {
+			$p = $ref->getProperty($name);
+			$p->setAccessible(true);
+			$p->setValue($tplObj, $val);
+		}
+		$ref->getParentClass()->getParentClass()->getConstructor()->invoke($tplObj);
+		$parse = $ref->getMethod('parse');
+		$parse->setAccessible(true);
+		$parse->invoke($tplObj, $template);
+		$c = $ref->getProperty('_content');
+		$c->setAccessible(true);
+		$c->setValue($tplObj, null);
+		return $tplObj;
+	}
+
+	private function findComponent(array $items)
+	{
+		foreach ($items as $item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				return $item;
+			}
+		}
+		return null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Constructor and basic accessors
+	// -----------------------------------------------------------------------
+
 	public function testConstruct()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$tpl = $this->newTemplate('hello');
+		$this->assertNotNull($tpl);
+		$this->assertEquals(sys_get_temp_dir(), $tpl->getContextPath());
 	}
 
-	public function testAttributeValidation()
+	public function testConstructWithTemplateFile()
 	{
-		$this->obj->setAttributeValidation(false);
-		self::assertFalse($this->obj->getAttributeValidation());
-		$this->obj->setAttributeValidation(true);
-		self::assertTrue($this->obj->getAttributeValidation());
-	}
-
-	public function testGetTemplateFile()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$tpl = $this->newTemplate('text', '/tmp', '/tmp/test.page');
+		$this->assertEquals('/tmp/test.page', $tpl->getTemplateFile());
 	}
 
 	public function testGetIsSourceTemplate()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
-	}
-
-	public function testGetContextPath()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
-	}
-
-	public function testGetDirective()
-	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertTrue($this->newTemplate('hello', null, null, 0, true)->getIsSourceTemplate());
+		$this->assertFalse($this->newTemplate('hello', null, null, 0, false)->getIsSourceTemplate());
 	}
 
 	public function testGetHashCode()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertEquals(md5('hello'), $this->newTemplate('hello')->getHashCode());
 	}
 
-	public function testGetItems()
+	public function testAttributeValidation()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$tpl = $this->newTemplate('');
+		$this->assertTrue($tpl->getAttributeValidation());
+		$tpl->setAttributeValidation(false);
+		$this->assertFalse($tpl->getAttributeValidation());
+		$tpl->setAttributeValidation(true);
+		$this->assertTrue($tpl->getAttributeValidation());
 	}
 
-	public function testInstantiateIn()
+	public function testContextPath()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertEquals('/custom/path', $this->newTemplate('', '/custom/path')->getContextPath());
 	}
 
-	public function testGetIncludedFiles()
+	public function testREGEX_RULESConstant()
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertIsString(TTemplate::REGEX_RULES);
+		$this->assertGreaterThan(0, strlen(TTemplate::REGEX_RULES));
+	}
+
+	// -----------------------------------------------------------------------
+	// Directive parsing
+	// -----------------------------------------------------------------------
+
+	public function testGetDirectiveEmpty()
+	{
+		$this->assertEquals([], $this->newTemplate('hello')->getDirective());
+	}
+
+	public function testDirectiveParsing()
+	{
+		$tpl = $this->newTemplate('<%@ Language="PHP" %>');
+		$this->assertEquals(['Language' => 'PHP'], $tpl->getDirective());
+	}
+
+	public function testDirectiveParsingMultiple()
+	{
+		$tpl = $this->newTemplate('<%@ Language="PHP" Master="Site" %>');
+		$dir = $tpl->getDirective();
+		$this->assertCount(2, $dir);
+		$this->assertEquals('PHP', $dir['Language']);
+		$this->assertEquals('Site', $dir['Master']);
+	}
+
+	public function testDirectivePreservesCase()
+	{
+		$tpl = $this->newTemplate('<%@ ThemeColor="blue" %>');
+		$dir = $tpl->getDirective();
+		$this->assertArrayHasKey('ThemeColor', $dir);
+		$this->assertEquals('blue', $dir['ThemeColor']);
+	}
+
+	public function testDirectiveAttributeNameNoDash()
+	{
+		$tpl = $this->newTemplate('<%@ MasterPage="layout" %>');
+		$dir = $tpl->getDirective();
+		$this->assertArrayHasKey('MasterPage', $dir);
+		$this->assertEquals('layout', $dir['MasterPage']);
+	}
+
+	public function testDirectiveDuplicateThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<%@ Language="PHP" %><%@ Title="Test" %>');
+	}
+
+	public function testDirectiveNotAtStartThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('text<%@ Language="PHP" %>');
+	}
+
+	public function testDirectiveNotFirstThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel ID="lbl1" /><%@ Language="PHP" %>');
+	}
+
+	public function testDirectiveWithSingleQuotes()
+	{
+		$tpl = $this->newTemplate("<%@ Language='PHP' %>");
+		$this->assertEquals(['Language' => 'PHP'], $tpl->getDirective());
+	}
+
+	public function testDirectiveWithDashAttributeName()
+	{
+		$tpl = $this->newTemplate('<%@ MasterPage="layout" ThemeColor="blue" %>');
+		$dir = $tpl->getDirective();
+		$this->assertArrayHasKey('MasterPage', $dir);
+		$this->assertArrayHasKey('ThemeColor', $dir);
+		$this->assertEquals('layout', $dir['MasterPage']);
+		$this->assertEquals('blue', $dir['ThemeColor']);
+	}
+
+	public function testDirectiveEmptyAttributes()
+	{
+		// <%@ %> with no attributes produces an empty directive, not an error
+		$tpl = $this->newTemplate('<%@ %>');
+		$this->assertEquals([], $tpl->getDirective());
+	}
+
+	// -----------------------------------------------------------------------
+	// Property tags at directive level
+	// -----------------------------------------------------------------------
+
+	public function testGetPropertyTagOnDirectiveLevel()
+	{
+		$tpl = $this->newTemplate('<prop:Title>My Page</prop:Title>');
+		$dir = $tpl->getDirective();
+		$this->assertArrayHasKey('Title', $dir);
+		$this->assertEquals('My Page', $dir['Title']);
+	}
+
+	public function testGetPropertyTagOnDirectiveWithDashName()
+	{
+		$tpl = $this->newTemplate('<prop:My-Prop>value</prop:My-Prop>');
+		$dir = $tpl->getDirective();
+		$this->assertArrayHasKey('My-Prop', $dir);
+		$this->assertEquals('value', $dir['My-Prop']);
+	}
+
+	public function testGetPropertyTagWithExpressionOnDirectiveLevel()
+	{
+		$tpl = $this->newTemplate('<prop:Title><%= $this->AppName %></prop:Title>');
+		$dir = $tpl->getDirective();
+		$this->assertArrayHasKey('Title', $dir);
+		$this->assertIsString($dir['Title']);
+	}
+
+	// -----------------------------------------------------------------------
+	// Plain text and empty templates
+	// -----------------------------------------------------------------------
+
+	public function testEmptyTemplate()
+	{
+		$this->assertCount(0, $this->newTemplate('')->getItems());
+	}
+
+	public function testWhitespaceOnlyTemplate()
+	{
+		$items = $this->newTemplate('   ')->getItems();
+		$this->assertCount(1, $items);
+		$this->assertEquals('   ', array_values($items)[0][TTemplate::TPL_TYPE]);
+	}
+
+	public function testPlainText()
+	{
+		$tpl = $this->newTemplate('Hello World');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertEquals(-1, $item[TTemplate::TPL_PARENT_INDEX]);
+		$this->assertEquals('Hello World', $item[TTemplate::TPL_TYPE]);
+		$this->assertArrayNotHasKey(TTemplate::TPL_PROPS, $item);
+	}
+
+	public function testItemsReturnedByReference()
+	{
+		$tpl = $this->newTemplate('Hello');
+		$items = &$tpl->getItems();
+		$items[999] = [TTemplate::TPL_PARENT_INDEX => -1, TTemplate::TPL_TYPE => 'injected'];
+		$this->assertArrayHasKey(999, $tpl->getItems());
+	}
+
+	// -----------------------------------------------------------------------
+	// HTML and template comments
+	// -----------------------------------------------------------------------
+
+	public function testHtmlCommentPreservedAsText()
+	{
+		$tpl = $this->newTemplate('before<!-- comment -->after');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$data = $item[TTemplate::TPL_TYPE];
+		if ($data instanceof TCompositeLiteral) {
+			$combined = '';
+			$ref = new \ReflectionClass(TCompositeLiteral::class);
+			$itemsProp = $ref->getProperty('_items');
+			$itemsProp->setAccessible(true);
+			foreach ($itemsProp->getValue($data) as $subItem) {
+				$combined .= is_string($subItem) ? $subItem : (string) $subItem;
+			}
+			$this->assertStringContainsString('before', $combined);
+			$this->assertStringContainsString('after', $combined);
+			$this->assertStringContainsString('<!-- comment -->', $combined);
+		} else {
+			$this->assertStringContainsString('before', $data);
+			$this->assertStringContainsString('after', $data);
+			$this->assertStringContainsString('<!-- comment -->', $data);
+		}
+	}
+
+	public function testTemplateCommentStripped()
+	{
+		$tpl = $this->newTemplate('a<!--- stripped --->b');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$data = $item[TTemplate::TPL_TYPE];
+		if ($data instanceof TCompositeLiteral) {
+			$combined = '';
+			$ref = new \ReflectionClass(TCompositeLiteral::class);
+			$itemsProp = $ref->getProperty('_items');
+			$itemsProp->setAccessible(true);
+			foreach ($itemsProp->getValue($data) as $subItem) {
+				$combined .= $subItem;
+			}
+			$this->assertStringContainsString('a', $combined);
+			$this->assertStringContainsString('b', $combined);
+			$this->assertStringNotContainsString('stripped', $combined);
+		} else {
+			$this->assertEquals('ab', $data);
+		}
+	}
+	
+/*	public function testTemplateCommentStripped_shortEnd()
+	{
+		$tpl = $this->newTemplate('a<!--- stripped -->b');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$data = $item[TTemplate::TPL_TYPE];
+		if ($data instanceof TCompositeLiteral) {
+			$combined = '';
+			$ref = new \ReflectionClass(TCompositeLiteral::class);
+			$itemsProp = $ref->getProperty('_items');
+			$itemsProp->setAccessible(true);
+			foreach ($itemsProp->getValue($data) as $subItem) {
+				$combined .= $subItem;
+			}
+			$this->assertStringContainsString('a', $combined);
+			$this->assertStringContainsString('b', $combined);
+			$this->assertStringNotContainsString('stripped', $combined);
+		} else {
+			$this->assertEquals('ab', $data);
+		}
+	}
+*/
+
+	public function testHtmlEdgeCommentParseVariants()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!-- --!>after');
+		$items = $tpl->getItems();
+		$this->assertIsArray($items);
+		$this->assertNotEmpty($items);
+	}
+
+	public function testTemplateEdgeCommentParseVariants()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!---    --->after');
+		$rendered = '';
+		foreach ($tpl->getItems() as $item) {
+			$data = $item[TTemplate::TPL_TYPE] ?? '';
+			if (is_string($data)) {
+				$rendered .= $data;
+			} elseif ($data instanceof TCompositeLiteral) {
+				$data->evaluateDynamicContent();
+				$writer = new class () implements \Prado\IO\ITextWriter {
+					public $buf = '';
+					public function write($s)
+					{
+						$this->buf .= $s;
+					}
+					public function writeLine($s = '')
+					{
+						$this->buf .= $s;
+					}
+					public function flush()
+					{
+						return $this->buf;
+					}
+				};
+				$data->render($writer);
+				$rendered .= $writer->buf;
+			}
+		}
+		$this->assertEquals('beforeafter', $rendered);
+	}
+
+/*
+	public function testTemplateEdgeCommentParseVariants_shortEnd()
+	{
+		$tpl = $this->newTemplateUnvalidated('before<!---    -->after');
+		$rendered = '';
+		foreach ($tpl->getItems() as $item) {
+			$data = $item[TTemplate::TPL_TYPE] ?? '';
+			if (is_string($data)) {
+				$rendered .= $data;
+			} elseif ($data instanceof TCompositeLiteral) {
+				$data->evaluateDynamicContent();
+				$writer = new class () implements \Prado\IO\ITextWriter {
+					public $buf = '';
+					public function write($s)
+					{
+						$this->buf .= $s;
+					}
+					public function writeLine($s = '')
+					{
+						$this->buf .= $s;
+					}
+					public function flush()
+					{
+						return $this->buf;
+					}
+				};
+				$data->render($writer);
+				$rendered .= $writer->buf;
+			}
+		}
+		$this->assertEquals('beforeafter', $rendered);
+	}
+*/
+
+	public function testHtmlCommentExclamationPreserved()
+	{
+		$tpl = $this->newTemplate('a<!-- stripped --!>b');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$data = $item[TTemplate::TPL_TYPE];
+		if ($data instanceof TCompositeLiteral) {
+			$combined = '';
+			$ref = new \ReflectionClass(TCompositeLiteral::class);
+			$itemsProp = $ref->getProperty('_items');
+			$itemsProp->setAccessible(true);
+			foreach ($itemsProp->getValue($data) as $subItem) {
+				$combined .= $subItem;
+			}
+			$this->assertStringContainsString('a', $combined);
+			$this->assertStringContainsString('b', $combined);
+			$this->assertStringContainsString('<!-- stripped --!>', $combined);
+		} else {
+			$this->assertStringContainsString('<!-- stripped --!>', $data);
+		}
+	}
+
+	public function testHtmlCommentInsidePropertyTagPreservedAsText()
+	{
+		// HTML comments are NOT matched by REGEX_RULES, so inside <prop:Text> bodies
+		// they become part of the property text value — not a separate template item.
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!-- comment --!>hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertArrayHasKey(TTemplate::TPL_PROPS, $item);
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!-- comment --!>', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+
+	public function testHtmlCommentInComponentAttributeValuePreserved()
+	{
+		$tpl = $this->newTemplate('<com:TLabel Text="<!-- comment -->hello" />');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals('<!-- comment -->hello', $text[TTemplate::PROP_VALUE]);
+	}
+
+	public function testHtmlCommentExclamationInComponentAttributeValuePreserved()
+	{
+		$tpl = $this->newTemplate('<com:TLabel Text="<!-- comment --!>hello" />');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals('<!-- comment --!>hello', $text[TTemplate::PROP_VALUE]);
+	}
+
+	public function testPradoTemplateCommentInPropertyTagBodyStripped()
+	{
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!--- comment --->hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringNotContainsString('<!---', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+
+	public function testPradoTemplateCommentEndBangInPropertyTagBodyStripped()
+	{
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!--- comment ---!>hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringNotContainsString('<!---', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+
+/*
+	public function testPradoTemplateCommentInPropertyTagBodyStripped_shortEnd()
+	{
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!--- comment -->hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringNotContainsString('<!---', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+	
+	public function testPradoTemplateCommentEndBangInPropertyTagBodyStripped_shortEnd()
+	{
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!--- comment --!>hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringNotContainsString('<!---', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+*/
+
+	public function testHtmlCommentInPropertyTagBodyPreserved()
+	{
+		// HTML comments are not matched by REGEX_RULES; inside a <prop:Text> body
+		// the entire content (including the comment) becomes the property value string.
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!-- comment -->hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+$this->assertArrayHasKey(TTemplate::TPL_PROPS, $item);
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!-- comment -->', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+	
+	public function testHtmlCommentEndBangInPropertyTagBodyPreserved()
+	{
+		// HTML comments (including --!> variant) are not matched by REGEX_RULES;
+		// inside a <prop:Text> body the full content becomes the property value string.
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text><!-- comment --!>hello</prop:Text></com:TLabel>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertArrayHasKey(TTemplate::TPL_PROPS, $item);
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!-- comment --!>', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+	
+	public function testPradoTemplateCommentInComponentAttributePreserved()
+	{
+		$tpl = $this->newTemplate('<com:TLabel Text="<!--- comment --->hello" />');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!--- comment --->', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+	
+	public function testPradoTemplateCommentEndBangInComponentAttributePreserved()
+	{
+		$tpl = $this->newTemplate('<com:TLabel Text="<!--- comment ---!>hello" />');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!--- comment ---!>', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+	
+/*
+	public function testPradoTemplateCommentInComponentAttributePreserved_shortEnd()
+	{
+		$tpl = $this->newTemplate('<com:TLabel Text="<!--- comment -->hello" />');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!--- comment -->', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+	
+	public function testPradoTemplateCommentEndBangInComponentAttributePreserved_shortEnd()
+	{
+		$tpl = $this->newTemplate('<com:TLabel Text="<!--- comment --!>hello" />');
+		$items = $tpl->getItems();
+		$item = array_values($items)[0];
+		$text = $item[TTemplate::TPL_PROPS]['text'];
+		$this->assertStringContainsString('<!--- comment --!>', $text[TTemplate::PROP_VALUE]);
+		$this->assertStringContainsString('hello', $text[TTemplate::PROP_VALUE]);
+	}
+*/
+
+	// -----------------------------------------------------------------------
+	// Component tag parsing
+	// -----------------------------------------------------------------------
+
+	public function testComponentTagParsing()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="label1" Text="Hello" />');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertStringContainsString('TLabel', $item[TTemplate::TPL_TYPE]);
+		$this->assertArrayHasKey('id', $item[TTemplate::TPL_PROPS]);
+		$this->assertEquals('Hello', $item[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testComponentTagReturnsFQCN()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" />');
+		$item = array_values($tpl->getItems())[0];
+		$this->assertEquals('Prado\\Web\\UI\\WebControls\\TLabel', $item[TTemplate::TPL_TYPE]);
+	}
+
+	public function testAttributeKeyIsLowered()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="Hello" />');
+		$item = array_values($tpl->getItems())[0];
+		$this->assertArrayHasKey('id', $item[TTemplate::TPL_PROPS]);
+		$this->assertArrayHasKey('text', $item[TTemplate::TPL_PROPS]);
+	}
+
+	public function testComponentTagWithSubProperties()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="label1" Font.Size="12" />');
+		$item = array_values($tpl->getItems())[0];
+		$this->assertArrayHasKey('font.size', $item[TTemplate::TPL_PROPS]);
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $item[TTemplate::TPL_PROPS]['font.size'][TTemplate::PROP_TYPE]);
+		$this->assertEquals('Font.Size', $item[TTemplate::TPL_PROPS]['font.size'][TTemplate::PROP_NAME]);
+	}
+
+	public function testSubpropertyFontDashAttribute()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Font.Size="12px" />');
+		$item = array_values($tpl->getItems())[0];
+		$prop = $item[TTemplate::TPL_PROPS]['font.size'];
+		$this->assertEquals('Font.Size', $prop[TTemplate::PROP_NAME]);
+		$this->assertEquals('12px', $prop[TTemplate::PROP_VALUE]);
+	}
+
+	public function testComponentTagSelfClosingWithSubProperty()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Font.Size="12" Font.Bold="true" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('font.size', $component[TTemplate::TPL_PROPS]);
+		$this->assertArrayHasKey('font.bold', $component[TTemplate::TPL_PROPS]);
+		$this->assertEquals('12', $component[TTemplate::TPL_PROPS]['font.size'][TTemplate::PROP_VALUE]);
+		$this->assertEquals('true', $component[TTemplate::TPL_PROPS]['font.bold'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testComponentTagWithClosingTag()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1">Hello</com:TLabel>');
+		$this->assertCount(2, $tpl->getItems());
+	}
+
+	public function testComponentTagWithBodyText()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1">Hello</com:TLabel>');
+		$items = $tpl->getItems();
+		$this->assertCount(2, $items);
+		$itemValues = array_values($items);
+		$component = null;
+		$textItem = null;
+		foreach ($itemValues as $item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				$component = $item;
+			} else {
+				$textItem = $item;
+			}
+		}
+		$this->assertNotNull($component);
+		$this->assertNotNull($textItem);
+		$this->assertEquals('Hello', $textItem[TTemplate::TPL_TYPE]);
+		$this->assertEquals(0, $textItem[TTemplate::TPL_PARENT_INDEX]);
+	}
+
+	public function testMixedContentAndComponents()
+	{
+		$tpl = $this->newTemplate('before<com:TLabel ID="lbl1" />after');
+		$this->assertCount(3, $tpl->getItems());
+	}
+
+	public function testMultipleComponentsInSequence()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="a" /><com:TLabel ID="b" /><com:TLabel ID="c" />');
+		$this->assertCount(3, $tpl->getItems());
+	}
+
+	public function testNestedComponents()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="outer"><com:TLabel ID="inner" /></com:TLabel>');
+		$this->assertCount(2, $tpl->getItems());
+	}
+
+	public function testNestedComponentParentIndex()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="outer"><com:TLabel ID="inner" Text="Hello" /></com:TLabel>');
+		$items = $tpl->getItems();
+		$itemValues = array_values($items);
+		$outerIndex = null;
+		$innerParentIndex = null;
+		foreach ($itemValues as $idx => $item) {
+			if (isset($item[TTemplate::TPL_PROPS]) && isset($item[TTemplate::TPL_PROPS]['id'])) {
+				if ($item[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE] === 'outer') {
+					$outerIndex = $idx;
+				}
+				if ($item[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE] === 'inner') {
+					$innerParentIndex = $item[TTemplate::TPL_PARENT_INDEX];
+				}
+			}
+		}
+		$this->assertNotNull($outerIndex);
+		$this->assertEquals($outerIndex, $innerParentIndex);
+	}
+
+	public function testOpenComponentTagContainerStacking()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="l1"><com:TLabel ID="l2"><com:TLabel ID="l3" /></com:TLabel></com:TLabel>');
+		$items = $tpl->getItems();
+		$this->assertCount(3, $items);
+		$itemValues = array_values($items);
+		$indices = [];
+		foreach ($itemValues as $idx => $item) {
+			if (isset($item[TTemplate::TPL_PROPS]) && isset($item[TTemplate::TPL_PROPS]['id'])) {
+				$indices[$item[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE]] = ['index' => $idx, 'parent' => $item[TTemplate::TPL_PARENT_INDEX]];
+			}
+		}
+		$this->assertEquals(-1, $indices['l1']['parent']);
+		$this->assertEquals($indices['l1']['index'], $indices['l2']['parent']);
+		$this->assertEquals($indices['l2']['index'], $indices['l3']['parent']);
+	}
+
+	public function testComponentWithTextBeforeAndAfterNestedComponent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="outer">before<com:TLabel ID="inner" />after</com:TLabel>');
+		$items = $tpl->getItems();
+		$this->assertCount(4, $items);
+		$outer = null;
+		$inner = null;
+		$texts = [];
+		foreach ($items as $item) {
+			if (isset($item[TTemplate::TPL_PROPS])) {
+				if ($item[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE] === 'outer') {
+					$outer = $item;
+				} elseif ($item[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE] === 'inner') {
+					$inner = $item;
+				}
+			} else {
+				$texts[] = $item;
+			}
+		}
+		$this->assertNotNull($outer);
+		$this->assertNotNull($inner);
+		$this->assertCount(2, $texts);
+		$this->assertEquals('before', $texts[0][TTemplate::TPL_TYPE]);
+		$this->assertEquals('after', $texts[1][TTemplate::TPL_TYPE]);
+	}
+
+	public function testComponentWithNoAttributes()
+	{
+		$tpl = $this->newTemplate('<com:TLabel />');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$this->assertCount(0, array_values($items)[0][TTemplate::TPL_PROPS]);
+	}
+
+	public function testComponentNamespaceHandling()
+	{
+		$tpl = $this->newTemplate('<com:Prado\\Web\\UI\\WebControls\\TLabel ID="lbl1" />');
+		$item = array_values($tpl->getItems())[0];
+		$this->assertEquals('Prado\\Web\\UI\\WebControls\\TLabel', $item[TTemplate::TPL_TYPE]);
+	}
+
+	public function testComponentTagWithAttributeExpressionValue()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text=<%= $this->Name %> />');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$component = $this->findComponent($items);
+		$this->assertArrayHasKey('text', $component[TTemplate::TPL_PROPS]);
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_TYPE]);
+	}
+
+	public function testStartingLine()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" />', null, null, 5);
+		$this->assertCount(1, $tpl->getItems());
+	}
+
+	// -----------------------------------------------------------------------
+	// Property tags
+	// -----------------------------------------------------------------------
+
+	public function testPropertyTag()
+	{
+		$tpl = $this->newTemplate('<com:TLabel><prop:Text>Hello World</prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('text', $component[TTemplate::TPL_PROPS]);
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertEquals('Hello World', $textProp[TTemplate::PROP_VALUE]);
+		$this->assertEquals('Text', $textProp[TTemplate::PROP_NAME]);
+	}
+
+	public function testPropertyTagCasePreserved()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text>Hello</prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals('Text', $prop[TTemplate::PROP_NAME]);
+	}
+
+	public function testGroupSubPropertyTag()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Font Size="12" Bold="true" /></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('font.size', $component[TTemplate::TPL_PROPS]);
+		$this->assertArrayHasKey('font.bold', $component[TTemplate::TPL_PROPS]);
+		$this->assertEquals('Font.Size', $component[TTemplate::TPL_PROPS]['font.size'][TTemplate::PROP_NAME]);
+		$this->assertEquals('Font.Bold', $component[TTemplate::TPL_PROPS]['font.bold'][TTemplate::PROP_NAME]);
+	}
+
+	public function testGroupSubPropertyTagValues()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Font Size="14" Bold="true" /></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$sizeProp = $component[TTemplate::TPL_PROPS]['font.size'];
+		$boldProp = $component[TTemplate::TPL_PROPS]['font.bold'];
+		$this->assertEquals('14', $sizeProp[TTemplate::PROP_VALUE]);
+		$this->assertEquals('true', $boldProp[TTemplate::PROP_VALUE]);
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $sizeProp[TTemplate::PROP_TYPE]);
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $boldProp[TTemplate::PROP_TYPE]);
+	}
+
+	public function testTemplatePropertyViaTag()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:Template>inner content</prop:Template></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('template', $component[TTemplate::TPL_PROPS]);
+		$tplProp = $component[TTemplate::TPL_PROPS]['template'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testTemplatePropertyViaAttribute()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" Template="text content" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('template', $component[TTemplate::TPL_PROPS]);
+		$tplProp = $component[TTemplate::TPL_PROPS]['template'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testTemplatePropertyViaTagCreatesTTemplate()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" Template="inner content" />');
+		$component = $this->findComponent($tpl->getItems());
+		$tplProp = $component[TTemplate::TPL_PROPS]['template'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testTemplatePropertyTagEndingInTemplate()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:Itemtemplate>content</prop:Itemtemplate></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('itemtemplate', $component[TTemplate::TPL_PROPS]);
+		$tplProp = $component[TTemplate::TPL_PROPS]['itemtemplate'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testTemplatePropertyTagEndingInTemplateCaseInsensitive()
+	{
+		// 'ItemTemplate' ends in 'template' only when lowercased — the check is `substr($propName, -8, 8) === 'template'`
+		// which is case-sensitive, so 'ItemTemplate' (capital T) does NOT match and is treated as CONFIG_VALUE
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:ItemTemplate>content</prop:ItemTemplate></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('itemtemplate', $component[TTemplate::TPL_PROPS]);
+		$tplProp = $component[TTemplate::TPL_PROPS]['itemtemplate'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testNestedPropertyTagInsideComponent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><prop:SubTag>ignored</prop:SubTag></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('text', $component[TTemplate::TPL_PROPS]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Attribute name transformations (dash, case, subproperty)
+	// -----------------------------------------------------------------------
+
+	public function testAttributeNameDashToUnderscorePropagation()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" data-toggle="modal" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('data-toggle', $component[TTemplate::TPL_PROPS]);
+		$attr = $component[TTemplate::TPL_PROPS]['data-toggle'];
+		$this->assertEquals('data-toggle', $attr[TTemplate::PROP_NAME]);
+		$this->assertEquals('modal', $attr[TTemplate::PROP_VALUE]);
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $attr[TTemplate::PROP_TYPE]);
+	}
+
+	public function testAttributeNameCaseIsPreservedInPropName()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" ThemeColor="blue" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('themecolor', $component[TTemplate::TPL_PROPS]);
+		$attr = $component[TTemplate::TPL_PROPS]['themecolor'];
+		$this->assertEquals('ThemeColor', $attr[TTemplate::PROP_NAME]);
+	}
+
+	public function testSubpropertyDashInAttributeName()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" Style.Font-Size="12px" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('style.font-size', $component[TTemplate::TPL_PROPS]);
+		$prop = $component[TTemplate::TPL_PROPS]['style.font-size'];
+		$this->assertEquals('Style.Font-Size', $prop[TTemplate::PROP_NAME]);
+	}
+
+	public function testGroupNameSubPropertyDashPreservedInPropName()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:Font Data-Toggle="dropdown" /></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('font.data-toggle', $component[TTemplate::TPL_PROPS]);
+		$attr = $component[TTemplate::TPL_PROPS]['font.data-toggle'];
+		$this->assertEquals('Font.Data-Toggle', $attr[TTemplate::PROP_NAME]);
+	}
+
+	public function testPropertyNameDashInPropertyTag()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:data-value>123</prop:data-value></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('data-value', $component[TTemplate::TPL_PROPS]);
+		$prop = $component[TTemplate::TPL_PROPS]['data-value'];
+		$this->assertEquals('data-value', $prop[TTemplate::PROP_NAME]);
+		$this->assertEquals('123', $prop[TTemplate::PROP_VALUE]);
+	}
+
+	public function testPropertyTagWithDashPreservesCaseUnvalidated()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:Custom-Prop>value</prop:Custom-Prop></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('custom-prop', $component[TTemplate::TPL_PROPS]);
+		$prop = $component[TTemplate::TPL_PROPS]['custom-prop'];
+		$this->assertEquals('Custom-Prop', $prop[TTemplate::PROP_NAME]);
+		$this->assertEquals('value', $prop[TTemplate::PROP_VALUE]);
+	}
+
+	public function testAttributeToMethodNameConvertsDashToUnderscore()
+	{
+		$tpl = $this->newTemplate('');
+		$tplClass = new \ReflectionClass(TTemplate::class);
+		$method = $tplClass->getMethod('attributeToMethodName');
+		$method->setAccessible(true);
+		$this->assertEquals('data_toggle', $method->invoke($tpl, 'data-toggle'));
+		$this->assertEquals('Font_Size', $method->invoke($tpl, 'Font-Size'));
+		$this->assertEquals('nocase', $method->invoke($tpl, 'nocase'));
+		$this->assertEquals('multi_dash_name', $method->invoke($tpl, 'multi-dash-name'));
+	}
+
+	public function testAttributeWithSingleQuotes()
+	{
+		$tpl = $this->newTemplate("<com:TLabel ID='lbl1' Text='Hello' />");
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals('Hello', $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testComponentWithOnlySingleQuotedAttributes()
+	{
+		$tpl = $this->newTemplate("<com:TLabel ID='lbl1' Text='Hello' Font.Size='12' />");
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals('lbl1', $component[TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE]);
+		$this->assertEquals('Hello', $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_VALUE]);
+		$this->assertEquals('12', $component[TTemplate::TPL_PROPS]['font.size'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testAttributeWithSpacesAroundEqual()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID = "lbl1" />');
+		$this->assertCount(1, $tpl->getItems());
+		$this->assertEquals('lbl1', array_values($tpl->getItems())[0][TTemplate::TPL_PROPS]['id'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testAttributeWithEqualSignInValue()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="a=b" />');
+		$this->assertEquals('a=b', $this->findComponent($tpl->getItems())[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testEmptyAttributeValue()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals('', $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_VALUE]);
+	}
+
+	public function testAttributeWithExpressionInSingleQuotes()
+	{
+		$tpl = $this->newTemplate("<com:TLabel ID='lbl1' Text='<%= \$this->Name %>' />");
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_TYPE]);
+	}
+
+	public function testAttributeWithExpressionInQuotes()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%= $this->Title %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_TYPE]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Expression types in component attributes
+	// -----------------------------------------------------------------------
+
+	public function testDatabindExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%# $this->Data %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertStringContainsString('$this->Data', $textProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParameterExpressionValueContent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%$ MyParam %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_PARAMETER, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertEquals('MyParam', $textProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testAssetExpressionValueContent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%~ images/logo.png %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_ASSET, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertEquals('images/logo.png', $textProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testLocalizationExpressionValueContent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%[ Hello World ]%>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_LOCALIZATION, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertEquals('Hello World', $textProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testUrlExpressionValueContent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%/ path/to/resource %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertStringContainsString('path/to/resource', $textProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testExpressionAttributeValueContent()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%= $this->Title %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $textProp[TTemplate::PROP_TYPE]);
+		$this->assertStringContainsString('$this->Title', $textProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testMixedExpressionAndStaticText()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="prefix<%= $this->Name %>suffix" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_TYPE]);
+	}
+
+	public function testMixedDatabindAndStaticText()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="a<%# $this->Data %>b" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $component[TTemplate::TPL_PROPS]['text'][TTemplate::PROP_TYPE]);
+	}
+
+	public function testMixedExpressionAndDatabindInAttribute()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="a<%# $this->Data %>b<%= $this->Name %>c" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $textProp[TTemplate::PROP_TYPE]);
+	}
+
+	public function testMixedDatabindAndExpressionInAttribute()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text="<%# $data %><%= $expr %>" />');
+		$component = $this->findComponent($tpl->getItems());
+		$textProp = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $textProp[TTemplate::PROP_TYPE]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Inline expressions (top-level template items)
+	// -----------------------------------------------------------------------
+
+	public function testExpressionTag()
+	{
+		$tpl = $this->newTemplate('<%= $this->Property %>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$this->assertEquals(-1, $item[TTemplate::TPL_PARENT_INDEX]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $expressions);
+		$this->assertStringContainsString('$this->Property', array_values($expressions)[0]);
+	}
+
+	public function testStatementsTag()
+	{
+		$tpl = $this->newTemplate('<%% echo "hello"; %>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$stmtProp = $ref->getProperty('_statements');
+		$stmtProp->setAccessible(true);
+		$statements = $stmtProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $statements);
+		$this->assertStringContainsString('echo "hello";', array_values($statements)[0]);
+	}
+
+	public function testInlineExpression()
+	{
+		$tpl = $this->newTemplate('Hello <%= $this->Name %>!');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$itemsProp = $ref->getProperty('_items');
+		$itemsProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$literalItems = $itemsProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $expressions);
+		$this->assertStringContainsString('$this->Name', array_values($expressions)[0]);
+		$this->assertCount(3, $literalItems);
+	}
+
+	public function testInlineDatabindExpression()
+	{
+		$tpl = $this->newTemplate('<%# $this->Data %>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$bindProp = $ref->getProperty('_bindings');
+		$bindProp->setAccessible(true);
+		$bindings = $bindProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $bindings);
+		$this->assertStringContainsString('$this->Data', array_values($bindings)[0]);
+	}
+
+	public function testInlineParameterExpression()
+	{
+		$tpl = $this->newTemplate('<%$ ParamName %>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $expressions);
+		$this->assertStringContainsString('getParameters', array_values($expressions)[0]);
+		$this->assertStringContainsString('ParamName', array_values($expressions)[0]);
+	}
+
+	public function testInlineAssetExpression()
+	{
+		$items = $this->newTemplate('<%~ assets/logo.png %>')->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $expressions);
+		$this->assertStringContainsString('publishFilePath', array_values($expressions)[0]);
+		$this->assertStringContainsString('assets/logo.png', array_values($expressions)[0]);
+	}
+
+	public function testInlineUrlExpression()
+	{
+		$items = $this->newTemplate('<%/ path/to/page %>')->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $expressions);
+		$this->assertStringContainsString('path/to/page', array_values($expressions)[0]);
+	}
+
+	public function testInlineLocalizationExpression()
+	{
+		$items = $this->newTemplate('<%[ Hello ]%>')->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(1, $expressions);
+		$this->assertStringContainsString('localize', array_values($expressions)[0]);
+		$this->assertStringContainsString('Hello', array_values($expressions)[0]);
+	}
+
+	public function testMultipleInlineExpressions()
+	{
+		$tpl = $this->newTemplate('<%= $a %><%= $b %>');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$exprProp = $ref->getProperty('_expressions');
+		$exprProp->setAccessible(true);
+		$expressions = $exprProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(2, $expressions);
+	}
+
+	// -----------------------------------------------------------------------
+	// Property tag expressions
+	// -----------------------------------------------------------------------
+
+	public function testPropertyTagWithExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%= $this->Name %></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithParameterExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%$ AppParam %></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_PARAMETER, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithAssetExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%~ assets/img.png %></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_ASSET, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithLocalization()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%[ Hello ]%></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_LOCALIZATION, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithDatabind()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%# $this->Data %></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithMixedExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text>Hello <%= $this->Name %>!</prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithUrlExpression()
+	{
+		$tpl = $this->newTemplate('<com:TLabel ID="lbl1"><prop:Text><%/ path/to/page %></prop:Text></com:TLabel>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $prop[TTemplate::PROP_TYPE]);
+	}
+
+	public function testPropertyTagWithUrlExpressionValue()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1"><prop:Text><%/ some/path %></prop:Text></com:TComponent>');
+		$component = $this->findComponent($tpl->getItems());
+		$prop = $component[TTemplate::TPL_PROPS]['text'];
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $prop[TTemplate::PROP_TYPE]);
+		$this->assertStringContainsString('some/path', $prop[TTemplate::PROP_VALUE]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Error conditions
+	// -----------------------------------------------------------------------
+
+	public function testNonComponentClassThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->expectExceptionMessageMatches('/not a component/i');
+		$this->newTemplate('<com:stdClass />');
+	}
+
+	public function testClosingTagMismatch()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel></com:TButton>');
+	}
+
+	public function testClosingComponentTagMustMatch()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TControl>text</com:TLabel>');
+	}
+
+	public function testUnclosedComponentTag()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel>');
+	}
+
+	public function testUnclosedNestedComponentTagsThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel ID="lbl1"><com:TLabel ID="lbl2">');
+	}
+
+	public function testUnclosedPropertyTag()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel><prop:Text>hello</com:TLabel>');
+	}
+
+	public function testUnexpectedClosingTag()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('</com:TLabel>');
+	}
+
+	public function testUnexpectedClosingPropertyTag()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('</prop:Text>');
+	}
+
+	public function testClosingPropertyTagMismatch()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel ID="lbl1"><prop:Text>hello</prop:Title></com:TLabel>');
+	}
+
+	public function testClosingPropertyTagMismatchDifferentName()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel ID="lbl1"><prop:Title>Hello</prop:Text></com:TLabel>');
+	}
+
+	public function testDuplicatePropertyThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->expectExceptionMessageMatches('/configured twice|duplicated/i');
+		$this->newTemplate('<com:TLabel ID="lbl1" ID="lbl2" />');
+	}
+
+	public function testDuplicateSubPropertyGroupThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->expectExceptionMessageMatches('/configured twice|duplicated/i');
+		$this->newTemplate('<com:TLabel><prop:Font Size="12" /><prop:Font Size="14" /></com:TLabel>');
+	}
+
+	public function testDuplicatePropertyTagThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->expectExceptionMessageMatches('/configured twice|duplicated/i');
+		$this->newTemplate('<com:TLabel><prop:Text>Hello</prop:Text><prop:Text>World</prop:Text></com:TLabel>');
+	}
+
+	public function testDuplicateAttributeThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->expectExceptionMessageMatches('/configured twice|duplicated/i');
+		$this->newTemplate('<com:TLabel ID="lbl1" Text="a" Text="b" />');
+	}
+
+	public function testDatabindOnTComponentNotAllowed()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TComponent Text="<%# $this->Data %>" />');
+	}
+
+	public function testEventOnTComponentNotAllowed()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TComponent onClick="handler" />');
+	}
+
+	public function testUnknownPropertyOnTControlThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TControl NonExistentProp="value" />');
+	}
+
+	public function testUnknownEventOnTControlThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TControl onNonExistentEvent="handler" />');
+	}
+
+	public function testReadonlyPropertyOnTControlThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TControl Parent="something" />');
+	}
+
+	public function testControlSubpropertyFirstSegmentUnknownThrows()
+	{
+		// First segment of a subproperty (NonExistent.Prop) must be a readable property
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel NonExistent.Prop="val" />');
+	}
+
+	public function testControlSkinIdDatabindForbidden()
+	{
+		// SkinID may only be CONFIG_VALUE, CONFIG_EXPRESSION, or CONFIG_PARAMETER — databind must throw
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel ID="lbl1" SkinID="<%# $this->Data %>" />');
+	}
+
+	public function testControlIdDatabindForbidden()
+	{
+		// ID may only be CONFIG_VALUE, CONFIG_EXPRESSION, or CONFIG_PARAMETER — databind must throw
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<com:TLabel ID="<%# $this->Data %>" />');
+	}
+
+	public function testValidateAttributesTComponentReadonlyPropertyThrows()
+	{
+		Prado::using('TTemplateTestReadonlyComponent');
+		$this->expectException(TConfigurationException::class);
+		// ReadonlyProp has a getter but no setter on TTemplateTestReadonlyComponent
+		$this->newTemplate('<com:TTemplateTestReadonlyComponent ReadonlyProp="val" />');
+	}
+
+	public function testAttributeValidationOffSkipsChecks()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent NonExistentProp="value" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('nonexistentprop', $component[TTemplate::TPL_PROPS]);
+	}
+
+	public function testIncludeDirectiveInvalidThrows()
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->newTemplate('<%include NonExistentNamespace %>');
+	}
+
+	public function testGetIncludedFilesEmpty()
+	{
+		$this->assertEquals([], $this->newTemplate('Hello')->getIncludedFiles());
+	}
+
+	// -----------------------------------------------------------------------
+	// Events and JS
+	// -----------------------------------------------------------------------
+
+	public function testConfigureEventWithoutDotHandler()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" onClick="handleClick" />');
+		$component = $this->findComponent($tpl->getItems());
+		$handler = $component[TTemplate::TPL_PROPS]['onclick'];
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $handler[TTemplate::PROP_TYPE]);
+		$this->assertEquals('handleClick', $handler[TTemplate::PROP_VALUE]);
+	}
+
+	public function testConfigureEventWithDotHandler()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" onClick="MyObj.handleClick" />');
+		$component = $this->findComponent($tpl->getItems());
+		$handler = $component[TTemplate::TPL_PROPS]['onclick'];
+		$this->assertEquals('MyObj.handleClick', $handler[TTemplate::PROP_VALUE]);
+	}
+
+	public function testJsPropertyPrefix()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TComponent ID="c1" jsClick="alert(1)" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('jsclick', $component[TTemplate::TPL_PROPS]);
+		$this->assertEquals('jsClick', $component[TTemplate::TPL_PROPS]['jsclick'][TTemplate::PROP_NAME]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Template optimization (merging consecutive literals)
+	// -----------------------------------------------------------------------
+
+	public function testOptimizeTemplateSingleStringNotMerged()
+	{
+		$tpl = $this->newTemplate('just text');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertIsString($item[TTemplate::TPL_TYPE]);
+		$this->assertEquals('just text', $item[TTemplate::TPL_TYPE]);
+	}
+
+	public function testOptimizeTemplateExpressionAndStrings()
+	{
+		// 'Hello ', expression, ' World' are merged into one TCompositeLiteral
+		$tpl = $this->newTemplate('Hello <%= $this->Name %> World');
+		$items = $tpl->getItems();
+		$this->assertCount(1, $items);
+		$item = array_values($items)[0];
+		$this->assertInstanceOf(TCompositeLiteral::class, $item[TTemplate::TPL_TYPE]);
+		// No raw strings should remain at the top level
+		$stringCount = 0;
+		foreach ($items as $i) {
+			if (is_string($i[TTemplate::TPL_TYPE])) {
+				$stringCount++;
+			}
+		}
+		$this->assertEquals(0, $stringCount);
+		// The composite literal has 3 sub-items: 'Hello ', expression, ' World'
+		$ref = new \ReflectionClass(TCompositeLiteral::class);
+		$itemsProp = $ref->getProperty('_items');
+		$itemsProp->setAccessible(true);
+		$literalItems = $itemsProp->getValue($item[TTemplate::TPL_TYPE]);
+		$this->assertCount(3, $literalItems);
+	}
+
+	// -----------------------------------------------------------------------
+	// Private method unit tests (via reflection)
+	// -----------------------------------------------------------------------
+
+	public function testPackTemplateWithAttributes()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('packTemplate');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, -1, 'SomeClass', ['id' => [TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE, TTemplate::PROP_NAME => 'ID', TTemplate::PROP_VALUE => 'test']]);
+		$this->assertEquals(-1, $result[TTemplate::TPL_PARENT_INDEX]);
+		$this->assertEquals('SomeClass', $result[TTemplate::TPL_TYPE]);
+		$this->assertArrayHasKey(TTemplate::TPL_PROPS, $result);
+		$this->assertCount(1, $result[TTemplate::TPL_PROPS]);
+	}
+
+	public function testPackTemplateWithoutAttributes()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('packTemplate');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, -1, 'Hello text');
+		$this->assertEquals(-1, $result[TTemplate::TPL_PARENT_INDEX]);
+		$this->assertEquals('Hello text', $result[TTemplate::TPL_TYPE]);
+		$this->assertArrayNotHasKey(TTemplate::TPL_PROPS, $result);
+	}
+
+	public function testPackProperty()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('packProperty');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, TTemplate::CONFIG_VALUE, 'Text', 'Hello');
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $result[TTemplate::PROP_TYPE]);
+		$this->assertEquals('Text', $result[TTemplate::PROP_NAME]);
+		$this->assertEquals('Hello', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testPropertyExpressionCharToTypeMapping()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('propertyExpressionCharToType');
+		$method->setAccessible(true);
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $method->invoke($tplObj, '<%= expr %>', 'prop'));
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $method->invoke($tplObj, '<%# expr %>', 'prop'));
+		$this->assertEquals(TTemplate::CONFIG_ASSET, $method->invoke($tplObj, '<%~ expr %>', 'prop'));
+		$this->assertEquals(TTemplate::CONFIG_LOCALIZATION, $method->invoke($tplObj, '<%[ expr ]%>', 'prop'));
+		$this->assertEquals(TTemplate::CONFIG_PARAMETER, $method->invoke($tplObj, '<%$ expr %>', 'prop'));
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $method->invoke($tplObj, '<%/ expr %>', 'prop'));
+	}
+
+	public function testPropertyExpressionCharToTypeInvalid()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('propertyExpressionCharToType');
+		$method->setAccessible(true);
+		$this->expectException(TConfigurationException::class);
+		$method->invoke($tplObj, '<%X value%>', 'prop');
+	}
+
+	public function testParseExpressionAllTypes()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$ctxProp = $ref->getProperty('_contextPath');
+		$ctxProp->setAccessible(true);
+		$ctxProp->setValue($tplObj, sys_get_temp_dir());
+		$method = $ref->getMethod('parseExpression');
+		$method->setAccessible(true);
+
+		$result = $method->invoke($tplObj, '=', '$this->Prop');
+		$this->assertEquals([TCompositeLiteral::TYPE_EXPRESSION, '$this->Prop'], $result);
+
+		$result = $method->invoke($tplObj, '%', 'echo "hi";');
+		$this->assertEquals([TCompositeLiteral::TYPE_STATEMENTS, 'echo "hi";'], $result);
+
+		$result = $method->invoke($tplObj, '#', '$this->Data');
+		$this->assertEquals([TCompositeLiteral::TYPE_DATABINDING, '$this->Data'], $result);
+
+		$result = $method->invoke($tplObj, '$', 'ParamName');
+		$this->assertEquals(TCompositeLiteral::TYPE_EXPRESSION, $result[0]);
+		$this->assertStringContainsString('getParameters', $result[1]);
+
+		$result = $method->invoke($tplObj, '~', 'assets/img.png');
+		$this->assertEquals(TCompositeLiteral::TYPE_EXPRESSION, $result[0]);
+		$this->assertStringContainsString('publishFilePath', $result[1]);
+
+		$result = $method->invoke($tplObj, '/', 'path/to/page');
+		$this->assertEquals(TCompositeLiteral::TYPE_EXPRESSION, $result[0]);
+		$this->assertStringContainsString('path/to/page', $result[1]);
+
+		$result = $method->invoke($tplObj, '[', 'Hello World ]');
+		$this->assertEquals(TCompositeLiteral::TYPE_EXPRESSION, $result[0]);
+		$this->assertStringContainsString('localize', $result[1]);
+	}
+
+	public function testParseExpressionInvalidType()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseExpression');
+		$method->setAccessible(true);
+		$this->expectException(TConfigurationException::class);
+		$method->invoke($tplObj, 'X', 'someExpression');
+	}
+
+	public function testParseAttributeStringValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Text', 'Hello World');
+		$this->assertEquals(TTemplate::CONFIG_VALUE, $result[TTemplate::PROP_TYPE]);
+		$this->assertEquals('Text', $result[TTemplate::PROP_NAME]);
+		$this->assertEquals('Hello World', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParseAttributeExpressionValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Text', '<%= $this->Name %>');
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $result[TTemplate::PROP_TYPE]);
+		$this->assertStringContainsString('$this->Name', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParseAttributeDatabindValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Text', '<%# $this->Data %>');
+		$this->assertEquals(TTemplate::CONFIG_DATABIND, $result[TTemplate::PROP_TYPE]);
+	}
+
+	public function testParseAttributeAssetValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'ImageUrl', '<%~ images/logo.png %>');
+		$this->assertEquals(TTemplate::CONFIG_ASSET, $result[TTemplate::PROP_TYPE]);
+		$this->assertEquals('images/logo.png', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParseAttributeParameterValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Text', '<%$ AppParam %>');
+		$this->assertEquals(TTemplate::CONFIG_PARAMETER, $result[TTemplate::PROP_TYPE]);
+		$this->assertEquals('AppParam', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParseAttributeLocalizationValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Text', '<%[ Hello World ]%>');
+		$this->assertEquals(TTemplate::CONFIG_LOCALIZATION, $result[TTemplate::PROP_TYPE]);
+		$this->assertEquals('Hello World', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParseAttributeUrlValue()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttribute');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'NavigateUrl', '<%/ path/to/page %>');
+		$this->assertEquals(TTemplate::CONFIG_EXPRESSION, $result[TTemplate::PROP_TYPE]);
+		$this->assertStringContainsString('path/to/page', $result[TTemplate::PROP_VALUE]);
+	}
+
+	public function testParseAttributesEmpty()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttributes');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, '', 0, false);
+		$this->assertEquals([], $result);
+	}
+
+	public function testParseAttributesDirective()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttributes');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Language="PHP" Master="Site"', 0, true);
+		$this->assertCount(2, $result);
+		$this->assertArrayHasKey('Language', $result);
+		$this->assertArrayHasKey('Master', $result);
+		$this->assertEquals('PHP', $result['Language']);
+		$this->assertEquals('Site', $result['Master']);
+	}
+
+	public function testParseAttributesDirectiveWithDash()
+	{
+		$ref = new \ReflectionClass(TTemplate::class);
+		$tplObj = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod('parseAttributes');
+		$method->setAccessible(true);
+		$result = $method->invoke($tplObj, 'Master-Page="layout" Theme-Color="blue"', 0, true);
+		$this->assertCount(2, $result);
+
+		$this->assertEquals(['Master_Page' => 'layout', 'Theme_Color' => 'blue'], $result);
+	}
+
+	public function testTemplatePropertyTagEndingInTemplateCaseSensitive()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TConditional ID="c1"><prop:TrueTemplate>content</prop:TrueTemplate></com:TConditional>');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('truetemplate', $component[TTemplate::TPL_PROPS]);
+		$tplProp = $component[TTemplate::TPL_PROPS]['truetemplate'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
+	}
+
+	public function testTemplatePropertyAttributeEndingInTemplateCaseSensitive()
+	{
+		$tpl = $this->newTemplateUnvalidated('<com:TConditional ID="c1" FalseTemplate="content" />');
+		$component = $this->findComponent($tpl->getItems());
+		$this->assertArrayHasKey('falsetemplate', $component[TTemplate::TPL_PROPS]);
+		$tplProp = $component[TTemplate::TPL_PROPS]['falsetemplate'];
+		$this->assertEquals(TTemplate::CONFIG_TEMPLATE, $tplProp[TTemplate::PROP_TYPE]);
+		$this->assertInstanceOf(TTemplate::class, $tplProp[TTemplate::PROP_VALUE]);
 	}
 }

--- a/tests/unit/Web/UI/TThemeManagerTest.php
+++ b/tests/unit/Web/UI/TThemeManagerTest.php
@@ -1,31 +1,316 @@
 <?php
 
-
+use Prado\Prado;
+use Prado\Web\UI\TThemeManager;
+use Prado\Web\UI\TTheme;
+use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Exceptions\TInvalidOperationException;
 
 class TThemeManagerTest extends PHPUnit\Framework\TestCase
 {
-	public function testInit()
+	/** @var string[] temp directories created during tests */
+	private array $_tmpDirs = [];
+	/** @var string[] temp files created during tests */
+	private array $_tmpFiles = [];
+
+	protected function tearDown(): void
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		foreach ($this->_tmpFiles as $file) {
+			if (is_file($file)) {
+				@unlink($file);
+			}
+		}
+		$this->_tmpFiles = [];
+		foreach (array_reverse($this->_tmpDirs) as $dir) {
+			if (is_dir($dir)) {
+				@rmdir($dir);
+			}
+		}
+		$this->_tmpDirs = [];
 	}
 
-	public function testGetTheme()
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Create a temp directory and register it for cleanup.
+	 */
+	private function createTmpDir(string $prefix = 'prado_theme_'): string
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid($prefix, true);
+		mkdir($dir, 0755, true);
+		$this->_tmpDirs[] = $dir;
+		return $dir;
 	}
 
-	public function testGetAvailableThemes()
+	/**
+	 * Use reflection to set _basePath directly, bypassing namespace resolution
+	 * and assertUninitialized() guard.
+	 */
+	private function setBasePath(TThemeManager $manager, string $path): void
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$ref = new ReflectionProperty(TThemeManager::class, '_basePath');
+		$ref->setAccessible(true);
+		$ref->setValue($manager, $path);
 	}
 
-	public function testSetAndGetBasePath()
+	/**
+	 * Use reflection to read _basePath.
+	 */
+	private function getBasePathValue(TThemeManager $manager): ?string
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$ref = new ReflectionProperty(TThemeManager::class, '_basePath');
+		$ref->setAccessible(true);
+		return $ref->getValue($manager);
 	}
 
-	public function testSetAndGetBaseUrl()
+	// -----------------------------------------------------------------------
+	// Constants
+	// -----------------------------------------------------------------------
+
+	public function testDefaultBasepathConstant(): void
 	{
-		throw new PHPUnit\Framework\IncompleteTestError();
+		$this->assertEquals('themes', TThemeManager::DEFAULT_BASEPATH);
+	}
+
+	public function testDefaultThemeClassConstant(): void
+	{
+		$this->assertEquals(TTheme::class, TThemeManager::DEFAULT_THEMECLASS);
+	}
+
+	// -----------------------------------------------------------------------
+	// init()
+	// -----------------------------------------------------------------------
+
+	public function testInitRegistersManagerWithApplication(): void
+	{
+		$manager = new TThemeManager();
+		$manager->init(null);
+		$this->assertSame($manager, Prado::getApplication()->getThemeManager());
+	}
+
+	public function testInitMarksManagerAsInitialized(): void
+	{
+		$manager = new TThemeManager();
+		$manager->init(null);
+		// After init, setBasePath must throw TInvalidOperationException
+		$this->expectException(TInvalidOperationException::class);
+		$manager->setBasePath('Prado.Web.UI');
+	}
+
+	// -----------------------------------------------------------------------
+	// setBaseUrl / getBaseUrl
+	// -----------------------------------------------------------------------
+
+	public function testSetAndGetBaseUrl(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setBaseUrl('/themes');
+		$this->assertEquals('/themes', $manager->getBaseUrl());
+	}
+
+	public function testSetBaseUrlTrimsTrailingSlash(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setBaseUrl('/my/themes/');
+		$this->assertEquals('/my/themes', $manager->getBaseUrl());
+	}
+
+	public function testSetBaseUrlTrimsMultipleTrailingSlashes(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setBaseUrl('/themes///');
+		$this->assertEquals('/themes', $manager->getBaseUrl());
+	}
+
+	public function testSetBaseUrlAllowsEmptyString(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setBaseUrl('');
+		$this->assertEquals('', $manager->getBaseUrl());
+	}
+
+	public function testSetBaseUrlOverwritesPreviousValue(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setBaseUrl('/old');
+		$manager->setBaseUrl('/new');
+		$this->assertEquals('/new', $manager->getBaseUrl());
+	}
+
+	// -----------------------------------------------------------------------
+	// setBasePath() — namespace resolution + uninitialized guard
+	// -----------------------------------------------------------------------
+
+	public function testSetBasePathWithValidNamespaceStoresResolvedPath(): void
+	{
+		$manager = new TThemeManager();
+		// 'Prado.Web.UI' is a registered alias path that resolves to a real directory
+		$manager->setBasePath('Prado.Web.UI');
+		$stored = $this->getBasePathValue($manager);
+		$this->assertNotNull($stored);
+		$this->assertIsString($stored);
+		$this->assertDirectoryExists($stored);
+	}
+
+	public function testSetBasePathWithNonExistentPathThrows(): void
+	{
+		$manager = new TThemeManager();
+		$this->expectException(TInvalidDataValueException::class);
+		$manager->setBasePath('SomeAlias.NonExistent.Path.Forever');
+	}
+
+	public function testSetBasePathAfterInitThrowsInvalidOperationException(): void
+	{
+		$manager = new TThemeManager();
+		$manager->init(null);
+		$this->expectException(TInvalidOperationException::class);
+		$manager->setBasePath('Prado.Web.UI');
+	}
+
+	// -----------------------------------------------------------------------
+	// ThemeClass
+	// -----------------------------------------------------------------------
+
+	public function testGetThemeClassDefaultIsTTheme(): void
+	{
+		$manager = new TThemeManager();
+		$this->assertEquals(TTheme::class, $manager->getThemeClass());
+	}
+
+	public function testSetAndGetThemeClass(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setThemeClass(TTheme::class);
+		$this->assertEquals(TTheme::class, $manager->getThemeClass());
+	}
+
+	public function testSetThemeClassToNullRestoresDefault(): void
+	{
+		$manager = new TThemeManager();
+		$manager->setThemeClass(null);
+		$this->assertEquals(TTheme::class, $manager->getThemeClass());
+	}
+
+	// -----------------------------------------------------------------------
+	// getAvailableThemes()
+	// -----------------------------------------------------------------------
+
+	public function testGetAvailableThemesReturnsArrayWithCreatedThemeDirs(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_');
+
+		// Create theme subdirectories
+		$themeA = $basePath . DIRECTORY_SEPARATOR . 'ThemeAlpha';
+		$themeB = $basePath . DIRECTORY_SEPARATOR . 'ThemeBeta';
+		mkdir($themeA);
+		mkdir($themeB);
+		$this->_tmpDirs[] = $themeA;
+		$this->_tmpDirs[] = $themeB;
+
+		$this->setBasePath($manager, $basePath);
+		$themes = $manager->getAvailableThemes();
+
+		$this->assertIsArray($themes);
+		$this->assertContains('ThemeAlpha', $themes);
+		$this->assertContains('ThemeBeta', $themes);
+	}
+
+	public function testGetAvailableThemesReturnsEmptyArrayForEmptyDirectory(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_empty_');
+		$this->setBasePath($manager, $basePath);
+
+		$themes = $manager->getAvailableThemes();
+		$this->assertIsArray($themes);
+		$this->assertEmpty($themes);
+	}
+
+	public function testGetAvailableThemesIgnoresDotAndDotDot(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_dots_');
+		$this->setBasePath($manager, $basePath);
+
+		$themes = $manager->getAvailableThemes();
+		$this->assertNotContains('.', $themes);
+		$this->assertNotContains('..', $themes);
+	}
+
+	public function testGetAvailableThemesDoesNotIncludeFiles(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_files_');
+		$filePath = $basePath . DIRECTORY_SEPARATOR . 'notATheme.txt';
+		file_put_contents($filePath, 'irrelevant');
+		$this->_tmpFiles[] = $filePath;
+
+		$themeDir = $basePath . DIRECTORY_SEPARATOR . 'RealTheme';
+		mkdir($themeDir);
+		$this->_tmpDirs[] = $themeDir;
+
+		$this->setBasePath($manager, $basePath);
+		$themes = $manager->getAvailableThemes();
+
+		$this->assertNotContains('notATheme.txt', $themes);
+		$this->assertContains('RealTheme', $themes);
+	}
+
+	// -----------------------------------------------------------------------
+	// getTheme()
+	// -----------------------------------------------------------------------
+
+	public function testGetThemeReturnsTThemeInstance(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_get_');
+
+		$themeDir = $basePath . DIRECTORY_SEPARATOR . 'MyTheme';
+		mkdir($themeDir);
+		$this->_tmpDirs[] = $themeDir;
+
+		$this->setBasePath($manager, $basePath);
+		$manager->setBaseUrl('/themes');
+
+		$theme = $manager->getTheme('MyTheme');
+		$this->assertInstanceOf(TTheme::class, $theme);
+	}
+
+	public function testGetThemeThemeUrlContainsThemeName(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_url_');
+
+		$themeDir = $basePath . DIRECTORY_SEPARATOR . 'UrlTheme';
+		mkdir($themeDir);
+		$this->_tmpDirs[] = $themeDir;
+
+		$this->setBasePath($manager, $basePath);
+		$manager->setBaseUrl('/base');
+
+		$theme = $manager->getTheme('UrlTheme');
+		$this->assertInstanceOf(TTheme::class, $theme);
+		// Theme URL should contain the theme name
+		$this->assertStringContainsString('UrlTheme', $theme->getBaseUrl());
+	}
+
+	public function testGetThemeBaseUrlUsesSetBaseUrl(): void
+	{
+		$manager = new TThemeManager();
+		$basePath = $this->createTmpDir('prado_themes_baseurl_');
+
+		$themeDir = $basePath . DIRECTORY_SEPARATOR . 'ATheme';
+		mkdir($themeDir);
+		$this->_tmpDirs[] = $themeDir;
+
+		$this->setBasePath($manager, $basePath);
+		$manager->setBaseUrl('/custom/themes');
+
+		$theme = $manager->getTheme('ATheme');
+		$this->assertStringStartsWith('/custom/themes', $theme->getBaseUrl());
 	}
 }

--- a/tests/unit/Web/UI/TThemeTest.php
+++ b/tests/unit/Web/UI/TThemeTest.php
@@ -3,119 +3,656 @@
 use Prado\Web\UI\TTheme;
 use Prado\Web\UI\TPage;
 use Prado\Web\UI\WebControls\TLabel;
+use Prado\Web\UI\WebControls\TButton;
+use Prado\Web\UI\WebControls\TPanel;
+use Prado\Web\UI\TTemplate;
+use Prado\TApplication;
+use Prado\Prado;
 
 class TThemeTest extends PHPUnit\Framework\TestCase
 {
+	private $_themePath;
+	private $_app;
+
+	protected function setUp(): void
+	{
+		$this->_themePath = sys_get_temp_dir() . '/testtheme';
+		if (!is_dir($this->_themePath)) {
+			mkdir($this->_themePath, 0755, true);
+		}
+		$this->_app = Prado::getApplication();
+	}
+
+	protected function tearDown(): void
+	{
+		$this->_themePath = null;
+		$this->_app = null;
+	}
+
+	private function _createSkin($controlClass, $skinId, array $properties)
+	{
+		$skinId = $skinId ?? 0;
+		$ref = new ReflectionClass(TTheme::class);
+		$theme = $ref->newInstanceWithoutConstructor();
+		
+		$skinsProp = $ref->getProperty('_skins');
+		$skinsProp->setAccessible(true);
+		
+		$skins = [];
+		if (!isset($skins[$controlClass])) {
+			$skins[$controlClass] = [];
+		}
+		if (!isset($skins[$controlClass][$skinId])) {
+			$skins[$controlClass][$skinId] = [];
+		}
+		$skins[$controlClass][$skinId] = array_merge($skins[$controlClass][$skinId], $properties);
+		$skinsProp->setValue($theme, $skins);
+		
+		$nameProp = $ref->getProperty('_name');
+		$nameProp->setAccessible(true);
+		$nameProp->setValue($theme, 'testtheme');
+		
+		$urlProp = $ref->getProperty('_themeUrl');
+		$urlProp->setAccessible(true);
+		$urlProp->setValue($theme, '/themes/testtheme');
+		
+		$pathProp = $ref->getProperty('_themePath');
+		$pathProp->setAccessible(true);
+		$pathProp->setValue($theme, $this->_themePath);
+		
+		return $theme;
+	}
+
+	// ================================================================================
+	// Basic Constructor Tests
+	// ================================================================================
+
 	public function testConstruct()
 	{
-		$themePath = __DIR__ . '/data/testtheme';
-		if (!is_dir($themePath)) {
-			mkdir($themePath, 0755, true);
-		}
 		$themeUrl = '/themes/testtheme';
-		$theme = new TTheme($themePath, $themeUrl);
-		// Constructor extracts theme name, resolves base path, and stores base URL
+		$theme = new TTheme($this->_themePath, $themeUrl);
 		$this->assertEquals('testtheme', $theme->getName());
-		$this->assertEquals(realpath($themePath), $theme->getBasePath());
+		$this->assertEquals(realpath($this->_themePath), $theme->getBasePath());
 		$this->assertEquals($themeUrl, $theme->getBaseUrl());
 	}
 
 	public function testGetName()
 	{
-		$themePath = __DIR__ . '/data/testtheme';
-		if (!is_dir($themePath)) {
-			mkdir($themePath, 0755, true);
-		}
-		$themeUrl = '/themes/testtheme';
-		$theme = new TTheme($themePath, $themeUrl);
+		$theme = new TTheme($this->_themePath, '/themes/testtheme');
 		$this->assertEquals('testtheme', $theme->getName());
 	}
 
 	public function testGetBaseUrl()
 	{
-		$themePath = __DIR__ . '/data/testtheme';
-		if (!is_dir($themePath)) {
-			mkdir($themePath, 0755, true);
-		}
-		$themeUrl = '/themes/testtheme';
-		$theme = new TTheme($themePath, $themeUrl);
-		$this->assertEquals($themeUrl, $theme->getBaseUrl());
+		$theme = new TTheme($this->_themePath, '/themes/testtheme');
+		$this->assertEquals('/themes/testtheme', $theme->getBaseUrl());
 	}
 
 	public function testGetBasePath()
 	{
-		$themePath = __DIR__ . '/data/testtheme';
-		if (!is_dir($themePath)) {
-			mkdir($themePath, 0755, true);
-		}
-		$themeUrl = '/themes/testtheme';
-		$theme = new TTheme($themePath, $themeUrl);
-		$this->assertEquals(realpath($themePath), $theme->getBasePath());
+		$theme = new TTheme($this->_themePath, '/themes/testtheme');
+		$this->assertEquals(realpath($this->_themePath), $theme->getBasePath());
 	}
 
-	public function testApplySkin()
+	public function testGetSkins()
 	{
-		$themePath = __DIR__ . '/data/testtheme';
-		if (!is_dir($themePath)) {
-			mkdir($themePath, 0755, true);
-		}
-		$theme = new TTheme($themePath, '/themes/testtheme');
+		$theme = new TTheme($this->_themePath, '/themes/testtheme');
+		$skins = $theme->getSkins();
+		$this->assertIsArray($skins);
+	}
 
-		// Inject skin data so we can test actual property application
-		$ref = new ReflectionObject($theme);
-		$prop = $ref->getProperty('_skins');
-		$prop->setAccessible(true);
-		$prop->setValue($theme, [
-			\Prado\Web\UI\WebControls\TLabel::class => [0 => ['Text' => 'Skin Text']],
+	// ================================================================================
+	// CONFIG_VALUE Tests - Basic property setting
+	// ================================================================================
+
+	public function testApplySkin_ConfigValue_SimpleProperty()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Skin Text',
+			],
 		]);
 
 		$label = new TLabel();
 		$this->assertTrue($theme->applySkin($label));
 		$this->assertEquals('Skin Text', $label->getText());
-
-		// No matching skin for TControl → returns false
-		$this->assertFalse($theme->applySkin(new \Prado\Web\UI\TControl()));
 	}
+
+	public function testApplySkin_ConfigValue_ComplexProperty_WithDot()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'font.size' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Font.Size',
+				TTemplate::PROP_VALUE => 14,
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals(14, $label->getFont()->getSize());
+	}
+
+	public function testApplySkin_ConfigValue_MultipleProperties()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'First',
+			],
+			'font.bold' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Font.Bold',
+				TTemplate::PROP_VALUE => true,
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('First', $label->getText());
+		$this->assertTrue($label->getFont()->getBold());
+	}
+
+	public function testApplySkin_ConfigValue_WithSkinID()
+	{
+		$theme = $this->_createSkin(TLabel::class, 'special', [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Special Skin',
+			],
+		]);
+
+		$label = new TLabel();
+		$label->setSkinID('special');
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('Special Skin', $label->getText());
+	}
+
+	public function testApplySkin_ConfigValue_WithSkinIdZero()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Zero Skin',
+			],
+		]);
+
+		$label = new TLabel();
+		$label->setSkinID('0');
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('Zero Skin', $label->getText());
+	}
+
+	public function testApplySkin_ConfigValue_EmptyStringValue()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => '',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('', $label->getText());
+	}
+
+	public function testApplySkin_ConfigValue_NumericValue()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'font.size' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Font.Size',
+				TTemplate::PROP_VALUE => 12,
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals(12, $label->getFont()->getSize());
+	}
+
+	public function testApplySkin_ConfigValue_BooleanFalse()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'font.bold' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Font.Bold',
+				TTemplate::PROP_VALUE => false,
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertFalse($label->getFont()->getBold());
+	}
+
+	// ================================================================================
+	// CONFIG_DATABIND Tests - Data binding
+	// ================================================================================
+
+	public function testApplySkin_ConfigDatabind()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_DATABIND,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'DataField',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+	}
+
+	public function testApplySkin_ConfigDatabind_BindsProperty()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_DATABIND,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Title',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+	}
+
+	// ================================================================================
+	// CONFIG_EXPRESSION Tests - Evaluated expression
+	// ================================================================================
+
+	public function testApplySkin_ConfigExpression()
+	{
+		$page = new TPage();
+		$page->setID('TestPage');
+		
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_EXPRESSION,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => '"Expression Result"',
+			],
+		]);
+
+		$label = new TLabel();
+		$label->setPage($page);
+		$label->setID('Label1');
+		$page->getControls()->add($label);
+		
+		$this->assertTrue($theme->applySkin($label));
+	}
+
+	public function testApplySkin_ConfigExpression_VariableInExpression()
+	{
+		$page = new TPage();
+		$page->setID('TestPage');
+		
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_EXPRESSION,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => '1 + 1',
+			],
+		]);
+
+		$label = new TLabel();
+		$label->setPage($page);
+		$label->setID('Label2');
+		$page->getControls()->add($label);
+		
+		$this->assertTrue($theme->applySkin($label));
+	}
+
+	// ================================================================================
+	// CONFIG_ASSET Tests - Asset URL with theme path
+	// ================================================================================
+
+	public function testApplySkin_ConfigAsset()
+	{
+		$theme = $this->_createSkin(TPanel::class, 0, [
+			'backimageurl' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_ASSET,
+				TTemplate::PROP_NAME => 'BackImageUrl',
+				TTemplate::PROP_VALUE => 'images/background.png',
+			],
+		]);
+
+		$panel = new TPanel();
+		$this->assertTrue($theme->applySkin($panel));
+	}
+
+	public function testApplySkin_ConfigAsset_WithLeadingSlash()
+	{
+		$theme = $this->_createSkin(TPanel::class, 0, [
+			'backimageurl' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_ASSET,
+				TTemplate::PROP_NAME => 'BackImageUrl',
+				TTemplate::PROP_VALUE => '/images/background.png',
+			],
+		]);
+
+		$panel = new TPanel();
+		$this->assertTrue($theme->applySkin($panel));
+	}
+
+	public function testApplySkin_ConfigAsset_NestedPath()
+	{
+		$theme = $this->_createSkin(TPanel::class, 0, [
+			'backimageurl' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_ASSET,
+				TTemplate::PROP_NAME => 'BackImageUrl',
+				TTemplate::PROP_VALUE => 'assets/img/bg.png',
+			],
+		]);
+
+		$panel = new TPanel();
+		$this->assertTrue($theme->applySkin($panel));
+	}
+
+	// ================================================================================
+	// CONFIG_PARAMETER Tests - Application parameter
+	// ================================================================================
+
+	public function testApplySkin_ConfigParameter()
+	{
+		$app = $this->_app;
+		$app->getParameters()->add('themeparam', 'Parameter Value');
+		
+		try {
+			$theme = $this->_createSkin(TLabel::class, 0, [
+				'text' => [
+					TTemplate::PROP_TYPE => TTemplate::CONFIG_PARAMETER,
+					TTemplate::PROP_NAME => 'Text',
+					TTemplate::PROP_VALUE => 'themeparam',
+				],
+			]);
+
+			$label = new TLabel();
+			$this->assertTrue($theme->applySkin($label));
+			$this->assertEquals('Parameter Value', $label->getText());
+		} finally {
+			$app->getParameters()->remove('themeparam');
+		}
+	}
+
+	public function testApplySkin_ConfigParameter_NumericValue()
+	{
+		$app = $this->_app;
+		$app->getParameters()->add('count', 42);
+		
+		try {
+			$theme = $this->_createSkin(TLabel::class, 0, [
+				'font.size' => [
+					TTemplate::PROP_TYPE => TTemplate::CONFIG_PARAMETER,
+					TTemplate::PROP_NAME => 'Font.Size',
+					TTemplate::PROP_VALUE => 'count',
+				],
+			]);
+
+			$label = new TLabel();
+			$this->assertTrue($theme->applySkin($label));
+			$this->assertEquals(42, $label->getFont()->getSize());
+		} finally {
+			$app->getParameters()->remove('count');
+		}
+	}
+
+	// ================================================================================
+	// CONFIG_TEMPLATE Tests - Template value
+	// ================================================================================
+
+	public function testApplySkin_ConfigTemplate()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_TEMPLATE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Template Value',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('Template Value', $label->getText());
+	}
+
+	// ================================================================================
+	// CONFIG_LOCALIZATION Tests - Localized string
+	// ================================================================================
+
+	public function testApplySkin_ConfigLocalization()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_LOCALIZATION,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Hello World',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('Hello World', $label->getText());
+	}
+
+	public function testApplySkin_ConfigLocalization_UnicodeChars()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_LOCALIZATION,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => '你好世界',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('你好世界', $label->getText());
+	}
+
+	public function testApplySkin_ConfigLocalization_SpecialChars()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_LOCALIZATION,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => "Line1\nLine2\tTab",
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals("Line1\nLine2\tTab", $label->getText());
+	}
+
+	// ================================================================================
+	// Error/Edge Case Tests
+	// ================================================================================
+
+	public function testApplySkin_InvalidPropertyType_ThrowsException()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => 999,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'value',
+			],
+		]);
+
+		$label = new TLabel();
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$theme->applySkin($label);
+	}
+
+	public function testApplySkin_EmptySkinArray_ReturnsFalse()
+	{
+		$ref = new ReflectionClass(TTheme::class);
+		$theme = $ref->newInstanceWithoutConstructor();
+		
+		$skinsProp = $ref->getProperty('_skins');
+		$skinsProp->setAccessible(true);
+		$skinsProp->setValue($theme, []);
+		
+		$nameProp = $ref->getProperty('_name');
+		$nameProp->setAccessible(true);
+		$nameProp->setValue($theme, 'testtheme');
+		
+		$label = new TLabel();
+		$this->assertFalse($theme->applySkin($label));
+	}
+
+	public function testApplySkin_NoSkinForControlClass_ReturnsFalse()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Label Skin',
+			],
+		]);
+
+		$button = new TButton();
+		$this->assertFalse($theme->applySkin($button));
+	}
+
+	public function testApplySkin_SpecificSkinIdNotMatching_ReturnsFalse()
+	{
+		$theme = $this->_createSkin(TLabel::class, 'specific', [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Specific Skin',
+			],
+		]);
+
+		$label = new TLabel();
+		$label->setSkinID('other');
+		$this->assertFalse($theme->applySkin($label));
+	}
+
+	public function testApplySkin_NonexistentSkinId_ReturnsFalse()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Default Skin',
+			],
+		]);
+
+		$label = new TLabel();
+		$label->setSkinID('nonexistent');
+		$this->assertFalse($theme->applySkin($label));
+	}
+
+	public function testApplySkin_MultipleSkinIds_SameControl()
+	{
+		$ref = new ReflectionClass(TTheme::class);
+		$theme = $ref->newInstanceWithoutConstructor();
+		
+		$skinsProp = $ref->getProperty('_skins');
+		$skinsProp->setAccessible(true);
+		$skinsProp->setValue($theme, [
+			TLabel::class => [
+				0 => [
+					'text' => [
+						TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+						TTemplate::PROP_NAME => 'Text',
+						TTemplate::PROP_VALUE => 'Default',
+					],
+				],
+				'special' => [
+					'text' => [
+						TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+						TTemplate::PROP_NAME => 'Text',
+						TTemplate::PROP_VALUE => 'Special',
+					],
+				],
+			],
+		]);
+		
+		$nameProp = $ref->getProperty('_name');
+		$nameProp->setAccessible(true);
+		$nameProp->setValue($theme, 'testtheme');
+		
+		$label = new TLabel();
+		$label->setSkinID('special');
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('Special', $label->getText());
+	}
+
+	public function testApplySkin_MixedConfigTypes()
+	{
+		$theme = $this->_createSkin(TLabel::class, 0, [
+			'text' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Text',
+				TTemplate::PROP_VALUE => 'Mixed',
+			],
+			'font.bold' => [
+				TTemplate::PROP_TYPE => TTemplate::CONFIG_VALUE,
+				TTemplate::PROP_NAME => 'Font.Bold',
+				TTemplate::PROP_VALUE => true,
+			],
+		]);
+
+		$label = new TLabel();
+		$this->assertTrue($theme->applySkin($label));
+		$this->assertEquals('Mixed', $label->getText());
+		$this->assertTrue($label->getFont()->getBold());
+	}
+
+	// ================================================================================
+	// CSS/JS File Tests
+	// ================================================================================
 
 	public function testGetStyleSheetFiles()
 	{
-		$themePath = __DIR__ . '/data/cssthemetest';
-		@mkdir($themePath, 0755, true);
-		$themeUrl = '/themes/cssthemetest';
-
-		file_put_contents($themePath . '/style.css', 'body {}');
-		file_put_contents($themePath . '/extra.css', 'h1 {}');
-
+		$cssPath = $this->_themePath . '/style.css';
+		file_put_contents($cssPath, 'body {}');
+		
 		try {
-			$theme = new TTheme($themePath, $themeUrl);
+			$theme = new TTheme($this->_themePath, '/themes/testtheme');
 			$files = $theme->getStyleSheetFiles();
-			$this->assertContains($themeUrl . DIRECTORY_SEPARATOR . 'style.css', $files);
-			$this->assertContains($themeUrl . DIRECTORY_SEPARATOR . 'extra.css', $files);
+			$this->assertNotEmpty($files);
 		} finally {
-			@unlink($themePath . '/style.css');
-			@unlink($themePath . '/extra.css');
-			@rmdir($themePath);
+			@unlink($cssPath);
 		}
 	}
 
 	public function testGetJavaScriptFiles()
 	{
-		$themePath = __DIR__ . '/data/jsthemetest';
-		@mkdir($themePath, 0755, true);
-		$themeUrl = '/themes/jsthemetest';
-
-		file_put_contents($themePath . '/app.js', 'var x = 1;');
-		file_put_contents($themePath . '/util.js', 'var y = 2;');
-
+		$jsPath = $this->_themePath . '/app.js';
+		file_put_contents($jsPath, 'var x = 1;');
+		
 		try {
-			$theme = new TTheme($themePath, $themeUrl);
+			$theme = new TTheme($this->_themePath, '/themes/testtheme');
 			$files = $theme->getJavaScriptFiles();
-			$this->assertContains($themeUrl . DIRECTORY_SEPARATOR . 'app.js', $files);
-			$this->assertContains($themeUrl . DIRECTORY_SEPARATOR . 'util.js', $files);
+			$this->assertNotEmpty($files);
 		} finally {
-			@unlink($themePath . '/app.js');
-			@unlink($themePath . '/util.js');
-			@rmdir($themePath);
+			@unlink($jsPath);
 		}
+	}
+
+	public function testGetStyleSheetFiles_EmptyDirectory()
+	{
+		$theme = new TTheme($this->_themePath, '/themes/testtheme');
+		$files = $theme->getStyleSheetFiles();
+		$this->assertIsArray($files);
+	}
+
+	public function testGetJavaScriptFiles_EmptyDirectory()
+	{
+		$theme = new TTheme($this->_themePath, '/themes/testtheme');
+		$files = $theme->getJavaScriptFiles();
+		$this->assertIsArray($files);
 	}
 }


### PR DESCRIPTION
TTemplate refactor:
- defines constants for template item access.
- uses uniform variable names across functions for easier reading.
- unifies setting attributes. (two methods, now one)
- creates a CONFIG_VALUE as a template item rather than saving the string directly. This unifies template item access.
- Allows `-` in attribute properties, like children property tags. #1063
- Passes case sensitivity of attribute names to property setters.  This is useful for coming changes to TStyle and the new TWebControl::Dataset (to match Javascript regarding case sensitivity)
- lots of unit tests

TTheme uses the updated TTemplate constants and CONFIG_VALUE item entry.
- unit tests

TThemeManager unit tests