### PR TITLE
Fixed Playwright tests with fragile timing.

### DIFF
--- a/tests/playwright/features/NamespacesTestCase.spec.js
+++ b/tests/playwright/features/NamespacesTestCase.spec.js
@@ -5,10 +5,8 @@ test('NamespacesTestCase', async ({ page }) => {
   const h = genericHelper(page);
 
   await h.url('features/index.php?page=Namespaces.WithoutNamespace');
-  await h.pause(50);
-  expect(await h.source()).toContain('Without Namespaces loaded');
+  await h.assertSourceContains('Without Namespaces loaded');
 
   await h.url('features/index.php?page=Namespaces.WithNamespace');
-  await h.pause(50);
-  expect(await h.source()).toContain('With Namespaces loaded');
+  await h.assertSourceContains('With Namespaces loaded');
 });

--- a/tests/playwright/quickstart/Controls/CheckBoxListTestCase.spec.js
+++ b/tests/playwright/quickstart/Controls/CheckBoxListTestCase.spec.js
@@ -15,33 +15,23 @@ test('QuickstartCheckBoxListTestCase', async ({ page }) => {
   // Check box list's behavior upon postback
   await h.byXPath("//input[@name='ctl0$body$CheckBoxList$c2' and @value='value 3']").click();
   await h.byXPath("//input[@type='submit' and @value='Submit']").click();
-  await h.pause(50);
-  const src1 = await h.source();
-  expect(src1).toContain('Your selection is: (Index: 1, Value: value 2, Text: item 2)(Index: 2, Value: value 3, Text: item 3)(Index: 4, Value: value 5, Text: item 5)');
+  await h.assertSourceContains('Your selection is: (Index: 1, Value: value 2, Text: item 2)(Index: 2, Value: value 3, Text: item 3)(Index: 4, Value: value 5, Text: item 5)');
 
   // Auto postback check box list
   await h.byXPath("//input[@name='ctl0$body$ctl7$c1' and @value='value 2']").click();
-  await h.pause(50);
-  const src2 = await h.source();
-  expect(src2).toContain('Your selection is: (Index: 4, Value: value 5, Text: item 5)');
+  await h.assertSourceContains('Your selection is: (Index: 4, Value: value 5, Text: item 5)');
 
   // Databind to an integer-indexed array
   await h.byXPath("//input[@name='ctl0$body$DBCheckBoxList1$c1' and @value='1']").click();
-  await h.pause(50);
-  const src3 = await h.source();
-  expect(src3).toContain('Your selection is: (Index: 1, Value: 1, Text: item 2)');
+  await h.assertSourceContains('Your selection is: (Index: 1, Value: 1, Text: item 2)');
 
   // Databind to an associative array:
   await h.byXPath("//input[@name='ctl0$body$DBCheckBoxList2$c1' and @value='key 2']").click();
-  await h.pause(50);
-  const src4 = await h.source();
-  expect(src4).toContain('Your selection is: (Index: 1, Value: key 2, Text: item 2)');
+  await h.assertSourceContains('Your selection is: (Index: 1, Value: key 2, Text: item 2)');
 
   // Databind with DataTextField and DataValueField specified
   await h.byXPath("//input[@name='ctl0$body$DBCheckBoxList3$c2' and @value='003']").click();
-  await h.pause(50);
-  const src5 = await h.source();
-  expect(src5).toContain('Your selection is: (Index: 2, Value: 003, Text: Cary)');
+  await h.assertSourceContains('Your selection is: (Index: 2, Value: 003, Text: Cary)');
 
   // CheckBox list causing validation
   await h.assertNotVisible('ctl0_body_ctl8');


### PR DESCRIPTION
Webkit was being slower than 50ms in these checks

This could happen in any browser testing these.