### PR TITLE
Adds Event Parameter Lifecycle to TComponent::raiseEvent, TEventParameter::ReadOnly

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -26,6 +26,8 @@ eventhandler_no_set_handler				= TEventHandler cannot set the event handler, ind
 eventhandler_bad_offset					= TEventHandler does not have offset "{0}".
 
 eventparam_readonly						= {0} is read-only.
+eventparam_readonly_set					= {0} cannot change ReadOnly once it has been set.
+eventparam_readonly_not_self			= {0} ReadOnly can only be set internally.
 
 list_index_invalid						= Index '{0}' is out of range.
 list_item_inexistent					= The item cannot be found in the list.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -25,6 +25,8 @@ eventhandler_lost_weak_ref				= TEventHandler cannot invoke the event handler be
 eventhandler_no_set_handler				= TEventHandler cannot set the event handler, index "{0}".
 eventhandler_bad_offset					= TEventHandler does not have offset "{0}".
 
+eventparam_readonly						= {0} is read-only.
+
 list_index_invalid						= Index '{0}' is out of range.
 list_item_inexistent					= The item cannot be found in the list.
 list_data_not_iterable					= Data must be either an array or an object implementing Traversable interface.

--- a/framework/IEventCycleParameter.php
+++ b/framework/IEventCycleParameter.php
@@ -81,8 +81,8 @@ interface IEventCycleParameter extends IEventParameter
 	 * @param string $name The event name (lowercase)
 	 * @param mixed $sender The object raising the event
 	 * @param TEventParameter $param The event parameter instance
-	 * @param null|int $responsetype How results should be tabulated (see TEventResults constants)
-	 * @param null|callable $postfunction Optional callable for post-processing each handler response
+	 * @param ?int $responsetype How results should be tabulated (see TEventResults constants)
+	 * @param ?callable $postfunction Optional callable for post-processing each handler response
 	 * @see TComponent::raiseEvent
 	 * @see TEventResults
 	 */
@@ -114,8 +114,8 @@ interface IEventCycleParameter extends IEventParameter
 	 * @param string $name The event name (lowercase)
 	 * @param mixed $sender The object raising the event
 	 * @param TEventParameter $param The event parameter instance
-	 * @param null|int $responsetype How responses were tabulated
-	 * @param null|callable $postfunction The post-processing function that was used
+	 * @param ?int $responsetype How responses were tabulated
+	 * @param ?callable $postfunction The post-processing function that was used
 	 * @see TComponent::raiseEvent
 	 * @see TEventResults
 	 */

--- a/framework/IEventCycleParameter.php
+++ b/framework/IEventCycleParameter.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * IEventCycleParameter interface.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado;
+
+/**
+ * IEventCycleParameter interface.
+ *
+ * Extends {@see IEventParameter} to provide event lifecycle hooks that are invoked
+ * by {@see TComponent::raiseEvent} before and after event handlers are executed.
+ *
+ * This interface allows event parameters to participate in the event raising process
+ * by providing hooks for pre-processing before handlers are called and post-processing
+ * after all handlers have completed. This is useful for:
+ * - Logging event execution.
+ * - Modifying event parameters before they reach handlers.
+ * - Processing or aggregating handler responses.
+ * - Implementing event caching or optimization strategies.
+ *
+ * When an event parameter implements this interface, {@see TComponent::raiseEvent}
+ * automatically invokes the lifecycle methods at appropriate points:
+ * 1. Before event handlers: {@see preRaiseEvent} is called.
+ * 2. Event handlers are executed in standard fashion.
+ * 3. After event handlers: {@see postRaiseEvent} is called with all responses.
+ *
+ * The lifecycle methods receive the same parameters used in the event raising process,
+ * allowing the parameter to access the event name, sender, response type, and post-function.
+ *
+ * Usage example:
+ * ```php
+ * class TLoggingEventParameter extends TEventParameter implements IEventCycleParameter
+ * {
+ *     public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction)
+ *     {
+ *         // Log that event is about to be raised
+ *         Prado::log("Event {$name} raised by " . $sender::class, 'info');
+ *     }
+ *
+ *     public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction)
+ *     {
+ *         // Log results after event processing
+ *         $responseCount = is_array($responses) ? count($responses) : 0;
+ *         Prado::log("Event {$name} completed with {$responseCount} responses", 'info');
+ *     }
+ * }
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.3.3
+ * @see TComponent::raiseEvent
+ * @see TEventParameter
+ */
+interface IEventCycleParameter extends IEventParameter
+{
+	/**
+	 * Invoked before event handlers are executed during {@see TComponent::raiseEvent}.
+	 *
+	 * This method is called immediately after the event name is set on the parameter
+	 * and before any event handlers are invoked. It allows the event parameter to
+	 * perform pre-processing, validation, or initialization based on the event context.
+	 *
+	 * The method receives all parameters involved in the event raising process:
+	 * - $name: The event name (lowercase)
+	 * - $sender: The object raising the event
+	 * - $param: The event parameter instance itself
+	 * - $responsetype: How to handle handler responses (EVENT_RESULT_FILTER, etc.)
+	 * - $postfunction: Optional callable for per-handler response processing
+	 *
+	 * This is useful for:
+	 * - Logging/debugging event execution
+	 * - Validating or modifying event context before handlers run
+	 * - Setting up state for tracking during the event lifecycle
+	 *
+	 * @param string $name The event name (lowercase)
+	 * @param mixed $sender The object raising the event
+	 * @param TEventParameter $param The event parameter instance
+	 * @param null|int $responsetype How results should be tabulated (see TEventResults constants)
+	 * @param null|callable $postfunction Optional callable for post-processing each handler response
+	 * @see TComponent::raiseEvent
+	 * @see TEventResults
+	 */
+	public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction);
+
+	/**
+	 * Invoked after all event handlers have been executed during {@see TComponent::raiseEvent}.
+	 *
+	 * This method is called after all event handlers complete execution and after any
+	 * response filtering or post-processing has occurred. It receives the aggregated
+	 * responses from all handlers, allowing the event parameter to perform final
+	 * processing, aggregation, or cleanup.
+	 *
+	 * The method receives:
+	 * - $responses: Array of handler responses (or filtered responses based on responsetype)
+	 * - $name: The event name (lowercase)
+	 * - $sender: The object raising the event
+	 * - $param: The event parameter instance
+	 * - $responsetype: How responses were tabulated
+	 * - $postfunction: The post-processing function that was used
+	 *
+	 * This is useful for:
+	 * - Aggregating or analyzing handler responses
+	 * - Logging event completion and results
+	 * - Implementing caching or memoization of results
+	 * - Cleanup of state set up in preRaiseEvent
+	 *
+	 * @param array $responses Aggregated responses from all event handlers
+	 * @param string $name The event name (lowercase)
+	 * @param mixed $sender The object raising the event
+	 * @param TEventParameter $param The event parameter instance
+	 * @param null|int $responsetype How responses were tabulated
+	 * @param null|callable $postfunction The post-processing function that was used
+	 * @see TComponent::raiseEvent
+	 * @see TEventResults
+	 */
+	public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction);
+}

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1428,13 +1428,18 @@ class TComponent
 	 * specifying {@see \Prado\TEventResults::EVENT_REVERSE} can be used to reverse the order of the
 	 * handlers.
 	 *
+	 * If `$param` implements {@see \Prado\IEventCycleParameter}, its
+	 * {@see \Prado\IEventCycleParameter::preRaiseEvent} and
+	 * {@see \Prado\IEventCycleParameter::postRaiseEvent} are called for pre- and
+	 * post-processing of the event lifecycle.
+	 *
 	 * @param string $name the event name
 	 * @param mixed $sender the event sender object
 	 * @param \Prado\TEventParameter $param the event parameter
-	 * @param null|numeric $responsetype how the results of the event are tabulated.  default: {@see EVENT_RESULT_FILTER}  The default filters out
-	 *		null responses. optional
-	 * @param null|callable $postfunction any per handler filtering of the response result needed is passed through
-	 *		this if not null. default: null.  optional
+	 * @param null|numeric $responsetype how the results of the event are tabulated.
+	 *      default: {@see EVENT_RESULT_FILTER}  The default filters out null responses. optional
+	 * @param null|callable $postfunction any per handler filtering of the response result needed
+	 *		is passed through this if not null. default: null.  optional
 	 * @throws TInvalidOperationException if the event is undefined
 	 * @throws TInvalidDataValueException If an event handler is invalid
 	 * @return mixed the results of the event
@@ -1456,6 +1461,9 @@ class TComponent
 
 		if ($param instanceof IEventParameter) {
 			$param->setEventName($name);
+		}
+		if (($param instanceof TComponent && $param->isa(IEventCycleParameter::class)) || $param instanceof IEventCycleParameter) {
+			$param->preRaiseEvent($name, $sender, $param, $responsetype, $postfunction);
 		}
 
 		$this->callBehaviorsMethod('dyPreRaiseEvent', $name, $name, $sender, $param, $responsetype, $postfunction);
@@ -1541,6 +1549,10 @@ class TComponent
 		}
 
 		$this->callBehaviorsMethod('dyPostRaiseEvent', $responses, $responses, $name, $sender, $param, $responsetype, $postfunction);
+
+		if (($param instanceof TComponent && $param->isa(IEventCycleParameter::class)) || $param instanceof IEventCycleParameter) {
+			$param->postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction);
+		}
 
 		return $responses;
 	}

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -15,6 +15,7 @@
 namespace Prado;
 
 use ArrayAccess;
+use Prado\Exceptions\TInvalidOperationException;
 
 /**
  * TEventParameter class.
@@ -35,8 +36,13 @@ use ArrayAccess;
  * handlers that modify the parameter object (e.g., TMap) but does not change the
  * TEventParameter's reference to that object.
  *
+ * TEventParameter supports a {@see setReadOnly ReadOnly} mode. When ReadOnly is true,
+ * any attempt to mutate the parameter — via {@see setParameter}, {@see offsetSet}, or
+ * {@see offsetUnset} — will throw a {@see \Prado\Exceptions\TInvalidOperationException}.
+ * Reads are always permitted regardless of ReadOnly state.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @author Brad Anderson <belisoful@icloud.com> ArrayAccess, ParameterChanged
+ * @author Brad Anderson <belisoful@icloud.com> ArrayAccess, ParameterChanged, ReadOnly
  * @since 3.0
  */
 class TEventParameter extends \Prado\TComponent implements IEventParameter, ArrayAccess
@@ -44,6 +50,7 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	private string $_eventName = '';
 	private mixed $_param = null;
 	private bool $_parameterChanged = false;
+	private bool $_readOnly = false;
 
 	/**
 	 * Constructor.
@@ -90,10 +97,14 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 
 	/**
 	 * @param mixed $value parameter of the event
+	 * @throws TInvalidOperationException if the TEventParameter is read-only
 	 * @since 4.3.0
 	 */
 	public function setParameter(mixed $value)
 	{
+		if ($this->getReadOnly()) {
+			throw new TInvalidOperationException('eventparam_readonly', $this::class);
+		}
 		$this->setParameterChanged($value !== $this->_param);
 		$this->_param = $value;
 	}
@@ -130,6 +141,26 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	public function resetParameterChanged()
 	{
 		$this->_parameterChanged = false;
+	}
+
+	/**
+	 * @return bool whether the TEventParameter is read-only
+	 * @since 4.3.3
+	 */
+	public function getReadOnly(): bool
+	{
+		return $this->_readOnly;
+	}
+
+	/**
+	 * When ReadOnly is true, any call to {@see setParameter}, {@see offsetSet}, or
+	 * {@see offsetUnset} will throw a {@see \Prado\Exceptions\TInvalidOperationException}.
+	 * @param bool $value whether the TEventParameter should be read-only
+	 * @since 4.3.3
+	 */
+	public function setReadOnly(bool $value)
+	{
+		$this->_readOnly = $value;
 	}
 
 	/**
@@ -181,10 +212,14 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 * this has no effect.
 	 * @param mixed $offset the offset to set element
 	 * @param mixed $item the element value
+	 * @throws TInvalidOperationException if the TEventParameter is read-only
 	 * @since 4.3.3
 	 */
 	public function offsetSet($offset, $item): void
 	{
+		if ($this->getReadOnly()) {
+			throw new TInvalidOperationException('eventparam_readonly', $this::class);
+		}
 		if ($this->_param === null) {
 			$this->setParameter([]);
 		}
@@ -209,10 +244,14 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 * is an array (or ArrayAccess) this will unset the item at $offset.  Otherwise
 	 * this has no effect.
 	 * @param mixed $offset the offset to unset element
+	 * @throws TInvalidOperationException if the TEventParameter is read-only
 	 * @since 4.3.3
 	 */
 	public function offsetUnset($offset): void
 	{
+		if ($this->getReadOnly()) {
+			throw new TInvalidOperationException('eventparam_readonly', $this::class);
+		}
 		if (!$this->getParameterIsArray() || !isset($this->_param[$offset])) {
 			return;
 		}

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -194,6 +194,39 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 		return is_array($this->_param) || $this->_param instanceof ArrayAccess;
 	}
 
+	/**
+	 * Called by {@see TComponent::raiseEvent} before any event handlers are invoked.
+	 * Subclasses that implement {@see IEventCycleParameter} may override this to
+	 * perform pre-processing. This base implementation does nothing.
+	 *
+	 * @param string $name the event name
+	 * @param mixed $sender the object raising the event
+	 * @param TEventParameter $param the event parameter
+	 * @param ?int $responsetype how responses are tabulated
+	 * @param ?callable $postfunction optional per-handler response filter
+	 * @since 4.3.3
+	 */
+	public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction)
+	{
+	}
+
+	/**
+	 * Called by {@see TComponent::raiseEvent} after all event handlers have run.
+	 * Subclasses that implement {@see IEventCycleParameter} may override this to
+	 * inspect or transform the aggregated responses. This base implementation does nothing.
+	 *
+	 * @param array $responses aggregated responses from all event handlers
+	 * @param string $name the event name
+	 * @param mixed $sender the object raising the event
+	 * @param TEventParameter $param the event parameter
+	 * @param ?int $responsetype how responses were tabulated
+	 * @param ?callable $postfunction the post-processing function that was used
+	 * @since 4.3.3
+	 */
+	public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction)
+	{
+	}
+
 	//	----- ArrayAccess -----
 
 	/**

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -22,8 +22,8 @@ use Prado\Exceptions\TInvalidOperationException;
  *
  * TEventParameter is the base class for all event parameter classes.
  * When raising an event, this class captures the event name being raised by being
- * an {@see \Prado\IEventParameter}. TEventParameter encapsulates the parameter data for
- * events. The event parameter is set via {@see setParameter Parameter} property
+ * an {@see IEventParameter}. TEventParameter encapsulates the parameter data for
+ * events. The event parameter is set via {@see setParameter} property
  * or by constructor parameter.
  *
  * TEventParameter also implements \ArrayAccess to allow direct access to the
@@ -41,8 +41,12 @@ use Prado\Exceptions\TInvalidOperationException;
  * {@see offsetUnset} — will throw a {@see \Prado\Exceptions\TInvalidOperationException}.
  * Reads are always permitted regardless of ReadOnly state.
  *
+ * Subclasses may implement {@see IEventCycleParameter} to participate in the event raising
+ * process via {@see IEventCycleParameter::preRaiseEvent} and
+ * {@see IEventCycleParameter::postRaiseEvent} lifecycle hooks.
+ *
  * @author Qiang Xue <qiang.xue@gmail.com>
- * @author Brad Anderson <belisoful@icloud.com> ArrayAccess, ParameterChanged, ReadOnly
+ * @author Brad Anderson <belisoful@icloud.com> ArrayAccess, ParameterChanged, Event Life Cycle
  * @since 3.0
  */
 class TEventParameter extends \Prado\TComponent implements IEventParameter, ArrayAccess
@@ -50,16 +54,18 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	private string $_eventName = '';
 	private mixed $_param = null;
 	private bool $_parameterChanged = false;
-	private bool $_readOnly = false;
+	private ?bool $_readOnly = null;
 
 	/**
 	 * Constructor.
 	 * @param null|mixed $parameter parameter of the event
+	 * @param bool $readOnly
 	 * @since 4.3.0
 	 */
-	public function __construct(mixed $parameter = null)
+	public function __construct(mixed $parameter = null, $readOnly = false)
 	{
 		$this->setParameter($parameter);
+		$this->setReadOnly($readOnly);
 		$this->resetParameterChanged();
 		parent::__construct();
 	}
@@ -102,9 +108,7 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function setParameter(mixed $value)
 	{
-		if ($this->getReadOnly()) {
-			throw new TInvalidOperationException('eventparam_readonly', $this::class);
-		}
+		$this->assertMutable();
 		$this->setParameterChanged($value !== $this->_param);
 		$this->_param = $value;
 	}
@@ -119,14 +123,11 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	}
 
 	/**
-	 * This provides handlers to be able to set the "parameter changed" if the internal
-	 * Event Parameter was an object, like TMap.  The handler can changed the TMap
-	 * (event parameter object) without changing the TEventParameter::Parameter. This
-	 * method provides a way to "manually" set the ParameterChanged of the event.
-	 * This is a one-way function where once ParameterChanged is true, it remains true
-	 * until {@see resetParameterChanged} is called. If false is passed, this method
-	 * does nothing.
-	 * @param bool $value Sets if the Parameter has changed.
+	 * Manually marks the parameter as changed. Useful when the parameter is a
+	 * mutable object (e.g. TMap) whose contents change without replacing the reference.
+	 * One-way: once `true`, stays `true` until {@see resetParameterChanged}.
+	 * Passing `false` is a no-op.
+	 * @param bool $value whether the parameter has changed.
 	 * @since 4.3.3
 	 */
 	public function setParameterChanged(bool $value)
@@ -149,18 +150,39 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function getReadOnly(): bool
 	{
-		return $this->_readOnly;
+		return (bool) $this->_readOnly;
 	}
 
 	/**
-	 * When ReadOnly is true, any call to {@see setParameter}, {@see offsetSet}, or
-	 * {@see offsetUnset} will throw a {@see \Prado\Exceptions\TInvalidOperationException}.
-	 * @param bool $value whether the TEventParameter should be read-only
+	 * Sets the ReadOnly state. Internal use only; may only be called once and only
+	 * from within the object itself (constructor or subclass methods).
+	 * @param bool $value whether the TEventParameter should be read-only.
+	 * @throws TInvalidOperationException if ReadOnly has already been set, or if
+	 *   called from outside the object.
 	 * @since 4.3.3
 	 */
-	public function setReadOnly(bool $value)
+	public function setReadOnly($value)
 	{
-		$this->_readOnly = $value;
+		if ($this->_readOnly !== null) {
+			throw new TInvalidOperationException('eventparam_readonly_set', $this::class);
+		}
+		if (!Prado::isCallingSelf()) {
+			throw new TInvalidOperationException('eventparam_readonly_not_self', $this::class);
+		}
+		$this->_readOnly = (bool) $value;
+	}
+
+	/**
+	 * Asserts that the TEventParameter is mutable, throwing a
+	 * {@see TInvalidOperationException} if {@see getReadOnly ReadOnly} is true.
+	 * @throws TInvalidOperationException if the TEventParameter is read-only
+	 * @since 4.3.3
+	 */
+	protected function assertMutable(): void
+	{
+		if ($this->getReadOnly()) {
+			throw new TInvalidOperationException('eventparam_readonly', $this::class);
+		}
 	}
 
 	/**
@@ -217,9 +239,7 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function offsetSet($offset, $item): void
 	{
-		if ($this->getReadOnly()) {
-			throw new TInvalidOperationException('eventparam_readonly', $this::class);
-		}
+		$this->assertMutable();
 		if ($this->_param === null) {
 			$this->setParameter([]);
 		}
@@ -249,9 +269,7 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	 */
 	public function offsetUnset($offset): void
 	{
-		if ($this->getReadOnly()) {
-			throw new TInvalidOperationException('eventparam_readonly', $this::class);
-		}
+		$this->assertMutable();
 		if (!$this->getParameterIsArray() || !isset($this->_param[$offset])) {
 			return;
 		}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -238,6 +238,7 @@ return [
 'TTranslate' => 'Prado\I18N\TTranslate',
 'TTranslateParameter' => 'Prado\I18N\TTranslateParameter',
 'IDataRenderer' => 'Prado\IDataRenderer',
+'IEventCycleParameter' => 'Prado\IEventCycleParameter',
 'IEventParameter' => 'Prado\IEventParameter',
 'IModule' => 'Prado\IModule',
 'ITextWriter' => 'Prado\IO\ITextWriter',

--- a/tests/unit/IEventCycleParameterTest.php
+++ b/tests/unit/IEventCycleParameterTest.php
@@ -1,0 +1,386 @@
+<?php
+
+use Prado\IEventCycleParameter;
+use Prado\IEventParameter;
+use Prado\TComponent;
+use Prado\TEventParameter;
+use Prado\TEventResults;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A minimal TComponent subclass that exposes a single 'OnTestEvent' event,
+ * used to drive raiseEvent in all lifecycle tests.
+ */
+class EventCycleHost extends TComponent
+{
+	public function onTestEvent($param)
+	{
+		return $this->raiseEvent('OnTestEvent', $this, $param);
+	}
+
+	public function onTestEventWith($param, $responsetype = null, $postfunction = null)
+	{
+		return $this->raiseEvent('OnTestEvent', $this, $param, $responsetype, $postfunction);
+	}
+}
+
+/**
+ * A TEventParameter subclass that records every lifecycle call made to it,
+ * so tests can assert call order, arguments, and counts.
+ */
+class RecordingEventParameter extends TEventParameter implements IEventCycleParameter
+{
+	public array $preCalls = [];
+	public array $postCalls = [];
+
+	public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction)
+	{
+		$this->preCalls[] = compact('name', 'sender', 'param', 'responsetype', 'postfunction');
+	}
+
+	public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction)
+	{
+		$this->postCalls[] = compact('responses', 'name', 'sender', 'param', 'responsetype', 'postfunction');
+	}
+}
+
+/**
+ * A plain PHP class (not a TComponent) that implements IEventCycleParameter directly,
+ * used to test the non-TComponent branch of the raiseEvent check.
+ */
+class PlainCycleParameter implements IEventCycleParameter
+{
+	public string $_eventName = '';
+	public array $preCalls = [];
+	public array $postCalls = [];
+
+	public function getEventName(): string
+	{
+		return $this->_eventName;
+	}
+
+	public function setEventName(string $value)
+	{
+		$this->_eventName = $value;
+	}
+
+	public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction)
+	{
+		$this->preCalls[] = compact('name', 'sender', 'param', 'responsetype', 'postfunction');
+	}
+
+	public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction)
+	{
+		$this->postCalls[] = compact('responses', 'name', 'sender', 'param', 'responsetype', 'postfunction');
+	}
+}
+
+class IEventCycleParameterTest extends TestCase
+{
+	private EventCycleHost $host;
+
+	protected function setUp(): void
+	{
+		$this->host = new EventCycleHost();
+	}
+
+	protected function tearDown(): void
+	{
+		$this->host->onTestEvent(null);
+	}
+
+	// ================================================================================
+	// Interface Contract Tests
+	// ================================================================================
+
+	public function testInterfaceExtendsIEventParameter()
+	{
+		$this->assertTrue(is_a(IEventCycleParameter::class, IEventParameter::class, true));
+	}
+
+	public function testTEventParameterDoesNotImplementIEventCycleParameter()
+	{
+		$param = new TEventParameter();
+		$this->assertNotInstanceOf(IEventCycleParameter::class, $param);
+	}
+
+	public function testPlainClassImplementsIEventCycleParameter()
+	{
+		$param = new PlainCycleParameter();
+		$this->assertInstanceOf(IEventCycleParameter::class, $param);
+	}
+
+	// ================================================================================
+	// IEventCycleParameter Concrete Implementation Tests
+	// ================================================================================
+
+	public function testPreRaiseEventStubDoesNotThrow()
+	{
+		// TEventParameter has no stubs — only subclasses implementing IEventCycleParameter
+		// define pre/postRaiseEvent. Verify a concrete implementor can be called without throwing.
+		$param = new RecordingEventParameter();
+		$param->preRaiseEvent('ontestevent', $this->host, $param, null, null);
+		$this->assertTrue(true);
+	}
+
+	public function testPostRaiseEventStubDoesNotThrow()
+	{
+		$param = new RecordingEventParameter();
+		$param->postRaiseEvent([], 'ontestevent', $this->host, $param, null, null);
+		$this->assertTrue(true);
+	}
+
+	// ================================================================================
+	// raiseEvent calls preRaiseEvent and postRaiseEvent (TComponent param)
+	// ================================================================================
+
+	public function testPreRaiseEventCalledBeforeHandlers()
+	{
+		$order = [];
+		$param = new RecordingEventParameter();
+		// Record original pre so we can prepend to $order
+		$param->preCalls = [];
+
+		// Override preRaiseEvent via anonymous subclass to capture call order
+		$param2 = new class extends RecordingEventParameter {
+			public array $order = [];
+			public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction)
+			{
+				parent::preRaiseEvent($name, $sender, $param, $responsetype, $postfunction);
+				$this->order[] = 'pre';
+			}
+		};
+		$this->host->attachEventHandler('OnTestEvent', function ($sender, $param) use (&$param2) {
+			$param2->order[] = 'handler';
+		});
+		$this->host->onTestEvent($param2);
+
+		$this->assertEquals(['pre', 'handler'], $param2->order);
+	}
+
+	public function testPostRaiseEventCalledAfterHandlers()
+	{
+		$param = new class extends RecordingEventParameter {
+			public array $order = [];
+			public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction)
+			{
+				parent::postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction);
+				$this->order[] = 'post';
+			}
+		};
+		$this->host->attachEventHandler('OnTestEvent', function ($sender, $p) use (&$param) {
+			$param->order[] = 'handler';
+		});
+		$this->host->onTestEvent($param);
+
+		$this->assertEquals(['handler', 'post'], $param->order);
+	}
+
+	public function testPreThenHandlersThenPost()
+	{
+		$param = new class extends RecordingEventParameter {
+			public array $order = [];
+			public function preRaiseEvent($name, $sender, $p, $responsetype, $postfunction)
+			{
+				$this->order[] = 'pre';
+			}
+			public function postRaiseEvent($responses, $name, $sender, $p, $responsetype, $postfunction)
+			{
+				$this->order[] = 'post';
+			}
+		};
+		$this->host->attachEventHandler('OnTestEvent', function ($sender, $p) use (&$param) {
+			$param->order[] = 'handler1';
+		});
+		$this->host->attachEventHandler('OnTestEvent', function ($sender, $p) use (&$param) {
+			$param->order[] = 'handler2';
+		});
+		$this->host->onTestEvent($param);
+
+		$this->assertEquals(['pre', 'handler1', 'handler2', 'post'], $param->order);
+	}
+
+	public function testPreAndPostCalledExactlyOnce()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->attachEventHandler('OnTestEvent', function ($sender, $p) {});
+		$this->host->attachEventHandler('OnTestEvent', function ($sender, $p) {});
+		$this->host->onTestEvent($param);
+
+		$this->assertCount(1, $param->preCalls);
+		$this->assertCount(1, $param->postCalls);
+	}
+
+	public function testPreAndPostCalledEvenWithNoHandlers()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertCount(1, $param->preCalls);
+		$this->assertCount(1, $param->postCalls);
+	}
+
+	// ================================================================================
+	// Arguments passed to preRaiseEvent
+	// ================================================================================
+
+	public function testPreRaiseEventReceivesCorrectName()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertEquals('ontestevent', $param->preCalls[0]['name']);
+	}
+
+	public function testPreRaiseEventReceivesCorrectSender()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertSame($this->host, $param->preCalls[0]['sender']);
+	}
+
+	public function testPreRaiseEventReceivesParamInstance()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertSame($param, $param->preCalls[0]['param']);
+	}
+
+	public function testPreRaiseEventReceivesResponsetype()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEventWith($param, TEventResults::EVENT_RESULT_ALL);
+
+		$this->assertSame(TEventResults::EVENT_RESULT_ALL, $param->preCalls[0]['responsetype']);
+	}
+
+	public function testPreRaiseEventReceivesPostfunction()
+	{
+		$param = new RecordingEventParameter();
+		$fn = static fn($s, $p, $c, $r) => $r;
+		$this->host->onTestEventWith($param, null, $fn);
+
+		$this->assertSame($fn, $param->preCalls[0]['postfunction']);
+	}
+
+	// ================================================================================
+	// Arguments passed to postRaiseEvent
+	// ================================================================================
+
+	public function testPostRaiseEventReceivesResponses()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->attachEventHandler('OnTestEvent', fn($s, $p) => 'response1');
+		$this->host->attachEventHandler('OnTestEvent', fn($s, $p) => 'response2');
+		$this->host->onTestEvent($param);
+
+		$this->assertContains('response1', $param->postCalls[0]['responses']);
+		$this->assertContains('response2', $param->postCalls[0]['responses']);
+	}
+
+	public function testPostRaiseEventReceivesCorrectName()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertEquals('ontestevent', $param->postCalls[0]['name']);
+	}
+
+	public function testPostRaiseEventReceivesCorrectSender()
+	{
+		$param = new RecordingEventParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertSame($this->host, $param->postCalls[0]['sender']);
+	}
+
+	public function testPostRaiseEventResponsesAreFiltered()
+	{
+		// Default responsetype is EVENT_RESULT_FILTER — null responses are stripped
+		$param = new RecordingEventParameter();
+		$this->host->attachEventHandler('OnTestEvent', fn($s, $p) => null);
+		$this->host->attachEventHandler('OnTestEvent', fn($s, $p) => 'kept');
+		$this->host->onTestEvent($param);
+
+		$responses = $param->postCalls[0]['responses'];
+		$this->assertNotContains(null, $responses);
+		$this->assertContains('kept', $responses);
+	}
+
+	// ================================================================================
+	// Plain (non-TComponent) IEventCycleParameter
+	// ================================================================================
+
+	public function testPlainParamPreRaiseEventCalled()
+	{
+		$param = new PlainCycleParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertCount(1, $param->preCalls);
+	}
+
+	public function testPlainParamPostRaiseEventCalled()
+	{
+		$param = new PlainCycleParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertCount(1, $param->postCalls);
+	}
+
+	public function testPlainParamReceivesCorrectName()
+	{
+		$param = new PlainCycleParameter();
+		$this->host->onTestEvent($param);
+
+		$this->assertEquals('ontestevent', $param->preCalls[0]['name']);
+	}
+
+	public function testPlainParamPreAndPostCalledInOrder()
+	{
+		$order = [];
+		$param = new class implements IEventCycleParameter {
+			public string $_eventName = '';
+			public array $order = [];
+			public function getEventName(): string { return $this->_eventName; }
+			public function setEventName(string $value) { $this->_eventName = $value; }
+			public function preRaiseEvent($name, $sender, $param, $responsetype, $postfunction)
+			{
+				$this->order[] = 'pre';
+			}
+			public function postRaiseEvent($responses, $name, $sender, $param, $responsetype, $postfunction)
+			{
+				$this->order[] = 'post';
+			}
+		};
+		$this->host->attachEventHandler('OnTestEvent', function ($s, $p) use (&$param) {
+			$param->order[] = 'handler';
+		});
+		$this->host->onTestEvent($param);
+
+		$this->assertEquals(['pre', 'handler', 'post'], $param->order);
+	}
+
+	// ================================================================================
+	// Null param — no lifecycle calls
+	// ================================================================================
+
+	public function testNullParamDoesNotTriggerLifecycle()
+	{
+		// Simply must not throw — no IEventCycleParameter to call
+		$this->host->onTestEvent(null);
+		$this->assertTrue(true);
+	}
+
+	public function testNonCycleParamDoesNotTriggerLifecycle()
+	{
+		// A plain TEventParameter does not implement IEventCycleParameter, so
+		// raiseEvent will not call preRaiseEvent/postRaiseEvent on it. The stub
+		// methods exist for subclasses to override but do not trigger the lifecycle.
+		// Verify this does not throw.
+		$param = new TEventParameter('value');
+		$this->host->onTestEvent($param);
+		$this->assertTrue(true);
+	}
+}

--- a/tests/unit/TEventParameterTest.php
+++ b/tests/unit/TEventParameterTest.php
@@ -732,118 +732,155 @@ class TEventParameterTest extends TestCase
 		$this->assertFalse($param->getReadOnly());
 	}
 
-	public function testSetReadOnlyTrue()
+	public function testReadOnlyTrueViaConstructor()
 	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
+		$param = new TEventParameter('value', true);
 		$this->assertTrue($param->getReadOnly());
 	}
 
-	public function testSetReadOnlyFalse()
+	public function testReadOnlyFalseViaConstructor()
 	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
-		$param->setReadOnly(false);
+		$param = new TEventParameter('value', false);
 		$this->assertFalse($param->getReadOnly());
 	}
 
-	public function testSetReadOnlyToggle()
+	public function testSetReadOnlyThrowsWhenCalledExternally()
 	{
 		$param = new TEventParameter('value');
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->setReadOnly(true);
-		$this->assertTrue($param->getReadOnly());
-		$param->setReadOnly(false);
-		$this->assertFalse($param->getReadOnly());
-		$param->setReadOnly(true);
-		$this->assertTrue($param->getReadOnly());
+	}
+
+	public function testSetReadOnlyThrowsWhenAlreadySet()
+	{
+		// Use a subclass to expose setReadOnly as a second internal call
+		$param = new class('value', false) extends TEventParameter {
+			public function trySetReadOnly(bool $value): void
+			{
+				$this->setReadOnly($value);
+			}
+		};
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->trySetReadOnly(true);
 	}
 
 	public function testSetParameterThrowsWhenReadOnly()
 	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
+		$param = new TEventParameter('value', true);
 		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->setParameter('new value');
 	}
 
-	public function testSetParameterAllowedAfterReadOnlyReset()
-	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
-		$param->setReadOnly(false);
-		$param->setParameter('new value');
-		$this->assertEquals('new value', $param->getParameter());
-	}
-
 	public function testOffsetSetThrowsWhenReadOnly()
 	{
-		$param = new TEventParameter(['key' => 'value']);
-		$param->setReadOnly(true);
+		$param = new TEventParameter(['key' => 'value'], true);
 		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->offsetSet('key', 'new value');
 	}
 
 	public function testOffsetSetOnNullThrowsWhenReadOnly()
 	{
-		$param = new TEventParameter(null);
-		$param->setReadOnly(true);
+		$param = new TEventParameter(null, true);
 		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->offsetSet('key', 'value');
 	}
 
 	public function testOffsetUnsetThrowsWhenReadOnly()
 	{
-		$param = new TEventParameter(['key' => 'value']);
-		$param->setReadOnly(true);
+		$param = new TEventParameter(['key' => 'value'], true);
 		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->offsetUnset('key');
 	}
 
 	public function testOffsetUnsetOnNonArrayThrowsWhenReadOnly()
 	{
-		$param = new TEventParameter('string');
-		$param->setReadOnly(true);
+		$param = new TEventParameter('string', true);
 		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->offsetUnset('key');
 	}
 
 	public function testGetParameterAllowedWhenReadOnly()
 	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
+		$param = new TEventParameter('value', true);
 		$this->assertEquals('value', $param->getParameter());
 	}
 
 	public function testOffsetGetAllowedWhenReadOnly()
 	{
-		$param = new TEventParameter(['key' => 'value']);
-		$param->setReadOnly(true);
+		$param = new TEventParameter(['key' => 'value'], true);
 		$this->assertEquals('value', $param->offsetGet('key'));
 	}
 
 	public function testOffsetExistsAllowedWhenReadOnly()
 	{
-		$param = new TEventParameter(['key' => 'value']);
-		$param->setReadOnly(true);
+		$param = new TEventParameter(['key' => 'value'], true);
 		$this->assertTrue($param->offsetExists('key'));
 		$this->assertFalse($param->offsetExists('missing'));
 	}
 
 	public function testSetEventNameAllowedWhenReadOnly()
 	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
+		$param = new TEventParameter('value', true);
 		$param->setEventName('SomeEvent');
 		$this->assertEquals('SomeEvent', $param->getEventName());
 	}
 
 	public function testReadOnlyDoesNotAffectParameterChanged()
 	{
-		$param = new TEventParameter('value');
-		$param->setReadOnly(true);
+		$param = new TEventParameter('value', true);
 		$this->assertFalse($param->getParameterChanged());
-		// Manual flag still works
+		// Manual flag still works when read-only
 		$param->setParameterChanged(true);
 		$this->assertTrue($param->getParameterChanged());
+	}
+
+	// ================================================================================
+	// assertMutable Tests
+	// ================================================================================
+
+	private function makeExposed(mixed $parameter = null, bool $readOnly = false): object
+	{
+		return new class($parameter, $readOnly) extends TEventParameter {
+			public function callAssertMutable(): void
+			{
+				$this->assertMutable();
+			}
+		};
+	}
+
+	public function testAssertMutablePassesWhenNotReadOnly()
+	{
+		$param = $this->makeExposed('value', false);
+		// Must not throw
+		$param->callAssertMutable();
+		$this->assertFalse($param->getReadOnly());
+	}
+
+	public function testAssertMutableThrowsWhenReadOnly()
+	{
+		$param = $this->makeExposed('value', true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->callAssertMutable();
+	}
+
+	public function testAssertMutableThrowsOnSetParameterWhenReadOnly()
+	{
+		$param = $this->makeExposed('value', true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->setParameter('new');
+	}
+
+	public function testAssertMutableThrowsOnOffsetSetWhenReadOnly()
+	{
+		$param = $this->makeExposed(['key' => 'value'], true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->offsetSet('key', 'new');
+	}
+
+	public function testAssertMutableThrowsOnOffsetUnsetWhenReadOnly()
+	{
+		$param = $this->makeExposed(['key' => 'value'], true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->offsetUnset('key');
 	}
 }

--- a/tests/unit/TEventParameterTest.php
+++ b/tests/unit/TEventParameterTest.php
@@ -721,4 +721,129 @@ class TEventParameterTest extends TestCase
 		$param = new TEventParameter([]);
 		$this->assertTrue($param->getParameterIsArray());
 	}
+
+	// ================================================================================
+	// ReadOnly Property Tests
+	// ================================================================================
+
+	public function testReadOnlyDefaultIsFalse()
+	{
+		$param = new TEventParameter('value');
+		$this->assertFalse($param->getReadOnly());
+	}
+
+	public function testSetReadOnlyTrue()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$this->assertTrue($param->getReadOnly());
+	}
+
+	public function testSetReadOnlyFalse()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$param->setReadOnly(false);
+		$this->assertFalse($param->getReadOnly());
+	}
+
+	public function testSetReadOnlyToggle()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$this->assertTrue($param->getReadOnly());
+		$param->setReadOnly(false);
+		$this->assertFalse($param->getReadOnly());
+		$param->setReadOnly(true);
+		$this->assertTrue($param->getReadOnly());
+	}
+
+	public function testSetParameterThrowsWhenReadOnly()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->setParameter('new value');
+	}
+
+	public function testSetParameterAllowedAfterReadOnlyReset()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$param->setReadOnly(false);
+		$param->setParameter('new value');
+		$this->assertEquals('new value', $param->getParameter());
+	}
+
+	public function testOffsetSetThrowsWhenReadOnly()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->setReadOnly(true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->offsetSet('key', 'new value');
+	}
+
+	public function testOffsetSetOnNullThrowsWhenReadOnly()
+	{
+		$param = new TEventParameter(null);
+		$param->setReadOnly(true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->offsetSet('key', 'value');
+	}
+
+	public function testOffsetUnsetThrowsWhenReadOnly()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->setReadOnly(true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->offsetUnset('key');
+	}
+
+	public function testOffsetUnsetOnNonArrayThrowsWhenReadOnly()
+	{
+		$param = new TEventParameter('string');
+		$param->setReadOnly(true);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$param->offsetUnset('key');
+	}
+
+	public function testGetParameterAllowedWhenReadOnly()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$this->assertEquals('value', $param->getParameter());
+	}
+
+	public function testOffsetGetAllowedWhenReadOnly()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->setReadOnly(true);
+		$this->assertEquals('value', $param->offsetGet('key'));
+	}
+
+	public function testOffsetExistsAllowedWhenReadOnly()
+	{
+		$param = new TEventParameter(['key' => 'value']);
+		$param->setReadOnly(true);
+		$this->assertTrue($param->offsetExists('key'));
+		$this->assertFalse($param->offsetExists('missing'));
+	}
+
+	public function testSetEventNameAllowedWhenReadOnly()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$param->setEventName('SomeEvent');
+		$this->assertEquals('SomeEvent', $param->getEventName());
+	}
+
+	public function testReadOnlyDoesNotAffectParameterChanged()
+	{
+		$param = new TEventParameter('value');
+		$param->setReadOnly(true);
+		$this->assertFalse($param->getParameterChanged());
+		// Manual flag still works
+		$param->setParameterChanged(true);
+		$this->assertTrue($param->getParameterChanged());
+	}
 }


### PR DESCRIPTION
This is useful to lock down Violations as its passed around in TCspReporterService.