### PR TITLE
TPgsqlMetaData - fix for null string passed into substr - PHP8 changed its behavior

### DIFF
--- a/framework/Data/Common/Pgsql/TPgsqlMetaData.php
+++ b/framework/Data/Common/Pgsql/TPgsqlMetaData.php
@@ -230,8 +230,8 @@ class TPgsqlMetaData extends TDbMetaData
 		if ($col['atthasdef']) {
 			$info['DefaultValue'] = $col['adsrc'];
 		}
-		if ($col['attisserial'] || substr($col['adsrc'], 0, 8) === 'nextval(') {
-			if (($sequence = $this->getSequenceName($tableInfo, $col['adsrc'])) !== null) {
+		if ($col['attisserial'] || substr($col['adsrc'] ?? '', 0, 8) === 'nextval(') {
+			if (($sequence = $this->getSequenceName($tableInfo, $col['adsrc'] ?? '')) !== null) {
 				$info['SequenceName'] = $sequence;
 				unset($info['DefaultValue']);
 			}


### PR DESCRIPTION
Found this in the Data refactor.