### PR TITLE
Github CI adds MacOS 15 (latest) and Windows Server 2022  (latest) + bug fixes for windows/Mac

### DIFF
--- a/.github/workflows/prado.yml
+++ b/.github/workflows/prado.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           php-version: '8.2'
           # memcached extension omitted: libmemcached is not available on Windows
-          extensions: ctype, dom, intl, json, mbstring, pdo_mysql, pdo_pgsql, pdo_sqlite, openssl, pcre, spl, zip, zlib
+          extensions: ctype, dom, intl, json, mbstring, pdo_mysql, pdo_pgsql, pdo_sqlite, openssl, pcre, spl, bz2, xsl, zip, zlib
           tools: php-cs-fixer, phpstan, cs2pr
 
       - name: Validate composer.json and composer.lock

--- a/.github/workflows/prado.yml
+++ b/.github/workflows/prado.yml
@@ -93,8 +93,138 @@ jobs:
         run: |
           composer functionaltest
 
+  prado-macos:
+    name: Prado (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: ctype, dom, intl, json, mbstring, memcached, pdo_mysql, pdo_pgsql, pdo_sqlite, openssl, pcre, spl, zlib
+          tools: php-cs-fixer, phpstan, cs2pr
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
+      - name: Validate code syntax using php-cs-fixer
+        run: php-cs-fixer fix -vvv --dry-run --using-cache=no --format=checkstyle | cs2pr
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Validate code using phpstan
+        run: phpstan analyse --error-format=checkstyle | cs2pr
+
+      - name: Setup MySQL service
+        run: |
+          MYSQL=$(brew list --formula 2>/dev/null | grep '^mysql' | sort -V | tail -1)
+          [ -z "$MYSQL" ] && brew install mysql && MYSQL=mysql
+          brew services start "$MYSQL"
+          sleep 5
+          $(brew --prefix "$MYSQL")/bin/mysql -uroot < ./tests/initdb_mysql.sql
+
+      - name: Setup PostgreSQL service
+        run: |
+          PG=$(brew list --formula 2>/dev/null | grep '^postgresql' | sort -V | tail -1)
+          [ -z "$PG" ] && brew install postgresql && PG=postgresql
+          brew services start "$PG"
+          sleep 5
+          $(brew --prefix "$PG")/bin/createdb -h 127.0.0.1 prado_unitest
+          $(brew --prefix "$PG")/bin/psql -h 127.0.0.1 prado_unitest -f ./tests/initdb_pgsql.sql
+
+      - name: Setup Memcached service
+        run: |
+          brew install memcached
+          brew services start memcached
+
+      - name: Run Unit Tests
+        run: composer unittest
+
+  prado-windows:
+    name: Prado (Windows)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Configure git for LF line endings
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          # memcached extension omitted: libmemcached is not available on Windows
+          extensions: ctype, dom, intl, json, mbstring, pdo_mysql, pdo_pgsql, pdo_sqlite, openssl, pcre, spl, zip, zlib
+          tools: php-cs-fixer, phpstan, cs2pr
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
+      - name: Validate code syntax using php-cs-fixer
+        run: php-cs-fixer fix -vvv --dry-run --using-cache=no --format=checkstyle | cs2pr
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Disable phpdocumentor shim plugin (GPG key import fails on Windows)
+        run: composer config allow-plugins.phpdocumentor/shim false
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Validate code using phpstan
+        run: phpstan analyse --error-format=checkstyle | cs2pr
+
+      - name: Setup MySQL service
+        uses: shogo82148/actions-setup-mysql@v1
+        with:
+          mysql-version: '8.0'
+          auto-start: true
+
+      - name: Init MySQL schema
+        run: mysql -uroot < ./tests/initdb_mysql.sql
+
+      - name: Setup PostgreSQL service
+        shell: pwsh
+        run: |
+          # The runner image installs PostgreSQL but leaves the service disabled.
+          # PGBIN, PGDATA, and PGPASSWORD (=root) are pre-set as machine env vars.
+          & "$env:PGBIN\pg_ctl.exe" start -D $env:PGDATA -w
+          & "$env:PGBIN\createdb.exe" -h 127.0.0.1 -U postgres prado_unitest
+          & "$env:PGBIN\psql.exe" -h 127.0.0.1 -U postgres prado_unitest -f .\tests\initdb_pgsql.sql
+
+      - name: Run Unit Tests
+        run: composer unittest
+
   db-mssql:
-    name: SQL Server
+    name: Microsoft SQL Server
     runs-on: ubuntu-latest
     services:
       mssql:

--- a/framework/IO/TTarFileExtractor.php
+++ b/framework/IO/TTarFileExtractor.php
@@ -1133,8 +1133,9 @@ class TTarFileExtractor
 	 * `reason`, and `security` fields.  Populated after {@see extract()}; null before.
 	 * Returns the full metadata map for every entry in the archive.
 	 *
-	 * Keys are normalized relative paths; directory keys always end with
-	 * {@see DIRECTORY_SEPARATOR}.  Directory entries precede file entries.
+	 * Keys are normalized relative POSIX paths (always forward-slash separated);
+	 * directory keys always end with `'/'` and appear immediately before their
+	 * own children in the ordering (see {@see _sortManifest()}).
 	 *
 	 * Each value array contains at minimum:
 	 *  - `path`           string   Canonical map key (matches the array key);
@@ -1172,8 +1173,9 @@ class TTarFileExtractor
 	 *  - `checksum`       int      Stored header checksum.
 	 *  - `filesafe`       bool     True when `tarpath_norm` contains no traversal
 	 *                              sequences (i.e. would not escape the destination).
-	 *  - `linksafe`       bool     True when `tarlink_norm` contains no traversal
-	 *                              sequences.  Always true for non-link types.
+	 *  - `linksafe`       mixed    `true` when `tarlink_norm` is safe; `false` when it
+	 *                              contains traversal sequences.  Empty string (`''`)
+	 *                              for non-link types (falsy, but not a bool).
 	 *  - `device`         bool     True for character / block special device entries.
 	 *  - `extracted`      bool     Was the entry extracted.
 	 *  - `extractedPath`  string   Absolute path of the extracted file, directory,
@@ -1228,7 +1230,8 @@ class TTarFileExtractor
 
 	/**
 	 * Returns an ordered list of relative entry paths contained in the archive.
-	 * Directories appear before files and always end with {@see DIRECTORY_SEPARATOR}.
+	 * Entries are sorted alphabetically; each directory key (which always ends
+	 * with `'/'`) appears immediately before its own children.
 	 * Triggers a lazy scan when the archive has not yet been extracted.
 	 *
 	 * @return string[]
@@ -1253,8 +1256,9 @@ class TTarFileExtractor
 	/**
 	 * Returns the full metadata map for every entry in the archive.
 	 *
-	 * Keys are normalized relative paths; directory keys always end with
-	 * {@see DIRECTORY_SEPARATOR}.  Directory entries precede file entries.
+	 * Keys are normalized relative POSIX paths (always forward-slash separated);
+	 * directory keys always end with `'/'` and appear immediately before their
+	 * own children in the ordering (see {@see _sortManifest()}).
 	 *
 	 * Each value array contains at minimum:
 	 *  - `path`           string   Canonical map key (matches the array key);
@@ -1292,8 +1296,9 @@ class TTarFileExtractor
 	 *  - `checksum`       int      Stored header checksum.
 	 *  - `filesafe`       bool     True when `tarpath_norm` contains no traversal
 	 *                              sequences (i.e. would not escape the destination).
-	 *  - `linksafe`       bool     True when `tarlink_norm` contains no traversal
-	 *                              sequences.  Always true for non-link types.
+	 *  - `linksafe`       mixed    `true` when `tarlink_norm` is safe; `false` when it
+	 *                              contains traversal sequences.  Empty string (`''`)
+	 *                              for non-link types (falsy, but not a bool).
 	 *  - `device`         bool     True for character / block special device entries.
 	 *  - `reason`         string   Present only when the entry would be skipped during
 	 *                              extraction (e.g. 'zip_slip', 'device', 'symlink',
@@ -1365,7 +1370,8 @@ class TTarFileExtractor
 
 	/**
 	 * Returns the clean manifest entry for the given path, or null if not found.
-	 * The returned array does not include `extracted`, `extractedPath`, or `reason`.
+	 * The returned array does not include `extracted` or `extractedPath`.
+	 * `reason` (and `security`) are preserved when present.
 	 *
 	 * @param string $path Relative archive path.
 	 * @return ?array
@@ -1488,9 +1494,9 @@ class TTarFileExtractor
 	/**
 	 * Returns the OS-native path (`filepath`) for the given archive entry.
 	 *
-	 * Derived from `tarpath` by replacing `/` with {@see DIRECTORY_SEPARATOR}.
-	 * On Linux and macOS this is identical to `tarpath`.  The trailing `/` that tar
-	 * appends to directory entries is preserved.  For the traversal-safe
+	 * Derived from `tarpath` by replacing `/` with {@see DIRECTORY_SEPARATOR}
+	 * after prefix removal.  The trailing separator that tar appends to directory
+	 * entries is preserved as {@see DIRECTORY_SEPARATOR}.  For the traversal-safe
 	 * variant see {@see getManifestFilePathNormalized()}.
 	 *
 	 * @param string $path Relative archive path.
@@ -1506,10 +1512,10 @@ class TTarFileExtractor
 	/**
 	 * Returns the normalized OS-native path (`filepath_norm`) for the given archive entry.
 	 *
-	 * Derived from `tarpath_norm` by replacing `/` with {@see DIRECTORY_SEPARATOR}.
-	 * Trailing slashes are stripped (directory entries appear without a trailing
-	 * separator) and traversal sequences are resolved.  On Linux and macOS this is
-	 * identical to `tarpath_norm`.
+	 * Derived from `tarpath_norm` by replacing `/` with {@see DIRECTORY_SEPARATOR}
+	 * and stripping the trailing separator.  Directory entries therefore appear
+	 * without a trailing separator here, unlike `tarpath_norm` which preserves the
+	 * trailing `'/'`.  Traversal sequences are resolved.
 	 *
 	 * @param string $path Relative archive path.
 	 * @return ?string Normalized OS-native path (no trailing separator), or null if not found.
@@ -3714,8 +3720,21 @@ class TTarFileExtractor
 	}
 
 	/**
-	 * Sorts $manifest so that directory entries precede file entries.
-	 * Within each group keys are sorted alphabetically.
+	 * Sorts $manifest so that entries are ordered alphabetically, with each
+	 * directory appearing immediately before its own children.
+	 *
+	 * Example:
+	 *   a_file.txt
+	 *   b_file.txt
+	 *   c_dir/
+	 *   c_dir/a_file.txt
+	 *   c_dir/b_file.txt
+	 *   d_file.txt
+	 *
+	 * This is achieved by stripping the trailing `'/'` from directory keys
+	 * before comparing, so `c_dir/` and `c_dir/a_file.txt` compare as `c_dir`
+	 * vs `c_dir/a_file.txt` — making the directory sort just before its children.
+	 * Manifest keys always use POSIX `'/'`; `DIRECTORY_SEPARATOR` is not used.
 	 *
 	 * @param array &$manifest
 	 * @since 4.3.3
@@ -3726,12 +3745,18 @@ class TTarFileExtractor
 			return;
 		}
 		uksort($manifest, static function (string $a, string $b): int {
-			$aDir = str_ends_with($a, DIRECTORY_SEPARATOR);
-			$bDir = str_ends_with($b, DIRECTORY_SEPARATOR);
-			if ($aDir !== $bDir) {
-				return $aDir ? -1 : 1;
+			// Strip trailing '/' so 'c_dir/' compares as 'c_dir', causing it to
+			// sort immediately before 'c_dir/child.txt'.  Manifest keys always use
+			// POSIX forward-slash; DIRECTORY_SEPARATOR is not used here.
+			$aCmp = rtrim($a, '/');
+			$bCmp = rtrim($b, '/');
+			$cmp = strcmp($aCmp, $bCmp);
+			if ($cmp !== 0) {
+				return $cmp;
 			}
-			return strcmp($a, $b);
+			// Tie: same path after stripping (e.g. a file named 'foo' alongside a
+			// directory 'foo/').  The directory entry sorts first.
+			return str_ends_with($a, '/') ? -1 : 1;
 		});
 	}
 

--- a/framework/IO/TTarFileExtractor.php
+++ b/framework/IO/TTarFileExtractor.php
@@ -1133,7 +1133,7 @@ class TTarFileExtractor
 	 * `reason`, and `security` fields.  Populated after {@see extract()}; null before.
 	 * Returns the full metadata map for every entry in the archive.
 	 *
-	 * Keys are normalised relative paths; directory keys always end with
+	 * Keys are normalized relative paths; directory keys always end with
 	 * {@see DIRECTORY_SEPARATOR}.  Directory entries precede file entries.
 	 *
 	 * Each value array contains at minimum:
@@ -1144,21 +1144,21 @@ class TTarFileExtractor
 	 *  - `typeflag`       int      One of the TYPE_* constants.
 	 *  - `tarpath`        string   Raw POSIX path as stored in the tar header
 	 *                              (forward-slash separated, may have a leading `/`).
-	 *  - `tarpath_norm`   string   Normalised POSIX relative path (no leading `/`,
+	 *  - `tarpath_norm`   string   Normalized POSIX relative path (no leading `/`,
 	 *                              no `..` sequences); used as the manifest key.
 	 *  - `tarlink`        string   Raw POSIX link target as stored in the tar header
 	 *                              (empty for non-link types).
-	 *  - `tarlink_norm`   string   Normalised POSIX relative link target (no leading
+	 *  - `tarlink_norm`   string   Normalized POSIX relative link target (no leading
 	 *                              `/`, no `..` sequences).  Empty for non-link types.
 	 *  - `filepath`       string   OS-native working path after prefix removal,
 	 *                              using {@see DIRECTORY_SEPARATOR}.
-	 *  - `filepath_norm`  string   Normalised OS-native relative path (no leading
+	 *  - `filepath_norm`  string   Normalized OS-native relative path (no leading
 	 *                              separator, no `..` sequences), using
 	 *                              {@see DIRECTORY_SEPARATOR}.
 	 *  - `filename`       string   Entry basename — `basename($filepath_norm)`.
 	 *  - `linkpath`       string   OS-native symlink / hard-link target using
 	 *                              {@see DIRECTORY_SEPARATOR} (empty for other types).
-	 *  - `linkpath_norm`  string   Normalised OS-native link target path, using
+	 *  - `linkpath_norm`  string   Normalized OS-native link target path, using
 	 *                              {@see DIRECTORY_SEPARATOR}.  Empty for non-link types.
 	 *  - `linkname`       string   Link-target basename — `basename($linkpath_norm)`.
 	 *                              Empty for non-link types.
@@ -1253,7 +1253,7 @@ class TTarFileExtractor
 	/**
 	 * Returns the full metadata map for every entry in the archive.
 	 *
-	 * Keys are normalised relative paths; directory keys always end with
+	 * Keys are normalized relative paths; directory keys always end with
 	 * {@see DIRECTORY_SEPARATOR}.  Directory entries precede file entries.
 	 *
 	 * Each value array contains at minimum:
@@ -1264,21 +1264,21 @@ class TTarFileExtractor
 	 *  - `typeflag`       int      One of the TYPE_* constants.
 	 *  - `tarpath`        string   Raw POSIX path as stored in the tar header
 	 *                              (forward-slash separated, may have a leading `/`).
-	 *  - `tarpath_norm`   string   Normalised POSIX relative path (no leading `/`,
+	 *  - `tarpath_norm`   string   Normalized POSIX relative path (no leading `/`,
 	 *                              no `..` sequences); used as the manifest key.
 	 *  - `tarlink`        string   Raw POSIX link target as stored in the tar header
 	 *                              (empty for non-link types).
-	 *  - `tarlink_norm`   string   Normalised POSIX relative link target (no leading
+	 *  - `tarlink_norm`   string   Normalized POSIX relative link target (no leading
 	 *                              `/`, no `..` sequences).  Empty for non-link types.
 	 *  - `filepath`       string   OS-native working path after prefix removal,
 	 *                              using {@see DIRECTORY_SEPARATOR}.
-	 *  - `filepath_norm`  string   Normalised OS-native relative path (no leading
+	 *  - `filepath_norm`  string   Normalized OS-native relative path (no leading
 	 *                              separator, no `..` sequences), using
 	 *                              {@see DIRECTORY_SEPARATOR}.
 	 *  - `filename`       string   Entry basename — `basename($filepath_norm)`.
 	 *  - `linkpath`       string   OS-native symlink / hard-link target using
 	 *                              {@see DIRECTORY_SEPARATOR} (empty for other types).
-	 *  - `linkpath_norm`  string   Normalised OS-native link target path, using
+	 *  - `linkpath_norm`  string   Normalized OS-native link target path, using
 	 *                              {@see DIRECTORY_SEPARATOR}.  Empty for non-link types.
 	 *  - `linkname`       string   Link-target basename — `basename($linkpath_norm)`.
 	 *                              Empty for non-link types.
@@ -1435,14 +1435,14 @@ class TTarFileExtractor
 	}
 
 	/**
-	 * Returns the normalised POSIX path (`tarpath_norm`) for the given archive entry.
+	 * Returns the normalized POSIX path (`tarpath_norm`) for the given archive entry.
 	 *
 	 * Traversal sequences are resolved and leading `/` is stripped.  The trailing `/`
 	 * that tar appends to directory entries is preserved so that directory entries
 	 * remain distinguishable from files.
 	 *
 	 * @param string $path Relative archive path.
-	 * @return ?string Normalised POSIX path (trailing separator preserved for directories),
+	 * @return ?string Normalized POSIX path (trailing separator preserved for directories),
 	 *                 or null if not found.
 	 * @since 4.3.3
 	 */
@@ -1457,7 +1457,7 @@ class TTarFileExtractor
 	 *
 	 * Returns an empty string for non-link entries (regular files, directories).
 	 * Returns null if the path is not found in the manifest.
-	 * For the normalised variant see {@see getManifestTarLinkNormalized()}.
+	 * For the normalized variant see {@see getManifestTarLinkNormalized()}.
 	 *
 	 * @param string $path Relative archive path.
 	 * @return ?string Raw POSIX link target (empty for non-link entries), or null if not found.
@@ -1469,14 +1469,14 @@ class TTarFileExtractor
 	}
 
 	/**
-	 * Returns the normalised POSIX link target (`tarlink_norm`) for the given archive entry.
+	 * Returns the normalized POSIX link target (`tarlink_norm`) for the given archive entry.
 	 *
 	 * Traversal sequences are resolved and leading `/` is stripped.
 	 * Returns an empty string for non-link entries (regular files, directories).
 	 * Returns null if the path is not found in the manifest.
 	 *
 	 * @param string $path Relative archive path.
-	 * @return ?string Normalised POSIX link target (empty for non-link entries),
+	 * @return ?string Normalized POSIX link target (empty for non-link entries),
 	 *                 or null if not found.
 	 * @since 4.3.3
 	 */
@@ -1504,7 +1504,7 @@ class TTarFileExtractor
 	}
 
 	/**
-	 * Returns the normalised OS-native path (`filepath_norm`) for the given archive entry.
+	 * Returns the normalized OS-native path (`filepath_norm`) for the given archive entry.
 	 *
 	 * Derived from `tarpath_norm` by replacing `/` with {@see DIRECTORY_SEPARATOR}.
 	 * Trailing slashes are stripped (directory entries appear without a trailing
@@ -1512,7 +1512,7 @@ class TTarFileExtractor
 	 * identical to `tarpath_norm`.
 	 *
 	 * @param string $path Relative archive path.
-	 * @return ?string Normalised OS-native path (no trailing separator), or null if not found.
+	 * @return ?string Normalized OS-native path (no trailing separator), or null if not found.
 	 * @since 4.3.3
 	 */
 	public function getManifestFilePathNormalized(string $path): ?string
@@ -1526,7 +1526,7 @@ class TTarFileExtractor
 	 * Derived from `tarlink` by replacing `/` with {@see DIRECTORY_SEPARATOR}.
 	 * Returns an empty string for non-link entries (regular files, directories).
 	 * Returns null if the path is not found in the manifest.
-	 * For the normalised variant see {@see getManifestLinkPathNormalized()}.
+	 * For the normalized variant see {@see getManifestLinkPathNormalized()}.
 	 *
 	 * @param string $path Relative archive path.
 	 * @return ?string OS-native link target (empty for non-link entries), or null if not found.
@@ -1538,7 +1538,7 @@ class TTarFileExtractor
 	}
 
 	/**
-	 * Returns the normalised OS-native link target (`linkpath_norm`) for the given archive entry.
+	 * Returns the normalized OS-native link target (`linkpath_norm`) for the given archive entry.
 	 *
 	 * Derived from `tarlink_norm` by replacing `/` with {@see DIRECTORY_SEPARATOR}.
 	 * Trailing slashes and traversal sequences are resolved.
@@ -1546,7 +1546,7 @@ class TTarFileExtractor
 	 * Returns null if the path is not found in the manifest.
 	 *
 	 * @param string $path Relative archive path.
-	 * @return ?string Normalised OS-native link target (empty for non-link entries),
+	 * @return ?string Normalized OS-native link target (empty for non-link entries),
 	 *                 or null if not found.
 	 * @since 4.3.3
 	 */
@@ -3057,8 +3057,15 @@ class TTarFileExtractor
 
 		$cmdPath = null;
 		$cmdFlags = null;
+		// 'which' is the Unix tool locator; on Windows use 'where' (and take only the first line).
+		$isWindows = self::isSystemWindows();
 		foreach ($candidates as [$name, $flags]) {
-			$found = trim((string) shell_exec('which ' . escapeshellarg($name)));
+			if ($isWindows) {
+				$raw = (string) shell_exec('where ' . escapeshellarg($name) . ' 2>NUL');
+				$found = trim(strtok($raw, "\r\n"));
+			} else {
+				$found = trim((string) shell_exec('which ' . escapeshellarg($name)));
+			}
 			if ($found !== '') {
 				$cmdPath = $found;
 				$cmdFlags = $flags;
@@ -3542,7 +3549,7 @@ class TTarFileExtractor
 			return false;
 		}
 
-		return str_starts_with($normalizedFilePath . DIRECTORY_SEPARATOR, $normalizedDestPath . DIRECTORY_SEPARATOR);
+		return str_starts_with($normalizedFilePath . '/', $normalizedDestPath . '/');
 	}
 
 	/**
@@ -3613,7 +3620,15 @@ class TTarFileExtractor
 	}
 
 	/**
-	 * Normalises path separators and removes Windows drive letters.
+	 * @return bool If the platform is Windows.
+	 */
+	protected static function isSystemWindows(): bool
+	{
+		return strncasecmp(PHP_OS, 'WIN', 3) === 0;
+	}
+
+	/**
+	 * Normalizes path separators and removes Windows drive letters.
 	 *
 	 * @param string $p_destPath
 	 * @param bool   $p_remove_disk_letter
@@ -3621,7 +3636,7 @@ class TTarFileExtractor
 	 */
 	protected function _translateWinPath(string $p_destPath, bool $p_remove_disk_letter = true): string
 	{
-		if (strncasecmp(PHP_OS, 'WIN', 3) !== 0) {
+		if (!self::isSystemWindows()) {
 			return $p_destPath;
 		}
 		if ($p_remove_disk_letter && ($v_position = strpos($p_destPath, ':')) !== false) {
@@ -3650,14 +3665,18 @@ class TTarFileExtractor
 		if ($this->_tarManifest === null) {
 			return null;
 		}
+		// Manifest keys always use POSIX forward-slash; normalise Windows backslashes.
+		$path = str_replace('\\', '/', $path);
 		if (isset($this->_tarManifest[$path])) {
 			return $path;
 		}
-		$withSep = rtrim($path, '/\\') . DIRECTORY_SEPARATOR;
+		// Try adding a trailing slash (directory key convention).
+		$withSep = rtrim($path, '/') . '/';
 		if (isset($this->_tarManifest[$withSep])) {
 			return $withSep;
 		}
-		$withoutSep = rtrim($path, '/\\');
+		// Try without trailing slash (file key convention).
+		$withoutSep = rtrim($path, '/');
 		if ($withoutSep !== $path && isset($this->_tarManifest[$withoutSep])) {
 			return $withoutSep;
 		}
@@ -3676,14 +3695,18 @@ class TTarFileExtractor
 		if ($this->_tarExtractManifest === null) {
 			return null;
 		}
+		// Extraction manifest keys always use POSIX forward-slash; normalise Windows backslashes.
+		$path = str_replace('\\', '/', $path);
 		if (isset($this->_tarExtractManifest[$path])) {
 			return $path;
 		}
-		$withSep = rtrim($path, '/\\') . DIRECTORY_SEPARATOR;
+		// Try adding a trailing slash (directory key convention).
+		$withSep = rtrim($path, '/') . '/';
 		if (isset($this->_tarExtractManifest[$withSep])) {
 			return $withSep;
 		}
-		$withoutSep = rtrim($path, '/\\');
+		// Try without trailing slash (file key convention).
+		$withoutSep = rtrim($path, '/');
 		if ($withoutSep !== $path && isset($this->_tarExtractManifest[$withoutSep])) {
 			return $withoutSep;
 		}

--- a/framework/Util/Helpers/TProcessHelper.php
+++ b/framework/Util/Helpers/TProcessHelper.php
@@ -256,21 +256,31 @@ class TProcessHelper
 			$pid = getmypid();
 		}
 		if (static::isSystemWindows()) {
-			$output = shell_exec("wmic process where ProcessId={$pid} get priority");
-			preg_match('/^\s*Priority\s*\r?\n\s*(\d+)/m', $output, $matches);
-			if (isset($matches[1])) {
-				$priorityValues = [ // Map Windows Priority Numbers to Linux style Numbers
-					TProcessWindowsPriority::Idle => static::WINDOWS_IDLE_PRIORITY,
-					TProcessWindowsPriority::BelowNormal => static::WINDOWS_BELOW_NORMAL_PRIORITY,
-					TProcessWindowsPriority::Normal => static::WINDOWS_NORMAL_PRIORITY,
-					TProcessWindowsPriority::AboveNormal => static::WINDOWS_ABOVE_NORMAL_PRIORITY,
-					TProcessWindowsPriority::HighPriority => static::WINDOWS_HIGH_PRIORITY,
-					TProcessWindowsPriority::Realtime => static::WINDOWS_REALTIME_PRIORITY,
-				];
-				return $priorityValues[$matches[1]] ?? null;
-			} else {
+			// wmic is deprecated and removed on modern Windows (Server 2025 / Win11+); use PowerShell.
+			$psOutput = shell_exec("powershell -NoProfile -Command \"try { (Get-Process -Id $pid).PriorityClass } catch { '' }\" 2>NUL");
+			// PowerShell returns the ProcessPriorityClass enum name, e.g. 'Normal', 'BelowNormal'.
+			$psName = strtolower(trim((string) $psOutput));
+			$psToNumeric = [
+				'idle' => TProcessWindowsPriority::Idle,
+				'belownormal' => TProcessWindowsPriority::BelowNormal,
+				'normal' => TProcessWindowsPriority::Normal,
+				'abovenormal' => TProcessWindowsPriority::AboveNormal,
+				'high' => TProcessWindowsPriority::HighPriority,
+				'realtime' => TProcessWindowsPriority::Realtime,
+			];
+			$numericPriority = $psToNumeric[$psName] ?? null;
+			if ($numericPriority === null) {
 				return null;
 			}
+			$priorityValues = [ // Map TProcessWindowsPriority numeric values to Prado/Linux-style values
+				TProcessWindowsPriority::Idle => static::WINDOWS_IDLE_PRIORITY,
+				TProcessWindowsPriority::BelowNormal => static::WINDOWS_BELOW_NORMAL_PRIORITY,
+				TProcessWindowsPriority::Normal => static::WINDOWS_NORMAL_PRIORITY,
+				TProcessWindowsPriority::AboveNormal => static::WINDOWS_ABOVE_NORMAL_PRIORITY,
+				TProcessWindowsPriority::HighPriority => static::WINDOWS_HIGH_PRIORITY,
+				TProcessWindowsPriority::Realtime => static::WINDOWS_REALTIME_PRIORITY,
+			];
+			return $priorityValues[$numericPriority] ?? null;
 		} else {
 			if (strlen($priority = trim(shell_exec('exec ps -o nice= -p ' . $pid)))) {
 				return (int) $priority;
@@ -291,28 +301,24 @@ class TProcessHelper
 			$pid = getmypid();
 		}
 		if (static::isSystemWindows()) {
-			$priorityValues = [ // The priority cap to windows text priority.
-				-15 => TProcessWindowsPriorityName::Realtime,
-				-10 => TProcessWindowsPriorityName::HighPriority,
-				-5 => TProcessWindowsPriorityName::AboveNormal,
-				4 => TProcessWindowsPriorityName::Normal,
-				9 => TProcessWindowsPriorityName::BelowNormal,
-				PHP_INT_MAX => TProcessWindowsPriorityName::Idle,
+			// wmic is deprecated and removed on modern Windows (Server 2025 / Win11+); use PowerShell.
+			// Map Prado priority thresholds to PowerShell ProcessPriorityClass enum names.
+			$psNames = [
+				-15 => 'RealTime',
+				-10 => 'High',
+				-5 => 'AboveNormal',
+				4 => 'Normal',
+				9 => 'BelowNormal',
+				PHP_INT_MAX => 'Idle',
 			];
-			foreach ($priorityValues as $keyPriority => $priorityName) {
+			foreach ($psNames as $keyPriority => $psName) {
 				if ($priority <= $keyPriority) {
 					break;
 				}
 			}
-			$command = "wmic process where ProcessId={$pid} CALL setpriority \"$priorityName\"";
-			$result = shell_exec($command);
-			if (strpos($result, 'successful') !== false) {
-				return true;
-			}
-			if (!preg_match('/ReturnValue\s*=\s*(\d+);/m', $result, $matches)) {
-				return false;
-			}
-			return $matches[1] === 0;
+			$exitCode = -1;
+			exec("powershell -NoProfile -Command \"try { (Get-Process -Id $pid).PriorityClass = [System.Diagnostics.ProcessPriorityClass]::$psName; exit 0 } catch { exit 1 }\" 2>NUL", $psOut, $exitCode);
+			return $exitCode === 0;
 		} else {
 			if (static::isSystemMacOS()) {
 				if (($pp = static::getProcessPriority($pid)) === null) {

--- a/framework/Util/TSignalsDispatcher.php
+++ b/framework/Util/TSignalsDispatcher.php
@@ -17,6 +17,33 @@ use Prado\Exceptions\{TInvalidOperationException, TInvalidDataValueException};
 use Prado\TComponent;
 use Prado\Util\Helpers\TProcessHelper;
 
+// Signal constants are provided by the pcntl extension (Linux/macOS only).
+// Define POSIX-standard stub values on systems where pcntl is unavailable (e.g. Windows)
+// so the class can be loaded.  The actual signal functionality is guarded by hasSignals().
+if (!function_exists('pcntl_signal')) {
+	defined('SIGALRM') || define('SIGALRM', 14);
+	defined('SIGHUP') || define('SIGHUP', 1);
+	defined('SIGINT') || define('SIGINT', 2);
+	defined('SIGQUIT') || define('SIGQUIT', 3);
+	defined('SIGTRAP') || define('SIGTRAP', 5);
+	defined('SIGABRT') || define('SIGABRT', 6);
+	defined('SIGUSR1') || define('SIGUSR1', 10);
+	defined('SIGUSR2') || define('SIGUSR2', 12);
+	defined('SIGTERM') || define('SIGTERM', 15);
+	defined('SIGCHLD') || define('SIGCHLD', 17);
+	defined('SIGCONT') || define('SIGCONT', 18);
+	defined('SIGTSTP') || define('SIGTSTP', 20);
+	defined('SIGTTIN') || define('SIGTTIN', 21);
+	defined('SIGTTOU') || define('SIGTTOU', 22);
+	defined('SIGURG') || define('SIGURG', 23);
+	defined('SIGBUS') || define('SIGBUS', 7);
+	defined('SIGFPE') || define('SIGFPE', 8);
+	defined('SIGILL') || define('SIGILL', 4);
+	defined('SIGPIPE') || define('SIGPIPE', 13);
+	defined('SIGSEGV') || define('SIGSEGV', 11);
+	defined('SIGSYS') || define('SIGSYS', 31);
+}
+
 /**
  * TSignalsDispatcher class.
  *
@@ -214,11 +241,17 @@ class TSignalsDispatcher extends TComponent implements \Prado\ISingleton
 	 */
 	public function attach(): bool
 	{
-		if (!static::hasSignals() || self::$_singleton !== null) {
+		if (self::$_singleton !== null) {
 			return false;
 		}
 
+		// Always register as singleton (even without pcntl) so the object can be used
+		// for non-signal purposes (e.g. child-PID tracking, testing).
 		self::$_singleton = $this;
+
+		if (!static::hasSignals()) {
+			return false; // Singleton set; signal handlers cannot be registered without pcntl.
+		}
 
 		if (self::$_asyncSignals === null) {
 			static::setAsyncSignals(true);
@@ -303,7 +336,9 @@ class TSignalsDispatcher extends TComponent implements \Prado\ISingleton
 		static::$_alarms = [];
 		self::$_singleton = null;
 
-		static::setAsyncSignals(self::$_priorAsync);
+		if (static::hasSignals()) {
+			static::setAsyncSignals(self::$_priorAsync);
+		}
 		self::$_priorAsync = null;
 		self::$_asyncSignals = null;
 

--- a/framework/Web/TUrlManager.php
+++ b/framework/Web/TUrlManager.php
@@ -102,7 +102,8 @@ class TUrlManager extends \Prado\TModule
 			case THttpRequestUrlFormat::Path:
 				return $request->getApplicationUrl() . '/' . strtr($url, [$amp => '/', '?' => '/', '=' => $request->getUrlParamSeparator()]);
 			case THttpRequestUrlFormat::HiddenPath:
-				return rtrim(dirname($request->getApplicationUrl()), '/') . '/' . strtr($url, [$amp => '/', '?' => '/', '=' => $request->getUrlParamSeparator()]);
+				// dirname() returns '\' on Windows for root-level paths; normalize to '/' unconditionally.
+				return rtrim(str_replace('\\', '/', dirname($request->getApplicationUrl())), '/') . '/' . strtr($url, [$amp => '/', '?' => '/', '=' => $request->getUrlParamSeparator()]);
 			default:
 				return $request->getApplicationUrl() . '?' . $url;
 		}

--- a/tests/unit/Data/TDbCommandTest.php
+++ b/tests/unit/Data/TDbCommandTest.php
@@ -15,6 +15,9 @@ class TDbCommandTest extends PHPUnit\Framework\TestCase
 
 	protected function setUp(): void
 	{
+		// Defensive unlink
+		@unlink(TEST_DB_FILE);
+
 		// create application just to provide application mode
 		new TApplication(__DIR__, false, TApplication::CONFIG_TYPE_PHP);
 
@@ -27,7 +30,10 @@ class TDbCommandTest extends PHPUnit\Framework\TestCase
 
 	protected function tearDown(): void
 	{
-		$this->_connection = null;
+		if ($this->_connection !== null) {
+			$this->_connection->Active = false;
+			$this->_connection = null;
+		}
 		@unlink(TEST_DB_FILE);
 	}
 

--- a/tests/unit/Data/TDbConnectionTest.php
+++ b/tests/unit/Data/TDbConnectionTest.php
@@ -21,6 +21,7 @@ class TDbConnectionTest extends PHPUnit\Framework\TestCase
 
 	protected function setUp(): void
 	{
+		// Defensive unlink
 		@unlink(TEST_DB_FILE);
 		@unlink(TEST_DB_FILE2);
 
@@ -35,8 +36,17 @@ class TDbConnectionTest extends PHPUnit\Framework\TestCase
 
 	protected function tearDown(): void
 	{
-		$this->_connection1 = null;
-		$this->_connection2 = null;
+		// Explicitly close PDO connections before unlinking to release file locks on Windows.
+		if ($this->_connection1 !== null) {
+			$this->_connection1->Active = false;
+			$this->_connection1 = null;
+		}
+		if ($this->_connection2 !== null) {
+			$this->_connection2->Active = false;
+			$this->_connection2 = null;
+		}
+		@unlink(TEST_DB_FILE);
+		@unlink(TEST_DB_FILE2);
 	}
 
 	public function testActive()

--- a/tests/unit/Data/TDbDataReaderTest.php
+++ b/tests/unit/Data/TDbDataReaderTest.php
@@ -50,7 +50,12 @@ class TDbDataReaderTest extends PHPUnit\Framework\TestCase
 
 	protected function tearDown(): void
 	{
-		$this->_connection = null;
+		// Explicitly close the PDO connection before unlinking to release the file
+		// lock on Windows (where an open handle prevents unlink from succeeding).
+		if ($this->_connection !== null) {
+			$this->_connection->Active = false;
+			$this->_connection = null;
+		}
 		@unlink(TEST_DB_FILE);
 	}
 

--- a/tests/unit/Data/TDbTransactionTest.php
+++ b/tests/unit/Data/TDbTransactionTest.php
@@ -13,6 +13,10 @@ class TDbTransactionTest extends PHPUnit\Framework\TestCase
 
 	protected function setUp(): void
 	{
+		// Remove any stale DB file from a previous test run (guards against Windows
+		// file-lock failures leaving the file behind after tearDown).
+		@unlink(TEST_DB_FILE);
+
 		// create application just to provide application mode
 		new TApplication(__DIR__, false, TApplication::CONFIG_TYPE_PHP);
 
@@ -23,7 +27,12 @@ class TDbTransactionTest extends PHPUnit\Framework\TestCase
 
 	protected function tearDown(): void
 	{
-		$this->_connection = null;
+		// Explicitly close the PDO connection before unlinking to release the file
+		// lock on Windows (where an open handle prevents unlink from succeeding).
+		if ($this->_connection !== null) {
+			$this->_connection->Active = false;
+			$this->_connection = null;
+		}
 		@unlink(TEST_DB_FILE);
 	}
 

--- a/tests/unit/IO/TTarFileExtractorManifestTest.php
+++ b/tests/unit/IO/TTarFileExtractorManifestTest.php
@@ -86,29 +86,86 @@ class TTarFileExtractorManifestTest extends TestCase
 		$this->assertContains('root.txt', $paths);
 	}
 
-	public function testDirectoriesAlwaysPrecedeFilesInPathMap()
+	public function testManifestSortIsHierarchicalAndAlphabetical()
 	{
 		$tarFile = $this->testDir . '/ordering.tar';
-		// Archive has files first, then directory — map must reorder dirs before files.
+		// Archive entries in tar-file order (intentionally scrambled).
+		// After sorting the manifest must match the expected hierarchical order:
+		// each directory key appears immediately before its own children, while
+		// sibling entries are sorted alphabetically.
 		TarTestHelper::writeTar($tarFile, [
-			TarTestHelper::entry('z_file.txt', 'data'),
-			TarTestHelper::entry('a_dir/', '', '5'),
-			TarTestHelper::entry('a_dir/child.txt', 'child'),
+			TarTestHelper::entry('d_file.txt', 'data'),
+			TarTestHelper::entry('c_dir/', '', '5'),
+			TarTestHelper::entry('c_dir/b_file.txt', 'child b'),
+			TarTestHelper::entry('c_dir/a_file.txt', 'child a'),
+			TarTestHelper::entry('b_file.txt', 'data'),
+			TarTestHelper::entry('a_file.txt', 'data'),
 		]);
 
 		$extractor = new TTarFileExtractor($tarFile);
 		$paths = $extractor->getManifestPaths();
 
-		$firstDir = false;
-		foreach ($paths as $p) {
-			if (str_ends_with($p, '/')) {
-				$firstDir = true;
-			} elseif ($firstDir === false) {
-				// A file appeared before any directory — fail.
-				$this->fail('File appeared before directory in path map: ' . $p);
-			}
+		$this->assertSame([
+			'a_file.txt',
+			'b_file.txt',
+			'c_dir/',
+			'c_dir/a_file.txt',
+			'c_dir/b_file.txt',
+			'd_file.txt',
+		], $paths);
+	}
+
+	/**
+	 * _sortManifest must identify directory keys by the POSIX '/' suffix, not by
+	 * DIRECTORY_SEPARATOR.  On Windows DIRECTORY_SEPARATOR is '\', so using it would
+	 * cause every directory entry to be treated as a file and the dirs-first ordering
+	 * would silently break.  This test exercises _sortManifest directly via reflection
+	 * with keys that end with '/' and asserts that directories are sorted before files
+	 * on every platform — including Windows.
+	 *
+	 * The test also explicitly demonstrates that str_ends_with($key, DIRECTORY_SEPARATOR)
+	 * is NOT a reliable check: on Windows it returns false for a key like 'dir/', whereas
+	 * str_ends_with($key, '/') correctly returns true.
+	 */
+	public function testSortManifestUsesPosixSlashNotDirectorySeparator()
+	{
+		$extractor = new TTarFileExtractor('');
+
+		// 'z_dir/' must sort immediately before its child 'z_dir/file.txt'.
+		// 'a_file.txt' < 'z_dir' alphabetically, so it comes first.
+		// Keys always use POSIX '/'; the tie-break that places 'z_dir/' before
+		// 'z_dir/file.txt' relies on str_ends_with($key, '/'), NOT DIRECTORY_SEPARATOR.
+		// On Windows DIRECTORY_SEPARATOR === '\\', so using it would make rtrim
+		// and the tie-break behave incorrectly for POSIX keys.
+		$manifest = [
+			'z_dir/file.txt' => ['tarpath_norm' => 'z_dir/file.txt', 'typeflag' => TTarFileExtractor::TYPE_FILE],
+			'z_dir/'         => ['tarpath_norm' => 'z_dir/',         'typeflag' => TTarFileExtractor::TYPE_DIRECTORY],
+			'a_file.txt'     => ['tarpath_norm' => 'a_file.txt',     'typeflag' => TTarFileExtractor::TYPE_FILE],
+		];
+
+		$method = new \ReflectionMethod(TTarFileExtractor::class, '_sortManifest');
+		$method->setAccessible(true);
+		$method->invokeArgs($extractor, [&$manifest]);
+
+		$keys = array_keys($manifest);
+
+		// Expected: a_file.txt, z_dir/, z_dir/file.txt
+		$this->assertSame(['a_file.txt', 'z_dir/', 'z_dir/file.txt'], $keys,
+			'Directory key must sort immediately before its children'
+		);
+
+		// Explicitly demonstrate the '/' vs DIRECTORY_SEPARATOR distinction.
+		// Manifest keys always end with '/' for directories; on Windows
+		// DIRECTORY_SEPARATOR is '\\', so the old check would have failed.
+		$this->assertTrue(str_ends_with('z_dir/', '/'),
+			"Manifest directory key ends with '/'"
+		);
+		if (DIRECTORY_SEPARATOR !== '/') {
+			$this->assertFalse(str_ends_with('z_dir/', DIRECTORY_SEPARATOR),
+				"str_ends_with('z_dir/', DIRECTORY_SEPARATOR) is false on Windows — "
+				. "using DIRECTORY_SEPARATOR would mis-classify the directory key"
+			);
 		}
-		$this->assertTrue($firstDir, 'Expected at least one directory entry');
 	}
 
 	public function testDirectoryKeyEndsWithDirectorySeparator()

--- a/tests/unit/IO/TTarFileExtractorManifestTest.php
+++ b/tests/unit/IO/TTarFileExtractorManifestTest.php
@@ -120,7 +120,8 @@ class TTarFileExtractorManifestTest extends TestCase
 
 		$extractor = new TTarFileExtractor($tarFile);
 		$map = $extractor->getManifest();
-		$key = 'mydir' . DIRECTORY_SEPARATOR;
+		// Manifest keys always use POSIX forward-slash, regardless of OS.
+		$key = 'mydir/';
 
 		$this->assertArrayHasKey($key, $map);
 	}
@@ -839,7 +840,7 @@ class TTarFileExtractorManifestTest extends TestCase
 		$extractor = new TTarFileExtractor($tarFile);
 		$map = $extractor->getManifest();
 
-		$this->assertArrayHasKey('gz_dir' . DIRECTORY_SEPARATOR, $map);
+		$this->assertArrayHasKey('gz_dir/', $map); // Manifest keys always use POSIX forward-slash.
 		$this->assertArrayHasKey('gz_dir/gz.txt', $map);
 	}
 
@@ -956,11 +957,14 @@ class TTarFileExtractorManifestTest extends TestCase
 
 		$this->assertArrayHasKey('mylink.txt', $map);
 		$this->assertSame('symlink', $map['mylink.txt']['type']);
-		$this->assertSame($longLink, $map['mylink.txt']['linkpath']);
+		$this->assertSame($longLink, $map['mylink.txt']['tarlink']); // tarlink is always POSIX; linkpath is OS-native.
 	}
 
 	public function testGnuLongLinkExtracted()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+		}
 		// Long link target that is safe (resides inside extraction dir).
 		$subdir = str_repeat('s', 40);
 		$longLink = $subdir . '/' . str_repeat('t', 50) . '.txt'; // safe relative path
@@ -977,7 +981,7 @@ class TTarFileExtractorManifestTest extends TestCase
 		$this->assertTrue($result);
 		$this->assertFileExists($this->extractDir . '/mylink.txt');
 		$map = $extractor->getManifest();
-		$this->assertSame($longLink, $map['mylink.txt']['linkpath']);
+		$this->assertSame($longLink, $map['mylink.txt']['tarlink']); // tarlink is always POSIX; linkpath is OS-native.
 	}
 
 	// ---------------------------------------------------------------------------
@@ -1203,6 +1207,9 @@ class TTarFileExtractorManifestTest extends TestCase
 
 	public function testSafeSymlinkExtracted()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+		}
 		$tarFile = $this->testDir . '/safe_symlink.tar';
 		TarTestHelper::writeTar($tarFile, [
 			TarTestHelper::entry('target.txt', 'target content'),
@@ -1247,7 +1254,7 @@ class TTarFileExtractorManifestTest extends TestCase
 		$this->assertTrue($extractor->hasSkippedFiles());
 		$skipped = array_values($extractor->getSkippedFiles());
 		$this->assertSame('symlink', $skipped[0]['reason']);
-		$this->assertSame('../../../etc/passwd', $skipped[0]['linkpath']);
+		$this->assertSame('../../../etc/passwd', $skipped[0]['tarlink']); // tarlink is always POSIX; linkpath is OS-native.
 		$this->assertFileDoesNotExist($this->extractDir . '/evil_link.txt');
 	}
 
@@ -1431,7 +1438,7 @@ class TTarFileExtractorManifestTest extends TestCase
 
 		$this->assertTrue($result);
 		$map = $extractor->getExtractManifest();
-		$this->assertArrayHasKey('dir' . DIRECTORY_SEPARATOR, $map);
+		$this->assertArrayHasKey('dir/', $map); // Manifest keys always use POSIX forward-slash.
 		$this->assertArrayHasKey('dir/url_file.txt', $map);
 		$this->assertTrue($map['dir/url_file.txt']['extracted']);
 	}
@@ -1568,6 +1575,9 @@ class TTarFileExtractorManifestTest extends TestCase
 
 	public function testSymlinkEntryInMap()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+		}
 		$tarFile = $this->testDir . '/sym_map.tar';
 		TarTestHelper::writeTar($tarFile, [
 			TarTestHelper::entry('target.txt', 'data'),

--- a/tests/unit/IO/TTarFileExtractorTest.php
+++ b/tests/unit/IO/TTarFileExtractorTest.php
@@ -279,6 +279,9 @@ class TTarFileExtractorTest extends TestCase
 
 	public function testExtractSymlinkWithinDestination()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+		}
 		$tarFile = $this->testDir . '/safe_symlink.tar';
 		TarTestHelper::writeTar($tarFile, [
 			TarTestHelper::entry('target.txt', 'Target content'),
@@ -299,6 +302,9 @@ class TTarFileExtractorTest extends TestCase
 
 	public function testExtractSymlinkWithRelativePathWithinDestination()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+		}
 		$tarFile = $this->testDir . '/relative_symlink.tar';
 
 		mkdir($this->extractDir . '/subdir', 0o777, true);
@@ -531,7 +537,7 @@ class TTarFileExtractorTest extends TestCase
 		$this->assertCount(1, $skipped);
 		$this->assertEquals('symlink', $skipped[0]['reason']);
 		$this->assertStringContainsString('mylink', $skipped[0]['filepath']);
-		$this->assertEquals('/etc/passwd', $skipped[0]['linkpath']);
+		$this->assertEquals('/etc/passwd', $skipped[0]['tarlink']); // tarlink is always POSIX; linkpath is OS-native.
 
 		unlink($tarFile);
 	}
@@ -571,7 +577,7 @@ class TTarFileExtractorTest extends TestCase
 		$this->assertEquals('hardlink', $skipped[0]['reason']);
 		$this->assertEquals('linkpath_above_root', $skipped[0]['security']);
 		$this->assertStringContainsString('mylink', $skipped[0]['filepath']);
-		$this->assertEquals('/etc/passwd', $skipped[0]['linkpath']);
+		$this->assertEquals('/etc/passwd', $skipped[0]['tarlink']); // tarlink is always POSIX; linkpath is OS-native.
 
 		unlink($tarFile);
 	}

--- a/tests/unit/IO/TTarFileExtractorZipSlipTest.php
+++ b/tests/unit/IO/TTarFileExtractorZipSlipTest.php
@@ -205,6 +205,9 @@ class TTarFileExtractorZipSlipTest extends TestCase
 
 	public function testExtractAllowedSymlinkWithinDestination(): void
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+		}
 		$tarFile = $this->createTarWithSafeSymlink();
 
 		$extractor = new TTarFileExtractor($tarFile);

--- a/tests/unit/Security/TUserManagerTest.php
+++ b/tests/unit/Security/TUserManagerTest.php
@@ -77,7 +77,7 @@ class TUserManagerTest extends PHPUnit\Framework\TestCase
 			$userManager = new TUserManager();
 			$userManager->setUserFile('App.users');
 			$userManager->init(new TXmlDocument()); // Empty config
-			self::assertEquals(__DIR__ . '/users.xml', $userManager->getUserFile());
+			self::assertEquals(str_replace('\\', '/', __DIR__ . '/users.xml'), str_replace('\\', '/', $userManager->getUserFile()));
 			unlink(__DIR__ . '/users.xml');
 			$userManager = null;
 		}

--- a/tests/unit/Util/Behaviors/TApplicationSignalTest.php
+++ b/tests/unit/Util/Behaviors/TApplicationSignalTest.php
@@ -31,8 +31,11 @@ class TApplicationSignalTest extends PHPUnit\Framework\TestCase
 
 	public function testAttachDetach()
 	{
+		if (!TSignalsDispatcher::hasSignals()) {
+			$this->markTestSkipped('pcntl signals are not available on this platform.');
+		}
 		$app = Prado::getApplication();
-		
+
 		self::assertNull(TSignalsDispatcher::singleton(false));
 		$this->behavior->setSignalsClass(TTestAppSignalsDispatcher::class);
 		

--- a/tests/unit/Util/Behaviors/TCaptureForkLogTest.php
+++ b/tests/unit/Util/Behaviors/TCaptureForkLogTest.php
@@ -4,6 +4,7 @@ use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\TComponent;
 use Prado\Prado;
 use Prado\Util\Behaviors\TMapLazyLoadBehavior;
+use Prado\Util\Helpers\TProcessHelper;
 
 
 class TCaptureForkLogTest extends PHPUnit\Framework\TestCase
@@ -24,6 +25,10 @@ class TCaptureForkLogTest extends PHPUnit\Framework\TestCase
 
 	public function testFork()
 	{
+		if (!TProcessHelper::isForkable()) {
+			$this->markTestSkipped('pcntl_fork is not available on this platform.');
+		}
+
 		$logger = Prado::getLogger();
 
 		$logger->deleteLogs();

--- a/tests/unit/Util/Helpers/TProcessHelperTest.php
+++ b/tests/unit/Util/Helpers/TProcessHelperTest.php
@@ -124,6 +124,7 @@ class TProcessHelperTest extends PHPUnit\Framework\TestCase
 		$process = proc_open($command, $descriptorspec, $pipes);
 		$info = proc_get_status($process);
 		$pid = $info['pid'];
+		usleep(50_000); // Allow time for the process to appear in the OS task list (needed on Windows).
 		self::assertTrue(TProcessHelper::isRunning($pid));
 		
 		self::assertTrue(is_int($processPriority = TProcessHelper::getProcessPriority($pid)));
@@ -154,7 +155,8 @@ class TProcessHelperTest extends PHPUnit\Framework\TestCase
 			$this->assertEquals($expected, TProcessHelper::escapeShellArg($argument));
 			
 			$argument = '"quoted"';
-			$expected = '\\"quoted\\"';
+			// 'quoted' is non-quote content so $addQuote=true; result is outer double-quotes wrapping the escaped inner quotes.
+			$expected = '"\"quoted\""';
 			$this->assertEquals($expected, TProcessHelper::escapeShellArg($argument));
 			
 			$argument = '%ENVIRONMENT%';

--- a/tests/unit/Util/TLoggerTest.php
+++ b/tests/unit/Util/TLoggerTest.php
@@ -430,11 +430,16 @@ class TLoggerTest extends PHPUnit\Framework\TestCase
 		$logger = new TTestLogger();
 		
 		$logger->log('message1', TLogger::INFO);
+		// Use explicitly increasing timestamps well past message1 so the sort order is
+		// deterministic even on fast machines where all microtime(true) calls may return
+		// the same value (the stable usort would otherwise preserve the _profileLogs-first
+		// merge order and put profiler1 before message1).
+		$t = microtime(true) + 0.1;
 		$newLogs = [
-				['profiler1', TLogger::PROFILE_BEGIN, \Prado\TApplication::class, microtime(true), memory_get_usage(), 'page.ctl1', null, -10000],
-				['messageChild', TLogger::INFO, \Prado\TModule::class, microtime(true), memory_get_usage(), 'page.ctl1', null, -10000],
-				['profiler1', TLogger::PROFILE_BEGIN, \Prado\TApplication::class, microtime(true), memory_get_usage(), 'page.ctl1', null, -11111],
-				['profiler1', TLogger::PROFILE_END, \Prado\TApplication::class, microtime(true), memory_get_usage(), 'page.ctl1', null, -11111],
+				['profiler1', TLogger::PROFILE_BEGIN, \Prado\TApplication::class, $t + 0.001, memory_get_usage(), 'page.ctl1', null, -10000],
+				['messageChild', TLogger::INFO, \Prado\TModule::class, $t + 0.002, memory_get_usage(), 'page.ctl1', null, -10000],
+				['profiler1', TLogger::PROFILE_BEGIN, \Prado\TApplication::class, $t + 0.003, memory_get_usage(), 'page.ctl1', null, -11111],
+				['profiler1', TLogger::PROFILE_END, \Prado\TApplication::class, $t + 0.004, memory_get_usage(), 'page.ctl1', null, -11111],
 			];
 		$logger->mergeLogs($newLogs);
 		

--- a/tests/unit/Util/TLoggerTest.php
+++ b/tests/unit/Util/TLoggerTest.php
@@ -338,7 +338,9 @@ class TLoggerTest extends PHPUnit\Framework\TestCase
 		
 		$logger->log('msg0', TLogger::INFO, \Prado\TApplication::class, 'page.div.ctl2');
 		$logger->log('token1', TLogger::PROFILE_BEGIN, \Prado\Web\THttpRequest::class, 'page.ctl1');
+		usleep(1000); // ensure a measurable gap before and after $middleTime on fast hardware (e.g. Apple Silicon)
 		$middleTime = microtime(true);
+		usleep(1000);
 		$logger->log('token2', TLogger::PROFILE_BEGIN);
 		$logger->log('token1', TLogger::PROFILE_END, \Prado\TApplication::class, 'page.ctl1');
 		$logger->log('msg1', TLogger::DEBUG, \Prado\TModule::class, 'page2.other.ctl3');

--- a/tests/unit/Util/TSignalsDispatcherTest.php
+++ b/tests/unit/Util/TSignalsDispatcherTest.php
@@ -221,6 +221,9 @@ class TSignalsDispatcherTest extends PHPUnit\Framework\TestCase
 	
 	public function testTEventSubscription()
 	{
+		if (!TSignalsDispatcher::hasSignals()) {
+			$this->markTestSkipped('pcntl signals are not available on this platform.');
+		}
 		$this->dispatcher = TSignalsDispatcher::singleton();
 		$subscription = new TEventSubscription($this->dispatcher, SIGTERM, $handler = function($sender, $param) {return true;}, 5);
 		self::assertTrue($subscription->getIsSubscribed());
@@ -308,6 +311,9 @@ class TSignalsDispatcherTest extends PHPUnit\Framework\TestCase
 	
 	public function testInvoke()
 	{
+		if (!TSignalsDispatcher::hasSignals()) {
+			$this->markTestSkipped('pcntl signals are not available on this platform.');
+		}
 		// Preset custom handlers, stored on attach, to be restored on detach
 		$ogHandler = new TTestSignalInvokable(8);
 		
@@ -481,6 +487,9 @@ class TSignalsDispatcherTest extends PHPUnit\Framework\TestCase
 	
 	public function testDelegateChild()
 	{
+		if (!TSignalsDispatcher::hasSignals()) {
+			$this->markTestSkipped('pcntl signals are not available on this platform.');
+		}
 		$this->dispatcher = new TTestSignalsDispatcher();
 		
 		$this->dispatcher->delegateChild($this->dispatcher, null);

--- a/tests/unit/Web/TAssetManagerTest.php
+++ b/tests/unit/Web/TAssetManagerTest.php
@@ -48,7 +48,8 @@ class TAssetManagerTest extends PHPUnit\Framework\TestCase
 		}
 
 		if (self::$assetDir === null) {
-			self::$assetDir = __DIR__ . '/assets';
+			// Use DIRECTORY_SEPARATOR so the path matches what framework internals produce on all OSes.
+			self::$assetDir = __DIR__ . DIRECTORY_SEPARATOR . 'assets';
 		}
 		// Make asset directory if not exists
 		if (!file_exists(self::$assetDir)) {
@@ -162,7 +163,7 @@ class TAssetManagerTest extends PHPUnit\Framework\TestCase
 		$fileToPublish = __DIR__ . '/data/pradoheader.gif';
 		$publishedUrl = $manager->publishFilePath($fileToPublish);
 		$publishedFile = self::$assetDir . $publishedUrl;
-		self::assertEquals($publishedFile, $manager->getPublishedPath($fileToPublish));
+		self::assertEquals(str_replace('\\', '/', $publishedFile), str_replace('\\', '/', $manager->getPublishedPath($fileToPublish)));
 		self::assertEquals($publishedUrl, $manager->getPublishedUrl($fileToPublish));
 		self::assertTrue(is_file($publishedFile));
 
@@ -184,7 +185,7 @@ class TAssetManagerTest extends PHPUnit\Framework\TestCase
 		$dirToPublish = __DIR__ . '/data';
 		$publishedUrl = $manager->publishFilePath($dirToPublish);
 		$publishedDir = self::$assetDir . $publishedUrl;
-		self::assertEquals($publishedDir, $manager->getPublishedPath($dirToPublish));
+		self::assertEquals(str_replace('\\', '/', $publishedDir), str_replace('\\', '/', $manager->getPublishedPath($dirToPublish)));
 		self::assertEquals($publishedUrl, $manager->getPublishedUrl($dirToPublish));
 		self::assertTrue(is_dir($publishedDir));
 		self::assertTrue(is_file($publishedDir . '/pradoheader.gif'));
@@ -594,6 +595,9 @@ class TAssetManagerTest extends PHPUnit\Framework\TestCase
 
 	public function testFileMode()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('File permission modes (chmod) are not honored on Windows NTFS.');
+		}
 		$manager = $this->newAssetManager();
 		$manager->setBaseUrl('/');
 		$manager->setFileMode(0644);
@@ -610,6 +614,9 @@ class TAssetManagerTest extends PHPUnit\Framework\TestCase
 
 	public function testDirMode()
 	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$this->markTestSkipped('Directory permission modes (chmod) are not honored on Windows NTFS.');
+		}
 		$manager = $this->newAssetManager();
 		$manager->setBaseUrl('/');
 		$manager->setDirMode(0755);

--- a/tests/unit/Web/UI/WebControls/TXmlTransformTest.php
+++ b/tests/unit/Web/UI/WebControls/TXmlTransformTest.php
@@ -45,7 +45,8 @@ class TXmlTransformTest extends PHPUnit\Framework\TestCase
 		$expected = $this->documentPath;
 		$transform = new TXmlTransform();
 		$transform->setDocumentPath('UnitTest.hello');
-		$this->assertEquals($expected, $transform->getDocumentPath());
+		// Normalize separators so the comparison is cross-platform (Windows may use backslashes).
+		$this->assertEquals(str_replace('\\', '/', $expected), str_replace('\\', '/', (string) $transform->getDocumentPath()));
 	}
 
 	public function testSetTransformContent()
@@ -72,7 +73,8 @@ class TXmlTransformTest extends PHPUnit\Framework\TestCase
 		$expected = $this->transformPath;
 		$transform = new TXmlTransform();
 		$transform->setTransformPath('UnitTest.hello');
-		$this->assertEquals($expected, $transform->getTransformPath());
+		// Normalize separators so the comparison is cross-platform (Windows may use backslashes).
+		$this->assertEquals(str_replace('\\', '/', $expected), str_replace('\\', '/', (string) $transform->getTransformPath()));
 	}
 
 	public function testAddParameter()


### PR DESCRIPTION
Given the complexity of TTarFileExtractor and weirdnesses with MacOS, I thought it prudent to test PRADO on Mac and Windows.

In this PR:
- Mac and Windows Github CI with PHP 8.2
- Fixed TTarFileExtractor to properly work on Windows.
- TProcessHelper update to current Windows 2022 Server and Windows 11 shell commands.
- TSignalsDispatcher fixes to account for lack of pcntl.
- fixed latent bug in THttpRequestUrlFormat::HiddenPath  regarding dirname. 

A perfect example of strangeness with Apple is their weird vendor specific additions to SQLite.  Testing Prado against PDO on Apple has brought a long standing PDO_SQLite (on macOS) bug to light. See: [https://github.com/php/php-src/issues/21936](https://github.com/php/php-src/issues/21936)