### PR TITLE
Fixed php-cs-fixer GitHub annotations

### DIFF
--- a/.github/workflows/prado.yml
+++ b/.github/workflows/prado.yml
@@ -42,7 +42,12 @@ jobs:
         run: composer validate --strict
 
       - name: Validate code syntax using php-cs-fixer
-        run: php-cs-fixer fix -vvv --dry-run --using-cache=no --format=checkstyle | cs2pr
+        run: |
+          php-cs-fixer check -vvv --using-cache=no || true
+          echo " "
+          echo "---------------------- Generating Annotations ----------------------"
+          echo "Run php-cs-fixer check --using-cache=no --format=checkstyle | cs2pr"
+          php-cs-fixer check --using-cache=no --format=checkstyle | cs2pr
 
       - name: Get composer cache directory
         id: composer-cache
@@ -132,7 +137,12 @@ jobs:
         run: composer validate --strict
 
       - name: Validate code syntax using php-cs-fixer
-        run: php-cs-fixer fix -vvv --dry-run --using-cache=no --format=checkstyle | cs2pr
+        run: |
+          php-cs-fixer check -vvv --using-cache=no || true
+          echo " "
+          echo "---------------------- Generating Annotations ----------------------"
+          echo "Run php-cs-fixer check --using-cache=no --format=checkstyle | cs2pr"
+          php-cs-fixer check --using-cache=no --format=checkstyle | cs2pr
 
       - name: Get composer cache directory
         id: composer-cache
@@ -201,7 +211,12 @@ jobs:
         run: composer validate --strict
 
       - name: Validate code syntax using php-cs-fixer
-        run: php-cs-fixer fix -vvv --dry-run --using-cache=no --format=checkstyle | cs2pr
+        run: |
+          php-cs-fixer check -vvv --using-cache=no || true
+          echo " "
+          echo "---------------------- Generating Annotations ----------------------"
+          echo "Run php-cs-fixer check --using-cache=no --format=checkstyle | cs2pr"
+          php-cs-fixer check --using-cache=no --format=checkstyle | cs2pr
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
php-cs-fixer requires two runs: one for the cli log and one for the GitHub Annotations.

This is because php-cs-fixer doesn't output its cli to stderr but to stdout, which is piped to cs2pr.  cs2pr gets confused by the broken format.

phpstan separates the formatted result (to stdout) from the cli log output  (to stderr).  php-cs-fixer doesn't have this separation, it must be run twice.