### PR TITLE
TDbCache - Fix: The moment the cache expires is still a valid cache.

### DIFF
--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -430,7 +430,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			$this->initializeCache();
 		}
 
-		$sql = 'SELECT value FROM ' . $this->_cacheTable . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>' . time() . ') ORDER BY expire DESC';
+		$sql = 'SELECT value FROM ' . $this->_cacheTable . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>=' . time() . ') ORDER BY expire DESC';
 		$command = $this->getDbConnection()->createCommand($sql);
 		try {
 			return unserialize($command->queryScalar());


### PR DESCRIPTION
The cache is only invalid after `expire`.