### PR TITLE
PHP FQN corrections

### DIFF
--- a/framework/Data/SqlMap/Configuration/TResultProperty.php
+++ b/framework/Data/SqlMap/Configuration/TResultProperty.php
@@ -291,13 +291,10 @@ class TResultProperty extends \Prado\TComponent
 	protected function getPropertyValueType()
 	{
 		if (class_exists($type = $this->getType(), false)) { //NO force autoloading
-			if ($type === 'TList') {
+			if (is_a($type, TList::class, true)) {
 				return self::LIST_TYPE;
 			}
 			$class = new ReflectionClass($type);
-			if ($class->isSubclassOf('TList')) {
-				return self::LIST_TYPE;
-			}
 			if ($class->implementsInterface('ArrayAccess')) {
 				return self::ARRAY_TYPE;
 			}

--- a/framework/TComponentReflection.php
+++ b/framework/TComponentReflection.php
@@ -74,9 +74,6 @@ class TComponentReflection extends \Prado\TComponent
 		$properties = [];
 		$events = [];
 		$methods = [];
-		// Use is_a() so that Prado3 short-name class aliases (created by Prado::using()
-		// via class_alias()) are resolved correctly. A plain === comparison against the
-		// FQN string would fail when _className is an alias such as 'TComponent'.
 		$isComponent = is_a($this->_className, TComponent::class, true);
 		foreach ($class->getMethods() as $method) {
 			if ($method->isPublic() || $method->isProtected()) {

--- a/framework/TComponentReflection.php
+++ b/framework/TComponentReflection.php
@@ -74,7 +74,10 @@ class TComponentReflection extends \Prado\TComponent
 		$properties = [];
 		$events = [];
 		$methods = [];
-		$isComponent = is_subclass_of($this->_className, 'TComponent') || strcasecmp($this->_className, 'TComponent') === 0;
+		// Use is_a() so that Prado3 short-name class aliases (created by Prado::using()
+		// via class_alias()) are resolved correctly. A plain === comparison against the
+		// FQN string would fail when _className is an alias such as 'TComponent'.
+		$isComponent = is_a($this->_className, TComponent::class, true);
 		foreach ($class->getMethods() as $method) {
 			if ($method->isPublic() || $method->isProtected()) {
 				$methodName = $method->getName();

--- a/framework/Web/UI/TTemplateControlInheritable.php
+++ b/framework/Web/UI/TTemplateControlInheritable.php
@@ -63,7 +63,7 @@ class TTemplateControlInheritable extends TTemplateControl
 	 */
 	public function doCreateChildControlsFor($parentClass)
 	{
-		if (false !== ($_parentClass = get_parent_class($parentClass)) && 'TTemplateControl' != $_parentClass) {
+		if (false !== ($_parentClass = get_parent_class($parentClass)) && TTemplateControl::class !== $_parentClass) {
 			$this->doCreateChildControlsFor($_parentClass);
 		}
 

--- a/framework/Web/UI/WebControls/TDataList.php
+++ b/framework/Web/UI/WebControls/TDataList.php
@@ -1091,7 +1091,7 @@ class TDataList extends TBaseDataList implements \Prado\Web\UI\INamingContainer,
 	public function renderItem($writer, $repeatInfo, $itemType, $index)
 	{
 		$item = $this->getItem($itemType, $index);
-		if ($repeatInfo->getRepeatLayout() === TRepeatLayout::Raw && $item::class === 'TDataListItem') {
+		if ($repeatInfo->getRepeatLayout() === TRepeatLayout::Raw && $item instanceof TDataListItem) {
 			$item->setTagName('div');
 		}
 		$item->renderControl($writer);

--- a/tests/unit/TComponentReflectionTest.php
+++ b/tests/unit/TComponentReflectionTest.php
@@ -1,0 +1,686 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Prado\TComponent;
+use Prado\TComponentReflection;
+use Prado\Exceptions\TInvalidDataTypeException;
+
+// ---------------------------------------------------------------------------
+// Fixture: a concrete TComponent subclass with one property, one event, one method
+// ---------------------------------------------------------------------------
+
+class ReflectionFixtureComponent extends TComponent
+{
+	private $_name = '';
+
+	/**
+	 * @return string the name.
+	 */
+	public function getName(): string
+	{
+		return $this->_name;
+	}
+
+	public function setName(string $value): void
+	{
+		$this->_name = $value;
+	}
+
+	/**
+	 * Fires when something happens.
+	 * @param \Prado\TEventParameter $param event parameter
+	 */
+	public function onSomethingHappened($param): void
+	{
+		$this->raiseEvent('OnSomethingHappened', $this, $param);
+	}
+
+	public function doWork(): void
+	{
+	}
+}
+
+// Subclass that adds an additional property, to test inheritance
+class ReflectionFixtureChild extends ReflectionFixtureComponent
+{
+	private $_value = 0;
+
+	/**
+	 * @return int the value.
+	 */
+	public function getValue(): int
+	{
+		return $this->_value;
+	}
+
+	public function setValue(int $v): void
+	{
+		$this->_value = $v;
+	}
+}
+
+// A plain PHP class — not a TComponent subclass
+class PlainPhpClass
+{
+	public function getFoo(): string
+	{
+		return 'foo';
+	}
+
+	public function setFoo(string $v): void
+	{
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Prado3 alias registration
+// class_alias() is idempotent when guarded; these simulate what Prado::using()
+// does when loading a Prado3 dot-notation class name.
+// ---------------------------------------------------------------------------
+
+if (!class_exists('Prado3Alias_TComponent', false)) {
+	class_alias(\Prado\TComponent::class, 'Prado3Alias_TComponent');
+}
+
+if (!class_exists('Prado3Alias_TList', false)) {
+	class_alias(\Prado\Collections\TList::class, 'Prado3Alias_TList');
+}
+
+// ---------------------------------------------------------------------------
+// Additional fixtures for edge-case coverage
+// ---------------------------------------------------------------------------
+
+/**
+ * A component whose only property has no setter (readonly).
+ */
+class ReadonlyPropComponent extends TComponent
+{
+	/**
+	 * @return int the answer.
+	 */
+	public function getAnswer(): int
+	{
+		return 42;
+	}
+	// intentionally no setAnswer()
+}
+
+/**
+ * A component with a protected getter — should appear as a protected property,
+ * not as a method.
+ */
+class ProtectedGetterComponent extends TComponent
+{
+	/**
+	 * @return string a secret value.
+	 */
+	protected function getSecret(): string
+	{
+		return 'shhh';
+	}
+}
+
+/**
+ * A component with a protected non-getter method and a public static method.
+ */
+class ProtectedStaticComponent extends TComponent
+{
+	protected function helperMethod(): void
+	{
+	}
+
+	public static function staticHelper(): string
+	{
+		return 'static';
+	}
+}
+
+/**
+ * A component whose getter has no @return docblock — type must be '{unknown}'
+ * and comments must be false.
+ */
+class NodocComponent extends TComponent
+{
+	public function getNoDoc(): string
+	{
+		return '';
+	}
+}
+
+/**
+ * Boundary: method named exactly 'get' (length 3) must NOT become a property.
+ * Method named exactly 'on' (length 2) must NOT become an event.
+ * Both must appear in getMethods().
+ */
+class BoundaryMethodComponent extends TComponent
+{
+	public function get(): string
+	{
+		return '';
+	}
+
+	public function on(): void
+	{
+	}
+}
+
+/**
+ * A component with multiple unrelated public methods to verify getMethods() sorting.
+ */
+class SortedMethodsComponent extends TComponent
+{
+	public function zebra(): void
+	{
+	}
+
+	public function apple(): void
+	{
+	}
+
+	public function mango(): void
+	{
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+class TComponentReflectionTest extends TestCase
+{
+	// ========================================================================
+	// Constructor
+	// ========================================================================
+
+	public function testConstructorAcceptsClassName(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertSame(ReflectionFixtureComponent::class, $r->getClassName());
+	}
+
+	public function testConstructorAcceptsObject(): void
+	{
+		$obj = new ReflectionFixtureComponent();
+		$r = new TComponentReflection($obj);
+		$this->assertSame(ReflectionFixtureComponent::class, $r->getClassName());
+	}
+
+	public function testConstructorThrowsOnInvalidString(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		new TComponentReflection('ThisClassDoesNotExist_XYZ');
+	}
+
+	public function testConstructorThrowsOnNonObject(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		new TComponentReflection(42);
+	}
+
+	// ========================================================================
+	// Properties reflection — TComponent subclass
+	// ========================================================================
+
+	public function testGetPropertiesReturnsTComponentProperties(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$props = $r->getProperties();
+
+		// The fixture defines getName/setName → property "Name"
+		$this->assertArrayHasKey('Name', $props);
+	}
+
+	public function testPropertyEntryHasExpectedKeys(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$prop = $r->getProperties()['Name'];
+
+		$this->assertArrayHasKey('type', $prop);
+		$this->assertArrayHasKey('readonly', $prop);
+		$this->assertArrayHasKey('protected', $prop);
+		$this->assertArrayHasKey('class', $prop);
+		$this->assertArrayHasKey('comments', $prop);
+	}
+
+	public function testPropertyReadonlyFalseWhenSetterExists(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertFalse($r->getProperties()['Name']['readonly']);
+	}
+
+	public function testPropertyTypeFromDocComment(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertSame('string', $r->getProperties()['Name']['type']);
+	}
+
+	public function testPropertyDeclaringClass(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertSame(
+			ReflectionFixtureComponent::class,
+			$r->getProperties()['Name']['class']
+		);
+	}
+
+	public function testPropertyProtectedFalseForPublicGetter(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertFalse($r->getProperties()['Name']['protected']);
+	}
+
+	// ========================================================================
+	// Readonly property (getter only, no setter)
+	// ========================================================================
+
+	public function testPropertyReadonlyTrueWhenNoSetter(): void
+	{
+		$r = new TComponentReflection(ReadonlyPropComponent::class);
+		$this->assertArrayHasKey('Answer', $r->getProperties());
+		$this->assertTrue($r->getProperties()['Answer']['readonly']);
+	}
+
+	public function testReadonlyPropertyTypeIsReflectedFromDocComment(): void
+	{
+		$r = new TComponentReflection(ReadonlyPropComponent::class);
+		$this->assertSame('int', $r->getProperties()['Answer']['type']);
+	}
+
+	// ========================================================================
+	// Protected getter → property with protected=true, absent from getMethods()
+	// ========================================================================
+
+	public function testProtectedGetterAppearsAsProperty(): void
+	{
+		$r = new TComponentReflection(ProtectedGetterComponent::class);
+		$this->assertArrayHasKey('Secret', $r->getProperties());
+	}
+
+	public function testProtectedGetterPropertyHasProtectedTrue(): void
+	{
+		$r = new TComponentReflection(ProtectedGetterComponent::class);
+		$this->assertTrue($r->getProperties()['Secret']['protected']);
+	}
+
+	public function testProtectedGetterNotExposedInMethods(): void
+	{
+		$r = new TComponentReflection(ProtectedGetterComponent::class);
+		$this->assertArrayNotHasKey('getSecret', $r->getMethods());
+	}
+
+	// ========================================================================
+	// Protected and static methods in getMethods()
+	// ========================================================================
+
+	public function testGetMethodsIncludesProtectedMethod(): void
+	{
+		$r = new TComponentReflection(ProtectedStaticComponent::class);
+		$this->assertArrayHasKey('helperMethod', $r->getMethods());
+	}
+
+	public function testProtectedMethodHasProtectedTrue(): void
+	{
+		$r = new TComponentReflection(ProtectedStaticComponent::class);
+		$this->assertTrue($r->getMethods()['helperMethod']['protected']);
+	}
+
+	public function testGetMethodsIncludesStaticMethod(): void
+	{
+		$r = new TComponentReflection(ProtectedStaticComponent::class);
+		$this->assertArrayHasKey('staticHelper', $r->getMethods());
+	}
+
+	public function testStaticMethodHasStaticTrue(): void
+	{
+		$r = new TComponentReflection(ProtectedStaticComponent::class);
+		$this->assertTrue($r->getMethods()['staticHelper']['static']);
+	}
+
+	public function testNonStaticMethodHasStaticFalse(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertFalse($r->getMethods()['doWork']['static']);
+	}
+
+	public function testGetMethodsEntryHasExpectedKeys(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$entry = $r->getMethods()['doWork'];
+		$this->assertArrayHasKey('class', $entry);
+		$this->assertArrayHasKey('protected', $entry);
+		$this->assertArrayHasKey('static', $entry);
+		$this->assertArrayHasKey('comments', $entry);
+	}
+
+	// ========================================================================
+	// Property with no @return docblock → type='{unknown}', comments=false
+	// ========================================================================
+
+	public function testPropertyTypeUnknownWhenNoDocComment(): void
+	{
+		$r = new TComponentReflection(NodocComponent::class);
+		$this->assertArrayHasKey('NoDoc', $r->getProperties());
+		$this->assertSame('{unknown}', $r->getProperties()['NoDoc']['type']);
+	}
+
+	public function testPropertyCommentsIsFalseWhenNoDocComment(): void
+	{
+		$r = new TComponentReflection(NodocComponent::class);
+		$this->assertFalse($r->getProperties()['NoDoc']['comments']);
+	}
+
+	// ========================================================================
+	// Boundary: method named exactly 'get' or 'on' — must NOT become property/event
+	// ========================================================================
+
+	public function testMethodNamedExactlyGetIsNotProperty(): void
+	{
+		$r = new TComponentReflection(BoundaryMethodComponent::class);
+		// 'get' is only 3 chars; isset($methodName[3]) is false → not a property getter
+		$this->assertArrayNotHasKey('', $r->getProperties());
+	}
+
+	public function testMethodNamedExactlyGetAppearsInMethods(): void
+	{
+		$r = new TComponentReflection(BoundaryMethodComponent::class);
+		// Since 'get' is not treated as a property getter, it is not reserved
+		// and should therefore appear in getMethods()
+		$this->assertArrayHasKey('get', $r->getMethods());
+	}
+
+	public function testMethodNamedExactlyOnIsNotEvent(): void
+	{
+		$r = new TComponentReflection(BoundaryMethodComponent::class);
+		// 'on' is only 2 chars; isset($methodName[2]) is false → not an event
+		$this->assertArrayNotHasKey('On', $r->getEvents());
+		$this->assertArrayNotHasKey('on', $r->getEvents());
+	}
+
+	public function testMethodNamedExactlyOnAppearsInMethods(): void
+	{
+		$r = new TComponentReflection(BoundaryMethodComponent::class);
+		$this->assertArrayHasKey('on', $r->getMethods());
+	}
+
+	// ========================================================================
+	// Inherited properties
+	// ========================================================================
+
+	public function testChildInheritsParentProperties(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureChild::class);
+		$props = $r->getProperties();
+
+		$this->assertArrayHasKey('Name', $props);
+		$this->assertArrayHasKey('Value', $props);
+	}
+
+	public function testInheritedPropertyHasParentClass(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureChild::class);
+		$this->assertSame(
+			ReflectionFixtureComponent::class,
+			$r->getProperties()['Name']['class']
+		);
+	}
+
+	public function testOwnPropertyHasOwnClass(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureChild::class);
+		$this->assertSame(
+			ReflectionFixtureChild::class,
+			$r->getProperties()['Value']['class']
+		);
+	}
+
+	// ========================================================================
+	// Events reflection
+	// ========================================================================
+
+	public function testGetEventsReturnsTComponentEvents(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$events = $r->getEvents();
+
+		// The fixture defines onSomethingHappened → event "OnSomethingHappened"
+		$this->assertArrayHasKey('OnSomethingHappened', $events);
+	}
+
+	public function testEventEntryHasExpectedKeys(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$event = $r->getEvents()['OnSomethingHappened'];
+
+		$this->assertArrayHasKey('class', $event);
+		$this->assertArrayHasKey('protected', $event);
+		$this->assertArrayHasKey('comments', $event);
+	}
+
+	public function testEventDeclaringClass(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertSame(
+			ReflectionFixtureComponent::class,
+			$r->getEvents()['OnSomethingHappened']['class']
+		);
+	}
+
+	public function testEventKeyFirstCharForcedUppercaseO(): void
+	{
+		// The reflect() method does: $methodName[0] = 'O';
+		// so a lowercase-'o' method like onSomethingHappened becomes 'OnSomethingHappened'.
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$events = $r->getEvents();
+		$this->assertArrayHasKey('OnSomethingHappened', $events);
+		$this->assertArrayNotHasKey('onSomethingHappened', $events);
+	}
+
+	public function testEventNotExposedInMethods(): void
+	{
+		// onSomethingHappened is an event and must not appear in getMethods()
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$this->assertArrayNotHasKey('onSomethingHappened', $r->getMethods());
+	}
+
+	// ========================================================================
+	// Methods reflection
+	// ========================================================================
+
+	public function testGetMethodsIncludesPublicNonPropertyMethod(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$methods = $r->getMethods();
+
+		$this->assertArrayHasKey('doWork', $methods);
+	}
+
+	public function testGetMethodsDoesNotIncludeGetterAsMethod(): void
+	{
+		// getter methods are surfaced as properties, not methods
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$methods = $r->getMethods();
+
+		$this->assertArrayNotHasKey('getName', $methods);
+	}
+
+	public function testGetMethodsDoesNotIncludeSetterAsMethod(): void
+	{
+		// setter methods are reserved alongside their getter
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$methods = $r->getMethods();
+
+		$this->assertArrayNotHasKey('setName', $methods);
+	}
+
+	public function testGetMethodsDoesNotIncludeMagicMethods(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$methods = $r->getMethods();
+
+		foreach (array_keys($methods) as $name) {
+			$this->assertStringNotContainsString('__', $name, "Magic method $name should not appear in getMethods()");
+		}
+	}
+
+	// ========================================================================
+	// Non-TComponent class — properties and events must be empty
+	// (exercises the TComponent::class fix: $isComponent must be false)
+	// ========================================================================
+
+	public function testNonComponentClassHasEmptyProperties(): void
+	{
+		$r = new TComponentReflection(PlainPhpClass::class);
+		$this->assertSame([], $r->getProperties());
+	}
+
+	public function testNonComponentClassHasEmptyEvents(): void
+	{
+		$r = new TComponentReflection(PlainPhpClass::class);
+		$this->assertSame([], $r->getEvents());
+	}
+
+	public function testNonComponentClassHasMethods(): void
+	{
+		// methods are still reflected for non-component classes
+		$r = new TComponentReflection(PlainPhpClass::class);
+		$methods = $r->getMethods();
+
+		// getFoo is a getter but $isComponent=false means it is NOT treated as a
+		// property getter, so it appears in getMethods() for plain classes
+		$this->assertArrayHasKey('getFoo', $methods);
+	}
+
+	public function testNonComponentClassSetterAlsoAppearsInMethods(): void
+	{
+		// For a non-component class the setter is not reserved either
+		$r = new TComponentReflection(PlainPhpClass::class);
+		$this->assertArrayHasKey('setFoo', $r->getMethods());
+	}
+
+	// ========================================================================
+	// TComponent itself
+	// ========================================================================
+
+	public function testReflectingTComponentItself(): void
+	{
+		$r = new TComponentReflection(TComponent::class);
+		// TComponent has properties like Behaviors, etc.
+		$this->assertNotEmpty($r->getProperties());
+		$this->assertSame(TComponent::class, $r->getClassName());
+	}
+
+	// ========================================================================
+	// Sorting: getProperties(), getEvents(), getMethods() — all sorted by key
+	// ========================================================================
+
+	public function testPropertiesAreSorted(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureChild::class);
+		$keys = array_keys($r->getProperties());
+		$sorted = $keys;
+		sort($sorted);
+		$this->assertSame($sorted, $keys, 'getProperties() should return entries sorted by name');
+	}
+
+	public function testEventsAreSorted(): void
+	{
+		$r = new TComponentReflection(ReflectionFixtureComponent::class);
+		$keys = array_keys($r->getEvents());
+		$sorted = $keys;
+		sort($sorted);
+		$this->assertSame($sorted, $keys, 'getEvents() should return entries sorted by name');
+	}
+
+	public function testMethodsAreSorted(): void
+	{
+		$r = new TComponentReflection(SortedMethodsComponent::class);
+		$keys = array_keys($r->getMethods());
+		$sorted = $keys;
+		sort($sorted);
+		$this->assertSame($sorted, $keys, 'getMethods() should return entries sorted by name');
+	}
+
+	// ========================================================================
+	// Prado3 class-alias compatibility
+	//
+	// Prado::using() registers class aliases (class_alias(FQN, shortName)) as a
+	// side-effect of autoloading.  The reflected class name stored in _className
+	// may therefore be an alias string rather than the FQN.  All code paths that
+	// test "is this a TComponent?" must use is_a() rather than === so that aliases
+	// resolve correctly.
+	// ========================================================================
+
+	public function testConstructorAcceptsPrado3AliasOfTComponentSubclass(): void
+	{
+		// 'Prado3Alias_TList' is class_alias'd to Prado\Collections\TList.
+		// class_exists('Prado3Alias_TList', false) must return true, so the
+		// constructor should store it as _className without autoloading.
+		$r = new TComponentReflection('Prado3Alias_TList');
+		$this->assertSame('Prado3Alias_TList', $r->getClassName());
+	}
+
+	public function testPrado3AliasSubclassIsReflectedAsComponent(): void
+	{
+		// When _className is a Prado3 alias of a TComponent subclass,
+		// $isComponent must be true → properties and events must be reflected.
+		$r = new TComponentReflection('Prado3Alias_TList');
+		// TList defines several properties (Count, ReadOnly, …)
+		$this->assertNotEmpty($r->getProperties());
+	}
+
+	public function testPrado3AliasSubclassEventsAreReflected(): void
+	{
+		$r = new TComponentReflection('Prado3Alias_TList');
+		// Because $isComponent is true, event methods (on*) are surfaced.
+		// The assertion just ensures the events array is not suppressed;
+		// TList may have zero events itself, so we only verify no exception is thrown
+		// and the return type is an array.
+		$this->assertIsArray($r->getEvents());
+	}
+
+	public function testConstructorAcceptsPrado3AliasOfTComponentItself(): void
+	{
+		// 'Prado3Alias_TComponent' is class_alias'd to Prado\TComponent.
+		// is_subclass_of('Prado3Alias_TComponent', TComponent::class) returns false
+		// because an alias of a class is not a *sub*class of itself.
+		// The old code relied on ($className === TComponent::class) which also fails
+		// for an alias.  is_a($className, TComponent::class, true) is the fix.
+		$r = new TComponentReflection('Prado3Alias_TComponent');
+		$this->assertSame('Prado3Alias_TComponent', $r->getClassName());
+	}
+
+	public function testPrado3AliasOfTComponentItselfIsReflectedAsComponent(): void
+	{
+		// The critical regression: if $isComponent is wrongly false for a TComponent
+		// alias, getProperties() returns [] even though TComponent has properties.
+		$r = new TComponentReflection('Prado3Alias_TComponent');
+		// TComponent defines at least the Behaviors property
+		$this->assertNotEmpty($r->getProperties(),
+			'Prado3 alias of TComponent itself must be treated as a component class');
+	}
+
+	public function testPrado3AliasOfTComponentEventsAreReflected(): void
+	{
+		$r = new TComponentReflection('Prado3Alias_TComponent');
+		$this->assertIsArray($r->getEvents());
+	}
+
+	public function testPrado3AliasDeclaringClassReturnsFqn(): void
+	{
+		// Declaring-class entries in property/event/method info always hold the
+		// canonical FQN (from ReflectionMethod::getDeclaringClass()->getName()),
+		// not the alias name — even when _className is an alias.
+		$r = new TComponentReflection('Prado3Alias_TList');
+		foreach ($r->getProperties() as $name => $prop) {
+			$this->assertTrue(
+				class_exists($prop['class'], false),
+				"Property '$name' declares class '{$prop['class']}' which is not a known class"
+			);
+		}
+	}
+
+	public function testPrado3AliasMethodsAreReflected(): void
+	{
+		// getMethods() must work correctly when _className is a Prado3 alias.
+		$r = new TComponentReflection('Prado3Alias_TList');
+		$this->assertIsArray($r->getMethods());
+	}
+}

--- a/tests/unit/Web/UI/WebControls/TDataListTest.php
+++ b/tests/unit/Web/UI/WebControls/TDataListTest.php
@@ -1,0 +1,1164 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Prado\IO\TTextWriter;
+use Prado\Web\UI\ITemplate;
+use Prado\Web\UI\TCommandEventParameter;
+use Prado\Web\UI\THtmlWriter;
+use Prado\Web\UI\TControl;
+use Prado\Web\UI\WebControls\TDataList;
+use Prado\Web\UI\WebControls\TDataListCommandEventParameter;
+use Prado\Web\UI\WebControls\TDataListItem;
+use Prado\Web\UI\WebControls\TListItemType;
+use Prado\Web\UI\WebControls\TRepeatDirection;
+use Prado\Web\UI\WebControls\TRepeatInfo;
+use Prado\Web\UI\WebControls\TRepeatLayout;
+use Prado\Web\UI\WebControls\TTableItemStyle;
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidOperationException;
+
+// ---------------------------------------------------------------------------
+// Prado3 alias registration — mirrors what Prado::using() does at runtime.
+// ---------------------------------------------------------------------------
+
+if (!class_exists('Prado3Alias_TDataList', false)) {
+	class_alias(\Prado\Web\UI\WebControls\TDataList::class, 'Prado3Alias_TDataList');
+}
+
+if (!class_exists('Prado3Alias_TDataListItem', false)) {
+	class_alias(\Prado\Web\UI\WebControls\TDataListItem::class, 'Prado3Alias_TDataListItem');
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Spy TDataListItem: records setTagName calls and short-circuits renderControl.
+ */
+class SpyDataListItem extends TDataListItem
+{
+	public bool $setTagNameCalled = false;
+	public ?string $lastTagName = null;
+
+	public function setTagName($value): void
+	{
+		$this->setTagNameCalled = true;
+		$this->lastTagName = $value;
+		parent::setTagName($value);
+	}
+
+	public function renderControl($writer): void
+	{
+		// no-op: we only care about setTagName, not actual rendering
+	}
+}
+
+/**
+ * A TControl that is NOT a TDataListItem.
+ * TDataListItemCollection accepts any TControl descendant.
+ */
+class NonDataListItem extends TControl
+{
+	public function renderControl($writer): void
+	{
+		// no-op
+	}
+}
+
+/**
+ * Minimal ITemplate stub — does nothing, just satisfies the type check.
+ */
+class StubTemplate implements ITemplate
+{
+	public function instantiateIn($parent): void
+	{
+	}
+
+	public function getIncludedFiles(): array
+	{
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+class TDataListTest extends TestCase
+{
+	// ========================================================================
+	// Helpers
+	// ========================================================================
+
+	private function writer(): THtmlWriter
+	{
+		return new THtmlWriter(new TTextWriter());
+	}
+
+	private function rawRepeatInfo(): TRepeatInfo
+	{
+		$ri = new TRepeatInfo();
+		$ri->setRepeatLayout(TRepeatLayout::Raw);
+		return $ri;
+	}
+
+	private function tableRepeatInfo(): TRepeatInfo
+	{
+		$ri = new TRepeatInfo();
+		$ri->setRepeatLayout(TRepeatLayout::Table);
+		return $ri;
+	}
+
+	/**
+	 * Build a TDataListCommandEventParameter from a plain command name string.
+	 */
+	private function makeCommandParam(string $commandName, TControl $item): TDataListCommandEventParameter
+	{
+		$cmdParam = new TCommandEventParameter($commandName, '');
+		return new TDataListCommandEventParameter($item, new NonDataListItem(), $cmdParam);
+	}
+
+	// ========================================================================
+	// renderItem — Raw layout + TDataListItem → setTagName('div') called
+	// ========================================================================
+
+	public function testRenderItemRawLayoutSetsTagNameOnDataListItem(): void
+	{
+		$list = new TDataList();
+
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->renderItem($this->writer(), $this->rawRepeatInfo(), TListItemType::Item, 0);
+
+		$this->assertTrue($item->setTagNameCalled, 'setTagName() should be called when layout is Raw and item is TDataListItem');
+		$this->assertSame('div', $item->lastTagName);
+	}
+
+	// ========================================================================
+	// renderItem — Raw layout + non-TDataListItem → setTagName NOT called
+	// ========================================================================
+
+	public function testRenderItemRawLayoutDoesNotSetTagNameOnNonDataListItem(): void
+	{
+		$list = new TDataList();
+
+		$item = new NonDataListItem();
+		$list->getItems()->add($item);
+
+		// NonDataListItem has no setTagName — the runtime would throw if it
+		// tried to call it, so a clean return means the branch was skipped.
+		$list->renderItem($this->writer(), $this->rawRepeatInfo(), TListItemType::Item, 0);
+
+		$this->assertTrue(true);
+	}
+
+	// ========================================================================
+	// renderItem — Table layout + TDataListItem → setTagName NOT called
+	// ========================================================================
+
+	public function testRenderItemTableLayoutDoesNotSetTagName(): void
+	{
+		$list = new TDataList();
+
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->renderItem($this->writer(), $this->tableRepeatInfo(), TListItemType::Item, 0);
+
+		$this->assertFalse($item->setTagNameCalled, 'setTagName() must NOT be called when layout is Table');
+	}
+
+	// ========================================================================
+	// renderItem — Flow layout + TDataListItem → setTagName NOT called
+	// ========================================================================
+
+	public function testRenderItemFlowLayoutDoesNotSetTagName(): void
+	{
+		$list = new TDataList();
+
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$ri = new TRepeatInfo();
+		$ri->setRepeatLayout(TRepeatLayout::Flow);
+
+		$list->renderItem($this->writer(), $ri, TListItemType::Item, 0);
+
+		$this->assertFalse($item->setTagNameCalled, 'setTagName() must NOT be called when layout is Flow');
+	}
+
+	// ========================================================================
+	// renderItem — Raw layout, AlternatingItem type → setTagName called
+	// ========================================================================
+
+	public function testRenderItemRawLayoutAlternatingItemSetsTagName(): void
+	{
+		$list = new TDataList();
+
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::AlternatingItem);
+		$list->getItems()->add($item);
+
+		$list->renderItem($this->writer(), $this->rawRepeatInfo(), TListItemType::AlternatingItem, 0);
+
+		$this->assertTrue($item->setTagNameCalled);
+		$this->assertSame('div', $item->lastTagName);
+	}
+
+	// ========================================================================
+	// getItems / getItemCount
+	// ========================================================================
+
+	public function testGetItemsReturnsEmptyCollectionInitially(): void
+	{
+		$list = new TDataList();
+		$this->assertSame(0, $list->getItemCount());
+	}
+
+	public function testGetItemCountAfterAddingItems(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$this->assertSame(1, $list->getItemCount());
+	}
+
+	public function testGetItemCountZeroWhenNoItemsEverAdded(): void
+	{
+		// _items is null initially; getItemCount() must short-circuit to 0
+		$list = new TDataList();
+		$this->assertSame(0, $list->getItemCount());
+	}
+
+	// ========================================================================
+	// RepeatLayout
+	// ========================================================================
+
+	public function testRepeatLayoutDefaultIsTable(): void
+	{
+		$list = new TDataList();
+		$this->assertSame(TRepeatLayout::Table, $list->getRepeatLayout());
+	}
+
+	public function testSetRepeatLayout(): void
+	{
+		$list = new TDataList();
+		$list->setRepeatLayout(TRepeatLayout::Raw);
+		$this->assertSame(TRepeatLayout::Raw, $list->getRepeatLayout());
+	}
+
+	public function testSetRepeatLayoutFlow(): void
+	{
+		$list = new TDataList();
+		$list->setRepeatLayout(TRepeatLayout::Flow);
+		$this->assertSame(TRepeatLayout::Flow, $list->getRepeatLayout());
+	}
+
+	// ========================================================================
+	// RepeatColumns / RepeatDirection / Caption
+	// ========================================================================
+
+	public function testRepeatColumnsDefaultIsZero(): void
+	{
+		$list = new TDataList();
+		$this->assertSame(0, $list->getRepeatColumns());
+	}
+
+	public function testSetRepeatColumns(): void
+	{
+		$list = new TDataList();
+		$list->setRepeatColumns(3);
+		$this->assertSame(3, $list->getRepeatColumns());
+	}
+
+	public function testRepeatDirectionDefaultIsVertical(): void
+	{
+		$list = new TDataList();
+		$this->assertSame(TRepeatDirection::Vertical, $list->getRepeatDirection());
+	}
+
+	public function testSetRepeatDirectionHorizontal(): void
+	{
+		$list = new TDataList();
+		$list->setRepeatDirection(TRepeatDirection::Horizontal);
+		$this->assertSame(TRepeatDirection::Horizontal, $list->getRepeatDirection());
+	}
+
+	public function testCaptionDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getCaption());
+	}
+
+	public function testSetCaption(): void
+	{
+		$list = new TDataList();
+		$list->setCaption('My Caption');
+		$this->assertSame('My Caption', $list->getCaption());
+	}
+
+	// ========================================================================
+	// ShowHeader / ShowFooter
+	// ========================================================================
+
+	public function testShowHeaderDefaultTrue(): void
+	{
+		$list = new TDataList();
+		$this->assertTrue($list->getShowHeader());
+	}
+
+	public function testSetShowHeaderFalse(): void
+	{
+		$list = new TDataList();
+		$list->setShowHeader(false);
+		$this->assertFalse($list->getShowHeader());
+	}
+
+	public function testSetShowHeaderStringCoercedToBool(): void
+	{
+		$list = new TDataList();
+		$list->setShowHeader('true');
+		$this->assertTrue($list->getShowHeader());
+	}
+
+	public function testShowFooterDefaultTrue(): void
+	{
+		$list = new TDataList();
+		$this->assertTrue($list->getShowFooter());
+	}
+
+	public function testSetShowFooterFalse(): void
+	{
+		$list = new TDataList();
+		$list->setShowFooter(false);
+		$this->assertFalse($list->getShowFooter());
+	}
+
+	// ========================================================================
+	// Templates — null accepted, ITemplate accepted, non-ITemplate throws
+	// ========================================================================
+
+	public function testItemTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getItemTemplate());
+	}
+
+	public function testSetItemTemplateNull(): void
+	{
+		$list = new TDataList();
+		$list->setItemTemplate(null);
+		$this->assertNull($list->getItemTemplate());
+	}
+
+	public function testSetItemTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setItemTemplate($tpl);
+		$this->assertSame($tpl, $list->getItemTemplate());
+	}
+
+	public function testSetItemTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		$list = new TDataList();
+		$list->setItemTemplate('not-a-template');
+	}
+
+	public function testAlternatingItemTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getAlternatingItemTemplate());
+	}
+
+	public function testSetAlternatingItemTemplateNull(): void
+	{
+		$list = new TDataList();
+		$list->setAlternatingItemTemplate(null);
+		$this->assertNull($list->getAlternatingItemTemplate());
+	}
+
+	public function testSetAlternatingItemTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setAlternatingItemTemplate($tpl);
+		$this->assertSame($tpl, $list->getAlternatingItemTemplate());
+	}
+
+	public function testSetAlternatingItemTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setAlternatingItemTemplate(42);
+	}
+
+	public function testSelectedItemTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getSelectedItemTemplate());
+	}
+
+	public function testSetSelectedItemTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setSelectedItemTemplate($tpl);
+		$this->assertSame($tpl, $list->getSelectedItemTemplate());
+	}
+
+	public function testSetSelectedItemTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setSelectedItemTemplate(new \stdClass());
+	}
+
+	public function testEditItemTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getEditItemTemplate());
+	}
+
+	public function testSetEditItemTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setEditItemTemplate($tpl);
+		$this->assertSame($tpl, $list->getEditItemTemplate());
+	}
+
+	public function testSetEditItemTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setEditItemTemplate([]);
+	}
+
+	public function testHeaderTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getHeaderTemplate());
+	}
+
+	public function testSetHeaderTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setHeaderTemplate($tpl);
+		$this->assertSame($tpl, $list->getHeaderTemplate());
+	}
+
+	public function testSetHeaderTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setHeaderTemplate('bad');
+	}
+
+	public function testFooterTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getFooterTemplate());
+	}
+
+	public function testSetFooterTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setFooterTemplate($tpl);
+		$this->assertSame($tpl, $list->getFooterTemplate());
+	}
+
+	public function testSetFooterTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setFooterTemplate(0);
+	}
+
+	public function testSeparatorTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getSeparatorTemplate());
+	}
+
+	public function testSetSeparatorTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setSeparatorTemplate($tpl);
+		$this->assertSame($tpl, $list->getSeparatorTemplate());
+	}
+
+	public function testSetSeparatorTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setSeparatorTemplate(false);
+	}
+
+	public function testEmptyTemplateDefaultIsNull(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getEmptyTemplate());
+	}
+
+	public function testSetEmptyTemplateITemplate(): void
+	{
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setEmptyTemplate($tpl);
+		$this->assertSame($tpl, $list->getEmptyTemplate());
+	}
+
+	public function testSetEmptyTemplateNonITemplateThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		(new TDataList())->setEmptyTemplate('oops');
+	}
+
+	// ========================================================================
+	// Renderers — default '', get/set via viewstate
+	// ========================================================================
+
+	public function testItemRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getItemRenderer());
+	}
+
+	public function testSetItemRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setItemRenderer('MyItemRenderer');
+		$this->assertSame('MyItemRenderer', $list->getItemRenderer());
+	}
+
+	public function testAlternatingItemRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getAlternatingItemRenderer());
+	}
+
+	public function testSetAlternatingItemRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setAlternatingItemRenderer('AltRenderer');
+		$this->assertSame('AltRenderer', $list->getAlternatingItemRenderer());
+	}
+
+	public function testEditItemRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getEditItemRenderer());
+	}
+
+	public function testSetEditItemRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setEditItemRenderer('EditRenderer');
+		$this->assertSame('EditRenderer', $list->getEditItemRenderer());
+	}
+
+	public function testSelectedItemRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getSelectedItemRenderer());
+	}
+
+	public function testSetSelectedItemRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setSelectedItemRenderer('SelRenderer');
+		$this->assertSame('SelRenderer', $list->getSelectedItemRenderer());
+	}
+
+	public function testSeparatorRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getSeparatorRenderer());
+	}
+
+	public function testSetSeparatorRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setSeparatorRenderer('SepRenderer');
+		$this->assertSame('SepRenderer', $list->getSeparatorRenderer());
+	}
+
+	public function testHeaderRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getHeaderRenderer());
+	}
+
+	public function testSetHeaderRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setHeaderRenderer('HeaderRenderer');
+		$this->assertSame('HeaderRenderer', $list->getHeaderRenderer());
+	}
+
+	public function testFooterRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getFooterRenderer());
+	}
+
+	public function testSetFooterRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setFooterRenderer('FooterRenderer');
+		$this->assertSame('FooterRenderer', $list->getFooterRenderer());
+	}
+
+	public function testEmptyRendererDefaultIsEmpty(): void
+	{
+		$list = new TDataList();
+		$this->assertSame('', $list->getEmptyRenderer());
+	}
+
+	public function testSetEmptyRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setEmptyRenderer('EmptyRenderer');
+		$this->assertSame('EmptyRenderer', $list->getEmptyRenderer());
+	}
+
+	// ========================================================================
+	// getHasHeader — ShowHeader × (template | renderer)
+	// ========================================================================
+
+	public function testGetHasHeaderFalseWithNoTemplateOrRenderer(): void
+	{
+		$list = new TDataList();
+		// ShowHeader=true (default) but no template or renderer
+		$this->assertFalse($list->getHasHeader());
+	}
+
+	public function testGetHasHeaderTrueWhenTemplateSetAndShowHeaderTrue(): void
+	{
+		$list = new TDataList();
+		$list->setHeaderTemplate(new StubTemplate());
+		$this->assertTrue($list->getHasHeader());
+	}
+
+	public function testGetHasHeaderTrueWhenRendererSetAndShowHeaderTrue(): void
+	{
+		$list = new TDataList();
+		$list->setHeaderRenderer('SomeRenderer');
+		$this->assertTrue($list->getHasHeader());
+	}
+
+	public function testGetHasHeaderFalseWhenShowHeaderFalseEvenWithTemplate(): void
+	{
+		$list = new TDataList();
+		$list->setHeaderTemplate(new StubTemplate());
+		$list->setShowHeader(false);
+		$this->assertFalse($list->getHasHeader());
+	}
+
+	public function testGetHasHeaderFalseWhenShowHeaderFalseEvenWithRenderer(): void
+	{
+		$list = new TDataList();
+		$list->setHeaderRenderer('SomeRenderer');
+		$list->setShowHeader(false);
+		$this->assertFalse($list->getHasHeader());
+	}
+
+	// ========================================================================
+	// getHasFooter — ShowFooter × (template | renderer)
+	// ========================================================================
+
+	public function testGetHasFooterFalseWithNoTemplateOrRenderer(): void
+	{
+		$list = new TDataList();
+		$this->assertFalse($list->getHasFooter());
+	}
+
+	public function testGetHasFooterTrueWhenTemplateSetAndShowFooterTrue(): void
+	{
+		$list = new TDataList();
+		$list->setFooterTemplate(new StubTemplate());
+		$this->assertTrue($list->getHasFooter());
+	}
+
+	public function testGetHasFooterTrueWhenRendererSetAndShowFooterTrue(): void
+	{
+		$list = new TDataList();
+		$list->setFooterRenderer('SomeRenderer');
+		$this->assertTrue($list->getHasFooter());
+	}
+
+	public function testGetHasFooterFalseWhenShowFooterFalseEvenWithTemplate(): void
+	{
+		$list = new TDataList();
+		$list->setFooterTemplate(new StubTemplate());
+		$list->setShowFooter(false);
+		$this->assertFalse($list->getHasFooter());
+	}
+
+	// ========================================================================
+	// getHasSeparators — no ShowSeparators guard
+	// ========================================================================
+
+	public function testGetHasSeparatorsFalseByDefault(): void
+	{
+		$list = new TDataList();
+		$this->assertFalse($list->getHasSeparators());
+	}
+
+	public function testGetHasSeparatorsTrueWhenTemplateSet(): void
+	{
+		$list = new TDataList();
+		$list->setSeparatorTemplate(new StubTemplate());
+		$this->assertTrue($list->getHasSeparators());
+	}
+
+	public function testGetHasSeparatorsTrueWhenRendererSet(): void
+	{
+		$list = new TDataList();
+		$list->setSeparatorRenderer('SepRenderer');
+		$this->assertTrue($list->getHasSeparators());
+	}
+
+	// ========================================================================
+	// getHeader / getFooter — null before databind
+	// ========================================================================
+
+	public function testGetHeaderNullInitially(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getHeader());
+	}
+
+	public function testGetFooterNullInitially(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getFooter());
+	}
+
+	// ========================================================================
+	// SelectedItemIndex
+	// ========================================================================
+
+	public function testSelectedItemIndexDefaultIsMinusOne(): void
+	{
+		$list = new TDataList();
+		$this->assertSame(-1, $list->getSelectedItemIndex());
+	}
+
+	public function testSetSelectedItemIndexNegativeClampedToMinusOne(): void
+	{
+		$list = new TDataList();
+		$list->setSelectedItemIndex(-99);
+		$this->assertSame(-1, $list->getSelectedItemIndex());
+	}
+
+	public function testSetSelectedItemIndex(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->setSelectedItemIndex(0);
+		$this->assertSame(0, $list->getSelectedItemIndex());
+	}
+
+	public function testSetSelectedItemIndexUpdatesItemType(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->setSelectedItemIndex(0);
+		$this->assertSame(TListItemType::SelectedItem, $item->getItemType());
+	}
+
+	public function testSetSelectedItemIndexDoesNotChangeEditItem(): void
+	{
+		// When item is in EditItem mode, setSelectedItemIndex must not change its type
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::EditItem);
+		$list->getItems()->add($item);
+
+		$list->setSelectedItemIndex(0);
+		// Item remains EditItem, not SelectedItem
+		$this->assertSame(TListItemType::EditItem, $item->getItemType());
+	}
+
+	// ========================================================================
+	// getSelectedItem
+	// ========================================================================
+
+	public function testGetSelectedItemNullWhenNoSelection(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getSelectedItem());
+	}
+
+	public function testGetSelectedItemReturnsCorrectItem(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+		$list->setSelectedItemIndex(0);
+
+		$this->assertSame($item, $list->getSelectedItem());
+	}
+
+	// ========================================================================
+	// getSelectedDataKey — throws when DataKeyField is empty
+	// ========================================================================
+
+	public function testGetSelectedDataKeyThrowsWhenDataKeyFieldEmpty(): void
+	{
+		$this->expectException(TInvalidOperationException::class);
+		$list = new TDataList();
+		$list->getSelectedDataKey();
+	}
+
+	// ========================================================================
+	// EditItemIndex
+	// ========================================================================
+
+	public function testEditItemIndexDefaultIsMinusOne(): void
+	{
+		$list = new TDataList();
+		$this->assertSame(-1, $list->getEditItemIndex());
+	}
+
+	public function testSetEditItemIndexNegativeClampedToMinusOne(): void
+	{
+		$list = new TDataList();
+		$list->setEditItemIndex(-5);
+		$this->assertSame(-1, $list->getEditItemIndex());
+	}
+
+	public function testSetEditItemIndex(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->setEditItemIndex(0);
+		$this->assertSame(0, $list->getEditItemIndex());
+	}
+
+	public function testSetEditItemIndexUpdatesItemType(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->setEditItemIndex(0);
+		$this->assertSame(TListItemType::EditItem, $item->getItemType());
+	}
+
+	// ========================================================================
+	// getEditItem
+	// ========================================================================
+
+	public function testGetEditItemNullWhenNoEdit(): void
+	{
+		$list = new TDataList();
+		$this->assertNull($list->getEditItem());
+	}
+
+	public function testGetEditItemReturnsCorrectItem(): void
+	{
+		$list = new TDataList();
+		$item = new SpyDataListItem();
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+		$list->setEditItemIndex(0);
+
+		$this->assertSame($item, $list->getEditItem());
+	}
+
+	// ========================================================================
+	// Style lazy initialisation — each style getter creates a TTableItemStyle
+	// ========================================================================
+
+	public function testGetItemStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$style = $list->getItemStyle();
+		$this->assertInstanceOf(TTableItemStyle::class, $style);
+	}
+
+	public function testGetItemStyleReturnsSameInstanceOnRepeatedCall(): void
+	{
+		$list = new TDataList();
+		$this->assertSame($list->getItemStyle(), $list->getItemStyle());
+	}
+
+	public function testGetAlternatingItemStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$this->assertInstanceOf(TTableItemStyle::class, $list->getAlternatingItemStyle());
+	}
+
+	public function testGetSelectedItemStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$this->assertInstanceOf(TTableItemStyle::class, $list->getSelectedItemStyle());
+	}
+
+	public function testGetEditItemStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$this->assertInstanceOf(TTableItemStyle::class, $list->getEditItemStyle());
+	}
+
+	public function testGetHeaderStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$this->assertInstanceOf(TTableItemStyle::class, $list->getHeaderStyle());
+	}
+
+	public function testGetFooterStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$this->assertInstanceOf(TTableItemStyle::class, $list->getFooterStyle());
+	}
+
+	public function testGetSeparatorStyleCreatesTableItemStyle(): void
+	{
+		$list = new TDataList();
+		$this->assertInstanceOf(TTableItemStyle::class, $list->getSeparatorStyle());
+	}
+
+	// ========================================================================
+	// CMD_* constants
+	// ========================================================================
+
+	public function testCmdSelectConstant(): void
+	{
+		$this->assertSame('Select', TDataList::CMD_SELECT);
+	}
+
+	public function testCmdEditConstant(): void
+	{
+		$this->assertSame('Edit', TDataList::CMD_EDIT);
+	}
+
+	public function testCmdUpdateConstant(): void
+	{
+		$this->assertSame('Update', TDataList::CMD_UPDATE);
+	}
+
+	public function testCmdDeleteConstant(): void
+	{
+		$this->assertSame('Delete', TDataList::CMD_DELETE);
+	}
+
+	public function testCmdCancelConstant(): void
+	{
+		$this->assertSame('Cancel', TDataList::CMD_CANCEL);
+	}
+
+	// ========================================================================
+	// bubbleEvent — non-TDataListCommandEventParameter → false
+	// ========================================================================
+
+	public function testBubbleEventReturnsFalseForNonCommandEventParameter(): void
+	{
+		$list = new TDataList();
+		$param = new \Prado\TEventParameter();
+		$this->assertFalse($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	// ========================================================================
+	// bubbleEvent — recognised commands (case-insensitive) → true
+	// ========================================================================
+
+	public function testBubbleEventReturnsTrueForSelectCommand(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('select', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForSelectCommandUpperCase(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('SELECT', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForEditCommand(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('Edit', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForEditCommandLowerCase(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('edit', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForDeleteCommand(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('Delete', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForDeleteCommandLowerCase(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('delete', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForUpdateCommand(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('Update', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForUpdateCommandUpperCase(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('UPDATE', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForCancelCommand(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('Cancel', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	public function testBubbleEventReturnsTrueForCancelCommandLowerCase(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('cancel', new NonDataListItem());
+		$this->assertTrue($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	// ========================================================================
+	// bubbleEvent — unrecognised command → false (onItemCommand still fires)
+	// ========================================================================
+
+	public function testBubbleEventReturnsFalseForUnknownCommand(): void
+	{
+		$list = new TDataList();
+		$param = $this->makeCommandParam('unknown_command', new NonDataListItem());
+		$this->assertFalse($list->bubbleEvent(new NonDataListItem(), $param));
+	}
+
+	// ========================================================================
+	// Prado3 class-alias compatibility
+	//
+	// Prado::using() registers class_alias() entries as a side-effect of
+	// autoloading.  The key invariants to verify:
+	//
+	// 1. The PHP `instanceof` operator used in renderItem() resolves correctly
+	//    even when class aliases are present in the runtime, because instanceof
+	//    works on the actual class hierarchy, not on string names.
+	//
+	// 2. TDataList (and its items) can be reflected by TComponentReflection
+	//    via a Prado3 alias — this exercises the is_a() fix in TComponentReflection.
+	//
+	// 3. TDataList property values (templates, renderers, etc.) are pure string
+	//    or object storage and are unaffected by class aliases.
+	// ========================================================================
+
+	public function testRenderItemRawLayoutInstanceofWorksWithPrado3AliasesPresent(): void
+	{
+		// With Prado3Alias_TDataListItem registered in the PHP runtime, the
+		// `$item instanceof TDataListItem` check inside renderItem() must still
+		// work correctly for genuine TDataListItem subclasses.
+		$list = new TDataList();
+		$item = new SpyDataListItem(); // extends TDataListItem
+		$item->setItemIndex(0);
+		$item->setItemType(TListItemType::Item);
+		$list->getItems()->add($item);
+
+		$list->renderItem($this->writer(), $this->rawRepeatInfo(), TListItemType::Item, 0);
+
+		// Alias presence must not break the instanceof branch — setTagName must fire.
+		$this->assertTrue($item->setTagNameCalled,
+			'instanceof TDataListItem must work even when Prado3 class aliases are registered');
+		$this->assertSame('div', $item->lastTagName);
+	}
+
+	public function testPrado3AliasTDataListCanBeReflected(): void
+	{
+		// Reflecting TDataList via a Prado3 alias exercises the is_a() fix in
+		// TComponentReflection::reflect().  If the fix is missing, $isComponent
+		// would wrongly be false and getProperties() would return [].
+		$r = new \Prado\TComponentReflection('Prado3Alias_TDataList');
+		$this->assertSame('Prado3Alias_TDataList', $r->getClassName());
+		$this->assertNotEmpty($r->getProperties(),
+			'TDataList properties must be reflected when accessed via a Prado3 alias');
+	}
+
+	public function testPrado3AliasTDataListEventsAreReflected(): void
+	{
+		$r = new \Prado\TComponentReflection('Prado3Alias_TDataList');
+		$events = $r->getEvents();
+		// TDataList defines OnItemCommand, OnEditCommand, etc.
+		$this->assertNotEmpty($events,
+			'TDataList events must be reflected when accessed via a Prado3 alias');
+	}
+
+	public function testPrado3AliasTDataListDeclaringClassReturnsFqn(): void
+	{
+		$r = new \Prado\TComponentReflection('Prado3Alias_TDataList');
+		foreach ($r->getProperties() as $name => $prop) {
+			$this->assertTrue(
+				class_exists($prop['class'], false),
+				"Property '$name' declares class '{$prop['class']}' which is not a known class"
+			);
+		}
+	}
+
+	public function testPrado3AliasTDataListItemCanBeReflected(): void
+	{
+		$r = new \Prado\TComponentReflection('Prado3Alias_TDataListItem');
+		$this->assertSame('Prado3Alias_TDataListItem', $r->getClassName());
+		// TDataListItem defines ItemIndex, ItemType, and Data properties
+		$this->assertArrayHasKey('ItemIndex', $r->getProperties());
+		$this->assertArrayHasKey('ItemType', $r->getProperties());
+	}
+
+	public function testPrado3AliasTemplateAndRendererStorageUnaffected(): void
+	{
+		// Template and renderer values are stored as-is (object ref / string).
+		// Prado3 class aliases in the runtime must not change their storage or retrieval.
+		$list = new TDataList();
+		$tpl = new StubTemplate();
+		$list->setItemTemplate($tpl);
+		$list->setItemRenderer('MyNamespace.MyItemRenderer');
+
+		$this->assertSame($tpl, $list->getItemTemplate());
+		$this->assertSame('MyNamespace.MyItemRenderer', $list->getItemRenderer());
+	}
+}


### PR DESCRIPTION
Audit of classes that are not using PHP FQN.
- TResultProperty::getPropertyValueType checks for TList.
- TComponentReflection::reflect checks against TComponent (unit tests)
- TTemplateControlInheritable::doCreateChildControlsFor checks parent for TTemplateControl.
- TDataList::renderItem checks for TDataListItem. (unit tests)