### PR TITLE
General fix for Prado3 class and directory paths

### DIFF
--- a/framework/Data/Common/TDbMetaData.php
+++ b/framework/Data/Common/TDbMetaData.php
@@ -127,6 +127,10 @@ abstract class TDbMetaData extends \Prado\TComponent
 		$key = $tableName === null ? $this->getDbConnection()->getConnectionString() : $tableName;
 		if (!isset($this->_tableInfoCache[$key])) {
 			$class = $this->getTableInfoClass();
+			$class = Prado::usingClass($class);
+			if (!is_string($class)) {
+				throw new TDbException('dbmetadata_tableinfo_class_invalid', $this->getTableInfoClass());
+			}
 			$tableInfo = $tableName === null ? new $class() : $this->createTableInfo($tableName);
 			$this->_tableInfoCache[$key] = $tableInfo;
 		}

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -67,6 +67,7 @@ application_service_unknown				= Requested service '{0}' is not defined.
 application_unavailable					= Application is unavailable at this time.
 application_service_unavailable			= Service '{0}' is unavailable at this time.
 application_moduleid_duplicated			= Application module ID '{0}' is not unique.
+application_module_class_invalid		= Application module class '{0}' is a directory namespace, not a class.
 application_runtimepath_failed			= Unable to create runtime path '{0}'. Make sure the parent directory exists and is writable by the Web process.
 
 appconfig_aliaspath_invalid				= Application configuration <alias id="{0}"> uses an invalid file path "{1}".
@@ -266,6 +267,7 @@ permissions_duplicate_permission		= TPermissionsManager permission '{0}' is alre
 permissions_role_children_invalid		= TPermissionsManager configuration role '{0}' has invalid children '{1}'.
 permissions_rule_invalid				= TPermissionsManager configuration permission rule '{0}' has properties that is not an array.
 permissions_rules_require_name			= TPermissionsManager rules must have a permission "name" property.
+permissions_rule_class_invalid			= TPermissionsManager permission rule class '{0}' is a directory namespace, not a class.
 permissions_children_invalid			= TPermissionsManager.*RoleChildren children must be a string or array but is '{0}'.
 permissions_permissionfile_invalid		= TPermissionsManager.PermissionFile '{0}' is not a valid file.
 
@@ -524,9 +526,11 @@ cachedependencylist_cachedependency_required = Only objects implementing ICacheD
 
 soapservice_configfile_invalid			= TSoapService.ConfigFile '{0}' does not exist. Note, it has to be specified in a namespace format and the file extension must be '.xml' or '.php'.
 soapservice_request_invalid				= SOAP server '{0}' not found.
+soapservice_server_invalid				= TSoapService SOAP server class '{0}' is invalid. It must be TSoapServer or a subclass.
 soapservice_serverid_required			= <soap> element must have 'id' attribute.
 soapservice_serverid_duplicated			= SOAP server ID '{0}' is duplicated.
 soapserver_id_invalid					= Invalid SOAP server ID '{0}'. It should not end with '.wsdl'.
+soapserver_provider_invalid				= TSoapServer provider class '{0}' could not be resolved.
 soapserver_version_invalid				= Invalid SOAP version '{0}'. It must be either '1.1' or '1.2'.
 
 jsonservice_id_required				= TJsonService requires 'id' attribute in its JSON elements.
@@ -633,6 +637,7 @@ ar_delete_invalid						= The {0} instance cannot be deleted because it is either
 
 dbmetadata_invalid_database_driver		= Driver '{0}' is unsupported. Please install its PRADO Driver, if available.
 dbmetadata_not_meta_data				= Expected driver class {1} but got class {0}.
+dbmetadata_tableinfo_class_invalid		= TDbMetaData table info class '{0}' is a directory namespace, not a class.
 
 datasource_dbconnection_invalid			= TDataSourceConfig.DbConnection '{0}' is invalid. Please make sure it points to a valid application module.
 distributeddatasource_child_required		= {0} requires one '{1}' child element at minimum.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -67,7 +67,6 @@ application_service_unknown				= Requested service '{0}' is not defined.
 application_unavailable					= Application is unavailable at this time.
 application_service_unavailable			= Service '{0}' is unavailable at this time.
 application_moduleid_duplicated			= Application module ID '{0}' is not unique.
-application_module_class_invalid		= Application module class '{0}' is a directory namespace, not a class.
 application_runtimepath_failed			= Unable to create runtime path '{0}'. Make sure the parent directory exists and is writable by the Web process.
 
 appconfig_aliaspath_invalid				= Application configuration <alias id="{0}"> uses an invalid file path "{1}".

--- a/framework/Prado.php
+++ b/framework/Prado.php
@@ -369,22 +369,67 @@ class Prado
 	}
 
 	/**
+	 * Resolves a namespace to a PHP class name, loading it if necessary.
+	 *
+	 * This is the preferred public API for converting a Prado3 dot-notation or
+	 * short class name to a fully-qualified PHP class name while also ensuring
+	 * the class is loaded. Combines {@see using()} with a Prado3-to-PHP namespace
+	 * fallback conversion so callers always receive a usable name.
+	 *
+	 * Returns false when the namespace identifies a directory (e.g. 'App.Common.*')
+	 * rather than a class, and null when the namespace could not be resolved at all.
+	 * Callers must check the return value before using it as a class name.
+	 *
+	 * ```php
+	 * $class = Prado::usingClass($class);
+	 * if (is_string($class)) {
+	 *     $obj = new $class();
+	 * }
+	 * ```
+	 *
+	 * @param string $namespace Prado3 dot-notation, short class name, or PHP FQN
+	 * @return null|false|string The resolved PHP fully-qualified class name, false
+	 *   when $namespace identifies a directory rather than a class, or null when
+	 *   $namespace could not be resolved to any known class.
+	 * @since 4.3.3
+	 */
+	public static function usingClass(string $namespace): string|false|null
+	{
+		$result = static::using($namespace);
+		if ($result === false) {
+			return null;   // namespace could not be resolved
+		}
+		if (str_ends_with($result, '\\')) {
+			return false;  // namespace is a directory, not a class
+		}
+		return $result;    // PHP fully-qualified class name
+	}
+
+	/**
 	 * Uses a namespace.
 	 * A namespace ending with an asterisk '*' refers to a directory, otherwise it represents a PHP file.
 	 * If the namespace corresponds to a directory, the directory will be appended
 	 * to the include path. If the namespace corresponds to a file, it will be included (include_once).
 	 * @param string $namespace namespace to be used
 	 * @throws TInvalidDataValueException if the namespace is invalid
+	 * @return false|string The resolved PHP fully-qualified class, interface, or trait name when the
+	 *   namespace identifies a loadable class. Returns a string ending in '\' when a directory
+	 *   namespace is successfully registered (e.g. 'Prado\Web\UI\'). Returns false when the
+	 *   namespace cannot be resolved.
+	 * @since 4.3.3 return type changed from void to string|bool; directory case returns namespace
+	 *   string ending in '\' instead of true since 4.3.3
 	 */
-	public static function using($namespace): void
+	public static function using($namespace): string|false
 	{
 		$namespace = static::prado3NamespaceToPhpNamespace($namespace);
 
-		if (isset(self::$_usings[$namespace]) ||
-			class_exists($namespace, false) ||
+		if (isset(self::$_usings[$namespace])) {
+			return $namespace . '\\';
+		}
+		if (class_exists($namespace, false) ||
 			interface_exists($namespace, false) ||
 			trait_exists($namespace, false)) {
-			return;
+			return $namespace;
 		}
 
 		if (array_key_exists($namespace, self::$classMap)) {
@@ -398,7 +443,7 @@ class Prado
 					!trait_exists($namespace)) {
 					class_alias($phpNamespace, $namespace);
 				}
-				return;
+				return $phpNamespace;
 			}
 		} elseif (($pos = strrpos($namespace, '\\')) === false) {
 			// trying to autoload an old class name
@@ -414,19 +459,21 @@ class Prado
 							!trait_exists($namespace)) {
 							class_alias($phpNamespace, $namespace);
 						}
-						return;
+						return $phpNamespace;
 					}
 				}
 			}
 		} elseif (($path = self::getPathOfNamespace($namespace, self::CLASS_FILE_EXT)) !== null) {
 			$className = substr($namespace, $pos + 1);
 			if ($className === '*') {  // a directory
-				self::$_usings[substr($namespace, 0, $pos)] = $path;
+				$dirNamespace = substr($namespace, 0, $pos);
+				self::$_usings[$dirNamespace] = $path;
+				return $dirNamespace . '\\';
 			} else {  // a file
 				if (class_exists($className, false) ||
 					interface_exists($className, false) ||
 					trait_exists($className, false)) {
-					return;
+					return $namespace;
 				}
 
 				if (file_exists($path)) {
@@ -436,9 +483,12 @@ class Prado
 						!trait_exists($className, false)) {
 						class_alias($namespace, $className);
 					}
+					return $namespace;
 				}
 			}
 		}
+
+		return false;
 	}
 
 	/**

--- a/framework/Prado.php
+++ b/framework/Prado.php
@@ -396,7 +396,7 @@ class Prado
 	public static function usingClass(string $namespace): string|false|null
 	{
 		$result = static::using($namespace);
-		if ($result === false) {
+		if ($result === null) {
 			return null;   // namespace could not be resolved
 		}
 		if (str_ends_with($result, '\\')) {
@@ -412,14 +412,14 @@ class Prado
 	 * to the include path. If the namespace corresponds to a file, it will be included (include_once).
 	 * @param string $namespace namespace to be used
 	 * @throws TInvalidDataValueException if the namespace is invalid
-	 * @return false|string The resolved PHP fully-qualified class, interface, or trait name when the
+	 * @return ?string The resolved PHP fully-qualified class, interface, or trait name when the
 	 *   namespace identifies a loadable class. Returns a string ending in '\' when a directory
-	 *   namespace is successfully registered (e.g. 'Prado\Web\UI\'). Returns false when the
+	 *   namespace is successfully registered (e.g. 'Prado\Web\UI\'). Returns null when the
 	 *   namespace cannot be resolved.
 	 * @since 4.3.3 return type changed from void to string|bool; directory case returns namespace
-	 *   string ending in '\' instead of true since 4.3.3
+	 *   string ending in '\' instead of true since 4.3.3; unresolvable case changed from false to null since 4.3.3
 	 */
-	public static function using($namespace): string|false
+	public static function using($namespace): ?string
 	{
 		$namespace = static::prado3NamespaceToPhpNamespace($namespace);
 
@@ -497,7 +497,7 @@ class Prado
 			}
 		}
 
-		return false;
+		return null;
 	}
 
 	/**

--- a/framework/Prado.php
+++ b/framework/Prado.php
@@ -473,6 +473,11 @@ class Prado
 				if (class_exists($className, false) ||
 					interface_exists($className, false) ||
 					trait_exists($className, false)) {
+					if (!class_exists($namespace, false) &&
+						!interface_exists($namespace, false) &&
+						!trait_exists($namespace, false)) {
+						class_alias($className, $namespace);
+					}
 					return $namespace;
 				}
 
@@ -482,6 +487,10 @@ class Prado
 						!interface_exists($className, false) &&
 						!trait_exists($className, false)) {
 						class_alias($namespace, $className);
+					} elseif (!class_exists($namespace, false) &&
+						!interface_exists($namespace, false) &&
+						!trait_exists($namespace, false)) {
+						class_alias($className, $namespace);
 					}
 					return $namespace;
 				}

--- a/framework/Security/Permissions/TPermissionsManager.php
+++ b/framework/Security/Permissions/TPermissionsManager.php
@@ -403,6 +403,10 @@ class TPermissionsManager extends \Prado\TModule implements IPermissions
 					throw new TConfigurationException('permissions_rules_require_name');
 				}
 				$class = $properties['class'] ?? TAuthorizationRule::class;
+				$class = Prado::usingClass($class);
+				if (!is_string($class)) {
+					throw new TConfigurationException('permissions_rule_class_invalid', $properties['class'] ?? '');
+				}
 				$action = $properties['action'] ?? '';
 				$users = $properties['users'] ?? '';
 				$roles = $properties['roles'] ?? '';

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -1301,11 +1301,10 @@ class TApplication extends TComponent implements ISingleton
 	/**
 	 * Registers or nullifies a lazy-module entry. Pass `null` to mark the slot
 	 * as consumed without removing the key (preserving the ID against reuse).
-	 * When a config tuple is provided the class name is resolved via
-	 * {@see Prado::usingClass()} so that Prado3 dot-notation and short class
-	 * names are normalized to a PHP fully-qualified name before storage.
-	 * This ensures methods such as {@see getModulesByType()} that compare stored
-	 * class names with PHP `is_a()` always receive a valid FQN.
+	 * When a config tuple is provided, the class name is normalized to a PHP FQN
+	 * via {@see Prado::usingClass()} when possible. If the class cannot be resolved at
+	 * registration time, the original name is kept and resolution is deferred to
+	 * {@see getModulesByType()} (lazy path) or {@see internalLoadModule()}.
 	 * @param string $id module ID.
 	 * @param ?array $config the registration tuple `[$class, $properties, $configElement]`,
 	 *   or `null` to mark the slot as consumed.
@@ -1315,11 +1314,23 @@ class TApplication extends TComponent implements ISingleton
 	{
 		if ($config !== null && isset($config[0])) {
 			$resolved = Prado::usingClass($config[0]);
-			if (!is_string($resolved)) {
-				throw new TConfigurationException('application_module_class_invalid', $config[0]);
+			if (is_string($resolved)) {
+				$config[0] = $resolved;
 			}
-			$config[0] = $resolved;
 		}
+		$this->setLazyModuleDirect($id, $config);
+	}
+
+	/**
+	 * Writes a lazy-module entry without class-name resolution.
+	 * Prefer {@see setLazyModule()} for new registrations; use this only when
+	 * the class name is already a PHP FQN (e.g. a normalization write-back).
+	 * @param string $id module ID.
+	 * @param ?array $config `[$class, $properties, $configElement]`, or `null` to consume the slot.
+	 * @since 4.3.3
+	 */
+	protected function setLazyModuleDirect(string $id, ?array $config): void
+	{
 		$this->_lazyModules[$id] = $config;
 	}
 
@@ -1395,7 +1406,19 @@ class TApplication extends TComponent implements ISingleton
 		$m = [];
 		foreach ($this->_modules as $id => $module) {
 			if ($module === null && $this->hasLazyModule($id)) {
-				[$moduleClass] = $this->getLazyModule($id);
+				$config = $this->getLazyModule($id);
+				$moduleClass = $config[0];
+				// If the class was unresolvable at registration time, try again now
+				// (e.g. the relevant using() may have been called since then).
+				$resolved = Prado::usingClass($moduleClass);
+				if (!is_string($resolved)) {
+					continue;
+				}
+				if ($resolved !== $moduleClass) {
+					$config[0] = $resolved;
+					$this->setLazyModuleDirect($id, $config);
+					$moduleClass = $resolved;
+				}
 				if ($strict ? ($moduleClass === $type) : is_a($moduleClass, $type, true)) {
 					$m[$id] = null;
 				}
@@ -1898,7 +1921,7 @@ class TApplication extends TComponent implements ISingleton
 	 * in `$_modules`. The lazy-module slot is nullified to prevent ID reuse.
 	 * The caller is responsible for calling `init()` on the returned module.
 	 *
-	 * @param string $id module ID registered in `$_lazyModules`.
+	 * @param string $id module ID registered with {@see setLazyModule()}.
 	 * @param bool $force when `true`, forces loading even if the `lazy` property is set. Defaults to `false`.
 	 * @return null|array{0: IModule, 1: mixed}|false a two-element array `[$module, $configElement]`
 	 *   ready for `$module->init($configElement)`, `null` if the module was deferred, or

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -1118,8 +1118,10 @@ class TApplication extends TComponent implements ISingleton
 		if (empty($class)) {
 			throw new TConfigurationException('application_service_class_required', $id);
 		}
-		if (!class_exists($class, true)) {
-			throw new TConfigurationException('application_service_class_not_found', $class);
+		$originalClass = $class;
+		$class = Prado::usingClass($class);
+		if (!is_string($class) || !class_exists($class, true)) {
+			throw new TConfigurationException('application_service_class_not_found', $class ?? $originalClass);
 		}
 		if (!is_a($class, IService::class, true)) {
 			throw new TConfigurationException('application_service_class_not_service', $class);
@@ -1217,6 +1219,10 @@ class TApplication extends TComponent implements ISingleton
 	 */
 	public function getRegisteredServiceByClass(string $class): ?string
 	{
+		$class = Prado::usingClass($class);
+		if (!is_string($class)) {
+			return null;
+		}
 		foreach ($this->getRegisteredServices() as $id => $serviceConfig) {
 			$serviceClass = $serviceConfig[0];
 			if ($serviceClass === $class || is_a($serviceClass, $class, true)) {
@@ -1240,6 +1246,10 @@ class TApplication extends TComponent implements ISingleton
 	 */
 	public function getRegisteredServicesByClass(string $class, bool $strict = false): array
 	{
+		$class = Prado::usingClass($class);
+		if (!is_string($class)) {
+			return [];
+		}
 		$ids = [];
 		foreach ($this->getRegisteredServices() as $id => $serviceConfig) {
 			$serviceClass = $serviceConfig[0];
@@ -1291,6 +1301,11 @@ class TApplication extends TComponent implements ISingleton
 	/**
 	 * Registers or nullifies a lazy-module entry. Pass `null` to mark the slot
 	 * as consumed without removing the key (preserving the ID against reuse).
+	 * When a config tuple is provided the class name is resolved via
+	 * {@see Prado::usingClass()} so that Prado3 dot-notation and short class
+	 * names are normalized to a PHP fully-qualified name before storage.
+	 * This ensures methods such as {@see getModulesByType()} that compare stored
+	 * class names with PHP `is_a()` always receive a valid FQN.
 	 * @param string $id module ID.
 	 * @param ?array $config the registration tuple `[$class, $properties, $configElement]`,
 	 *   or `null` to mark the slot as consumed.
@@ -1298,6 +1313,13 @@ class TApplication extends TComponent implements ISingleton
 	 */
 	protected function setLazyModule(string $id, ?array $config): void
 	{
+		if ($config !== null && isset($config[0])) {
+			$resolved = Prado::usingClass($config[0]);
+			if (!is_string($resolved)) {
+				throw new TConfigurationException('application_module_class_invalid', $config[0]);
+			}
+			$config[0] = $resolved;
+		}
 		$this->_lazyModules[$id] = $config;
 	}
 
@@ -1362,13 +1384,18 @@ class TApplication extends TComponent implements ISingleton
 	 * @param bool $strict should the module be the class or can the module be a subclass
 	 * @return array keys are the ids of the module and values are module of a specific class
 	 * @since 4.2.0
+	 * @todo 4.4 normalize to "ByClass"?
 	 */
 	public function getModulesByType($type, $strict = false)
 	{
+		$type = Prado::usingClass($type);
+		if (!is_string($type)) {
+			return [];
+		}
 		$m = [];
 		foreach ($this->_modules as $id => $module) {
 			if ($module === null && $this->hasLazyModule($id)) {
-				[$moduleClass, $initProperties, $configElement] = $this->getLazyModule($id);
+				[$moduleClass] = $this->getLazyModule($id);
 				if ($strict ? ($moduleClass === $type) : is_a($moduleClass, $type, true)) {
 					$m[$id] = null;
 				}

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1853,11 +1853,13 @@ class TComponent
 	 */
 	public function asa($behaviorname)
 	{
-		$behaviorname = strtolower($behaviorname);
-		if (isset($this->_m[$behaviorname])) {
-			return $this->_m[$behaviorname];
+		$behaviorname_lower = strtolower($behaviorname);
+		if (isset($this->_m[$behaviorname_lower])) {
+			return $this->_m[$behaviorname_lower];
 		}
-		if ((class_exists($behaviorname, false) || interface_exists($behaviorname, false)) && $this->_m) {
+
+		$behaviorname = Prado::usingClass($behaviorname);
+		if (is_string($behaviorname) && (class_exists($behaviorname, false) || interface_exists($behaviorname, false)) && $this->_m) {
 			foreach ($this->_m->toArray() as $behavior) {
 				if ($behavior instanceof $behaviorname) {
 					return $behavior;
@@ -1922,7 +1924,9 @@ class TComponent
 		if (isset($this->_m)) {
 			if ($class === null) {
 				return $this->_m->toArray();
-			} elseif (class_exists($class, false) || interface_exists($class, false)) {
+			}
+			$class = Prado::usingClass($class);
+			if (is_string($class) && (class_exists($class, false) || interface_exists($class, false))) {
 				return array_filter($this->_m->toArray(), fn ($b) => $b instanceof $class);
 			}
 		}

--- a/framework/Web/Services/TJsonService.php
+++ b/framework/Web/Services/TJsonService.php
@@ -15,6 +15,7 @@ use Prado\Prado;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\THttpException;
 use Prado\Web\Javascripts\TJavaScript;
+use Prado\Xml\TXmlElement;
 
 /**
  * TJsonService class provides to end-users javascript content response in
@@ -87,7 +88,7 @@ class TJsonService extends \Prado\TService
 					$this->_services[$id] = $json;
 				}
 			}
-		} else {
+		} elseif ($config instanceof TXmlElement) {
 			foreach ($config->getElementsByTagName('json') as $json) {
 				if (($id = $json->getAttribute('id')) !== null) {
 					$this->_services[$id] = $json;

--- a/framework/Web/Services/TPageService.php
+++ b/framework/Web/Services/TPageService.php
@@ -496,10 +496,10 @@ class TPageService extends \Prado\TService
 				$className = $namespacedClassName;
 			}
 		} else {
-			$className = $this->getBasePageClass();
-			Prado::using($className);
-			if (($pos = strrpos($className, '.')) !== false) {
-				$className = substr($className, $pos + 1);
+			$basePageClass = $this->getBasePageClass();
+			$className = Prado::usingClass($basePageClass);
+			if (!is_string($className)) {
+				throw new THttpException(404, 'pageservice_pageclass_unknown', $basePageClass);
 			}
 		}
 

--- a/framework/Web/Services/TRpcService.php
+++ b/framework/Web/Services/TRpcService.php
@@ -96,22 +96,18 @@ class TRpcService extends \Prado\TService
 			throw new TConfigurationException('rpcservice_apiprovider_required');
 		}
 
-		Prado::using($_providerClass);
-
-		$_providerClassName = ($_pos = strrpos($_providerClass, '.')) !== false ? substr($_providerClass, $_pos + 1) : $_providerClass;
-		if (!is_subclass_of($_providerClassName, self::BASE_API_PROVIDER)) {
-			throw new TConfigurationException('rpcservice_apiprovider_invalid');
+		$_providerClassName = Prado::usingClass($_providerClass);
+		if (!is_string($_providerClassName) || !is_subclass_of($_providerClassName, self::BASE_API_PROVIDER)) {
+			throw new TConfigurationException('rpcservice_apiprovider_invalid', $_providerClass);
 		}
 
 		if (($_rpcServerClass = $_properties->remove('server')) === null) {
 			$_rpcServerClass = self::BASE_RPC_SERVER;
 		}
 
-		Prado::using($_rpcServerClass);
-
-		$_rpcServerClassName = ($_pos = strrpos($_rpcServerClass, '.')) !== false ? substr($_rpcServerClass, $_pos + 1) : $_rpcServerClass;
-		if ($_rpcServerClassName !== self::BASE_RPC_SERVER && !is_subclass_of($_rpcServerClassName, self::BASE_RPC_SERVER)) {
-			throw new TConfigurationException('rpcservice_rpcserver_invalid');
+		$_rpcServerClassName = Prado::usingClass($_rpcServerClass);
+		if (!is_string($_rpcServerClassName) || ($_rpcServerClassName !== self::BASE_RPC_SERVER && !is_subclass_of($_rpcServerClassName, self::BASE_RPC_SERVER))) {
+			throw new TConfigurationException('rpcservice_rpcserver_invalid', $_rpcServerClass);
 		}
 
 		$_apiProvider = new $_providerClassName(new $_rpcServerClassName($protocolHandler));

--- a/framework/Web/Services/TSoapServer.php
+++ b/framework/Web/Services/TSoapServer.php
@@ -11,6 +11,7 @@
 
 namespace Prado\Web\Services;
 
+use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\TPropertyValue;
 use Prado\Prado;
@@ -73,8 +74,10 @@ class TSoapServer extends \Prado\TApplicationComponent
 	public function run()
 	{
 		if (($provider = $this->getProvider()) !== null) {
-			Prado::using($provider);
-			$providerClass = ($pos = strrpos($provider, '.')) !== false ? substr($provider, $pos + 1) : $provider;
+			$providerClass = Prado::usingClass($provider);
+			if (!is_string($providerClass)) {
+				throw new TConfigurationException('soapserver_provider_invalid', $provider);
+			}
 			$this->guessMethodCallRequested($providerClass);
 			$server = $this->createServer();
 			$server->setClass($providerClass, $this);
@@ -189,8 +192,10 @@ class TSoapServer extends \Prado\TApplicationComponent
 	{
 		if ($this->_wsdlUri === '') {
 			$provider = $this->getProvider();
-			$providerClass = ($pos = strrpos($provider, '.')) !== false ? substr($provider, $pos + 1) : $provider;
-			Prado::using($provider);
+			$providerClass = Prado::usingClass($provider);
+			if (!is_string($providerClass)) {
+				throw new TConfigurationException('soapserver_provider_invalid', $provider);
+			}
 			if ($this->getApplication()->getMode() === TApplicationMode::Performance && ($cache = $this->getApplication()->getCache()) !== null) {
 				$wsdl = $cache->get(self::WSDL_CACHE_PREFIX . $providerClass);
 				if (is_string($wsdl)) {

--- a/framework/Web/Services/TSoapService.php
+++ b/framework/Web/Services/TSoapService.php
@@ -248,9 +248,8 @@ class TSoapService extends \Prado\TService
 		if ($serverClass === null) {
 			$serverClass = self::DEFAULT_SOAP_SERVER;
 		}
-		Prado::using($serverClass);
-		$className = ($pos = strrpos($serverClass, '.')) !== false ? substr($serverClass, $pos + 1) : $serverClass;
-		if ($className !== self::DEFAULT_SOAP_SERVER && !is_subclass_of($className, self::DEFAULT_SOAP_SERVER)) {
+		$className = Prado::usingClass($serverClass);
+		if (!is_string($className) || ($className !== self::DEFAULT_SOAP_SERVER && !is_subclass_of($className, self::DEFAULT_SOAP_SERVER))) {
 			throw new TConfigurationException('soapservice_server_invalid', $serverClass);
 		}
 		$server = new $className();

--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -866,11 +866,9 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	 */
 	protected function validateAttributes($type, $attributes)
 	{
-		Prado::using($type);
-		if (($pos = strrpos($type, '.')) !== false) {
-			$className = substr($type, $pos + 1);
-		} else {
-			$className = $type;
+		$className = Prado::usingClass($type);
+		if (!is_string($className)) {
+			throw new TConfigurationException('template_component_required', $type);
 		}
 		$class = new \ReflectionClass($className);
 		if (!$this->_attributevalidation) {

--- a/framework/Web/UI/TTemplateManager.php
+++ b/framework/Web/UI/TTemplateManager.php
@@ -66,6 +66,7 @@ class TTemplateManager extends \Prado\TModule
 	 * Loads the template corresponding to the specified class name.
 	 * @param mixed $className
 	 * @return \Prado\Web\UI\TTemplate template for the class name, null if template doesn't exist.
+	 * @todo v4.4 normalize to "ByClass"?
 	 */
 	public function getTemplateByClassName($className)
 	{
@@ -86,7 +87,8 @@ class TTemplateManager extends \Prado\TModule
 		if ($tplClass === null) {
 			$tplClass = $this->_defaultTemplateClass;
 		}
-		if (!is_subclass_of($tplClass, ITemplate::class)) {
+		$tplClass = Prado::usingClass($tplClass);
+		if (!is_string($tplClass) || !is_subclass_of($tplClass, ITemplate::class)) {
 			return null;
 		}
 		if (($fileName = $this->getLocalizedTemplate($fileName, $culture)) !== null) {

--- a/tests/unit/Data/DbCommon/TDbMetaDataTest.php
+++ b/tests/unit/Data/DbCommon/TDbMetaDataTest.php
@@ -281,4 +281,158 @@ public function test_getInstance_raises_fxDataGetMetaDataInstance_for_unknown_dr
 		$this->assertEquals('alias', $metaData->quoteColumnAlias('"alias"'));
 		$this->assertEquals('alias', $metaData->quoteColumnAlias("'alias'"));
 	}
+
+	// -----------------------------------------------------------------------
+	// getTableInfo() — Prado3 dot-notation tableInfoClass resolution
+	// -----------------------------------------------------------------------
+
+	public function test_getTableInfo_withPrado3SystemDotNotationTableInfoClass(): void
+	{
+		$conn = $this->createMockConnection('test');
+		$conn->method('getConnectionString')->willReturn('test_prado3_system');
+
+		$metaData = new class($conn) extends TDbMetaData {
+			protected function createTableInfo($tableName)
+			{
+				return new \Prado\Data\Common\TDbTableInfo([]);
+			}
+
+			public function findTableNames($schema = '')
+			{
+				return [];
+			}
+
+			// Override to return a Prado3 System dot-notation class name
+			protected function getTableInfoClass(): string
+			{
+				return 'System.Data.Common.TDbTableInfo';
+			}
+		};
+
+		// Should resolve 'System.Data.Common.TDbTableInfo' → Prado\Data\Common\TDbTableInfo
+		// and instantiate it without error. Before the fix, PHP throws "Class not found".
+		$info = $metaData->getTableInfo(null);
+		$this->assertInstanceOf(\Prado\Data\Common\TDbTableInfo::class, $info);
+	}
+
+	public function test_getTableInfo_withPrado3PradoDotNotationTableInfoClass(): void
+	{
+		$conn = $this->createMockConnection('test');
+		$conn->method('getConnectionString')->willReturn('test_prado3_prado');
+
+		$metaData = new class($conn) extends TDbMetaData {
+			protected function createTableInfo($tableName)
+			{
+				return new \Prado\Data\Common\TDbTableInfo([]);
+			}
+
+			public function findTableNames($schema = '')
+			{
+				return [];
+			}
+
+			// Override to return a Prado3 Prado dot-notation class name
+			protected function getTableInfoClass(): string
+			{
+				return 'Prado.Data.Common.TDbTableInfo';
+			}
+		};
+
+		// Should resolve 'Prado.Data.Common.TDbTableInfo' → Prado\Data\Common\TDbTableInfo
+		$info = $metaData->getTableInfo(null);
+		$this->assertInstanceOf(\Prado\Data\Common\TDbTableInfo::class, $info);
+	}
+
+	// -----------------------------------------------------------------------
+	// getTableInfo() — usingClass() false / null edge cases
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A directory namespace returned by getTableInfoClass() (usingClass returns
+	 * false) must throw TDbException — a directory is not an instantiable class.
+	 */
+	public function test_getTableInfo_withDirectoryNamespaceTableInfoClass_throws(): void
+	{
+		$conn = $this->createMockConnection('test');
+		$conn->method('getConnectionString')->willReturn('test_dir_ns');
+
+		$metaData = new class($conn) extends TDbMetaData {
+			protected function createTableInfo($tableName)
+			{
+				return new \Prado\Data\Common\TDbTableInfo([]);
+			}
+
+			public function findTableNames($schema = '')
+			{
+				return [];
+			}
+
+			protected function getTableInfoClass(): string
+			{
+				return 'Prado\\Data\\Common\\*';
+			}
+		};
+
+		$this->expectException(TDbException::class);
+		$metaData->getTableInfo(null);
+	}
+
+	/**
+	 * A Prado3 directory dot-notation from getTableInfoClass() also throws.
+	 */
+	public function test_getTableInfo_withPrado3DirectoryNotation_throws(): void
+	{
+		$conn = $this->createMockConnection('test');
+		$conn->method('getConnectionString')->willReturn('test_prado3_dir');
+
+		$metaData = new class($conn) extends TDbMetaData {
+			protected function createTableInfo($tableName)
+			{
+				return new \Prado\Data\Common\TDbTableInfo([]);
+			}
+
+			public function findTableNames($schema = '')
+			{
+				return [];
+			}
+
+			protected function getTableInfoClass(): string
+			{
+				return 'System.Data.Common.*';
+			}
+		};
+
+		$this->expectException(TDbException::class);
+		$metaData->getTableInfo(null);
+	}
+
+	/**
+	 * An unresolvable class name from getTableInfoClass() (usingClass returns
+	 * null) must throw TDbException.
+	 */
+	public function test_getTableInfo_withUnknownTableInfoClass_throws(): void
+	{
+		$conn = $this->createMockConnection('test');
+		$conn->method('getConnectionString')->willReturn('test_unknown_class');
+
+		$metaData = new class($conn) extends TDbMetaData {
+			protected function createTableInfo($tableName)
+			{
+				return new \Prado\Data\Common\TDbTableInfo([]);
+			}
+
+			public function findTableNames($schema = '')
+			{
+				return [];
+			}
+
+			protected function getTableInfoClass(): string
+			{
+				return 'TFakeTableInfoClassXYZ99999';
+			}
+		};
+
+		$this->expectException(TDbException::class);
+		$metaData->getTableInfo(null);
+	}
 }

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -390,12 +390,12 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * using() returns false when the namespace cannot be resolved at all.
+	 * using() returns null when the namespace cannot be resolved at all.
 	 */
-	public function testUsing_withUnresolvableNamespace_returnsFalse(): void
+	public function testUsing_withUnresolvableNamespace_returnsNull(): void
 	{
 		$result = Prado::using('Prado\\NonExistent\\TFakeClassXYZ99999');
-		$this->assertFalse($result);
+		$this->assertNull($result);
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -696,16 +696,28 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 	// -------------------------------------------------------------------------
 
 	/**
+	 * Returns the path to the Prado3-style fixture directory and ensures its
+	 * path alias 'Prado3Fixture' is registered, so tests are self-contained.
+	 */
+	private function registerPrado3FixtureAlias(): string
+	{
+		$fixturePath = __DIR__ . '/Security/app/prado3stubs';
+		Prado::setPathOfAlias('Prado3Fixture', $fixturePath);
+		return $fixturePath;
+	}
+
+	/**
 	 * using() with a path-alias dot-notation pointing to a global-namespace class
 	 * must return the path-derived FQN AND make that FQN usable via class_exists.
 	 * @since 4.3.3
 	 */
 	public function testUsing_withPrado3GlobalNamespaceClass_returnsFqnAndCreatesAlias(): void
 	{
-		// 'Application' alias maps to tests/unit/Security/app; the fixture file
-		// defines class GlobalNsComponent in global namespace (no PHP namespace).
-		$fqn = Prado::using('Application.prado3stubs.GlobalNsComponent');
-		$this->assertSame('Application\\prado3stubs\\GlobalNsComponent', $fqn);
+		// Register a self-contained alias pointing directly at the fixture dir.
+		// The fixture file defines class GlobalNsComponent in global namespace.
+		$this->registerPrado3FixtureAlias();
+		$fqn = Prado::using('Prado3Fixture.GlobalNsComponent');
+		$this->assertSame('Prado3Fixture\\GlobalNsComponent', $fqn);
 		// The returned FQN must exist as a real (aliased) PHP class.
 		$this->assertTrue(class_exists($fqn, false), 'FQN must be resolvable via class_exists(false)');
 	}
@@ -717,9 +729,10 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 	 */
 	public function testUsingClass_withPrado3GlobalNamespaceClass_fqnPassesIsSubclassOf(): void
 	{
-		$fqn = Prado::usingClass('Application.prado3stubs.GlobalNsComponent');
+		$this->registerPrado3FixtureAlias();
+		$fqn = Prado::usingClass('Prado3Fixture.GlobalNsComponent');
 		$this->assertIsString($fqn);
-		$this->assertSame('Application\\prado3stubs\\GlobalNsComponent', $fqn);
+		$this->assertSame('Prado3Fixture\\GlobalNsComponent', $fqn);
 		// is_subclass_of must work via the reverse alias — this is what createPage
 		// and validateAttributes rely on for Prado3-style base classes.
 		$this->assertTrue(
@@ -737,9 +750,10 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 	public function testUsing_withAlreadyLoadedGlobalNamespaceClass_returnsFqnFromEarlyReturn(): void
 	{
 		// First call loads the class; second call hits the early-return branch.
-		Prado::using('Application.prado3stubs.GlobalNsComponent');
-		$fqn = Prado::using('Application.prado3stubs.GlobalNsComponent');
-		$this->assertSame('Application\\prado3stubs\\GlobalNsComponent', $fqn);
+		$this->registerPrado3FixtureAlias();
+		Prado::using('Prado3Fixture.GlobalNsComponent');
+		$fqn = Prado::using('Prado3Fixture.GlobalNsComponent');
+		$this->assertSame('Prado3Fixture\\GlobalNsComponent', $fqn);
 		$this->assertTrue(class_exists($fqn, false));
 		$this->assertTrue(is_subclass_of($fqn, \Prado\TComponent::class));
 	}

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -686,6 +686,63 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 		// Strict distinctness between the two non-string values
 		$this->assertNotSame($directory, $notFound, 'false and null must be strictly different');
 	}
+
+	// -------------------------------------------------------------------------
+	// Prado::using() — Prado3 global-namespace reverse alias
+	//
+	// When a class file defines its class in global namespace (Prado3 style),
+	// using() must create a reverse alias class_alias($shortName, $fqn) so the
+	// returned FQN string is a valid, usable PHP class name.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * using() with a path-alias dot-notation pointing to a global-namespace class
+	 * must return the path-derived FQN AND make that FQN usable via class_exists.
+	 * @since 4.3.3
+	 */
+	public function testUsing_withPrado3GlobalNamespaceClass_returnsFqnAndCreatesAlias(): void
+	{
+		// 'Application' alias maps to tests/unit/Security/app; the fixture file
+		// defines class GlobalNsComponent in global namespace (no PHP namespace).
+		$fqn = Prado::using('Application.prado3stubs.GlobalNsComponent');
+		$this->assertSame('Application\\prado3stubs\\GlobalNsComponent', $fqn);
+		// The returned FQN must exist as a real (aliased) PHP class.
+		$this->assertTrue(class_exists($fqn, false), 'FQN must be resolvable via class_exists(false)');
+	}
+
+	/**
+	 * usingClass() with a Prado3 dot-notation that points to a global-namespace
+	 * class must return the FQN, and that FQN must satisfy is_subclass_of.
+	 * @since 4.3.3
+	 */
+	public function testUsingClass_withPrado3GlobalNamespaceClass_fqnPassesIsSubclassOf(): void
+	{
+		$fqn = Prado::usingClass('Application.prado3stubs.GlobalNsComponent');
+		$this->assertIsString($fqn);
+		$this->assertSame('Application\\prado3stubs\\GlobalNsComponent', $fqn);
+		// is_subclass_of must work via the reverse alias — this is what createPage
+		// and validateAttributes rely on for Prado3-style base classes.
+		$this->assertTrue(
+			is_subclass_of($fqn, \Prado\TComponent::class),
+			'FQN alias must satisfy is_subclass_of against the real parent class'
+		);
+	}
+
+	/**
+	 * When using() is called a second time for the same global-namespace class
+	 * (already loaded), it must still return the correct FQN and the alias must
+	 * still be valid (early-return branch in using()).
+	 * @since 4.3.3
+	 */
+	public function testUsing_withAlreadyLoadedGlobalNamespaceClass_returnsFqnFromEarlyReturn(): void
+	{
+		// First call loads the class; second call hits the early-return branch.
+		Prado::using('Application.prado3stubs.GlobalNsComponent');
+		$fqn = Prado::using('Application.prado3stubs.GlobalNsComponent');
+		$this->assertSame('Application\\prado3stubs\\GlobalNsComponent', $fqn);
+		$this->assertTrue(class_exists($fqn, false));
+		$this->assertTrue(is_subclass_of($fqn, \Prado\TComponent::class));
+	}
 	
 	public function testMethod_Visible()
 	{

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -300,6 +300,10 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 	const CLASS_FQN = 'Prado\\Web\\UI\\WebControls\\TButton';
 	const CLASS_PRADO_FULLNAME = 'System.Web.UI.WebControls.TButton';
 
+	// -------------------------------------------------------------------------
+	// Prado::using() — existing load behaviour
+	// -------------------------------------------------------------------------
+
 	public function testUsingNamespace()
 	{
 		$this->assertFalse(class_exists(self::CLASS_FQN, false));
@@ -312,6 +316,375 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse(interface_exists(self::INTERFACE_SHORT_NAME, false));
 		Prado::using(self::INTERFACE_FQN);
 		$this->assertTrue(interface_exists(self::INTERFACE_SHORT_NAME, false));
+	}
+
+	// -------------------------------------------------------------------------
+	// Prado::using() — return-value contract (string|true|false)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * using() returns the PHP FQN string when it resolves a class that is
+	 * already loaded (bootstrap guarantees TApplication is present).
+	 */
+	public function testUsing_withAlreadyLoadedClassFqn_returnsString(): void
+	{
+		$result = Prado::using(\Prado\TApplication::class);
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\TApplication::class, $result);
+	}
+
+	/**
+	 * using() returns the PHP FQN string when it resolves a loadable interface.
+	 */
+	public function testUsing_withLoadableInterfaceFqn_returnsString(): void
+	{
+		$result = Prado::using(self::INTERFACE_FQN);
+		$this->assertIsString($result);
+		$this->assertSame(self::INTERFACE_FQN, $result);
+	}
+
+	/**
+	 * using() returns the registered PHP namespace string with a trailing '\' for a
+	 * valid directory namespace (e.g. 'Prado\Web\UI\*' → 'Prado\Web\UI\').
+	 */
+	public function testUsing_withDirectoryNamespace_returnsNamespaceStringWithTrailingBackslash(): void
+	{
+		$result = Prado::using('Prado\\Web\\UI\\*');
+		$this->assertIsString($result);
+		$this->assertSame('Prado\\Web\\UI\\', $result);
+	}
+
+	/**
+	 * using() accepts a Prado3 System.* directory notation and returns the
+	 * equivalent PHP namespace string with a trailing '\'.
+	 * 'System.Web.UI.*' → prado3ToPhp → 'Prado\Web\UI\*' → registers → 'Prado\Web\UI\'.
+	 */
+	public function testUsing_withPrado3SystemDirectoryNotation_returnsPhpNamespaceWithTrailingBackslash(): void
+	{
+		$result = Prado::using('System.Web.UI.*');
+		$this->assertIsString($result);
+		$this->assertSame('Prado\\Web\\UI\\', $result);
+	}
+
+	/**
+	 * using() accepts a Prado3 Prado.* directory notation and returns the
+	 * equivalent PHP namespace string with a trailing '\'.
+	 * 'Prado.Web.UI.*' → prado3ToPhp → 'Prado\Web\UI\*' → registers → 'Prado\Web\UI\'.
+	 */
+	public function testUsing_withPrado3PradoDirectoryNotation_returnsPhpNamespaceWithTrailingBackslash(): void
+	{
+		$result = Prado::using('Prado.Web.UI.*');
+		$this->assertIsString($result);
+		$this->assertSame('Prado\\Web\\UI\\', $result);
+	}
+
+	/**
+	 * using() returns a namespace string with trailing '\' for a namespace already
+	 * registered in $_usings (e.g. the pre-registered 'Prado' root).
+	 */
+	public function testUsing_withPreRegisteredNamespace_returnsStringWithTrailingBackslash(): void
+	{
+		$result = Prado::using('Prado');
+		$this->assertIsString($result);
+		$this->assertSame('Prado\\', $result);
+	}
+
+	/**
+	 * using() returns false when the namespace cannot be resolved at all.
+	 */
+	public function testUsing_withUnresolvableNamespace_returnsFalse(): void
+	{
+		$result = Prado::using('Prado\\NonExistent\\TFakeClassXYZ99999');
+		$this->assertFalse($result);
+	}
+
+	// -------------------------------------------------------------------------
+	// Prado::usingClass() — returns string (resolved PHP FQN)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * PHP FQN for an already-loaded class → same FQN returned.
+	 * TApplication is loaded at bootstrap, exercising the fast path
+	 * (class_exists() true before any file loading).
+	 */
+	public function testUsingClass_withAlreadyLoadedClassFqn_returnsString(): void
+	{
+		$result = Prado::usingClass(\Prado\TApplication::class);
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\TApplication::class, $result);
+	}
+
+	/**
+	 * PHP FQN for a loadable interface → same FQN returned.
+	 */
+	public function testUsingClass_withPhpFqnInterface_returnsString(): void
+	{
+		$result = Prado::usingClass(self::INTERFACE_FQN);
+		$this->assertIsString($result);
+		$this->assertSame(self::INTERFACE_FQN, $result);
+	}
+
+	/**
+	 * PHP FQN for a loadable trait → same FQN returned.
+	 */
+	public function testUsingClass_withPhpFqnTrait_returnsString(): void
+	{
+		$result = Prado::usingClass(\Prado\Util\Traits\TInitializedTrait::class);
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\Util\Traits\TInitializedTrait::class, $result);
+	}
+
+	/**
+	 * Short class name in classMap → resolved PHP FQN returned.
+	 * 'TApplication' maps to 'Prado\TApplication' via classMap.
+	 */
+	public function testUsingClass_withShortClassName_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('TApplication');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\TApplication::class, $result);
+	}
+
+	/**
+	 * Short interface name in classMap → resolved PHP FQN returned.
+	 * 'ICache' maps to 'Prado\Caching\ICache' via classMap.
+	 */
+	public function testUsingClass_withShortInterfaceName_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('ICache');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\Caching\ICache::class, $result);
+	}
+
+	/**
+	 * Short trait name in classMap → resolved PHP FQN returned.
+	 * 'TInitializedTrait' maps to 'Prado\Util\Traits\TInitializedTrait' via classMap.
+	 */
+	public function testUsingClass_withShortTraitName_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('TInitializedTrait');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\Util\Traits\TInitializedTrait::class, $result);
+	}
+
+	/**
+	 * Prado3 System.* dot-notation for a class → PHP FQN returned.
+	 * 'System.TApplication' → prado3ToPhp → 'Prado\TApplication'.
+	 */
+	public function testUsingClass_withPrado3SystemDotNotationClass_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('System.TApplication');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\TApplication::class, $result);
+	}
+
+	/**
+	 * Prado3 Prado.* dot-notation for a class → PHP FQN returned.
+	 * 'Prado.TApplication' → prado3ToPhp → 'Prado\TApplication'.
+	 */
+	public function testUsingClass_withPrado3PradoDotNotationClass_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('Prado.TApplication');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\TApplication::class, $result);
+	}
+
+	/**
+	 * Full Prado3 System.* path (the canonical Prado3 form) → PHP FQN returned.
+	 * CLASS_PRADO_FULLNAME = 'System.Web.UI.WebControls.TButton'
+	 */
+	public function testUsingClass_withPrado3SystemFullPath_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass(self::CLASS_PRADO_FULLNAME);
+		$this->assertIsString($result);
+		$this->assertSame(self::CLASS_FQN, $result);
+	}
+
+	/**
+	 * Full Prado3 Prado.* path → PHP FQN returned.
+	 */
+	public function testUsingClass_withPrado3PradoFullPath_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('Prado.Web.UI.WebControls.TButton');
+		$this->assertIsString($result);
+		$this->assertSame(self::CLASS_FQN, $result);
+	}
+
+	/**
+	 * Prado3 System.* notation for an interface → PHP FQN returned.
+	 * 'System.Caching.ICache' → 'Prado\Caching\ICache'.
+	 */
+	public function testUsingClass_withPrado3SystemDotNotationInterface_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('System.Caching.ICache');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\Caching\ICache::class, $result);
+	}
+
+	/**
+	 * Prado3 System.* notation for a trait → PHP FQN returned.
+	 * 'System.Util.Traits.TInitializedTrait' → 'Prado\Util\Traits\TInitializedTrait'.
+	 */
+	public function testUsingClass_withPrado3SystemDotNotationTrait_returnsPhpFqn(): void
+	{
+		$result = Prado::usingClass('System.Util.Traits.TInitializedTrait');
+		$this->assertIsString($result);
+		$this->assertSame(\Prado\Util\Traits\TInitializedTrait::class, $result);
+	}
+
+	/**
+	 * Calling usingClass() twice with the same FQN returns the same string
+	 * (idempotency — the already-loaded fast-path is exercised on the second call).
+	 */
+	public function testUsingClass_calledTwiceWithFqn_returnsSameString(): void
+	{
+		$first = Prado::usingClass(\Prado\TApplication::class);
+		$second = Prado::usingClass(\Prado\TApplication::class);
+		$this->assertIsString($first);
+		$this->assertSame($first, $second);
+	}
+
+	/**
+	 * Calling usingClass() twice with the same Prado3 name returns the same string.
+	 */
+	public function testUsingClass_calledTwiceWithPrado3Name_returnsSameString(): void
+	{
+		$first = Prado::usingClass('System.TApplication');
+		$second = Prado::usingClass('System.TApplication');
+		$this->assertIsString($first);
+		$this->assertSame($first, $second);
+	}
+
+	// -------------------------------------------------------------------------
+	// Prado::usingClass() — returns false (directory namespace)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A PHP directory namespace (ends with *) → strictly false, never null.
+	 */
+	public function testUsingClass_withPhpDirectoryNamespace_returnsFalse(): void
+	{
+		$result = Prado::usingClass('Prado\\Web\\UI\\*');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * A Prado3 System.* directory notation → false.
+	 * 'System.Web.UI.*' → prado3ToPhp → 'Prado\Web\UI\*' → directory.
+	 */
+	public function testUsingClass_withPrado3SystemDirectoryNotation_returnsFalse(): void
+	{
+		$result = Prado::usingClass('System.Web.UI.*');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * A Prado3 Prado.* directory notation → false.
+	 */
+	public function testUsingClass_withPrado3PradoDirectoryNotation_returnsFalse(): void
+	{
+		$result = Prado::usingClass('Prado.Web.UI.*');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * A namespace prefix already registered in $_usings → false.
+	 * 'Prado' is pre-registered at Prado class initialization time, so
+	 * using() returns 'Prado\' immediately without touching the filesystem,
+	 * and usingClass() maps that trailing-backslash string to false.
+	 */
+	public function testUsingClass_withRegisteredDirectoryPrefix_returnsFalse(): void
+	{
+		$result = Prado::usingClass('Prado');
+		$this->assertFalse($result);
+	}
+
+	// -------------------------------------------------------------------------
+	// Prado::usingClass() — returns null (namespace could not be resolved)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A well-formed PHP FQN that resolves to no file → null.
+	 */
+	public function testUsingClass_withUnknownPhpFqn_returnsNull(): void
+	{
+		$result = Prado::usingClass('Prado\\NonExistent\\TFakeClassXYZ99999');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * A Prado3 System.* name that converts to a non-existent class → null.
+	 */
+	public function testUsingClass_withUnknownPrado3SystemDotNotation_returnsNull(): void
+	{
+		$result = Prado::usingClass('System.NonExistent.TFakeClassXYZ99999');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * A Prado3 Prado.* name that converts to a non-existent class → null.
+	 */
+	public function testUsingClass_withUnknownPrado3PradoDotNotation_returnsNull(): void
+	{
+		$result = Prado::usingClass('Prado.NonExistent.TFakeClassXYZ99999');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * A short name not in classMap and not found in any registered directory → null.
+	 */
+	public function testUsingClass_withUnknownShortName_returnsNull(): void
+	{
+		$result = Prado::usingClass('TFakeClassThatDoesNotExistXYZ99999');
+		$this->assertNull($result);
+	}
+
+	// -------------------------------------------------------------------------
+	// Prado::usingClass() — type-distinctness of false vs null
+	//
+	// The call sites all use !is_string() to guard against both directory and
+	// not-found results. These tests verify that the two non-string return
+	// values are strictly distinct from each other AND both satisfy the guard.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The directory result is strictly false, not null.
+	 */
+	public function testUsingClass_directoryResult_isStrictlyFalseNotNull(): void
+	{
+		$result = Prado::usingClass('Prado\\Web\\UI\\*');
+		$this->assertFalse($result);
+		$this->assertNotNull($result);
+		$this->assertFalse(is_string($result), '!is_string() guard must catch false');
+	}
+
+	/**
+	 * The not-found result is strictly null, not false.
+	 */
+	public function testUsingClass_notFoundResult_isStrictlyNullNotFalse(): void
+	{
+		$result = Prado::usingClass('Prado\\NonExistent\\TFakeClassXYZ99999');
+		$this->assertNull($result);
+		$this->assertNotFalse($result);
+		$this->assertFalse(is_string($result), '!is_string() guard must catch null');
+	}
+
+	/**
+	 * Both false and null satisfy the !is_string() guard used at all call sites,
+	 * while a resolved string does not.
+	 */
+	public function testUsingClass_isStringGuard_distinguishesAllThreeOutcomes(): void
+	{
+		$resolved = Prado::usingClass(\Prado\TApplication::class);
+		$directory = Prado::usingClass('Prado\\Web\\UI\\*');
+		$notFound = Prado::usingClass('Prado\\NonExistent\\TFakeClassXYZ99999');
+
+		$this->assertTrue(is_string($resolved), 'Resolved FQN must satisfy is_string()');
+		$this->assertFalse(is_string($directory), 'Directory false must not satisfy is_string()');
+		$this->assertFalse(is_string($notFound), 'Not-found null must not satisfy is_string()');
+
+		// Strict distinctness between the two non-string values
+		$this->assertNotSame($directory, $notFound, 'false and null must be strictly different');
 	}
 	
 	public function testMethod_Visible()

--- a/tests/unit/Security/Permissions/TPermissionsManagerTest.php
+++ b/tests/unit/Security/Permissions/TPermissionsManagerTest.php
@@ -834,6 +834,118 @@ class TPermissionsManagerTest extends PHPUnit\Framework\TestCase
 		$userManager = null;
 	}
 
+	// -----------------------------------------------------------------------
+	// loadPermissionsData() — Prado3 dot-notation rule class resolution
+	// -----------------------------------------------------------------------
+
+	public function testLoadPermissionsData_withPrado3SystemDotNotationRuleClass(): void
+	{
+		$this->obj->setAutoAllowWithPermission(false);
+		$this->obj->setAutoPresetRules(false);
+		$this->obj->setAutoDenyAll(false);
+
+		// 'System.Security.TAuthorizationRule' resolves to Prado\Security\TAuthorizationRule
+		// Before the fix, new $class(...) fails: "Class 'System.Security.TAuthorizationRule' not found"
+		$this->obj->loadPermissionsData([
+			'permissionrules' => [
+				['name' => 'test_prado3_system', 'action' => 'deny', 'roles' => 'Default',
+					'class' => 'System.Security.TAuthorizationRule'],
+			],
+		]);
+
+		$this->obj->registerPermission('test_prado3_system', 'test permission');
+		$rules = $this->obj->getPermissionRules('test_prado3_system');
+		self::assertNotNull($rules);
+		self::assertInstanceOf(TAuthorizationRuleCollection::class, $rules);
+		self::assertEquals(1, count($rules));
+		self::assertInstanceOf(TAuthorizationRule::class, $rules[0]);
+		self::assertEquals('deny', $rules[0]->getAction());
+		self::assertEquals(['default'], $rules[0]->getRoles());
+	}
+
+	public function testLoadPermissionsData_withPrado3PradoDotNotationRuleClass(): void
+	{
+		$this->obj->setAutoAllowWithPermission(false);
+		$this->obj->setAutoPresetRules(false);
+		$this->obj->setAutoDenyAll(false);
+
+		// 'Prado.Security.TAuthorizationRule' resolves to Prado\Security\TAuthorizationRule
+		$this->obj->loadPermissionsData([
+			'permissionrules' => [
+				['name' => 'test_prado3_prado', 'action' => 'allow', 'roles' => 'Admin',
+					'class' => 'Prado.Security.TAuthorizationRule'],
+			],
+		]);
+
+		$this->obj->registerPermission('test_prado3_prado', 'test permission');
+		$rules = $this->obj->getPermissionRules('test_prado3_prado');
+		self::assertNotNull($rules);
+		self::assertInstanceOf(TAuthorizationRuleCollection::class, $rules);
+		self::assertEquals(1, count($rules));
+		self::assertInstanceOf(TAuthorizationRule::class, $rules[0]);
+		self::assertEquals('allow', $rules[0]->getAction());
+	}
+
+	// -----------------------------------------------------------------------
+	// loadPermissionsData() — usingClass() false / null edge cases
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A directory namespace as the rule class (usingClass returns false) must
+	 * throw TConfigurationException — not silently fall back to some default.
+	 */
+	public function testLoadPermissionsData_withDirectoryNamespaceRuleClass_throws(): void
+	{
+		$this->obj->setAutoAllowWithPermission(false);
+		$this->obj->setAutoPresetRules(false);
+		$this->obj->setAutoDenyAll(false);
+
+		$this->expectException(TConfigurationException::class);
+		$this->obj->loadPermissionsData([
+			'permissionrules' => [
+				['name' => 'test_dir', 'action' => 'deny', 'roles' => 'Default',
+					'class' => 'Prado\\Security\\*'],
+			],
+		]);
+	}
+
+	/**
+	 * A Prado3 directory dot-notation (usingClass returns false) also throws.
+	 */
+	public function testLoadPermissionsData_withPrado3DirectoryNotation_throws(): void
+	{
+		$this->obj->setAutoAllowWithPermission(false);
+		$this->obj->setAutoPresetRules(false);
+		$this->obj->setAutoDenyAll(false);
+
+		$this->expectException(TConfigurationException::class);
+		$this->obj->loadPermissionsData([
+			'permissionrules' => [
+				['name' => 'test_p3dir', 'action' => 'deny', 'roles' => 'Default',
+					'class' => 'System.Security.*'],
+			],
+		]);
+	}
+
+	/**
+	 * An unknown rule class (usingClass returns null) must throw
+	 * TConfigurationException.
+	 */
+	public function testLoadPermissionsData_withUnknownRuleClass_throws(): void
+	{
+		$this->obj->setAutoAllowWithPermission(false);
+		$this->obj->setAutoPresetRules(false);
+		$this->obj->setAutoDenyAll(false);
+
+		$this->expectException(TConfigurationException::class);
+		$this->obj->loadPermissionsData([
+			'permissionrules' => [
+				['name' => 'test_unknown', 'action' => 'deny', 'roles' => 'Default',
+					'class' => 'TFakeAuthRuleClassXYZ99999'],
+			],
+		]);
+	}
+
 	//  The last test because it sets the permissions module in the application
 	public function testGetManager()
 	{

--- a/tests/unit/Security/app/prado3stubs/GlobalNsComponent.php
+++ b/tests/unit/Security/app/prado3stubs/GlobalNsComponent.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Prado3-style fixture: class defined in global namespace (no PHP namespace declaration).
+ * Used by PradoBaseTest to verify that Prado::using() correctly creates the reverse
+ * FQN alias ('Application\prado3stubs\GlobalNsComponent' → GlobalNsComponent) so that
+ * the returned namespace string is a valid, usable PHP class name.
+ */
+class GlobalNsComponent extends \Prado\TComponent
+{
+}

--- a/tests/unit/TApplicationServiceTest.php
+++ b/tests/unit/TApplicationServiceTest.php
@@ -228,6 +228,110 @@ class TApplicationServiceTest extends PHPUnit\Framework\TestCase
 		$this->assertTrue($this->_app->hasRegisteredService('reg_svc'));
 	}
 
+	// -----------------------------------------------------------------------
+	// registerService — Prado3 dot-notation class name resolution
+	//
+	// Legacy application.xml files use dot-notation class names such as
+	// "System.Web.Services.TSoapService". Since PR #1105 introduced
+	// registerService(), passing such a name directly causes a
+	// TConfigurationException because class_exists('System...', true) returns
+	// false even after Prado::using() loads the underlying PHP class — no
+	// alias is created for the dot-notation form.
+	//
+	// Short classMap names (e.g. 'TJsonService') already work because
+	// Prado::using() creates a class_alias for them; that behaviour is
+	// documented here as a regression guard.
+	// -----------------------------------------------------------------------
+
+	public function testRegisterService_withPrado3SystemDotNotationSucceeds(): void
+	{
+		// 'System.Web.Services.TJsonService' is the Prado3 form of
+		// Prado\Web\Services\TJsonService. registerService() must resolve it
+		// via Prado::using() rather than calling class_exists() on the raw string.
+		$this->_app->registerService('prado3_sys', 'System.Web.Services.TJsonService');
+		$this->assertTrue($this->_app->hasRegisteredService('prado3_sys'));
+	}
+
+	public function testRegisterService_withPrado3PradoDotNotationSucceeds(): void
+	{
+		// 'Prado.Web.Services.TJsonService' uses dots in place of backslashes —
+		// another valid Prado3 form that must be resolved before class_exists().
+		$this->_app->registerService('prado3_dot', 'Prado.Web.Services.TJsonService');
+		$this->assertTrue($this->_app->hasRegisteredService('prado3_dot'));
+	}
+
+	public function testRegisterService_withClassMapShortNameSucceeds(): void
+	{
+		// Short classMap names (e.g. 'TJsonService') are already handled by the
+		// PHP autoloader via Prado::using() → class_alias(). This test documents
+		// that the current behaviour survives the fix.
+		$this->_app->registerService('prado3_short', 'TJsonService');
+		$this->assertTrue($this->_app->hasRegisteredService('prado3_short'));
+	}
+
+	public function testRegisterService_prado3SystemDotNotation_storesResolvableClass(): void
+	{
+		// The class stored in the registry must be recognisable as an IService
+		// implementor so that getRegisteredServiceByClass() / startService() work.
+		$this->_app->registerService('prado3_sys', 'System.Web.Services.TJsonService');
+		$entry = $this->_app->getRegisteredService('prado3_sys');
+		$storedClass = $entry[0];
+		$this->assertTrue(
+			is_a($storedClass, \Prado\IService::class, true),
+			"Stored class '{$storedClass}' must implement IService"
+		);
+	}
+
+	public function testRegisterService_prado3PradoDotNotation_storesResolvableClass(): void
+	{
+		$this->_app->registerService('prado3_dot', 'Prado.Web.Services.TJsonService');
+		$entry = $this->_app->getRegisteredService('prado3_dot');
+		$storedClass = $entry[0];
+		$this->assertTrue(
+			is_a($storedClass, \Prado\IService::class, true),
+			"Stored class '{$storedClass}' must implement IService"
+		);
+	}
+
+	public function testRegisterService_prado3SystemDotNotation_storesResolvableClassProperties(): void
+	{
+		// Properties and config element must be preserved alongside the resolved class.
+		$props = ['SomeProperty' => 'value'];
+		$this->_app->registerService('prado3_props', 'System.Web.Services.TJsonService', $props);
+		$entry = $this->_app->getRegisteredService('prado3_props');
+		$this->assertSame($props, $entry[1]);
+		$this->assertNull($entry[2]);
+	}
+
+	public function testGetRegisteredServiceByClass_withPrado3SystemDotNotationRegistration(): void
+	{
+		// A service registered with a Prado3 name must be discoverable by its
+		// canonical PHP class name via getRegisteredServiceByClass().
+		$this->_app->registerService('prado3_lookup', 'System.Web.Services.TJsonService');
+		$id = $this->_app->getRegisteredServiceByClass(\Prado\Web\Services\TJsonService::class);
+		$this->assertSame('prado3_lookup', $id);
+	}
+
+	public function testGetRegisteredServicesByClass_withPrado3SystemDotNotationRegistration(): void
+	{
+		// Same discoverability requirement for the plural variant.
+		$this->_app->registerService('prado3_lookup', 'System.Web.Services.TJsonService');
+		$ids = $this->_app->getRegisteredServicesByClass(\Prado\Web\Services\TJsonService::class);
+		$this->assertContains('prado3_lookup', $ids);
+	}
+
+	public function testStartService_withPrado3SystemDotNotationRegistration(): void
+	{
+		// Full round-trip: register with Prado3 name → startService → running instance.
+		// TJsonService::init(null) is safe: it skips JSON-endpoint parsing when
+		// $config is null (as it is when no config element was supplied).
+		$this->setServices([]);
+		$this->_app->registerService('prado3_start', 'System.Web.Services.TJsonService');
+		$this->_app->startService('prado3_start');
+		$this->assertInstanceOf(\Prado\Web\Services\TJsonService::class, $this->_app->getService());
+		$this->assertSame('prado3_start', $this->_app->getService()->getID());
+	}
+
 	public function testRegisterService_byClassStoresCorrectFormat(): void
 	{
 		$this->_app->registerService('reg_fmt', InitTrackingService::class);
@@ -291,9 +395,24 @@ class TApplicationServiceTest extends PHPUnit\Framework\TestCase
 
 	public function testRegisterService_nonExistentClassThrows(): void
 	{
+		// usingClass() returns null for an unknown name → !is_string() guard fires.
 		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
 		$this->expectExceptionMessage('ThisClassDoesNotExistAnywhere_XYZ');
 		$this->_app->registerService('bad', 'ThisClassDoesNotExistAnywhere_XYZ');
+	}
+
+	public function testRegisterService_withDirectoryNamespace_throws(): void
+	{
+		// usingClass() returns false for a directory namespace → !is_string() guard fires.
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$this->_app->registerService('dirservice', 'Prado\\Web\\Services\\*');
+	}
+
+	public function testRegisterService_withPrado3DirectoryNotation_throws(): void
+	{
+		// Prado3 dot-notation directory resolves to false → !is_string() guard fires.
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$this->_app->registerService('dirservice', 'System.Web.Services.*');
 	}
 
 	public function testRegisterService_nonServiceClassThrows(): void
@@ -416,6 +535,25 @@ class TApplicationServiceTest extends PHPUnit\Framework\TestCase
 	// getRegisteredServiceByClass — singular
 	// -----------------------------------------------------------------------
 
+	/**
+	 * A directory namespace (usingClass returns false) is not a valid class
+	 * to look up; the method returns null immediately.
+	 */
+	public function testGetRegisteredServiceByClass_withDirectoryNamespace_returnsNull(): void
+	{
+		$result = $this->_app->getRegisteredServiceByClass('Prado\\Web\\Services\\*');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * An unknown class name (usingClass returns null) also returns null immediately.
+	 */
+	public function testGetRegisteredServiceByClass_withUnknownClass_returnsNull(): void
+	{
+		$result = $this->_app->getRegisteredServiceByClass('TFakeServiceClassXYZ99999');
+		$this->assertNull($result);
+	}
+
 	public function testGetRegisteredServiceByClass_returnsNullWhenNoServices(): void
 	{
 		$this->setServices([]);
@@ -475,6 +613,24 @@ class TApplicationServiceTest extends PHPUnit\Framework\TestCase
 	// -----------------------------------------------------------------------
 	// getRegisteredServicesByClass — plural
 	// -----------------------------------------------------------------------
+
+	/**
+	 * A directory namespace (usingClass returns false) → empty array immediately.
+	 */
+	public function testGetRegisteredServicesByClass_withDirectoryNamespace_returnsEmptyArray(): void
+	{
+		$result = $this->_app->getRegisteredServicesByClass('Prado\\Web\\Services\\*');
+		$this->assertSame([], $result);
+	}
+
+	/**
+	 * An unknown class name (usingClass returns null) → empty array immediately.
+	 */
+	public function testGetRegisteredServicesByClass_withUnknownClass_returnsEmptyArray(): void
+	{
+		$result = $this->_app->getRegisteredServicesByClass('TFakeServiceClassXYZ99999');
+		$this->assertSame([], $result);
+	}
 
 	public function testGetRegisteredServicesByClass_returnsEmptyArrayWhenNoServices(): void
 	{

--- a/tests/unit/TApplicationTest.php
+++ b/tests/unit/TApplicationTest.php
@@ -1487,6 +1487,137 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// getModulesByType — lazy modules stored with PHP FQN class names
+	//
+	// setLazyModule() resolves and validates the class name before storing,
+	// so _lazyModules always contains PHP fully-qualified class names.
+	// getModulesByType() can therefore call is_a() directly on the stored
+	// value without any further resolution step.
+	// -----------------------------------------------------------------------
+
+	public function testGetModulesByType_lazyModule_withPrado3SystemDotNotation(): void
+	{
+		// setLazyModule converts 'System.Web.THttpSession' → Prado\Web\THttpSession
+		// before storage, so the value in _lazyModules is always the PHP FQN.
+		PradoUnit::setProp($this->_app, '_modules', ['lazy_m' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'lazy_m' => [\Prado\Web\THttpSession::class, [], null],
+		]);
+
+		$result = $this->_app->getModulesByType(\Prado\Web\THttpSession::class);
+		$this->assertArrayHasKey('lazy_m', $result);
+		$this->assertNull($result['lazy_m']);
+	}
+
+	public function testGetModulesByType_lazyModule_withPrado3PradoDotNotation(): void
+	{
+		// setLazyModule converts 'Prado.Web.THttpSession' → Prado\Web\THttpSession
+		// before storage; the stored value is always the PHP FQN.
+		PradoUnit::setProp($this->_app, '_modules', ['lazy_m' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'lazy_m' => [\Prado\Web\THttpSession::class, [], null],
+		]);
+
+		$result = $this->_app->getModulesByType(\Prado\Web\THttpSession::class);
+		$this->assertArrayHasKey('lazy_m', $result);
+		$this->assertNull($result['lazy_m']);
+	}
+
+	public function testGetModulesByType_lazyModule_withPrado3SystemDotNotation_strictMode(): void
+	{
+		// Strict mode (===) works because the stored PHP FQN matches exactly.
+		PradoUnit::setProp($this->_app, '_modules', ['lazy_m' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'lazy_m' => [\Prado\Web\THttpSession::class, [], null],
+		]);
+
+		$result = $this->_app->getModulesByType(\Prado\Web\THttpSession::class, true);
+		$this->assertArrayHasKey('lazy_m', $result);
+	}
+
+	public function testGetModulesByType_lazyModule_withPrado3DotNotation_doesNotMatchUnrelatedType(): void
+	{
+		// A lazy module must NOT appear in results for an unrelated type.
+		PradoUnit::setProp($this->_app, '_modules', ['lazy_m' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'lazy_m' => [\Prado\Web\THttpSession::class, [], null],
+		]);
+
+		$result = $this->_app->getModulesByType(\Prado\Caching\ICache::class);
+		$this->assertArrayNotHasKey('lazy_m', $result);
+	}
+
+	// -----------------------------------------------------------------------
+	// internalLoadModule — Prado3 dot-notation class name resolution
+	//
+	// internalLoadModule() calls Prado::createComponent($moduleClass), which
+	// already routes through prado3NamespaceToPhpNamespace() internally.
+	// getModule() is the public entry-point that forces a lazy module to load;
+	// these tests verify the full round-trip from Prado3 name → live instance.
+	//
+	// TSecurityManager is used because its init($config) never touches $config,
+	// making it safe to call with null in a test context.
+	// -----------------------------------------------------------------------
+
+	public function testGetModule_withPrado3SystemDotNotation_instantiatesCorrectClass(): void
+	{
+		// 'System.Security.TSecurityManager' is the Prado3 name for
+		// Prado\Security\TSecurityManager. getModule() must force-load it
+		// via internalLoadModule() → Prado::createComponent(), which resolves
+		// the Prado3 name, and return a live instance of the correct PHP class.
+		PradoUnit::setProp($this->_app, '_modules', ['prado3_mod' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'prado3_mod' => ['System.Security.TSecurityManager', [], null],
+		]);
+
+		$module = $this->_app->getModule('prado3_mod');
+		$this->assertInstanceOf(\Prado\Security\TSecurityManager::class, $module);
+	}
+
+	public function testGetModule_withPrado3PradoDotNotation_instantiatesCorrectClass(): void
+	{
+		// 'Prado.Security.TSecurityManager' uses dots instead of backslashes —
+		// another valid Prado3 form; createComponent() must resolve it identically.
+		PradoUnit::setProp($this->_app, '_modules', ['prado3_mod' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'prado3_mod' => ['Prado.Security.TSecurityManager', [], null],
+		]);
+
+		$module = $this->_app->getModule('prado3_mod');
+		$this->assertInstanceOf(\Prado\Security\TSecurityManager::class, $module);
+	}
+
+	public function testGetModule_withPrado3ClassMapShortName_instantiatesCorrectClass(): void
+	{
+		// Short classMap names (e.g. 'TSecurityManager') are resolved by
+		// Prado::using() into a class_alias. Verify the full load path works
+		// for this form too, as a regression guard.
+		PradoUnit::setProp($this->_app, '_modules', ['prado3_mod' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'prado3_mod' => ['TSecurityManager', [], null],
+		]);
+
+		$module = $this->_app->getModule('prado3_mod');
+		$this->assertInstanceOf(\Prado\Security\TSecurityManager::class, $module);
+	}
+
+	public function testGetModule_withPrado3SystemDotNotation_moduleIsRegisteredAfterLoad(): void
+	{
+		// After force-loading, the module must be findable via getModules() as a
+		// live instance (not null), and under the same ID it was registered with.
+		PradoUnit::setProp($this->_app, '_modules', ['prado3_mod' => null]);
+		PradoUnit::setProp($this->_app, '_lazyModules', [
+			'prado3_mod' => ['System.Security.TSecurityManager', [], null],
+		]);
+
+		$this->_app->getModule('prado3_mod');
+
+		$modules = $this->_app->getModules();
+		$this->assertArrayHasKey('prado3_mod', $modules);
+		$this->assertInstanceOf(\Prado\Security\TSecurityManager::class, $modules['prado3_mod']);
+	}
+
+	// -----------------------------------------------------------------------
 	// flushOutput
 	// -----------------------------------------------------------------------
 
@@ -1929,7 +2060,8 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	public function testSetLazyModule_registersConfig(): void
 	{
 		$acc    = $this->newLazyAccessor();
-		$config = ['MyClass', ['prop' => 'val'], null];
+		// setLazyModule() validates the class via usingClass() — must use a real class.
+		$config = [AppTestModule::class, ['prop' => 'val'], null];
 		$acc->pubSetLazyModule('mymod', $config);
 		$this->assertSame($config, $acc->pubGetLazyModule('mymod'));
 	}
@@ -1937,7 +2069,7 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	public function testHasLazyModule_trueAfterRegistration(): void
 	{
 		$acc = $this->newLazyAccessor();
-		$acc->pubSetLazyModule('mymod', ['Class', [], null]);
+		$acc->pubSetLazyModule('mymod', [AppTestModule::class, [], null]);
 		$this->assertTrue($acc->pubHasLazyModule('mymod'));
 	}
 
@@ -1950,7 +2082,7 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	public function testSetLazyModule_nullMarksSlotConsumed(): void
 	{
 		$acc = $this->newLazyAccessor();
-		$acc->pubSetLazyModule('consumed', ['C', [], null]);
+		$acc->pubSetLazyModule('consumed', [AppTestModule::class, [], null]);
 		// Nullify to mark as consumed (module has been loaded).
 		$acc->pubSetLazyModule('consumed', null);
 		$this->assertNull($acc->pubGetLazyModule('consumed'));
@@ -1960,7 +2092,7 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	{
 		// isset() on a null array value returns false.
 		$acc = $this->newLazyAccessor();
-		$acc->pubSetLazyModule('mod', ['C', [], null]);
+		$acc->pubSetLazyModule('mod', [AppTestModule::class, [], null]);
 		$acc->pubSetLazyModule('mod', null);
 		$this->assertFalse($acc->pubHasLazyModule('mod'));
 	}
@@ -1974,8 +2106,8 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	public function testGetLazyModuleCount_incrementsOnEachSet(): void
 	{
 		$acc = $this->newLazyAccessor();
-		$acc->pubSetLazyModule('a', ['A', [], null]);
-		$acc->pubSetLazyModule('b', ['B', [], null]);
+		$acc->pubSetLazyModule('a', [AppTestModule::class, [], null]);
+		$acc->pubSetLazyModule('b', [AppTestModuleSubclass::class, [], null]);
 		$this->assertSame(2, $acc->pubGetLazyModuleCount());
 	}
 
@@ -1984,7 +2116,7 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 		// Consumed (nulled) slots still contribute to the count — they are used
 		// as auto-ID seeds to prevent duplicate anonymous module IDs.
 		$acc = $this->newLazyAccessor();
-		$acc->pubSetLazyModule('mod', ['C', [], null]);
+		$acc->pubSetLazyModule('mod', [AppTestModule::class, [], null]);
 		$acc->pubSetLazyModule('mod', null);  // consume
 		$this->assertSame(1, $acc->pubGetLazyModuleCount());
 	}
@@ -1992,11 +2124,94 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	public function testSetLazyModule_overwritesExistingConfig(): void
 	{
 		$acc      = $this->newLazyAccessor();
-		$original = ['First', [], null];
-		$updated  = ['Second', ['x' => 1], null];
+		$original = [AppTestModule::class, [], null];
+		$updated  = [AppTestModuleSubclass::class, ['x' => 1], null];
 		$acc->pubSetLazyModule('mod', $original);
 		$acc->pubSetLazyModule('mod', $updated);
 		$this->assertSame($updated, $acc->pubGetLazyModule('mod'));
+	}
+
+	// -----------------------------------------------------------------------
+	// setLazyModule() — usingClass() edge cases (false / null return values)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A Prado3 System dot-notation class name is resolved to the PHP FQN at
+	 * store time, so getModulesByType() always sees a PHP-native class string.
+	 */
+	public function testSetLazyModule_withPrado3SystemDotNotation_storesResolvedFqn(): void
+	{
+		$acc = $this->newLazyAccessor();
+		$acc->pubSetLazyModule('p3mod', ['System.Web.THttpSession', [], null]);
+		$stored = $acc->pubGetLazyModule('p3mod');
+		$this->assertSame(\Prado\Web\THttpSession::class, $stored[0]);
+	}
+
+	/**
+	 * Same for Prado dot-notation.
+	 */
+	public function testSetLazyModule_withPrado3PradoDotNotation_storesResolvedFqn(): void
+	{
+		$acc = $this->newLazyAccessor();
+		$acc->pubSetLazyModule('p3mod', ['Prado.Web.THttpSession', [], null]);
+		$stored = $acc->pubGetLazyModule('p3mod');
+		$this->assertSame(\Prado\Web\THttpSession::class, $stored[0]);
+	}
+
+	/**
+	 * A directory namespace (usingClass returns false) throws at store time
+	 * rather than silently storing an unusable value.
+	 */
+	public function testSetLazyModule_withDirectoryNamespace_throws(): void
+	{
+		$acc = $this->newLazyAccessor();
+		$this->expectException(TConfigurationException::class);
+		$acc->pubSetLazyModule('dirmod', ['Prado\\Web\\UI\\*', [], null]);
+	}
+
+	/**
+	 * A Prado3 directory dot-notation (usingClass returns false) also throws.
+	 */
+	public function testSetLazyModule_withPrado3DirectoryNotation_throws(): void
+	{
+		$acc = $this->newLazyAccessor();
+		$this->expectException(TConfigurationException::class);
+		$acc->pubSetLazyModule('dirmod', ['System.Web.UI.*', [], null]);
+	}
+
+	/**
+	 * An unresolvable class name (usingClass returns null) throws at store time.
+	 */
+	public function testSetLazyModule_withUnknownClass_throws(): void
+	{
+		$acc = $this->newLazyAccessor();
+		$this->expectException(TConfigurationException::class);
+		$acc->pubSetLazyModule('badmod', ['TotallyFakeClassXYZ99999', [], null]);
+	}
+
+	// -----------------------------------------------------------------------
+	// getModulesByType() — usingClass() edge cases for the $type argument
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A directory namespace passed as $type (usingClass returns false)
+	 * results in an empty array — no modules match an unresolvable type.
+	 */
+	public function testGetModulesByType_withDirectoryNamespaceType_returnsEmptyArray(): void
+	{
+		$this->_app->setModule('live_m', new AppTestModule());
+		$result = $this->_app->getModulesByType('Prado\\Web\\UI\\*');
+		$this->assertSame([], $result);
+	}
+
+	/**
+	 * An unknown class name passed as $type (usingClass returns null)
+	 * results in an empty array.
+	 */
+	public function testGetModulesByType_withUnknownType_returnsEmptyArray(): void
+	{
+		$result = $this->_app->getModulesByType('TFakeClassThatDoesNotExistXYZ99999');
+		$this->assertSame([], $result);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/TApplicationTest.php
+++ b/tests/unit/TApplicationTest.php
@@ -34,6 +34,7 @@ class TApplicationTestAccessor extends TApplication
 	public function pubHasLazyModule(string $id): bool { return $this->hasLazyModule($id); }
 	public function pubGetLazyModule(string $id): ?array { return $this->getLazyModule($id); }
 	public function pubSetLazyModule(string $id, ?array $config): void { $this->setLazyModule($id, $config); }
+	public function pubSetLazyModuleDirect(string $id, ?array $config): void { $this->setLazyModuleDirect($id, $config); }
 	public function pubGetLazyModuleCount(): int { return $this->getLazyModuleCount(); }
 }
 
@@ -1489,10 +1490,9 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	// -----------------------------------------------------------------------
 	// getModulesByType — lazy modules stored with PHP FQN class names
 	//
-	// setLazyModule() resolves and validates the class name before storing,
-	// so _lazyModules always contains PHP fully-qualified class names.
-	// getModulesByType() can therefore call is_a() directly on the stored
-	// value without any further resolution step.
+	// When setLazyModule() can resolve the class at registration time it stores
+	// the PHP FQN directly. getModulesByType() then calls is_a() on the stored
+	// FQN without a further resolution step.
 	// -----------------------------------------------------------------------
 
 	public function testGetModulesByType_lazyModule_withPrado3SystemDotNotation(): void
@@ -1545,6 +1545,65 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 
 		$result = $this->_app->getModulesByType(\Prado\Caching\ICache::class);
 		$this->assertArrayNotHasKey('lazy_m', $result);
+	}
+
+	// -----------------------------------------------------------------------
+	// getModulesByType — deferred resolution of unresolved Prado3 dot-notation
+	//
+	// When setLazyModule() cannot resolve the class at registration time the
+	// raw name is stored. getModulesByType() calls usingClass() on the stored
+	// value and, if successful, normalises the entry to the PHP FQN for future
+	// calls. Directory namespaces (false) and unknown names (null) are skipped.
+	// -----------------------------------------------------------------------
+
+	public function testGetModulesByType_lazyModule_deferredResolution_resolvesPrado3DotNotation(): void
+	{
+		// Simulate a name that setLazyModule() could not resolve at registration
+		// time by storing the raw Prado3 dot-notation via setLazyModuleDirect().
+		$acc = $this->newLazyAccessor();
+		$acc->setModule('lazy_m', null);
+		$acc->pubSetLazyModuleDirect('lazy_m', ['System.Web.THttpSession', [], null]);
+
+		$result = $acc->getModulesByType(\Prado\Web\THttpSession::class);
+		$this->assertArrayHasKey('lazy_m', $result);
+		$this->assertNull($result['lazy_m']);
+	}
+
+	public function testGetModulesByType_lazyModule_deferredResolution_normalisesStoredEntry(): void
+	{
+		// After a successful deferred resolution the stored entry must be
+		// updated to the PHP FQN so subsequent calls skip the resolution step.
+		$acc = $this->newLazyAccessor();
+		$acc->setModule('lazy_m', null);
+		$acc->pubSetLazyModuleDirect('lazy_m', ['Prado.Web.THttpSession', [], null]);
+
+		$acc->getModulesByType(\Prado\Web\THttpSession::class);
+
+		$this->assertSame(\Prado\Web\THttpSession::class, $acc->pubGetLazyModule('lazy_m')[0]);
+	}
+
+	public function testGetModulesByType_lazyModule_deferredResolution_directoryNamespace_isSkipped(): void
+	{
+		// A stored class that resolves to a directory namespace (usingClass → false)
+		// must not appear in results.
+		$acc = $this->newLazyAccessor();
+		$acc->setModule('lazy_m', null);
+		$acc->pubSetLazyModuleDirect('lazy_m', ['Prado\\Web\\UI\\*', [], null]);
+
+		$result = $acc->getModulesByType(\Prado\Web\THttpSession::class);
+		$this->assertSame([], $result);
+	}
+
+	public function testGetModulesByType_lazyModule_deferredResolution_unknownClass_isSkipped(): void
+	{
+		// A stored class that cannot be resolved (usingClass → null) must not
+		// appear in results.
+		$acc = $this->newLazyAccessor();
+		$acc->setModule('lazy_m', null);
+		$acc->pubSetLazyModuleDirect('lazy_m', ['TotallyFakeClassXYZ99999', [], null]);
+
+		$result = $acc->getModulesByType(\Prado\Web\THttpSession::class);
+		$this->assertSame([], $result);
 	}
 
 	// -----------------------------------------------------------------------
@@ -2159,34 +2218,39 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * A directory namespace (usingClass returns false) throws at store time
-	 * rather than silently storing an unusable value.
+	 * A directory namespace (usingClass returns false) stores the original
+	 * class name unchanged — resolution is deferred to internalLoadModule().
 	 */
-	public function testSetLazyModule_withDirectoryNamespace_throws(): void
+	public function testSetLazyModule_withDirectoryNamespace_storesOriginal(): void
 	{
 		$acc = $this->newLazyAccessor();
-		$this->expectException(TConfigurationException::class);
 		$acc->pubSetLazyModule('dirmod', ['Prado\\Web\\UI\\*', [], null]);
+		$stored = $acc->pubGetLazyModule('dirmod');
+		$this->assertSame('Prado\\Web\\UI\\*', $stored[0]);
 	}
 
 	/**
-	 * A Prado3 directory dot-notation (usingClass returns false) also throws.
+	 * A Prado3 directory dot-notation (usingClass returns false) also stores
+	 * the original class name unchanged — resolution is deferred to internalLoadModule().
 	 */
-	public function testSetLazyModule_withPrado3DirectoryNotation_throws(): void
+	public function testSetLazyModule_withPrado3DirectoryNotation_storesOriginal(): void
 	{
 		$acc = $this->newLazyAccessor();
-		$this->expectException(TConfigurationException::class);
 		$acc->pubSetLazyModule('dirmod', ['System.Web.UI.*', [], null]);
+		$stored = $acc->pubGetLazyModule('dirmod');
+		$this->assertSame('System.Web.UI.*', $stored[0]);
 	}
 
 	/**
-	 * An unresolvable class name (usingClass returns null) throws at store time.
+	 * An unresolvable class name (usingClass returns null) stores the original
+	 * class name unchanged — resolution is deferred to internalLoadModule().
 	 */
-	public function testSetLazyModule_withUnknownClass_throws(): void
+	public function testSetLazyModule_withUnknownClass_storesOriginal(): void
 	{
 		$acc = $this->newLazyAccessor();
-		$this->expectException(TConfigurationException::class);
 		$acc->pubSetLazyModule('badmod', ['TotallyFakeClassXYZ99999', [], null]);
+		$stored = $acc->pubGetLazyModule('badmod');
+		$this->assertSame('TotallyFakeClassXYZ99999', $stored[0]);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/TComponentBehaviorTest.php
+++ b/tests/unit/TComponentBehaviorTest.php
@@ -830,4 +830,161 @@ class TComponentBehaviorTest extends TComponentTestBase
 			$this->assertEquals(4, $this->component->onMyEvent->getCount());
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// asa() and getBehaviors() — Prado3 dot-notation class name resolution
+	// -----------------------------------------------------------------------
+
+	/**
+	 * asa() with a Prado3 System dot-notation framework class name.
+	 *
+	 * FooBehavior extends TBehavior (\Prado\Util\TBehavior).
+	 * Calling asa('System.Util.TBehavior') must resolve to Prado\Util\TBehavior,
+	 * then return the attached FooBehavior since it is an instance of TBehavior.
+	 */
+	public function testAsA_withPrado3SystemDotNotation(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooBehaviorInstance', $foo);
+
+		// System.Util.TBehavior → Prado\Util\TBehavior; FooBehavior IS-A TBehavior
+		$result = $this->component->asa('System.Util.TBehavior');
+		$this->assertSame($foo, $result);
+
+		$this->component->detachBehavior('fooBehaviorInstance');
+	}
+
+	/**
+	 * asa() with a Prado3 Prado dot-notation framework class name.
+	 */
+	public function testAsA_withPrado3PradoDotNotation(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooBehaviorInstance2', $foo);
+
+		// Prado.Util.TBehavior → Prado\Util\TBehavior
+		$result = $this->component->asa('Prado.Util.TBehavior');
+		$this->assertSame($foo, $result);
+
+		$this->component->detachBehavior('fooBehaviorInstance2');
+	}
+
+	/**
+	 * asa() with a Prado3 name returns null when no attached behavior matches.
+	 */
+	public function testAsA_withPrado3DotNotation_returnsNullWhenNoMatch(): void
+	{
+		// Attach a FooFooBehavior but look up by TClassBehavior (unrelated) Prado3 name
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooForNullTest', $foo);
+
+		// Prado.Util.TClassBehavior is a class behavior interface, FooBehavior is NOT one
+		$result = $this->component->asa('Prado.Util.TClassBehavior');
+		$this->assertNull($result);
+
+		$this->component->detachBehavior('fooForNullTest');
+	}
+
+	/**
+	 * getBehaviors() filtered by a Prado3 System dot-notation class name.
+	 *
+	 * FooBehavior extends TBehavior; FooFooBehavior extends FooBehavior.
+	 * Both should be returned when filtering by 'System.Util.TBehavior'.
+	 */
+	public function testGetBehaviors_withPrado3SystemDotNotation(): void
+	{
+		$foo = new FooBehavior();
+		$foofoo = new FooFooBehavior();
+		$this->component->attachBehavior('fooB', $foo);
+		$this->component->attachBehavior('foofooB', $foofoo);
+
+		// System.Util.TBehavior → Prado\Util\TBehavior; both behaviors match
+		$result = $this->component->getBehaviors('System.Util.TBehavior');
+		$this->assertContains($foo, $result);
+		$this->assertContains($foofoo, $result);
+		$this->assertCount(2, $result);
+
+		$this->component->detachBehavior('fooB');
+		$this->component->detachBehavior('foofooB');
+	}
+
+	/**
+	 * getBehaviors() filtered by a Prado3 Prado dot-notation class name.
+	 */
+	public function testGetBehaviors_withPrado3PradoDotNotation(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooBehaviorPrado3', $foo);
+
+		// Prado.Util.TBehavior → Prado\Util\TBehavior
+		$result = $this->component->getBehaviors('Prado.Util.TBehavior');
+		$this->assertContains($foo, $result);
+		$this->assertCount(1, $result);
+
+		$this->component->detachBehavior('fooBehaviorPrado3');
+	}
+
+	// -----------------------------------------------------------------------
+	// asa() and getBehaviors() — usingClass() false / null edge cases
+	// -----------------------------------------------------------------------
+
+	/**
+	 * asa() with a directory namespace (usingClass returns false) must return
+	 * null — the !is_string() guard prevents searching the behavior list.
+	 */
+	public function testAsA_withDirectoryNamespace_returnsNull(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooDir', $foo);
+
+		$result = $this->component->asa('Prado\\Util\\*');
+		$this->assertNull($result);
+
+		$this->component->detachBehavior('fooDir');
+	}
+
+	/**
+	 * asa() with an unknown class name (usingClass returns null) must return
+	 * null — the !is_string() guard prevents searching the behavior list.
+	 */
+	public function testAsA_withUnknownClass_returnsNull(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooUnknown', $foo);
+
+		$result = $this->component->asa('TFakeBehaviorClassXYZ99999');
+		$this->assertNull($result);
+
+		$this->component->detachBehavior('fooUnknown');
+	}
+
+	/**
+	 * getBehaviors() with a directory namespace (usingClass returns false)
+	 * must return an empty array.
+	 */
+	public function testGetBehaviors_withDirectoryNamespace_returnsEmptyArray(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooDirB', $foo);
+
+		$result = $this->component->getBehaviors('Prado\\Util\\*');
+		$this->assertSame([], $result);
+
+		$this->component->detachBehavior('fooDirB');
+	}
+
+	/**
+	 * getBehaviors() with an unknown class name (usingClass returns null)
+	 * must return an empty array.
+	 */
+	public function testGetBehaviors_withUnknownClass_returnsEmptyArray(): void
+	{
+		$foo = new FooBehavior();
+		$this->component->attachBehavior('fooUnknownB', $foo);
+
+		$result = $this->component->getBehaviors('TFakeBehaviorClassXYZ99999');
+		$this->assertSame([], $result);
+
+		$this->component->detachBehavior('fooUnknownB');
+	}
 }

--- a/tests/unit/Web/UI/TTemplateManagerTest.php
+++ b/tests/unit/Web/UI/TTemplateManagerTest.php
@@ -176,4 +176,75 @@ class TTemplateManagerTest extends PHPUnit\Framework\TestCase
 		$result = $manager->getTemplateByClassName(\Prado\TComponent::class);
 		$this->assertNull($result);
 	}
+
+	// -----------------------------------------------------------------------
+	// getTemplateByFileName() — Prado3 dot-notation class name resolution
+	// -----------------------------------------------------------------------
+
+	public function testGetTemplateByFileNameWithPrado3SystemDotNotation(): void
+	{
+		$manager = new TTemplateManager();
+		$file = $this->createTplFile('content');
+		// System.Web.UI.TSkinTemplate resolves to Prado\Web\UI\TSkinTemplate via prado3NamespaceToPhpNamespace
+		$result = $manager->getTemplateByFileName($file, 'System.Web.UI.TSkinTemplate');
+		$this->assertInstanceOf(TSkinTemplate::class, $result);
+	}
+
+	public function testGetTemplateByFileNameWithPrado3PradoDotNotation(): void
+	{
+		$manager = new TTemplateManager();
+		$file = $this->createTplFile('content');
+		// Prado.Web.UI.TSkinTemplate resolves to Prado\Web\UI\TSkinTemplate
+		$result = $manager->getTemplateByFileName($file, 'Prado.Web.UI.TSkinTemplate');
+		$this->assertInstanceOf(TSkinTemplate::class, $result);
+	}
+
+	public function testGetTemplateByFileNameWithPrado3DotNotationDefaultClass(): void
+	{
+		$manager = new TTemplateManager();
+		// Set default template class using Prado3 dot-notation
+		$manager->setDefaultTemplateClass('System.Web.UI.TSkinTemplate');
+		$file = $this->createTplFile('content');
+		// getTemplateByFileName(null) falls back to default class; must resolve Prado3 name
+		$result = $manager->getTemplateByFileName($file, null);
+		$this->assertInstanceOf(TSkinTemplate::class, $result);
+	}
+
+	// -----------------------------------------------------------------------
+	// getTemplateByFileName() — usingClass() false / null edge cases
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A directory namespace (usingClass returns false) is not a valid template
+	 * class; getTemplateByFileName() must return null.
+	 */
+	public function testGetTemplateByFileName_withDirectoryNamespaceTplClass_returnsNull(): void
+	{
+		$manager = new TTemplateManager();
+		$file = $this->createTplFile('content');
+		$result = $manager->getTemplateByFileName($file, 'Prado\\Web\\UI\\*');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * A Prado3 directory dot-notation (usingClass returns false) also returns null.
+	 */
+	public function testGetTemplateByFileName_withPrado3DirectoryNotation_returnsNull(): void
+	{
+		$manager = new TTemplateManager();
+		$file = $this->createTplFile('content');
+		$result = $manager->getTemplateByFileName($file, 'System.Web.UI.*');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * An unknown class name (usingClass returns null) returns null.
+	 */
+	public function testGetTemplateByFileName_withUnknownTplClass_returnsNull(): void
+	{
+		$manager = new TTemplateManager();
+		$file = $this->createTplFile('content');
+		$result = $manager->getTemplateByFileName($file, 'TFakeTemplateClassXYZ99999');
+		$this->assertNull($result);
+	}
 }

--- a/tests/unit/Web/UI/TTemplateTest.php
+++ b/tests/unit/Web/UI/TTemplateTest.php
@@ -777,6 +777,22 @@ $this->assertArrayHasKey(TTemplate::TPL_PROPS, $item);
 		$this->assertEquals('Prado\\Web\\UI\\WebControls\\TLabel', $item[TTemplate::TPL_TYPE]);
 	}
 
+	public function testComponentTagWithPrado3SystemDotNotation()
+	{
+		// Prado3-style System.* dot-notation is converted to PHP FQN via usingClass()
+		$tpl = $this->newTemplate('<com:System.Web.UI.WebControls.TLabel ID="lbl1" />');
+		$item = array_values($tpl->getItems())[0];
+		$this->assertEquals('Prado\\Web\\UI\\WebControls\\TLabel', $item[TTemplate::TPL_TYPE]);
+	}
+
+	public function testComponentTagWithPrado3PradoDotNotation()
+	{
+		// Prado3-style Prado.* dot-notation (dots-to-backslashes) is resolved to PHP FQN
+		$tpl = $this->newTemplate('<com:Prado.Web.UI.WebControls.TLabel ID="lbl1" />');
+		$item = array_values($tpl->getItems())[0];
+		$this->assertEquals('Prado\\Web\\UI\\WebControls\\TLabel', $item[TTemplate::TPL_TYPE]);
+	}
+
 	public function testComponentTagWithAttributeExpressionValue()
 	{
 		$tpl = $this->newTemplate('<com:TLabel ID="lbl1" Text=<%= $this->Name %> />');
@@ -1329,6 +1345,16 @@ $this->assertArrayHasKey(TTemplate::TPL_PROPS, $item);
 		$this->expectException(TConfigurationException::class);
 		$this->expectExceptionMessageMatches('/not a component/i');
 		$this->newTemplate('<com:stdClass />');
+	}
+
+	public function testComponentTag_withUnresolvableClass_throwsComponentRequired()
+	{
+		// usingClass() returns null for a class that cannot be found anywhere;
+		// validateAttributes() must throw template_component_required rather than
+		// crashing with a ReflectionException or a silent failure
+		$this->expectException(TConfigurationException::class);
+		$this->expectExceptionMessageMatches('/not a component/i');
+		$this->newTemplate('<com:TFakeClassXYZ99999 />');
 	}
 
 	public function testClosingTagMismatch()


### PR DESCRIPTION
This Addresses #1110.

Prado::using returns the PHP FQN of the class or null. if the namespace is not found, it's aliased with the classname.
Prado::usingClass call to include a class, call to convert from a Prado3 name spaced class to PHP FQN. 
TComponent::getBehaviors and asa PHP FQN conversion
TApplication - multiple points of PHP FQN conversion

Classes affected by lack of Prado3 class names:
 - TDbMetaData::getTableInfoClass - namespace class from getTableInfoClass.
 - TPermissionsManager::loadPermissionsData - namespace class from Permissions Rule Class.
 - TPageService::createPage - namespace class from getBasePageClass.
 - TRpcService::createApiProvider - namespace `class` and `server` (optional) from apiProviders given an id parameter.
 - TSoapServer::run & getWsdl - namespace class from getProvider.
 - TSoapService::createServer - namespace class from serverID
 - TTemplate::validateAttributes - validate parameter `$type` class
 - TTemplateManager::getTemplateByClassName namespace class from parameter `$className`
 
 TJsonService - config bug exposed by testing the Service API of TApplication - meta bug fix inception.