### PR TITLE
Fix for CultureInfo finding Resource Bundles with mixed ICU/POSIX languages

### DIFF
--- a/framework/I18N/TGlobalization.php
+++ b/framework/I18N/TGlobalization.php
@@ -23,6 +23,12 @@ use Prado\TPropertyValue;
  * are determined. See TGlobalizationAutoDetect for example of
  * setting the Culture based on browser settings.
  *
+ * **POSIX underscore convention** — culture identifiers are stored and
+ * propagated in POSIX form (underscore separator, e.g. "en_US", "zh_TW").
+ * Incoming BCP 47 hyphen-separated values (the web/browser standard, e.g.
+ * "en-US", "zh-TW") are normalized to POSIX form in {@see setCulture()}.
+ * See {@see CultureInfo} for details on the POSIX/BCP 47 relationship.
+ *
  * @author Wei Zhuo<weizhuo[at]gmail[dot]com>
  * @since 3.0
  */
@@ -156,10 +162,17 @@ class TGlobalization extends \Prado\TModule
 	}
 
 	/**
+	 * Sets the active culture using the POSIX underscore convention
+	 * (e.g. "en_US", "zh_TW").  Hyphen-separated BCP 47 values coming from
+	 * browsers or HTTP Accept-Language headers (e.g. "en-US", "zh-TW") are
+	 * normalized to the POSIX form so the rest of the framework remains
+	 * consistent.  See {@see CultureInfo} for details on the POSIX/BCP 47
+	 * relationship.
 	 * @param string $culture culture, e.g. <tt>en_US</tt> for American English
 	 */
 	public function setCulture($culture)
 	{
+		// POSIX convention: normalize any BCP 47 hyphens to underscores.
 		if (($culture = str_replace('-', '_', $culture)) != $this->_culture) {
 			$this->_culture = $culture;
 			$this->_cultureRTL = null;

--- a/framework/I18N/TGlobalizationAutoDetect.php
+++ b/framework/I18N/TGlobalizationAutoDetect.php
@@ -71,9 +71,17 @@ class TGlobalizationAutoDetect extends TGlobalization
 	}
 
 	/**
-	 * Checks wether the specified locale is valid and available
+	 * Checks whether the specified locale is valid and available.
+	 *
+	 * {@see \ResourceBundle::getLocales()} returns locale identifiers in a
+	 * format that varies by ICU version and locale: some entries use BCP 47
+	 * hyphens (e.g. "en-US"), others use POSIX underscores (e.g. "de_DE").
+	 * All three match directions are therefore tried, consistent with
+	 * {@see CultureInfo::validCulture()}: direct match, POSIX→BCP 47, and
+	 * BCP 47→POSIX.
 	 * @param mixed $locale
 	 * @return bool
+	 * @since 4.3.3
 	 */
 	protected function getIsValidLocale($locale)
 	{
@@ -81,7 +89,9 @@ class TGlobalizationAutoDetect extends TGlobalization
 		if ($allLocales === null) {
 			$allLocales = \ResourceBundle::getLocales('');
 		}
-		return in_array($locale, $allLocales);
+		return in_array($locale, $allLocales)
+			|| in_array(str_replace('_', '-', $locale), $allLocales)
+			|| in_array(str_replace('-', '_', $locale), $allLocales);
 	}
 
 	/**

--- a/framework/I18N/core/CultureInfo.php
+++ b/framework/I18N/core/CultureInfo.php
@@ -46,6 +46,27 @@ use IntlException;
  *
  * For example, Australian English is "en_AU".
  *
+ * **POSIX underscore convention** — PRADO uses the POSIX locale identifier
+ * format throughout (underscore separator, e.g. "en_AU", "zh_TW").  This
+ * differs from the BCP 47 web standard used by browsers and modern ICU
+ * (hyphen separator, e.g. "en-AU", "zh-TW").  {@see TGlobalization::setCulture()}
+ * normalizes incoming hyphen-separated values to the POSIX form so that the
+ * rest of the framework remains consistent.  Resource file names, page
+ * templates (e.g. Home.zh_TW.page), application config Culture attributes,
+ * and translation catalogue filenames (e.g. index.zh_TW.xml) all follow the
+ * same POSIX underscore convention.
+ *
+ * **ICU input vs ICU output** — ICU lookup functions that PRADO calls as
+ * inputs ({@see \ResourceBundle::create()}, {@see \IntlDateFormatter},
+ * {@see \NumberFormatter}) accept POSIX underscore form natively; no
+ * conversion is needed when passing PRADO culture strings to them.  The one
+ * exception is {@see \ResourceBundle::getLocales()}, which *outputs* locale
+ * identifiers in a format that varies by ICU version and locale: some entries
+ * use BCP 47 hyphens (e.g. "en-US"), others use POSIX underscores (e.g. "de_DE").
+ * Any code that compares a culture string against that list must bridge both
+ * directions — see {@see validCulture()} and
+ * {@see TGlobalizationAutoDetect::getIsValidLocale()}.
+ *
  * CultureInfo can format a number with formatNumber.
  *
  * The unit-related methods getUnit(), formatUnit(), and formatPerUnit() provide
@@ -206,12 +227,28 @@ class CultureInfo
 	/**
 	 * Determine if a given culture is valid. Simply checks that the
 	 * culture data exists.
+	 *
+	 * PRADO's convention uses underscores in culture identifiers (e.g. "de_DE"),
+	 * and {@see TGlobalization::setCulture()} normalizes any hyphen-separated
+	 * input to that form.  However, {@see ResourceBundle::getLocales()} returns
+	 * locale identifiers in a format that varies by ICU version and locale: some
+	 * entries use BCP 47 hyphens (e.g. "en-US"), others use POSIX underscores
+	 * (e.g. "de_DE").  All three cases are therefore tried here:
+	 *   1. Direct match (handles whichever form the list uses for this locale).
+	 *   2. POSIX → BCP 47 (underscore to hyphen): handles POSIX input when the
+	 *      ICU list stores the locale in BCP 47 form.
+	 *   3. BCP 47 → POSIX (hyphen to underscore): handles BCP 47 input when the
+	 *      ICU list stores the locale in POSIX form.
 	 * @param string $culture a culture
 	 * @return bool true if valid, false otherwise.
+	 * @since 4.3.3
 	 */
 	public static function validCulture($culture)
 	{
-		return in_array($culture, self::getCultures());
+		$cultures = self::getCultures();
+		return in_array($culture, $cultures)
+			|| in_array(str_replace('_', '-', $culture), $cultures)
+			|| in_array(str_replace('-', '_', $culture), $cultures);
 	}
 
 	/**
@@ -390,6 +427,13 @@ class CultureInfo
 	 * Gets a value indicating whether the current CultureInfo
 	 * represents a neutral culture. Returns true if the culture
 	 * only contains two characters.
+	 *
+	 * **POSIX assumption** — the two-character length test works for POSIX
+	 * neutral cultures (e.g. "zh", "fr") because PRADO normalises all culture
+	 * identifiers to the POSIX underscore form.  Note that BCP 47 locale tags
+	 * that include a script subtag (e.g. "zh-Hant-TW", length 10; "zh-Hant",
+	 * length 7) would not satisfy this check, but such tags are converted to
+	 * their POSIX equivalents before reaching this method.
 	 * @return bool true if culture is neutral, false otherwise.
 	 */
 	public function getIsNeutralCulture()
@@ -402,6 +446,12 @@ class CultureInfo
 	 * culture type. This is an EXPENSIVE function, it needs to traverse
 	 * a list of ICU files in the data directory.
 	 * This function can be called statically.
+	 *
+	 * **ICU vs POSIX** — {@see \ResourceBundle::getLocales()} returns locale
+	 * identifiers in BCP 47 hyphen form on modern ICU (e.g. "zh-TW"), while
+	 * PRADO's POSIX convention uses underscores (e.g. "zh_TW").  The list is
+	 * returned verbatim; callers such as {@see validCulture()} are responsible
+	 * for bridging the gap between the two forms.
 	 * @param int $type culture type, CultureInfo::ALL, CultureInfo::NEUTRAL
 	 * or CultureInfo::SPECIFIC.
 	 * @return array list of culture information available.

--- a/tests/unit/I18N/TGlobalizationAutoDetectTest.php
+++ b/tests/unit/I18N/TGlobalizationAutoDetectTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Prado\I18N\TGlobalizationAutoDetect;
+
+/**
+ * Exposes the protected getIsValidLocale() method for unit testing.
+ */
+class TGlobalizationAutoDetectTestable extends TGlobalizationAutoDetect
+{
+	public function isValidLocale(string $locale): bool
+	{
+		return $this->getIsValidLocale($locale);
+	}
+
+	/** Reset the language cache so each test starts clean. */
+	public function resetLanguages(): void
+	{
+		$this->languages = null;
+	}
+
+	/** Expose the protected getLanguages() for unit testing. */
+	public function getLanguages(): array
+	{
+		return parent::getLanguages();
+	}
+}
+
+class TGlobalizationAutoDetectTest extends TestCase
+{
+	private TGlobalizationAutoDetectTestable $autoDetect;
+
+	protected function setUp(): void
+	{
+		$this->autoDetect = new TGlobalizationAutoDetectTestable();
+	}
+
+	protected function tearDown(): void
+	{
+		// Restore Accept-Language so other tests are not affected.
+		unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+	}
+
+	// ── getIsValidLocale ────────────────────────────────────────────────────
+
+	/**
+	 * PRADO's POSIX underscore form must be accepted regardless of what
+	 * format ResourceBundle::getLocales() uses internally.  getIsValidLocale()
+	 * tries all three match directions (direct, POSIX→BCP 47, BCP 47→POSIX).
+	 */
+	public function testGetIsValidLocaleAcceptsPosixUnderscoreForm()
+	{
+		$this->assertTrue($this->autoDetect->isValidLocale('en_US'));
+		$this->assertTrue($this->autoDetect->isValidLocale('fr_FR'));
+		$this->assertTrue($this->autoDetect->isValidLocale('de_DE'));
+	}
+
+	/**
+	 * BCP 47 hyphen form must also be accepted.  ResourceBundle::getLocales()
+	 * stores some locales in BCP 47 form and some in POSIX form depending on
+	 * ICU version; getIsValidLocale() bridges both directions so that either
+	 * form can be validated successfully.
+	 */
+	public function testGetIsValidLocaleAcceptsBcp47HyphenForm()
+	{
+		$this->assertTrue($this->autoDetect->isValidLocale('en-US'));
+		$this->assertTrue($this->autoDetect->isValidLocale('fr-FR'));
+		$this->assertTrue($this->autoDetect->isValidLocale('de-DE'));
+	}
+
+	public function testGetIsValidLocaleRejectsInvalidLocale()
+	{
+		$this->assertFalse($this->autoDetect->isValidLocale('invalid_locale'));
+		$this->assertFalse($this->autoDetect->isValidLocale('xx_YY'));
+	}
+
+	// ── getLanguages ────────────────────────────────────────────────────────
+
+	/**
+	 * Browser Accept-Language headers are BCP 47 (hyphens).  getLanguages()
+	 * must convert them to POSIX underscore form before validating, and the
+	 * result must be in POSIX form for the rest of the framework.
+	 */
+	public function testGetLanguagesConvertsBcp47ToPosixForm()
+	{
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de-DE';
+		$this->autoDetect->resetLanguages();
+
+		$languages = $this->autoDetect->getLanguages();
+
+		$this->assertContains('de_DE', $languages);
+		$this->assertNotContains('de-DE', $languages);
+	}
+
+	public function testGetLanguagesAcceptsSimpleLanguageCode()
+	{
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'fr';
+		$this->autoDetect->resetLanguages();
+
+		$this->assertContains('fr', $this->autoDetect->getLanguages());
+	}
+
+	public function testGetLanguagesIgnoresQValues()
+	{
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.9,fr;q=0.8';
+		$this->autoDetect->resetLanguages();
+
+		$languages = $this->autoDetect->getLanguages();
+
+		$this->assertContains('en_US', $languages);
+		$this->assertContains('en', $languages);
+		$this->assertContains('fr', $languages);
+	}
+
+	public function testGetLanguagesReturnsEmptyArrayWhenHeaderAbsent()
+	{
+		unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+		$this->autoDetect->resetLanguages();
+
+		$this->assertSame([], $this->autoDetect->getLanguages());
+	}
+}

--- a/tests/unit/I18N/TGlobalizationTest.php
+++ b/tests/unit/I18N/TGlobalizationTest.php
@@ -1,0 +1,460 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Prado\I18N\TGlobalization;
+
+class TGlobalizationTest extends TestCase
+{
+	private TGlobalization $glob;
+
+	protected function setUp(): void
+	{
+		$this->glob = new TGlobalization();
+	}
+
+	// ── default state ───────────────────────────────────────────────────────
+
+	public function testDefaultCultureIsEn()
+	{
+		$this->assertSame('en', $this->glob->getDefaultCulture());
+	}
+
+	public function testDefaultCharsetIsUtf8()
+	{
+		$this->assertSame('UTF-8', $this->glob->getDefaultCharset());
+	}
+
+	public function testDefaultTranslateDefaultCultureIsTrue()
+	{
+		$this->assertTrue($this->glob->getTranslateDefaultCulture());
+	}
+
+	public function testGetCultureReturnsNullBeforeInit()
+	{
+		// setCulture() has never been called and init() has not run.
+		$this->assertNull($this->glob->getCulture());
+	}
+
+	public function testGetCharsetReturnsNullBeforeInit()
+	{
+		$this->assertNull($this->glob->getCharset());
+	}
+
+	// ── setCulture / getCulture ─────────────────────────────────────────────
+
+	public function testSetCultureStoresPosixForm()
+	{
+		$this->glob->setCulture('en_US');
+		$this->assertSame('en_US', $this->glob->getCulture());
+	}
+
+	/**
+	 * Browsers and HTTP Accept-Language headers send BCP 47 hyphen-separated
+	 * identifiers.  setCulture() must convert them to the POSIX underscore
+	 * form so the rest of the framework (file lookup, CultureInfo, etc.) works.
+	 */
+	public function testSetCultureNormalisesBcp47HyphensToPostixUnderscores()
+	{
+		$this->glob->setCulture('en-US');
+		$this->assertSame('en_US', $this->glob->getCulture());
+
+		$this->glob->setCulture('zh-TW');
+		$this->assertSame('zh_TW', $this->glob->getCulture());
+
+		$this->glob->setCulture('fr-FR');
+		$this->assertSame('fr_FR', $this->glob->getCulture());
+	}
+
+	/** BCP 47 script subtags also use hyphens; all must become underscores. */
+	public function testSetCultureNormalisesMultipleHyphens()
+	{
+		$this->glob->setCulture('zh-Hant-TW');
+		$this->assertSame('zh_Hant_TW', $this->glob->getCulture());
+	}
+
+	public function testSetCultureIdempotentWhenAlreadyPosix()
+	{
+		$this->glob->setCulture('de_DE');
+		$this->assertSame('de_DE', $this->glob->getCulture());
+	}
+
+	public function testSetCultureAcceptsNeutralCulture()
+	{
+		$this->glob->setCulture('fr');
+		$this->assertSame('fr', $this->glob->getCulture());
+	}
+
+	/**
+	 * When the new value is identical to the current value (after normalisation)
+	 * the assignment branch is skipped, so the RTL cache must NOT be cleared.
+	 * We hard-set the cache to a known value and verify it survives.
+	 */
+	public function testSetCultureSameValueDoesNotClearRtlCache()
+	{
+		$this->glob->setCulture('en');
+		$this->glob->setIsCultureRTL(true);        // poison cache with sentinel
+
+		$this->glob->setCulture('en');              // no-op: same value
+		$this->assertTrue($this->glob->getIsCultureRTL()); // cache still holds
+	}
+
+	/** Changing the culture must invalidate the RTL cache. */
+	public function testSetCultureClearsRtlCacheOnChange()
+	{
+		$this->glob->setCulture('ar');
+		$this->glob->getIsCultureRTL();             // populate cache (ar is RTL)
+		$this->assertTrue($this->glob->getIsCultureRTL());
+
+		$this->glob->setCulture('en');              // different value → clears cache
+		$this->assertFalse($this->glob->getIsCultureRTL()); // recomputed for 'en'
+	}
+
+	// ── setDefaultCulture / getDefaultCulture ───────────────────────────────
+
+	public function testSetDefaultCultureStoresPosixForm()
+	{
+		$this->glob->setDefaultCulture('de_DE');
+		$this->assertSame('de_DE', $this->glob->getDefaultCulture());
+	}
+
+	/** setDefaultCulture also follows the POSIX normalisation rule. */
+	public function testSetDefaultCultureNormalisesBcp47Hyphens()
+	{
+		$this->glob->setDefaultCulture('zh-TW');
+		$this->assertSame('zh_TW', $this->glob->getDefaultCulture());
+	}
+
+	// ── charset ─────────────────────────────────────────────────────────────
+
+	public function testSetGetCharset()
+	{
+		$this->glob->setCharset('ISO-8859-1');
+		$this->assertSame('ISO-8859-1', $this->glob->getCharset());
+	}
+
+	public function testSetGetDefaultCharset()
+	{
+		$this->glob->setDefaultCharset('windows-1252');
+		$this->assertSame('windows-1252', $this->glob->getDefaultCharset());
+	}
+
+	// ── setTranslateDefaultCulture / getTranslateDefaultCulture ────────────
+
+	public function testSetTranslateDefaultCultureWithBoolTrue()
+	{
+		$this->glob->setTranslateDefaultCulture(true);
+		$this->assertTrue($this->glob->getTranslateDefaultCulture());
+	}
+
+	public function testSetTranslateDefaultCultureWithBoolFalse()
+	{
+		$this->glob->setTranslateDefaultCulture(false);
+		$this->assertFalse($this->glob->getTranslateDefaultCulture());
+	}
+
+	public function testSetTranslateDefaultCultureWithStringTrue()
+	{
+		$this->glob->setTranslateDefaultCulture('true');
+		$this->assertTrue($this->glob->getTranslateDefaultCulture());
+
+		$this->glob->setTranslateDefaultCulture('TRUE');   // case-insensitive
+		$this->assertTrue($this->glob->getTranslateDefaultCulture());
+	}
+
+	public function testSetTranslateDefaultCultureWithStringFalse()
+	{
+		$this->glob->setTranslateDefaultCulture('false');
+		$this->assertFalse($this->glob->getTranslateDefaultCulture());
+	}
+
+	public function testSetTranslateDefaultCultureWithNumericString()
+	{
+		$this->glob->setTranslateDefaultCulture('1');
+		$this->assertTrue($this->glob->getTranslateDefaultCulture());
+
+		$this->glob->setTranslateDefaultCulture('0');
+		$this->assertFalse($this->glob->getTranslateDefaultCulture());
+	}
+
+	// ── getTranslationConfiguration ─────────────────────────────────────────
+
+	public function testGetTranslationConfigurationReturnsNullWhenNotConfigured()
+	{
+		// Default: _translateDefaultCulture=true, _translation=null
+		$this->assertNull($this->glob->getTranslationConfiguration());
+	}
+
+	/**
+	 * When TranslateDefaultCulture is false and the current culture matches
+	 * the default culture, no translation should be applied — returns null
+	 * regardless of whether _translation is set.
+	 */
+	public function testGetTranslationConfigurationReturnsNullWhenCultureMatchesDefaultAndTranslateDefaultIsOff()
+	{
+		$this->glob->setTranslateDefaultCulture(false);
+		$this->glob->setCulture('en');               // matches default 'en'
+		$this->glob->setTranslationCatalogue('messages');
+
+		$this->assertNull($this->glob->getTranslationConfiguration());
+	}
+
+	/**
+	 * When TranslateDefaultCulture is false but the current culture differs
+	 * from the default, the translation configuration IS returned.
+	 */
+	public function testGetTranslationConfigurationReturnsCatalogueWhenCultureDiffersFromDefault()
+	{
+		$this->glob->setTranslateDefaultCulture(false);
+		$this->glob->setCulture('fr');               // differs from default 'en'
+		$this->glob->setTranslationCatalogue('messages');
+
+		$config = $this->glob->getTranslationConfiguration();
+		$this->assertNotNull($config);
+		$this->assertSame('messages', $config['catalogue']);
+	}
+
+	/**
+	 * When TranslateDefaultCulture is true (the default), the translation
+	 * configuration is always returned, even when culture == defaultCulture.
+	 */
+	public function testGetTranslationConfigurationReturnsCatalogueWhenTranslateDefaultIsOn()
+	{
+		$this->glob->setTranslateDefaultCulture(true);
+		$this->glob->setCulture('en');               // matches default, but translate=true
+		$this->glob->setTranslationCatalogue('messages');
+
+		$config = $this->glob->getTranslationConfiguration();
+		$this->assertNotNull($config);
+		$this->assertSame('messages', $config['catalogue']);
+	}
+
+	// ── setTranslationCatalogue / getTranslationCatalogue ───────────────────
+
+	public function testSetGetTranslationCatalogue()
+	{
+		$this->glob->setTranslationCatalogue('messages');
+		$this->assertSame('messages', $this->glob->getTranslationCatalogue());
+	}
+
+	public function testSetTranslationCatalogueCanBeUpdated()
+	{
+		$this->glob->setTranslationCatalogue('messages');
+		$this->glob->setTranslationCatalogue('other');
+		$this->assertSame('other', $this->glob->getTranslationCatalogue());
+	}
+
+	// ── getCultureVariants ──────────────────────────────────────────────────
+
+	public function testGetCultureVariantsUsesCurrentCultureWhenNullPassed()
+	{
+		$this->glob->setCulture('en_US');
+		$this->assertSame(['en_US', 'en'], $this->glob->getCultureVariants());
+	}
+
+	public function testGetCultureVariantsForNeutralCulture()
+	{
+		$this->glob->setCulture('fr');
+		$this->assertSame(['fr'], $this->glob->getCultureVariants());
+	}
+
+	public function testGetCultureVariantsForSpecificCulture()
+	{
+		$this->assertSame(['de_DE', 'de'], $this->glob->getCultureVariants('de_DE'));
+	}
+
+	/** Three-level POSIX culture (script subtag) splits into three variants. */
+	public function testGetCultureVariantsForThreeLevelCulture()
+	{
+		$variants = $this->glob->getCultureVariants('zh_Hant_TW');
+		$this->assertSame(['zh_Hant_TW', 'zh_Hant', 'zh'], $variants);
+	}
+
+	/** Explicit culture param overrides the current culture. */
+	public function testGetCultureVariantsExplicitParamOverridesCurrentCulture()
+	{
+		$this->glob->setCulture('en_US');
+		$this->assertSame(['fr_FR', 'fr'], $this->glob->getCultureVariants('fr_FR'));
+	}
+
+	/**
+	 * BCP 47 input is normalised to POSIX by setCulture() before reaching
+	 * getCultureVariants(), so the variants are always underscore-separated.
+	 */
+	public function testGetCultureVariantsAfterBcp47Normalisation()
+	{
+		$this->glob->setCulture('zh-TW');           // normalised to zh_TW
+		$this->assertSame(['zh_TW', 'zh'], $this->glob->getCultureVariants());
+	}
+
+	// ── getLocalizedResource ────────────────────────────────────────────────
+
+	public function testGetLocalizedResourceReturnsAllVariantsInOrder()
+	{
+		// For en_US the expected order is:
+		//   directory variants (most specific first): en_US/, en/
+		//   filename variants (most specific first):  .en_US., .en.
+		//   original file (fallback)
+		$sep = DIRECTORY_SEPARATOR;
+		$expected = [
+			"path/to{$sep}en_US{$sep}Home.page",
+			"path/to{$sep}en{$sep}Home.page",
+			"path/to{$sep}Home.en_US.page",
+			"path/to{$sep}Home.en.page",
+			'path/to/Home.page',
+		];
+
+		$this->glob->setCulture('en_US');
+		$this->assertSame($expected, $this->glob->getLocalizedResource('path/to/Home.page'));
+	}
+
+	public function testGetLocalizedResourceWithExplicitCulture()
+	{
+		$sep = DIRECTORY_SEPARATOR;
+		$this->glob->setCulture('en');
+
+		$files = $this->glob->getLocalizedResource('path/to/Home.page', 'de_DE');
+
+		$this->assertContains("path/to{$sep}de_DE{$sep}Home.page", $files);
+		$this->assertContains("path/to{$sep}de{$sep}Home.page", $files);
+		$this->assertContains("path/to{$sep}Home.de_DE.page", $files);
+		$this->assertContains("path/to{$sep}Home.de.page", $files);
+		$this->assertNotContains("path/to{$sep}en{$sep}Home.page", $files); // explicit overrides
+	}
+
+	public function testGetLocalizedResourceAlwaysIncludesOriginalFileAsLast()
+	{
+		$this->glob->setCulture('fr');
+		$files = $this->glob->getLocalizedResource('path/to/Home.page');
+
+		$this->assertSame('path/to/Home.page', end($files));
+	}
+
+	public function testGetLocalizedResourceForNeutralCultureHasThreeEntries()
+	{
+		// neutral culture: 1 directory + 1 filename + 1 original = 3
+		$this->glob->setCulture('fr');
+		$this->assertCount(3, $this->glob->getLocalizedResource('path/to/Home.page'));
+	}
+
+	public function testGetLocalizedResourceForSpecificCultureHasFiveEntries()
+	{
+		// specific culture (2 variants): 2 directory + 2 filename + 1 original = 5
+		$this->glob->setCulture('en_US');
+		$this->assertCount(5, $this->glob->getLocalizedResource('path/to/Home.page'));
+	}
+
+	public function testGetLocalizedResourceForThreeLevelCultureHasSevenEntries()
+	{
+		// 3 variants: 3 directory + 3 filename + 1 original = 7
+		$this->glob->setCulture('zh_Hant_TW');
+		$this->assertCount(7, $this->glob->getLocalizedResource('path/to/Home.page'));
+	}
+
+	/**
+	 * Resource file names follow POSIX underscore convention.  A BCP 47 input
+	 * is normalised before lookup so the paths contain underscores, not hyphens.
+	 */
+	public function testGetLocalizedResourceBcp47InputProducesPosixUnderscorePaths()
+	{
+		$sep = DIRECTORY_SEPARATOR;
+		$this->glob->setCulture('zh-TW');           // normalised to zh_TW
+
+		$files = $this->glob->getLocalizedResource('path/to/Home.page');
+
+		$this->assertContains("path/to{$sep}zh_TW{$sep}Home.page", $files);
+		$this->assertContains("path/to{$sep}Home.zh_TW.page", $files);
+		$this->assertNotContains("path/to{$sep}zh-TW{$sep}Home.page", $files);
+		$this->assertNotContains("path/to{$sep}Home.zh-TW.page", $files);
+	}
+
+	// ── getIsCultureRTL / setIsCultureRTL ───────────────────────────────────
+
+	public function testGetIsCultureRtlReturnsFalseForLtrCulture()
+	{
+		$this->glob->setCulture('en');
+		$this->assertFalse($this->glob->getIsCultureRTL());
+	}
+
+	public function testGetIsCultureRtlReturnsTrueForRtlCulture()
+	{
+		$this->glob->setCulture('ar');              // Arabic is right-to-left
+		$this->assertTrue($this->glob->getIsCultureRTL());
+	}
+
+	/** Result for the current culture is cached after the first call. */
+	public function testGetIsCultureRtlCachesResultForCurrentCulture()
+	{
+		$this->glob->setCulture('en');
+		$this->glob->getIsCultureRTL();             // populate cache
+
+		// Poison the hard-set value; if cache is in use the poisoned value is returned.
+		$this->glob->setIsCultureRTL(true);
+		$this->assertTrue($this->glob->getIsCultureRTL()); // cache holds
+	}
+
+	/**
+	 * Querying an explicit culture that differs from the current culture must
+	 * NOT store the result in the cache; the next null-param call must still
+	 * recompute from the current culture.
+	 */
+	public function testGetIsCultureRtlDoesNotCacheForExplicitDifferentCulture()
+	{
+		$this->glob->setCulture('en');
+
+		$rtl = $this->glob->getIsCultureRTL('ar'); // compute for 'ar', must not cache
+		$this->assertTrue($rtl);
+
+		// 'en' cache must still be empty — hard-set to sentinel to distinguish
+		$this->glob->setIsCultureRTL(false);
+		$this->assertFalse($this->glob->getIsCultureRTL()); // returns hard-set 'en' cache
+	}
+
+	/**
+	 * Calling getIsCultureRTL() with an explicit culture equal to the current
+	 * culture must use — and populate — the cache just like the null-param form.
+	 */
+	public function testGetIsCultureRtlExplicitCultureMatchingCurrentUsesCacheSlot()
+	{
+		$this->glob->setCulture('ar');
+		$this->glob->getIsCultureRTL('ar');         // explicit == current → populates cache
+
+		$this->glob->setIsCultureRTL(false);        // overwrite cache to sentinel
+		$this->assertFalse($this->glob->getIsCultureRTL()); // cache consulted, returns false
+	}
+
+	public function testSetIsCultureRtlHardSetsBoolTrue()
+	{
+		$this->glob->setCulture('en');
+		$this->glob->setIsCultureRTL(true);
+		$this->assertTrue($this->glob->getIsCultureRTL());
+	}
+
+	public function testSetIsCultureRtlHardSetsBoolFalse()
+	{
+		$this->glob->setCulture('ar');
+		$this->glob->setIsCultureRTL(false);
+		$this->assertFalse($this->glob->getIsCultureRTL());
+	}
+
+	public function testSetIsCultureRtlAcceptsStringBooleans()
+	{
+		$this->glob->setCulture('en');
+
+		$this->glob->setIsCultureRTL('true');
+		$this->assertTrue($this->glob->getIsCultureRTL());
+
+		$this->glob->setIsCultureRTL('false');
+		$this->assertFalse($this->glob->getIsCultureRTL());
+	}
+
+	public function testSetIsCultureRtlAcceptsNumericStrings()
+	{
+		$this->glob->setCulture('en');
+
+		$this->glob->setIsCultureRTL('1');
+		$this->assertTrue($this->glob->getIsCultureRTL());
+
+		$this->glob->setIsCultureRTL('0');
+		$this->assertFalse($this->glob->getIsCultureRTL());
+	}
+}

--- a/tests/unit/I18N/core/CultureInfoTest.php
+++ b/tests/unit/I18N/core/CultureInfoTest.php
@@ -58,6 +58,21 @@ class CultureInfoTest extends TestCase
 		$this->assertFalse(CultureInfo::validCulture('invalid_culture'));
 	}
 
+	/**
+	 * ResourceBundle::getLocales() stores some locales in BCP 47 hyphen form
+	 * (e.g. "en-US") and others in POSIX underscore form (e.g. "de_DE"),
+	 * depending on ICU version and locale.  validCulture() must bridge all
+	 * directions so that both POSIX and BCP 47 inputs work regardless of which
+	 * format the underlying list uses for a given locale.
+	 */
+	public function testValidCultureBridgesPosixAndBcp47Forms()
+	{
+		// POSIX input — works whether the ICU list has "de_DE" or "de-DE"
+		$this->assertTrue(CultureInfo::validCulture('de_DE'));
+		// BCP 47 input — works whether the ICU list has "de-DE" or "de_DE"
+		$this->assertTrue(CultureInfo::validCulture('de-DE'));
+	}
+
 	public function testGetNativeName()
 	{
 		$culture = CultureInfo::getCultureInfo('en_US');
@@ -88,6 +103,24 @@ class CultureInfoTest extends TestCase
 
 		$this->assertTrue($neutralCulture->getIsNeutralCulture());
 		$this->assertFalse($specificCulture->getIsNeutralCulture());
+	}
+
+	/**
+	 * TGlobalization::setCulture() converts BCP 47 hyphens to POSIX underscores,
+	 * so a BCP 47 script-subtag locale like "zh-Hant-TW" arrives as "zh_Hant_TW"
+	 * (length 10).  getIsNeutralCulture() uses a strlen() == 2 test that relies
+	 * on the POSIX convention; it must correctly classify such a culture as
+	 * specific (not neutral).
+	 */
+	public function testGetIsNeutralCulturePosixNormalizedScriptSubtagIsSpecific()
+	{
+		// "zh-Hant-TW" → POSIX-normalised to "zh_Hant_TW" (length 10, has region subtag)
+		$specific = new CultureInfo('zh_Hant_TW');
+		$this->assertFalse($specific->getIsNeutralCulture());
+
+		// "zh-Hant" → POSIX-normalised to "zh_Hant" (length 7, script-only, no region)
+		$scriptOnly = new CultureInfo('zh_Hant');
+		$this->assertFalse($scriptOnly->getIsNeutralCulture());
 	}
 
 	public function testToString()


### PR DESCRIPTION
Documenting the use of POSIX language style rather than ICU Web style language values.
Unit tests for TGlobalization and TGlobalizationAutoDetect.