### PR TITLE
TComponent Bug fixes

### DIFF
--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -583,15 +583,15 @@ class TComponent
 	public function getClassHierarchy($lowercase = false)
 	{
 		static $_classhierarchy = [];
-		$class = $this::class;
+		$class = $cls = $this::class;
 		if (isset($_classhierarchy[$class]) && isset($_classhierarchy[$class][$lowercase ? 1 : 0])) {
 			return $_classhierarchy[$class][$lowercase ? 1 : 0];
 		}
 		$classes = [array_values(class_implements($class))];
 		do {
-			$classes[] = array_values(class_uses($class));
-			$classes[] = [$class];
-		} while ($class = get_parent_class($class));
+			$classes[] = array_values(class_uses($cls));
+			$classes[] = [$cls];
+		} while ($cls = get_parent_class($cls));
 		$classes = array_merge(...$classes);
 		if ($lowercase) {
 			$classes = array_map('strtolower', $classes);
@@ -633,7 +633,7 @@ class TComponent
 	 * ```
 	 * to be executed when listen is called.  All attached behaviors are notified through dyListen.
 	 *
-	 * @return numeric the number of global events that were registered to the global event registry
+	 * @return ?int the number of global events that were registered to the global event registry, or null if already listening
 	 */
 	public function listen()
 	{
@@ -672,7 +672,7 @@ class TComponent
 	 * ```
 	 * to be executed when listen is called.  All attached behaviors are notified through dyUnlisten.
 	 *
-	 * @return numeric the number of global events that were unregistered from the global event registry
+	 * @return ?int the number of global events that were unregistered from the global event registry, or null if not currently listening
 	 */
 	public function unlisten()
 	{
@@ -979,7 +979,10 @@ class TComponent
 		} elseif (Prado::method_visible($this, $jssetter = 'setjs' . $name)) {
 			$this->$jssetter(null);
 		} elseif (strncasecmp($name, 'on', 2) === 0 && method_exists($this, $name)) {
-			$this->_e[strtolower($name)]->clear();
+			$name = strtolower($name);
+			if (isset($this->_e[$name])) {
+				$this->_e[$name]->clear();
+			}
 		} elseif (strncasecmp($name, 'fx', 2) === 0) {
 			$this->getEventHandlers($name)->remove([$this, $name]);
 		} elseif ($this->_m !== null && $this->_m->getCount() > 0 && $this->getBehaviorsEnabled()) {
@@ -1162,6 +1165,9 @@ class TComponent
 	 */
 	protected function getCallChain($method, ...$args): ?TCallChain
 	{
+		if ($this->_m === null) {
+			return null;
+		}
 		$classArgs = $callchain = null;
 		foreach ($this->_m->toArray() as $behavior) {
 			if ($behavior->getEnabled() && (Prado::method_visible($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
@@ -1446,7 +1452,6 @@ class TComponent
 	 */
 	public function raiseEvent($name, $sender, $param, $responsetype = null, $postfunction = null)
 	{
-		$p = $param;
 		if (is_callable($responsetype)) {
 			$postfunction = $responsetype;
 			$responsetype = null;
@@ -1612,7 +1617,8 @@ class TComponent
 			$content = ob_get_contents();
 			ob_end_clean();
 			return $content;
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
+			ob_end_clean();
 			throw new TInvalidOperationException('component_statements_invalid', $this::class, $statements, $e->getMessage());
 		}
 	}
@@ -1913,10 +1919,12 @@ class TComponent
 	 */
 	public function getBehaviors(?string $class = null)
 	{
-		if ($class === null) {
-			return isset($this->_m) ? $this->_m->toArray() : [];
-		} elseif (class_exists($class, false) || interface_exists($class, false)) {
-			return array_filter($this->_m->toArray(), fn ($b) => $b instanceof $class);
+		if (isset($this->_m)) {
+			if ($class === null) {
+				return $this->_m->toArray();
+			} elseif (class_exists($class, false) || interface_exists($class, false)) {
+				return array_filter($this->_m->toArray(), fn ($b) => $b instanceof $class);
+			}
 		}
 		return [];
 	}

--- a/tests/unit/TComponentBehaviorTest.php
+++ b/tests/unit/TComponentBehaviorTest.php
@@ -25,6 +25,50 @@ class TComponentBehaviorTest extends TComponentTestBase
 		$this->assertEquals([strtolower(IDynamicMethods::class), strtolower(DynamicCatchingTrait::class), strtolower(DynamicCatchingComponent::class), strtolower(NewComponentNoListen::class), strtolower(NewComponentTestTrait::class), strtolower(NewComponent::class), strtolower(\Prado\TComponent::class)], $component->getClassHierarchy(true));
 	}
 
+	/**
+	 * Regression test for the getClassHierarchy() static-cache key bug.
+	 *
+	 * The do-while loop that walks get_parent_class() left $class set to false
+	 * after exhausting the hierarchy.  The cache write then used false as the
+	 * array key (coerced to 0 by PHP), so the lookup — which keys on the real
+	 * class-name string — never hit and every call recomputed from scratch.
+	 * The fix introduces a stable $origClass variable captured before the loop.
+	 *
+	 * We verify:
+	 *  - TComponent appears in the hierarchy (not false or a numeric artifact).
+	 *  - Both $lowercase variants return consistent results across repeated calls.
+	 *  - Two different classes return their own distinct hierarchies, not each
+	 *    other's (cross-contamination that would occur if both wrote to key [0]).
+	 */
+	public function testGetClassHierarchyCaching()
+	{
+		$component = new DynamicCatchingComponent();
+		$plain1 = $component->getClassHierarchy(false);
+		$plain2 = $component->getClassHierarchy(false);
+		$lower1 = $component->getClassHierarchy(true);
+		$lower2 = $component->getClassHierarchy(true);
+
+		// Results must be stable across repeated calls (cache hit or recompute).
+		$this->assertSame($plain1, $plain2, 'getClassHierarchy(false) returned different results on repeated calls');
+		$this->assertSame($lower1, $lower2, 'getClassHierarchy(true) returned different results on repeated calls');
+
+		// TComponent must appear in the hierarchy — not false/0 from the broken loop variable.
+		$this->assertContains(\Prado\TComponent::class, $plain1, 'TComponent missing from plain hierarchy');
+		$this->assertContains(strtolower(\Prado\TComponent::class), $lower1, 'TComponent missing from lowercase hierarchy');
+
+		// A second, simpler class must return its own distinct hierarchy.
+		$simple = new NewComponentNoListen();
+		$simpleHierarchy = $simple->getClassHierarchy(false);
+		$this->assertNotEquals($plain1, $simpleHierarchy, 'Different classes returned identical hierarchies — cache key collision');
+		$this->assertContains(NewComponentNoListen::class, $simpleHierarchy);
+		$this->assertNotContains(DynamicCatchingComponent::class, $simpleHierarchy);
+
+		// Calling getClassHierarchy() on DynamicCatchingComponent again after
+		// the NewComponentNoListen call must still return the correct result.
+		$plain3 = $component->getClassHierarchy(false);
+		$this->assertSame($plain1, $plain3, 'getClassHierarchy() result changed after another class computed its hierarchy');
+	}
+
 
 	public function testAsA()
 	{

--- a/tests/unit/TComponentDynamicTest.php
+++ b/tests/unit/TComponentDynamicTest.php
@@ -134,8 +134,34 @@ class TComponentDynamicTest extends TComponentTestBase
 			$button = $this->component->evaluateStatements($statements);
 			$this->fail('exception not raised when evaluating an invalid statement');
 		} catch (\Prado\Exceptions\TInvalidOperationException $e) {
-			ob_end_flush();
 		}
+	}
+
+	/**
+	 * Regression test for the ob_start() leak when eval() throws a \Throwable
+	 * (\Error subclass) rather than a \Exception.  Before the fix, the catch
+	 * block only caught \Exception, so \ParseError and \Error bypassed it and
+	 * left the output buffer open.
+	 */
+	public function testEvaluateStatementsObBufferCleanedOnError()
+	{
+		// \ParseError — invalid PHP syntax inside eval().
+		$levelBefore = ob_get_level();
+		try {
+			$this->component->evaluateStatements('{{{');
+			$this->fail('TInvalidOperationException not raised for parse error');
+		} catch (\Prado\Exceptions\TInvalidOperationException $e) {
+		}
+		$this->assertSame($levelBefore, ob_get_level(), 'ob_start() leaked after \ParseError in evaluateStatements()');
+
+		// \Error — calling a method on null.
+		$levelBefore = ob_get_level();
+		try {
+			$this->component->evaluateStatements('$x = null; $x->someMethod();');
+			$this->fail('TInvalidOperationException not raised for null method call');
+		} catch (\Prado\Exceptions\TInvalidOperationException $e) {
+		}
+		$this->assertSame($levelBefore, ob_get_level(), 'ob_start() leaked after \Error in evaluateStatements()');
 	}
 
 	public function testDynamicFunctionCall()

--- a/tests/unit/TComponentGlobalEventsTest.php
+++ b/tests/unit/TComponentGlobalEventsTest.php
@@ -102,4 +102,35 @@ class TComponentGlobalEventsTest extends TComponentTestBase
 		//This is from $this->component being instanced and listening.  $component is accessing the global event structure
 		$this->assertEquals(0, $component->getEventHandlers(TComponent::GLOBAL_RAISE_EVENT_LISTENER)->getCount());
 	}
+
+	/**
+	 * Regression test for listen() / unlisten() return-type correctness.
+	 *
+	 * Both methods return the count of fx events registered/unregistered on a
+	 * successful state change, but must return null (not 0 or false) when the
+	 * object is already in the requested state — i.e., listen() when already
+	 * listening, and unlisten() when already not listening.
+	 */
+	public function testListenUnlistenReturnNullWhenNoStateChange()
+	{
+		$component = new NewComponentNoListen();
+
+		// Not yet listening — listen() should return a positive int.
+		$count = $component->listen();
+		$this->assertIsInt($count);
+		$this->assertGreaterThan(0, $count);
+
+		// Already listening — second listen() must return null, not 0 or false.
+		$second = $component->listen();
+		$this->assertNull($second, 'listen() must return null when already listening');
+
+		// Unlisten — first call should return a positive int.
+		$count = $component->unlisten();
+		$this->assertIsInt($count);
+		$this->assertGreaterThan(0, $count);
+
+		// Already not listening — second unlisten() must return null.
+		$second = $component->unlisten();
+		$this->assertNull($second, 'unlisten() must return null when not listening');
+	}
 }


### PR DESCRIPTION
getClassHierarchy has a serious cache miss bug.  luckily fx methods are usually cached by TApplicationComponent.
@ctrlaltca I'd be interested in knowing how much faster things are with this bug fix, if you want to do a perf test.  Not required, just a curiosity.

check isset on _e and _m.  PHP 8 throws exceptions trying toString() on an unset property. PHP 7 did not.  fixed with unit tests.

evaluateStatements calls ob_end_clean on error.  bad unit tests accounted for this error.  fixed unit tests and fixed the bug.