### PR TITLE
TPropertyValueTest - filling in the unit test gaps

### DIFF
--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -31,7 +31,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(true, TPropertyValue::ensureBoolean('100'));
 		self::assertEquals(true, TPropertyValue::ensureBoolean(['value']));
 		self::assertEquals(true, TPropertyValue::ensureBoolean(new stdClass()));
-		
+
 		self::assertEquals(false, TPropertyValue::ensureBoolean(false));
 		self::assertEquals(false, TPropertyValue::ensureBoolean('false'));
 		self::assertEquals(false, TPropertyValue::ensureBoolean('FAlse'));
@@ -40,22 +40,101 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(false, TPropertyValue::ensureBoolean('value'));
 		self::assertEquals(false, TPropertyValue::ensureBoolean(null));
 	}
+
+	public function testEnsureBooleanEdgeCases()
+	{
+		// Empty string — not 'true', not numeric → false
+		self::assertFalse(TPropertyValue::ensureBoolean(''));
+
+		// Float 0.0 — non-string, (bool)0.0 = false
+		self::assertFalse(TPropertyValue::ensureBoolean(0.0));
+
+		// String '0.0' — is_numeric('0.0') true, but '0.0' == 0 (numeric compare) → false
+		self::assertFalse(TPropertyValue::ensureBoolean('0.0'));
+
+		// String '0.1' — is_numeric true, 0.1 != 0 → true
+		self::assertTrue(TPropertyValue::ensureBoolean('0.1'));
+
+		// Negative int — non-string, (bool)-1 = true
+		self::assertTrue(TPropertyValue::ensureBoolean(-1));
+
+		// Negative float — non-string, (bool)-0.5 = true
+		self::assertTrue(TPropertyValue::ensureBoolean(-0.5));
+
+		// Negative string — is_numeric '-1' true, -1 != 0 → true
+		self::assertTrue(TPropertyValue::ensureBoolean('-1'));
+
+		// Negative numeric string with decimal — is_numeric '-0.5' true, -0.5 != 0 → true
+		self::assertTrue(TPropertyValue::ensureBoolean('-0.5'));
+
+		// Empty array — non-string, (bool)[] = false
+		self::assertFalse(TPropertyValue::ensureBoolean([]));
+
+		// Non-empty array — non-string, (bool)[0] = true
+		self::assertTrue(TPropertyValue::ensureBoolean([0]));
+
+		// String 'TRUE' (all-caps) — strcasecmp → true
+		self::assertTrue(TPropertyValue::ensureBoolean('TRUE'));
+
+		// String '0' — is_numeric true, == 0 → false (already in base test, confirm)
+		self::assertFalse(TPropertyValue::ensureBoolean('0'));
+
+		// PHP's is_numeric() accepts surrounding whitespace, so '  1  ' is numeric
+		// and != 0 → true
+		self::assertTrue(TPropertyValue::ensureBoolean('  1  '));
+	}
 	
 	
 	public function testEnsureString()
 	{
 		$value = 'myLiteral';
 		$literal = new TJavaScriptLiteral($value);
-		
+
 		self::assertEquals($value, TPropertyValue::ensureString($literal));
 		self::assertEquals($value, TPropertyValue::ensureString($value));
-		
+
 		self::assertEquals('true', TPropertyValue::ensureString(true));
 		self::assertEquals('false', TPropertyValue::ensureString(false));
-		
+
 		self::assertEquals('0', TPropertyValue::ensureString(0));
 		self::assertEquals('', TPropertyValue::ensureString(null));
 		self::assertEquals('4.8', TPropertyValue::ensureString(4.8));
+	}
+
+	public function testEnsureStringEdgeCases()
+	{
+		// PHP_INT_MAX and PHP_INT_MIN — large integers round-trip through string
+		self::assertSame((string) PHP_INT_MAX, TPropertyValue::ensureString(PHP_INT_MAX));
+		self::assertSame((string) PHP_INT_MIN, TPropertyValue::ensureString(PHP_INT_MIN));
+
+		// Negative integer
+		self::assertSame('-5', TPropertyValue::ensureString(-5));
+
+		// Float zero — PHP casts 0.0 to '0'
+		self::assertSame('0', TPropertyValue::ensureString(0.0));
+
+		// Negative float
+		self::assertSame('-1.5', TPropertyValue::ensureString(-1.5));
+
+		// Special IEEE 754 floats
+		self::assertSame('INF', TPropertyValue::ensureString(INF));
+		self::assertSame('-INF', TPropertyValue::ensureString(-INF));
+		self::assertSame('NAN', TPropertyValue::ensureString(NAN));
+
+		// Empty string — passes through
+		self::assertSame('', TPropertyValue::ensureString(''));
+
+		// Integer 1 — (string)1 = '1', not the bool path
+		self::assertSame('1', TPropertyValue::ensureString(1));
+
+		// Object with __toString
+		$obj = new class {
+			public function __toString(): string
+			{
+				return 'stringified';
+			}
+		};
+		self::assertSame('stringified', TPropertyValue::ensureString($obj));
 	}
 	
 	public function testEnsureInteger()
@@ -79,6 +158,34 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(1, TPropertyValue::ensureInteger('1.5001'));
 		self::assertEquals(1, TPropertyValue::ensureInteger('1.99999'));
 	}
+
+	public function testEnsureIntegerEdgeCases()
+	{
+		// PHP_INT_MAX and PHP_INT_MIN round-trip
+		self::assertSame(PHP_INT_MAX, TPropertyValue::ensureInteger(PHP_INT_MAX));
+		self::assertSame(PHP_INT_MIN, TPropertyValue::ensureInteger(PHP_INT_MIN));
+
+		// Boolean coercion
+		self::assertSame(1, TPropertyValue::ensureInteger(true));
+		self::assertSame(0, TPropertyValue::ensureInteger(false));
+
+		// Negative int
+		self::assertSame(-5, TPropertyValue::ensureInteger(-5));
+
+		// Negative float truncates toward zero
+		self::assertSame(-3, TPropertyValue::ensureInteger(-3.7));
+		self::assertSame(-1, TPropertyValue::ensureInteger(-1.9999));
+
+		// Negative string
+		self::assertSame(-7, TPropertyValue::ensureInteger('-7'));
+		self::assertSame(-3, TPropertyValue::ensureInteger('-3.9'));
+
+		// Plain numeric string
+		self::assertSame(42, TPropertyValue::ensureInteger('42'));
+
+		// Large int string
+		self::assertSame(PHP_INT_MAX, TPropertyValue::ensureInteger((string) PHP_INT_MAX));
+	}
 	
 	public function testEnsureFloat()
 	{
@@ -91,11 +198,44 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(0.0001, TPropertyValue::ensureFloat(0.0001));
 		self::assertEquals(1.8, TPropertyValue::ensureFloat(1.8));
 		self::assertEquals(1.99999, TPropertyValue::ensureFloat(1.99999));
-		
+
 		self::assertEquals(0, TPropertyValue::ensureFloat('0'));
 		self::assertEquals(0.0001, TPropertyValue::ensureFloat('0.0001'));
 		self::assertEquals(1.8, TPropertyValue::ensureFloat('1.8'));
 		self::assertEquals(1.99999, TPropertyValue::ensureFloat('1.99999'));
+	}
+
+	public function testEnsureFloatEdgeCases()
+	{
+		// Boolean coercion
+		self::assertSame(1.0, TPropertyValue::ensureFloat(true));
+		self::assertSame(0.0, TPropertyValue::ensureFloat(false));
+
+		// Negative values
+		self::assertSame(-1.5, TPropertyValue::ensureFloat(-1.5));
+		self::assertSame(-1.5, TPropertyValue::ensureFloat('-1.5'));
+
+		// Scientific notation string
+		self::assertSame(100.0, TPropertyValue::ensureFloat('1.0e2'));
+		self::assertSame(0.001, TPropertyValue::ensureFloat('1e-3'));
+
+		// PHP_FLOAT_MAX round-trip
+		self::assertSame(PHP_FLOAT_MAX, TPropertyValue::ensureFloat(PHP_FLOAT_MAX));
+
+		// PHP_FLOAT_MIN (smallest positive float)
+		self::assertSame(PHP_FLOAT_MIN, TPropertyValue::ensureFloat(PHP_FLOAT_MIN));
+
+		// INF and -INF
+		self::assertTrue(is_infinite(TPropertyValue::ensureFloat(INF)));
+		self::assertGreaterThan(0.0, TPropertyValue::ensureFloat(INF));
+		self::assertTrue(is_infinite(TPropertyValue::ensureFloat(-INF)));
+		self::assertLessThan(0.0, TPropertyValue::ensureFloat(-INF));
+
+		// NAN
+		self::assertTrue(is_nan(TPropertyValue::ensureFloat(NAN)));
+
+		// Large integer preserves value as float
+		self::assertSame((float) PHP_INT_MAX, TPropertyValue::ensureFloat(PHP_INT_MAX));
 	}
 	
 	public function testEnsureArray()
@@ -108,13 +248,207 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals(['value'], TPropertyValue::ensureArray('value'));
 		self::assertEquals(['value'], TPropertyValue::ensureArray(' value '));
 		self::assertEquals([], TPropertyValue::ensureArray('()'));
-		//self::assertEquals(['test', 'value'], TPropertyValue::ensureArray('(test, value)'));
 		self::assertEquals(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
-		self::assertEquals(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
-		
-		//self::assertEquals([0 => [12, 'bcd', 'wxy', '']], TPropertyValue::ensureArray('( (12, \'bcd\', \'wxy\', "") )'));
-		//self::assertEquals([0 => 11, 1 => 'abc', 2 => 'xyz', 3 => '\'"dqt', 4 => '\'"sqt', 5 => [12, 'bcd', 'wxy', '']], 
-		//		TPropertyValue::ensureArray('( 11, "abc", \'xyz\', "\'\\"dqt", \'\\\'"sqt\', (12, \'bcd\', \'wxy\', ""))'));
+	}
+
+	// ── ensureArray: eval branch — string starting and ending with parentheses ──
+
+	public function testEnsureArrayEvalEmptyParens()
+	{
+		// '()' → eval('return array();') → []
+		self::assertSame([], TPropertyValue::ensureArray('()'));
+	}
+
+	public function testEnsureArrayEvalParensWithWhitespace()
+	{
+		// '( )' → eval('return array( );') → []
+		self::assertSame([], TPropertyValue::ensureArray('( )'));
+
+		// '(   )' → same
+		self::assertSame([], TPropertyValue::ensureArray('(   )'));
+	}
+
+	public function testEnsureArrayEvalOuterWhitespaceTrimmed()
+	{
+		// Leading/trailing whitespace on the whole string is trimmed before the
+		// paren check, so '  ("a", "b")  ' hits the eval branch.
+		self::assertSame(['a', 'b'], TPropertyValue::ensureArray('  ("a", "b")  '));
+	}
+
+	public function testEnsureArrayEvalDoubleQuotedStrings()
+	{
+		// Double-quoted string elements
+		self::assertSame(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
+		self::assertSame(['a', 'b', 'c'], TPropertyValue::ensureArray('("a", "b", "c")'));
+	}
+
+	public function testEnsureArrayEvalSingleQuotedStrings()
+	{
+		// Single-quoted string elements
+		self::assertSame(['my', 'prop'], TPropertyValue::ensureArray("('my', 'prop')"));
+		self::assertSame(['hello', 'world'], TPropertyValue::ensureArray("('hello', 'world')"));
+	}
+
+	public function testEnsureArrayEvalIntegerElements()
+	{
+		// Integer elements — eval parses them as PHP integers
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('(1, 2, 3)'));
+		self::assertSame([0, 100, -5], TPropertyValue::ensureArray('(0, 100, -5)'));
+	}
+
+	public function testEnsureArrayEvalFloatElements()
+	{
+		// Float elements
+		self::assertSame([1.5, 2.5], TPropertyValue::ensureArray('(1.5, 2.5)'));
+		self::assertSame([-0.5, 3.14], TPropertyValue::ensureArray('(-0.5, 3.14)'));
+	}
+
+	public function testEnsureArrayEvalMixedTypes()
+	{
+		// Mixed PHP types in one expression
+		self::assertSame([1, 'two', 3.0], TPropertyValue::ensureArray('(1, "two", 3.0)'));
+	}
+
+	public function testEnsureArrayEvalBooleanAndNull()
+	{
+		// PHP keywords true, false, null parsed by eval
+		self::assertSame([true, false, null], TPropertyValue::ensureArray('(true, false, null)'));
+	}
+
+	public function testEnsureArrayEvalAssociativeStringKeys()
+	{
+		// Associative array with string keys
+		self::assertSame(['x' => 1, 'y' => 2], TPropertyValue::ensureArray('("x" => 1, "y" => 2)'));
+	}
+
+	public function testEnsureArrayEvalAssociativeIntegerKeys()
+	{
+		// Explicit integer keys
+		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray('(5 => "a", 10 => "b")'));
+	}
+
+	public function testEnsureArrayEvalSingleElement()
+	{
+		// Single element
+		self::assertSame(['only'], TPropertyValue::ensureArray('("only")'));
+		self::assertSame([42], TPropertyValue::ensureArray('(42)'));
+	}
+
+	public function testEnsureArrayEvalNestedArrays()
+	{
+		// Nested arrays using the array() constructor inside the expression
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('(array(1, 2), array(3, 4))'));
+		self::assertSame([['a', 'b'], ['c']], TPropertyValue::ensureArray('(array("a", "b"), array("c"))'));
+	}
+
+	public function testEnsureArrayEvalEmptyStringElement()
+	{
+		// A single empty string element
+		self::assertSame([''], TPropertyValue::ensureArray('("")'));
+	}
+
+	public function testEnsureArrayEvalComplexExpression()
+	{
+		// A realistic config-style expression with integers, strings, and nested array
+		self::assertSame(
+			[11, 'abc', 'xyz', [12, 'bcd', 'wxy', '']],
+			TPropertyValue::ensureArray('(11, "abc", "xyz", array(12, "bcd", "wxy", ""))')
+		);
+	}
+
+	// ── ensureArray: non-eval string branch — plain strings ──────────────────
+
+	public function testEnsureArrayStringNotParens()
+	{
+		// A plain string with no surrounding parens is wrapped in an array
+		self::assertSame(['value'], TPropertyValue::ensureArray('value'));
+		self::assertSame(['hello world'], TPropertyValue::ensureArray('hello world'));
+	}
+
+	public function testEnsureArrayStringWithLeadingParenOnly()
+	{
+		// Starts with '(' but does NOT end with ')' → plain string, not eval
+		self::assertSame(['(partial'], TPropertyValue::ensureArray('(partial'));
+	}
+
+	public function testEnsureArrayStringWithTrailingParenOnly()
+	{
+		// Ends with ')' but does NOT start with '(' → plain string
+		self::assertSame(['partial)'], TPropertyValue::ensureArray('partial)'));
+	}
+
+	public function testEnsureArrayStringParenInsideMiddle()
+	{
+		// Parens are not at the outer boundary → plain string
+		self::assertSame(['a(b)c'], TPropertyValue::ensureArray('a(b)c'));
+	}
+
+	public function testEnsureArraySingleCharParens()
+	{
+		// Single-char strings: '(' or ')' have len=1 < 2, so do NOT trigger eval
+		self::assertSame(['('], TPropertyValue::ensureArray('('));
+		self::assertSame([')'], TPropertyValue::ensureArray(')'));
+	}
+
+	public function testEnsureArrayStringTrimmedBeforeParenCheck()
+	{
+		// After trim, 'value' = 'value' → plain string
+		self::assertSame(['value'], TPropertyValue::ensureArray(' value '));
+
+		// After trim, '' = '' → empty array
+		self::assertSame([], TPropertyValue::ensureArray('   '));
+	}
+
+	// ── ensureArray: non-string branch — (array) cast ─────────────────────────
+
+	public function testEnsureArrayNonStringNull()
+	{
+		// (array) null → []
+		self::assertSame([], TPropertyValue::ensureArray(null));
+	}
+
+	public function testEnsureArrayNonStringBooleans()
+	{
+		// (array) true → [true]
+		self::assertSame([true], TPropertyValue::ensureArray(true));
+		// (array) false → [false]
+		self::assertSame([false], TPropertyValue::ensureArray(false));
+	}
+
+	public function testEnsureArrayNonStringIntegers()
+	{
+		self::assertSame([0], TPropertyValue::ensureArray(0));
+		self::assertSame([1], TPropertyValue::ensureArray(1));
+		self::assertSame([-5], TPropertyValue::ensureArray(-5));
+	}
+
+	public function testEnsureArrayNonStringFloat()
+	{
+		self::assertSame([1.5], TPropertyValue::ensureArray(1.5));
+		self::assertSame([0.0], TPropertyValue::ensureArray(0.0));
+	}
+
+	public function testEnsureArrayNonStringArrayPassThrough()
+	{
+		// (array) array → same array
+		self::assertSame([], TPropertyValue::ensureArray([]));
+		self::assertSame(['a', 'b'], TPropertyValue::ensureArray(['a', 'b']));
+		self::assertSame(['key' => 'val'], TPropertyValue::ensureArray(['key' => 'val']));
+	}
+
+	public function testEnsureArrayNonStringObject()
+	{
+		// (array) stdClass → public properties become associative keys
+		$obj = new stdClass();
+		$obj->foo = 'bar';
+		$obj->num = 42;
+		self::assertSame(['foo' => 'bar', 'num' => 42], TPropertyValue::ensureArray($obj));
+	}
+
+	public function testEnsureArrayNonStringObjectEmpty()
+	{
+		// (array) empty stdClass → []
+		self::assertSame([], TPropertyValue::ensureArray(new stdClass()));
 	}
 	
 	public function testEnsureObject()
@@ -135,6 +469,37 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals($obj, TPropertyValue::ensureObject(['key' => 'Prop']));
 		self::assertEquals($obj, TPropertyValue::ensureObject($obj));
 	}
+
+	public function testEnsureObjectEdgeCases()
+	{
+		// Boolean inputs — PHP wraps scalars in stdClass{$scalar = value}
+		$obj = new stdClass();
+		$obj->scalar = true;
+		self::assertEquals($obj, TPropertyValue::ensureObject(true));
+
+		$obj->scalar = false;
+		self::assertEquals($obj, TPropertyValue::ensureObject(false));
+
+		// Float input
+		$obj->scalar = 1.5;
+		self::assertEquals($obj, TPropertyValue::ensureObject(1.5));
+
+		// Negative int
+		$obj->scalar = -3;
+		self::assertEquals($obj, TPropertyValue::ensureObject(-3));
+
+		// Array with multiple string keys
+		$source = ['a' => 1, 'b' => 2, 'c' => 3];
+		$expected = (object) $source;
+		self::assertEquals($expected, TPropertyValue::ensureObject($source));
+
+		// Existing non-stdClass object passes through as-is via (object) cast
+		// — (object) on a non-stdClass returns the same instance
+		$custom = new class {
+			public int $x = 42;
+		};
+		self::assertSame($custom, TPropertyValue::ensureObject($custom));
+	}
 	
 	public function testEnsureEnum()
 	{
@@ -145,14 +510,14 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		try {
 			self::assertEquals('value3', TPropertyValue::ensureEnum('value3', ['value', 'value2']));
 			self::fail('failed to throw TInvalidDataValueException for value not in array');
-		} catch(TInvalidDataValueException $e) {
+		} catch (TInvalidDataValueException $e) {
 		}
 		try {
 			self::assertEquals('Value', TPropertyValue::ensureEnum('Value', ['value', 'value2']));
 			self::fail('failed to throw TInvalidDataValueException for value not in array');
-		} catch(TInvalidDataValueException $e) {
+		} catch (TInvalidDataValueException $e) {
 		}
-		
+
 		// $enums = Class, look at class constant
 		self::assertEquals('Off', TPropertyValue::ensureEnum('Off', \Prado\TApplicationMode::class));
 		self::assertEquals('Debug', TPropertyValue::ensureEnum('Debug', \Prado\TApplicationMode::class));
@@ -161,12 +526,12 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		try {
 			self::assertEquals('value', TPropertyValue::ensureEnum('value', \Prado\TApplicationMode::class));
 			self::fail('failed to throw TInvalidDataValueException for value not in array');
-		} catch(TInvalidDataValueException $e) {
+		} catch (TInvalidDataValueException $e) {
 		}
-		
+
 		// $enums = Class, look at class constant
 		self::assertEquals('CLASS_FILE_EXT', TPropertyValue::ensureEnum('CLASS_FILE_EXT', \Prado\Prado::class));
-		
+
 		// more than one $enum param no function.
 		self::assertEquals('Off', TPropertyValue::ensureEnum('Off', 'Off', 'Debug', 'Normal', 'Performance'));
 		self::assertEquals('Debug', TPropertyValue::ensureEnum('Debug', 'Off', 'Debug', 'Normal', 'Performance'));
@@ -175,8 +540,75 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		try {
 			self::assertEquals('value', TPropertyValue::ensureEnum('value', 'Off', 'Debug', 'Normal', 'Performance'));
 			self::fail('failed to throw TInvalidDataValueException for value not in array');
-		} catch(TInvalidDataValueException $e) {
+		} catch (TInvalidDataValueException $e) {
 		}
+	}
+
+	public function testEnsureEnumEdgeCases()
+	{
+		// ── Array form — strict comparison ────────────────────────────────────
+
+		// Single-element array: only one valid value
+		self::assertEquals('only', TPropertyValue::ensureEnum('only', ['only']));
+
+		// Strict type check: string '1' does NOT match int 1 in array
+		try {
+			TPropertyValue::ensureEnum('1', [1, 2, 3]);
+			self::fail('Expected TInvalidDataValueException for type mismatch');
+		} catch (TInvalidDataValueException $e) {
+		}
+
+		// Empty array: always throws regardless of value
+		try {
+			TPropertyValue::ensureEnum('anything', []);
+			self::fail('Expected TInvalidDataValueException for empty enum array');
+		} catch (TInvalidDataValueException $e) {
+		}
+
+		// Exception message contains the invalid value
+		try {
+			TPropertyValue::ensureEnum('bad', ['good', 'ok']);
+			self::fail('Expected TInvalidDataValueException');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('bad', $e->getMessage());
+		}
+
+		// ── Variadic form (func_num_args > 2 or non-string second arg) ───────
+
+		// Single-element array form: value is in the array
+		self::assertEquals('only', TPropertyValue::ensureEnum('only', ['only']));
+
+		// Variadic form with many values
+		self::assertEquals('z', TPropertyValue::ensureEnum('z', 'a', 'b', 'c', 'z'));
+
+		// Variadic form throws when value absent
+		try {
+			TPropertyValue::ensureEnum('missing', 'a', 'b', 'c');
+			self::fail('Expected TInvalidDataValueException for variadic miss');
+		} catch (TInvalidDataValueException $e) {
+		}
+
+		// ── Class-constant form — returns the value as-is when found ─────────
+
+		// Case-sensitive: 'debug' (lowercase) is NOT a TApplicationMode constant
+		try {
+			TPropertyValue::ensureEnum('debug', \Prado\TApplicationMode::class);
+			self::fail('Expected TInvalidDataValueException for wrong case');
+		} catch (TInvalidDataValueException $e) {
+		}
+
+		// Exception message names valid constants
+		try {
+			TPropertyValue::ensureEnum('invalid', \Prado\TApplicationMode::class);
+			self::fail('Expected TInvalidDataValueException');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('Off', $e->getMessage());
+		}
+
+		// ── ReflectionClass cache: repeated calls do not throw ────────────────
+		// The static $types cache is populated on first call; second call reuses it.
+		self::assertEquals('Off', TPropertyValue::ensureEnum('Off', \Prado\TApplicationMode::class));
+		self::assertEquals('Debug', TPropertyValue::ensureEnum('Debug', \Prado\TApplicationMode::class));
 	}
 	
 	public function testEnsureNullIfEmpty()
@@ -189,13 +621,59 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertNull(TPropertyValue::ensureNullIfEmpty(null));
 		self::assertNull(TPropertyValue::ensureNullIfEmpty('0'));
 		self::assertNull(TPropertyValue::ensureNullIfEmpty(0));
-			
+
 		self::assertEquals(true, TPropertyValue::ensureNullIfEmpty(true));
 		self::assertEquals('value', TPropertyValue::ensureNullIfEmpty('value'));
 		self::assertEquals('11', TPropertyValue::ensureNullIfEmpty('11'));
 		self::assertEquals(11, TPropertyValue::ensureNullIfEmpty(11));
 		self::assertEquals([11], TPropertyValue::ensureNullIfEmpty([11]));
 		self::assertEquals(new stdClass(), TPropertyValue::ensureNullIfEmpty(new stdClass()));
+	}
+
+	public function testEnsureNullIfEmptyEdgeCases()
+	{
+		// ── Values that PHP empty() considers empty → null ──────────────────
+
+		// Float zero — empty(0.0) is true
+		self::assertNull(TPropertyValue::ensureNullIfEmpty(0.0));
+
+		// Negative zero is still zero — empty(-0) is true
+		self::assertNull(TPropertyValue::ensureNullIfEmpty(-0));
+
+		// ── The '0.0' vs '0' distinction — key PHP empty() edge case ────────
+
+		// String '0' → empty() returns true → null  (confirmed in base test)
+		self::assertNull(TPropertyValue::ensureNullIfEmpty('0'));
+
+		// String '0.0' → empty() returns FALSE (not a PHP-empty string)
+		self::assertSame('0.0', TPropertyValue::ensureNullIfEmpty('0.0'));
+
+		// String '00' → empty() returns false → '00'
+		self::assertSame('00', TPropertyValue::ensureNullIfEmpty('00'));
+
+		// String '0.00' → empty() returns false → '0.00'
+		self::assertSame('0.00', TPropertyValue::ensureNullIfEmpty('0.00'));
+
+		// ── Values that PHP empty() considers non-empty → returned as-is ─────
+
+		// String 'false' (not bool false) → non-empty → returned
+		self::assertSame('false', TPropertyValue::ensureNullIfEmpty('false'));
+
+		// String '0 ' (zero with space) → not '0' → non-empty → returned
+		self::assertSame('0 ', TPropertyValue::ensureNullIfEmpty('0 '));
+
+		// Negative number → non-empty → returned
+		self::assertSame(-1, TPropertyValue::ensureNullIfEmpty(-1));
+		self::assertSame(-0.1, TPropertyValue::ensureNullIfEmpty(-0.1));
+
+		// Non-empty array (even containing empty/falsy values) → returned
+		self::assertSame([0], TPropertyValue::ensureNullIfEmpty([0]));
+		self::assertSame([null], TPropertyValue::ensureNullIfEmpty([null]));
+		self::assertSame([false], TPropertyValue::ensureNullIfEmpty([false]));
+		self::assertSame([''], TPropertyValue::ensureNullIfEmpty(['']));
+
+		// Positive float → returned
+		self::assertSame(0.1, TPropertyValue::ensureNullIfEmpty(0.1));
 	}
 	
 	


### PR DESCRIPTION
I'd like these in place for any changes to ensureArray that _should_ be done to remove its PHP dependency.