### PR TITLE
PradoTestListener - start/stop Selenium Driver on proper test suite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,5 +26,7 @@
     <ini name="max_execution_time" value="1200"/>
     <ini name="memory_limit" value="1G"/>
     <const name="PRADO_TEST_RUN" value="true"/>
+    <!-- indicate Selenium test suite to start/stop Driver -->
+    <const name="SELENIUM_TESTSUITE_NAME" value="selenium"/>
   </php>
 </phpunit>

--- a/tests/FunctionalTests/run-selenium-tests.sh
+++ b/tests/FunctionalTests/run-selenium-tests.sh
@@ -32,7 +32,7 @@ for i in $(seq 1 150); do
 done
 
 # Run phpunit in the background so the parent-process poll can run alongside it.
-vendor/bin/phpunit --testsuite functional &
+vendor/bin/phpunit --testsuite selenium &
 PHPUNIT_PID=$!
 
 # Record the PID of the process that launched this script.

--- a/tests/test_tools/PradoTestListener.php
+++ b/tests/test_tools/PradoTestListener.php
@@ -20,7 +20,7 @@ class TestSuiteStarted implements Event\TestSuite\StartedSubscriber
 {
     public function notify(Event\TestSuite\Started $event): void
     {
-    	if($event->testSuite()->name() === 'functional') {
+    	if($event->testSuite()->name() === PradoTestListener::$SeleniumTestSuiteName) {
     		PradoGenericSelenium2TestSession::startDriver();
     	}
     }
@@ -30,7 +30,7 @@ class TestSuiteFinished implements Event\TestSuite\FinishedSubscriber
 {
     public function notify(Event\TestSuite\Finished $event): void
     {
-    	if($event->testSuite()->name() === 'functional') {
+    	if($event->testSuite()->name() === PradoTestListener::$SeleniumTestSuiteName) {
     		PradoGenericSelenium2TestSession::stopDriver();
     	}
     }
@@ -71,11 +71,17 @@ class PradoGenericSelenium2TestSession
 
 class PradoTestListener implements Runner\Extension\Extension
 {
+	// Default; overridden at bootstrap time by the SELENIUM_TESTSUITE_NAME const in phpunit.xml
+	public static $SeleniumTestSuiteName = 'selenium';
+
 	public function bootstrap(
 		TextUI\Configuration\Configuration $configuration,
 		Runner\Extension\Facade $facade,
 		Runner\Extension\ParameterCollection $parameters
 	): void {
+		if (defined('SELENIUM_TESTSUITE_NAME')) {
+			self::$SeleniumTestSuiteName = SELENIUM_TESTSUITE_NAME;
+		}
 		$facade->registerSubscribers(
 			new TestSuiteStarted(),
 			new TestSuiteFinished()


### PR DESCRIPTION
Not sure if this is even needed given that the selenium tests appear to be working.  Playwright should be concurrent to selenium until v4.4, when selenium is removed.