### PR TITLE
TErrorHandler update - THttpException and TExitException

### DIFF
--- a/framework/Exceptions/TErrorHandler.php
+++ b/framework/Exceptions/TErrorHandler.php
@@ -92,10 +92,14 @@ class TErrorHandler extends \Prado\TModule
 
 	/**
 	 * @var ?array cached path replacement map for hidePrivatePathParts()
+	 * @since 4.3.3
 	 */
 	private $_privatePathReplacements;
 
-	/** @var bool whether an error is currently being handled (prevents infinite loops) */
+	/**
+	 * @var bool whether an error is currently being handled (prevents infinite loops)
+	 * @since 4.3.3
+	 */
 	private bool $_handling = false;
 
 	/**
@@ -115,10 +119,7 @@ class TErrorHandler extends \Prado\TModule
 	 */
 	protected function setAppErrorHandler()
 	{
-		if (!($app = $this->getApplication())) {
-			return;
-		}
-		$app->setErrorHandler($this);
+		$this->getApplication()?->setErrorHandler($this);
 	}
 
 	/**

--- a/framework/Exceptions/TErrorHandler.php
+++ b/framework/Exceptions/TErrorHandler.php
@@ -18,34 +18,50 @@ use Prado\Prado;
  *
  * TErrorHandler handles all PHP user errors and exceptions generated during
  * servicing user requests. It displays these errors using different templates
- * and if possible, using languages preferred by the client user.
- * Note, PHP parsing errors cannot be caught and handled by TErrorHandler.
+ * and if possible, using languages preferred by the user.
+ * Note: PHP parsing errors cannot be caught and handled by TErrorHandler.
  *
  * The templates used to format the error output are stored under Prado\Exceptions.
  * You may choose to use your own templates, should you not like the templates
- * provided by Prado. Simply set {@see setErrorTemplatePath ErrorTemplatePath}
+ * provided by Prado. Simply set {@see setErrorTemplatePath()}
  * to the path (in namespace format) storing your own templates.
  *
- * There are two sets of templates, one for errors to be displayed to client users
+ * There are two sets of templates, one for errors to be displayed to users
  * (called external errors), one for errors to be displayed to system developers
  * (called internal errors). The template file name for the former is
- * <b>error[StatusCode][-LanguageCode].html</b>, and for the latter it is
- * <b>exception[-LanguageCode].html</b>, where StatusCode refers to response status
+ * `error[StatusCode][-LanguageCode].html`, and for the latter it is
+ * `exception[-LanguageCode].html`, where StatusCode refers to response status
  * code (e.g. 404, 500) specified when {@see \Prado\Exceptions\THttpException} is thrown,
- * and LanguageCode is the client user preferred language code (e.g. en, zh, de).
- * The templates <b>error.html</b> and <b>exception.html</b> are default ones
+ * and LanguageCode is the user preferred language code (e.g. en, zh, de).
+ * The templates `error.html` and `exception.html` are default ones
  * that are used if no other appropriate templates are available.
- * Note, these templates are not Prado control templates. They are simply
- * html files with keywords (e.g. %%ErrorMessage%%, %%Version%%)
+ * Note: these templates are not Prado control templates. They are simply
+ * HTML files with keywords (e.g. %%ErrorMessage%%, %%Version%%)
  * to be replaced with the corresponding information.
  *
- * By default, TErrorHandler is registered with {@see \Prado\TApplication} as the
- * error handler module. It can be accessed via {@see \Prado\TApplication::getErrorHandler()}.
- * You seldom need to deal with the error handler directly. It is mainly used
- * by the application object to handle errors.
+ * {@see init()} registers the instance with {@see \Prado\TApplication} as the
+ * error handler, accessible via {@see \Prado\TApplication::getErrorHandler()};
+ * the application then routes all unhandled errors and exceptions through
+ * {@see handleError()}.
  *
- * TErrorHandler may be configured in application configuration file as follows
- * <module id="error" class="TErrorHandler" ErrorTemplatePath="Prado\Exceptions" />
+ * TErrorHandler may be configured in application.xml as follows:
+ * ```xml
+ * <modules>
+ *   <module id="error" class="Prado\Exceptions\TErrorHandler" ErrorTemplatePath="Prado\Exceptions" />
+ * </modules>
+ * ```
+ *
+ * Or equivalently in application.php:
+ * ```php
+ * return [
+ *     'modules' => [
+ *         'error' => [
+ *             'class' => TErrorHandler::class,
+ *             'properties' => ['ErrorTemplatePath' => 'Prado\Exceptions'],
+ *         ],
+ *     ],
+ * ];
+ * ```
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.0
@@ -65,7 +81,7 @@ class TErrorHandler extends \Prado\TModule
 	 */
 	public const SOURCE_LINES = 12;
 	/**
-	 * number of prado internal function calls to be dropped from stack traces on fatal errors
+	 * number of Prado internal function calls to be dropped from stack traces on fatal errors
 	 */
 	public const FATAL_ERROR_TRACE_DROP_LINES = 5;
 
@@ -75,74 +91,194 @@ class TErrorHandler extends \Prado\TModule
 	private $_templatePath;
 
 	/**
-	 * Initializes the module.
-	 * This method is required by IModule and is invoked by application.
+	 * @var ?array cached path replacement map for hidePrivatePathParts()
+	 */
+	private $_privatePathReplacements;
+
+	/** @var bool whether an error is currently being handled (prevents infinite loops) */
+	private bool $_handling = false;
+
+	/**
+	 * Initializes the module and registers it as the application error handler.
 	 * @param \Prado\Xml\TXmlElement $config module configuration
 	 */
 	public function init($config)
 	{
-		$this->getApplication()->setErrorHandler($this);
+		$this->setAppErrorHandler();
 		parent::init($config);
 	}
 
 	/**
-	 * @return string the directory containing error template files.
+	 * Registers this handler as the application error handler when an application is available.
+	 * Called during {@see init()}; may also be called by behaviors or subclasses.
+	 * @since 4.3.3
 	 */
-	public function getErrorTemplatePath()
+	protected function setAppErrorHandler()
 	{
-		if ($this->_templatePath === null) {
-			$this->_templatePath = Prado::getFrameworkPath() . '/Exceptions/templates';
+		if (!($app = $this->getApplication())) {
+			return;
 		}
+		$app->setErrorHandler($this);
+	}
+
+	/**
+	 * Returns the built-in framework directory containing error and exception template files.
+	 * @return string absolute filesystem path to the framework templates directory
+	 * @since 4.3.3
+	 */
+	protected function getDefaultErrorTemplatePath(): string
+	{
+		return Prado::getFrameworkPath() . '/Exceptions/templates';
+	}
+
+	/**
+	 * Returns the cached path replacement map without building it.
+	 * @return ?array associative array of path => replacement strings, or null if not yet built
+	 * @since 4.3.3
+	 */
+	protected function getPrivatePathReplacementsDirect(): ?array
+	{
+		return $this->_privatePathReplacements;
+	}
+
+	/**
+	 * Sets the cached path replacement map directly.
+	 * @param ?array $value
+	 * @since 4.3.3
+	 */
+	protected function setPrivatePathReplacementsDirect($value): void
+	{
+		$this->_privatePathReplacements = $value;
+	}
+
+	/**
+	 * Returns the map used to replace private filesystem paths in output.
+	 * Builds and caches the map on first call.
+	 * @return array associative array of path => replacement strings
+	 * @since 4.3.3
+	 */
+	protected function getPrivatePathReplacements(): array
+	{
+		if ($this->getPrivatePathReplacementsDirect() === null) {
+			$aRpl = [];
+			$docRoot = $this->serverGlobal('DOCUMENT_ROOT') ?? '';
+			if ($docRoot !== '') {
+				$aRpl[$docRoot] = '${DocumentRoot}';
+				$aRpl[str_replace('/', DIRECTORY_SEPARATOR, $docRoot)] = '${DocumentRoot}';
+			}
+			$aRpl[PRADO_DIR . DIRECTORY_SEPARATOR] = '${PradoFramework}' . DIRECTORY_SEPARATOR;
+			if (isset($aRpl[DIRECTORY_SEPARATOR])) {
+				unset($aRpl[DIRECTORY_SEPARATOR]);
+			}
+			$this->setPrivatePathReplacementsDirect(array_reverse($aRpl, true));
+		}
+		return $this->getPrivatePathReplacementsDirect();
+	}
+
+	/**
+	 * Returns the raw template path property value without applying defaults.
+	 * @return ?string
+	 * @since 4.3.3
+	 */
+	protected function getErrorTemplatePathDirect(): ?string
+	{
 		return $this->_templatePath;
 	}
 
 	/**
-	 * Sets the path storing all error and exception template files.
-	 * The path must be in namespace format, such as Prado\Exceptions (which is the default).
-	 * @param string $value template path in namespace format
-	 * @throws TConfigurationException if the template path is invalid
+	 * Sets the template path property directly to a resolved filesystem path.
+	 * @param ?string $value
+	 * @since 4.3.3
 	 */
-	public function setErrorTemplatePath($value)
+	protected function setErrorTemplatePathDirect(?string $value): void
 	{
-		if (($templatePath = Prado::getPathOfNamespace($value)) !== null && is_dir($templatePath)) {
-			$this->_templatePath = $templatePath;
-		} else {
-			throw new TConfigurationException('errorhandler_errortemplatepath_invalid', $value);
-		}
+		$this->_templatePath = $value;
 	}
 
 	/**
-	 * Handles PHP user errors and exceptions.
-	 * This is the event handler responding to the <b>Error</b> event
-	 * raised in {@see \Prado\TApplication}.
-	 * The method mainly uses appropriate template to display the error/exception.
-	 * It terminates the application immediately after the error is displayed.
-	 * @param mixed $sender sender of the event
-	 * @param mixed $param event parameter (if the event is raised by TApplication, it refers to the exception instance)
+	 * Returns the directory containing error template files.
+	 * Defaults to the built-in framework templates directory.
+	 * @return string absolute filesystem path to the template directory
+	 */
+	public function getErrorTemplatePath()
+	{
+		$errorTemplatePath = $this->getErrorTemplatePathDirect();
+		if ($errorTemplatePath === null) {
+			$this->setErrorTemplatePathDirect($this->getDefaultErrorTemplatePath());
+			$errorTemplatePath = $this->getErrorTemplatePathDirect();
+		}
+		return $errorTemplatePath;
+	}
+
+	/**
+	 * Sets the directory containing error and exception template files.
+	 * The value must be a namespace path, e.g. 'Prado\Exceptions'.
+	 * @param string $value template path in namespace format
+	 * @throws TConfigurationException if the path does not resolve to a valid directory
+	 */
+	public function setErrorTemplatePath($value)
+	{
+		if (($templatePath = Prado::getPathOfNamespace($value)) === null || !is_dir($templatePath)) {
+			throw new TConfigurationException('errorhandler_errortemplatepath_invalid', $value);
+		}
+		$this->setErrorTemplatePathDirect($templatePath);
+	}
+
+	// ── Re-entrance guard ───────────────────────────────────────────────────────
+
+	/**
+	 * Returns whether an error is currently being handled by this instance.
+	 * Used by {@see handleError()} to detect recursive error conditions.
+	 * @return bool true when error handling is already in progress
+	 * @since 4.3.3
+	 */
+	protected function getIsHandled(): bool
+	{
+		return $this->_handling;
+	}
+
+	/**
+	 * Sets the re-entrance flag that tracks whether error handling is in progress.
+	 * @param bool $value true to mark handling as active, false to reset
+	 * @since 4.3.3
+	 */
+	protected function setIsHandled(bool $value): void
+	{
+		$this->_handling = $value;
+	}
+
+	// ── error handlers ───────────────────────────────────────────────────────
+
+	/**
+	 * Handles PHP user errors and exceptions raised during request servicing.
+	 * Responds to the {@see \Prado\TApplication} Error event.
+	 * Selects an external or debug template based on the exception type and application mode.
+	 * @param mixed $sender event sender
+	 * @param \Throwable $param the exception or error to handle
 	 */
 	public function handleError($sender, $param)
 	{
-		static $handling = false;
+		$handling = $this->getIsHandled();
 		// We need to restore error and exception handlers,
 		// because within error and exception handlers, new errors and exceptions
 		// cannot be handled properly by PHP
-		restore_error_handler();
-		restore_exception_handler();
+		$this->restoreErrorHandler();
+		$this->restoreExceptionHandler();
 		// ensure that we do not enter infinite loop of error handling
 		if ($handling) {
 			$this->handleRecursiveError($param);
 		} else {
-			$handling = true;
+			$this->setIsHandled(true);
 			if (($response = $this->getResponse()) !== null) {
 				$response->clear();
 			}
-			if (!headers_sent()) {
+			if (!$this->headersSent()) {
 				$header = 'Content-Type: text/html; charset=UTF-8';
 				$response = $this->getResponse();
 				if ($response) {
 					$response->appendHeader($header);
 				} else {
-					header($header);
+					$this->header($header);
 				}
 			}
 			if ($param instanceof THttpException) {
@@ -155,20 +291,21 @@ class TErrorHandler extends \Prado\TModule
 		}
 	}
 
-
 	/**
+	 * Strips private filesystem paths from a string to prevent leaking server layout.
+	 * Replaces the document root, the framework directory, and any per-frame source
+	 * directories found in the exception trace with safe placeholder tokens.
 	 * @param string $value
-	 * @param null|\Exception $exception
-	 * @return string
+	 * @param ?\Exception $exception
 	 * @since 3.1.6
 	 */
-	protected static function hideSecurityRelated($value, $exception = null)
+	protected function hideSecurityRelated($value, $exception = null): string
 	{
 		$aRpl = [];
 		if ($exception !== null && $exception instanceof \Exception) {
 			if ($exception instanceof TPhpFatalErrorException &&
 				function_exists('xdebug_get_function_stack')) {
-				$aTrace = array_slice(array_reverse(xdebug_get_function_stack()), self::FATAL_ERROR_TRACE_DROP_LINES, -1);
+				$aTrace = array_slice(array_reverse(xdebug_get_function_stack()), static::FATAL_ERROR_TRACE_DROP_LINES, -1);
 			} else {
 				$aTrace = $exception->getTrace();
 			}
@@ -179,8 +316,11 @@ class TErrorHandler extends \Prado\TModule
 				}
 			}
 		}
-		$aRpl[$_SERVER['DOCUMENT_ROOT']] = '${DocumentRoot}';
-		$aRpl[str_replace('/', DIRECTORY_SEPARATOR, $_SERVER['DOCUMENT_ROOT'])] = '${DocumentRoot}';
+		$docRoot = $this->serverGlobal('DOCUMENT_ROOT') ?? '';
+		if ($docRoot !== '') {
+			$aRpl[$docRoot] = '${DocumentRoot}';
+			$aRpl[str_replace('/', DIRECTORY_SEPARATOR, $docRoot)] = '${DocumentRoot}';
+		}
 		$aRpl[PRADO_DIR . DIRECTORY_SEPARATOR] = '${PradoFramework}' . DIRECTORY_SEPARATOR;
 		if (isset($aRpl[DIRECTORY_SEPARATOR])) {
 			unset($aRpl[DIRECTORY_SEPARATOR]);
@@ -191,30 +331,30 @@ class TErrorHandler extends \Prado\TModule
 	}
 
 	/**
-	 * Displays error to the client user.
-	 * THttpException and errors happened when the application is in <b>Debug</b>
-	 * mode will be displayed to the client user.
-	 * @param int $statusCode response status code
-	 * @param \Exception $exception exception instance
+	 * Renders a user-facing error page for the given HTTP status code.
+	 * Logs non-HTTP exceptions via {@see errorLog()}.
+	 * In non-Debug mode, strips sensitive path information from the error message.
+	 * @param int $statusCode
+	 * @param \Exception $exception
 	 */
-	protected function handleExternalError($statusCode, $exception)
+	protected function handleExternalError($statusCode, $exception): void
 	{
 		if (!($exception instanceof THttpException)) {
-			error_log($exception->__toString());
+			$this->errorLog($exception->__toString());
 		}
 
 		$content = $this->getErrorTemplate($statusCode, $exception);
 
-		$serverAdmin = $_SERVER['SERVER_ADMIN'] ?? '';
+		$serverAdmin = $this->serverGlobal('SERVER_ADMIN') ?? '';
 
 		$isDebug = $this->getApplication()->getMode() === TApplicationMode::Debug;
 
 		$errorMessage = $exception->getMessage();
 		if ($isDebug) {
-			$version = $_SERVER['SERVER_SOFTWARE'] . ' <a href="https://github.com/pradosoft/prado">PRADO</a>/' . Prado::getVersion();
+			$version = ($this->serverGlobal('SERVER_SOFTWARE') ?? '') . ' <a href="https://github.com/pradosoft/prado">PRADO</a>/' . Prado::getVersion();
 		} else {
 			$version = '';
-			$errorMessage = self::hideSecurityRelated($errorMessage, $exception);
+			$errorMessage = $this->hideSecurityRelated($errorMessage, $exception);
 		}
 		$tokens = [
 			'%%StatusCode%%' => "$statusCode",
@@ -222,7 +362,7 @@ class TErrorHandler extends \Prado\TModule
 			'%%ErrorCode%%' => $exception->getCode(),
 			'%%ServerAdmin%%' => $serverAdmin,
 			'%%Version%%' => $version,
-			'%%Time%%' => @strftime('%Y-%m-%d %H:%M', time()),
+			'%%Time%%' => date('Y-m-d H:i'),
 		];
 
 		$this->getApplication()->getResponse()->setStatusCode($statusCode, $isDebug ? $exception->getMessage() : null);
@@ -231,13 +371,15 @@ class TErrorHandler extends \Prado\TModule
 	}
 
 	/**
-	 * Handles error occurs during error handling (called recursive error).
-	 * THttpException and errors happened when the application is in <b>Debug</b>
-	 * mode will be displayed to the client user.
-	 * Error is displayed without using existing template to prevent further errors.
-	 * @param \Exception $exception exception instance
+	 * Handles an error that occurs while already handling another error.
+	 * In Debug mode, renders a minimal HTML page with the exception details.
+	 * In non-Debug mode, logs the error via {@see errorLog()} and sends a
+	 * `HTTP/1.0 500 Internal Error` header via {@see header()}, but only when
+	 * {@see headersSent()} reports that headers have not yet been sent.
+	 * Bypasses templates to avoid triggering further errors.
+	 * @param \Exception $exception
 	 */
-	protected function handleRecursiveError($exception)
+	protected function handleRecursiveError($exception): void
 	{
 		if ($this->getApplication()->getMode() === TApplicationMode::Debug) {
 			echo "<html><head><title>Recursive Error</title></head>\n";
@@ -245,43 +387,41 @@ class TErrorHandler extends \Prado\TModule
 			echo "<pre>" . $exception->__toString() . "</pre>\n";
 			echo "</body></html>";
 		} else {
-			error_log("Error happened while processing an existing error:\n" . $exception->__toString());
+			$this->errorLog("Error happened while processing an existing error:\n" . $exception->__toString());
 
-			$header = 'HTTP/1.0 500 Internal Error';
-			$response = $this->getResponse();
-			if ($response) {
-				$response->appendHeader($header);
-			} else {
-				header($header);
+			if (!$this->headersSent()) {
+				$value = 'HTTP/1.0 500 Internal Error';
+				$response = $this->getResponse();
+				if ($response) {
+					$response->appendHeader($value);
+				} else {
+					$this->header($value);
+				}
 			}
 		}
 	}
 
-	protected function hidePrivatePathParts($value)
-	{
-		static $aRpl;
-		if ($aRpl === null) {
-			$aRpl[$_SERVER['DOCUMENT_ROOT']] = '${DocumentRoot}';
-			$aRpl[str_replace('/', DIRECTORY_SEPARATOR, $_SERVER['DOCUMENT_ROOT'])] = '${DocumentRoot}';
-			$aRpl[PRADO_DIR . DIRECTORY_SEPARATOR] = '${PradoFramework}' . DIRECTORY_SEPARATOR;
-			if (isset($aRpl[DIRECTORY_SEPARATOR])) {
-				unset($aRpl[DIRECTORY_SEPARATOR]);
-			}
-			$aRpl = array_reverse($aRpl, true);
-		}
+	// ── Template and output helpers ──────────────────────────────────────────────
 
+	/**
+	 * Replaces private filesystem paths in a string using the instance replacement map.
+	 * @param string $value
+	 */
+	protected function hidePrivatePathParts($value): string
+	{
+		$aRpl = $this->getPrivatePathReplacements();
 		return str_replace(array_keys($aRpl), $aRpl, $value);
 	}
+
 	/**
-	 * Displays exception information.
-	 * Exceptions are displayed with rich context information, including
-	 * the call stack and the context source code.
-	 * This method is only invoked when application is in <b>Debug</b> mode.
-	 * @param \Exception $exception exception instance
+	 * Renders full exception details including source context and stack trace.
+	 * Used when the application is in Debug mode.
+	 * In CLI mode outputs plain text; in web mode renders the exception HTML template.
+	 * @param \Exception $exception
 	 */
 	protected function displayException($exception)
 	{
-		if (php_sapi_name() === 'cli') {
+		if ($this->phpSapiName() === 'cli') {
 			echo $exception->getMessage() . "\n";
 			echo $this->getExactTraceAsString($exception);
 			return;
@@ -307,7 +447,7 @@ class TErrorHandler extends \Prado\TModule
 		}
 
 		if ($this->getApplication()->getMode() === TApplicationMode::Debug) {
-			$version = $_SERVER['SERVER_SOFTWARE'] . ' <a href="https://github.com/pradosoft/prado">PRADO</a>/' . Prado::getVersion();
+			$version = ($this->serverGlobal('SERVER_SOFTWARE') ?? '') . ' <a href="https://github.com/pradosoft/prado">PRADO</a>/' . Prado::getVersion();
 		} else {
 			$version = '';
 		}
@@ -320,7 +460,7 @@ class TErrorHandler extends \Prado\TModule
 			'%%SourceCode%%' => $source,
 			'%%StackTrace%%' => htmlspecialchars($this->getExactTraceAsString($exception)),
 			'%%Version%%' => $version,
-			'%%Time%%' => @strftime('%Y-%m-%d %H:%M', time()),
+			'%%Time%%' => date('Y-m-d H:i'),
 		];
 
 		$content = $this->getExceptionTemplate($exception);
@@ -329,18 +469,19 @@ class TErrorHandler extends \Prado\TModule
 	}
 
 	/**
-	 * Retrieves the template used for displaying internal exceptions.
-	 * Internal exceptions will be displayed with source code causing the exception.
-	 * This occurs when the application is in debug mode.
-	 * @param \Exception $exception the exception to be displayed
-	 * @return string the template content
+	 * Returns the HTML template used for displaying exceptions in debug mode.
+	 * Respects the configured {@see getErrorTemplatePath()}, selecting a
+	 * language-specific variant (`exception-{lang}.html`) when available and
+	 * falling back to `exception.html`.
+	 * @param \Exception $exception
 	 */
-	protected function getExceptionTemplate($exception)
+	protected function getExceptionTemplate($exception): string
 	{
 		$lang = Prado::getPreferredLanguage();
-		$exceptionFile = Prado::getFrameworkPath() . '/Exceptions/templates/' . self::EXCEPTION_FILE_NAME . '-' . $lang . '.html';
+		$templatePath = $this->getErrorTemplatePath();
+		$exceptionFile = $templatePath . DIRECTORY_SEPARATOR . static::EXCEPTION_FILE_NAME . '-' . $lang . '.html';
 		if (!is_file($exceptionFile)) {
-			$exceptionFile = Prado::getFrameworkPath() . '/Exceptions/templates/' . self::EXCEPTION_FILE_NAME . '.html';
+			$exceptionFile = $templatePath . DIRECTORY_SEPARATOR . static::EXCEPTION_FILE_NAME . '.html';
 		}
 		if (($content = @file_get_contents($exceptionFile)) === false) {
 			die("Unable to open exception template file '$exceptionFile'.");
@@ -349,25 +490,24 @@ class TErrorHandler extends \Prado\TModule
 	}
 
 	/**
-	 * Retrieves the template used for displaying external exceptions.
-	 * External exceptions are those displayed to end-users. They do not contain
-	 * error source code. Therefore, you might want to override this method
-	 * to provide your own error template for displaying certain external exceptions.
-	 * The following tokens in the template will be replaced with corresponding content:
-	 * %%StatusCode%% : the status code of the exception
-	 * %%ErrorMessage%% : the error message (HTML encoded).
-	 * %%ErrorCode%% : the exception error code.
-	 * %%ServerAdmin%% : the server admin information (retrieved from Web server configuration)
-	 * %%Version%% : the version information of the Web server.
-	 * %%Time%% : the time the exception occurs at
+	 * Returns the HTML template used for displaying a user-facing error page.
+	 * Selects the most specific available template in priority order:
+	 * error{StatusCode}-{lang}.html, error{StatusCode}.html, error-{lang}.html, error.html.
 	 *
-	 * @param int $statusCode status code (such as 404, 500, etc.)
-	 * @param \Exception $exception the exception to be displayed
-	 * @return string the template content
+	 * Override to supply a custom template for specific status codes.
+	 * The returned content supports these replacement tokens:
+	 * - %%StatusCode%% — HTTP status code
+	 * - %%ErrorMessage%% — HTML-encoded error message
+	 * - %%ErrorCode%% — exception error code
+	 * - %%ServerAdmin%% — server administrator contact (from web server configuration)
+	 * - %%Version%% — web server and PRADO version string (debug mode only)
+	 * - %%Time%% — formatted timestamp of the error
+	 * @param int $statusCode
+	 * @param \Exception $exception
 	 */
-	protected function getErrorTemplate($statusCode, $exception)
+	protected function getErrorTemplate($statusCode, $exception): string
 	{
-		$base = $this->getErrorTemplatePath() . DIRECTORY_SEPARATOR . self::ERROR_FILE_NAME;
+		$base = $this->getErrorTemplatePath() . DIRECTORY_SEPARATOR . static::ERROR_FILE_NAME;
 		$lang = Prado::getPreferredLanguage();
 		if (is_file("$base$statusCode-$lang.html")) {
 			$errorFile = "$base$statusCode-$lang.html";
@@ -384,12 +524,21 @@ class TErrorHandler extends \Prado\TModule
 		return $content;
 	}
 
-	private function getExactTrace($exception)
+	/**
+	 * Returns the most relevant stack frame from an exception's trace.
+	 * For {@see TPhpErrorException}, returns the frame where the PHP error occurred.
+	 * For {@see TInvalidOperationException}, returns the frame that called __get or __set.
+	 * Returns null when no actionable frame is found or the frame is inside eval'd code
+	 * (detected by `": eval()'d code"` in the file path on PHP < 8, or `'function' => 'eval'`
+	 * on PHP 8+).
+	 * @param \Exception $exception
+	 */
+	protected function getExactTrace($exception): ?array
 	{
 		$result = null;
 		if ($exception instanceof TPhpFatalErrorException &&
 			function_exists('xdebug_get_function_stack')) {
-			$trace = array_slice(array_reverse(xdebug_get_function_stack()), self::FATAL_ERROR_TRACE_DROP_LINES, -1);
+			$trace = array_slice(array_reverse(xdebug_get_function_stack()), static::FATAL_ERROR_TRACE_DROP_LINES, -1);
 		} else {
 			$trace = $exception->getTrace();
 		}
@@ -408,18 +557,26 @@ class TErrorHandler extends \Prado\TModule
 				$result = $this->getPropertyAccessTrace($trace, '__set');
 			}
 		}
-		if ($result !== null && strpos($result['file'], ': eval()\'d code') !== false) {
+		if ($result !== null && (
+			strpos($result['file'], ': eval()\'d code') !== false
+			|| (isset($result['function']) && $result['function'] === 'eval')
+		)) {
 			return null;
 		}
 
 		return $result;
 	}
 
-	private function getExactTraceAsString($exception)
+	/**
+	 * Returns the exception stack trace as a string, with private paths sanitized.
+	 * When xdebug is active and the exception is a fatal error, uses the xdebug stack.
+	 * @param \Exception $exception
+	 */
+	protected function getExactTraceAsString($exception): string
 	{
 		if ($exception instanceof TPhpFatalErrorException &&
 			function_exists('xdebug_get_function_stack')) {
-			$trace = array_slice(array_reverse(xdebug_get_function_stack()), self::FATAL_ERROR_TRACE_DROP_LINES, -1);
+			$trace = array_slice(array_reverse(xdebug_get_function_stack()), static::FATAL_ERROR_TRACE_DROP_LINES, -1);
 			$txt = '';
 			$row = 0;
 
@@ -441,7 +598,12 @@ class TErrorHandler extends \Prado\TModule
 		return $this->hidePrivatePathParts($exception->getTraceAsString());
 	}
 
-	private function getPropertyAccessTrace($trace, $pattern)
+	/**
+	 * Scans a trace array for the outermost consecutive frame matching a magic method name.
+	 * @param array $trace
+	 * @param string $pattern
+	 */
+	protected function getPropertyAccessTrace($trace, $pattern): ?array
 	{
 		$result = null;
 		foreach ($trace as $t) {
@@ -454,11 +616,18 @@ class TErrorHandler extends \Prado\TModule
 		return $result;
 	}
 
-	private function getSourceCode($lines, $errorLine)
+	/**
+	 * Returns an HTML fragment showing the source lines surrounding an error line.
+	 * Displays {@see SOURCE_LINES} lines before and after the error line.
+	 * The error line itself is wrapped in a `<div class="error">` element.
+	 * @param null|array $lines
+	 * @param int $errorLine
+	 */
+	protected function getSourceCode($lines, $errorLine): string
 	{
 		$numLines = is_countable($lines) ? count($lines) : 0;
-		$beginLine = $errorLine - self::SOURCE_LINES >= 0 ? $errorLine - self::SOURCE_LINES : 0;
-		$endLine = $errorLine + self::SOURCE_LINES <= $numLines ? $errorLine + self::SOURCE_LINES : $numLines;
+		$beginLine = $errorLine - static::SOURCE_LINES >= 0 ? $errorLine - static::SOURCE_LINES : 0;
+		$endLine = $errorLine + static::SOURCE_LINES <= $numLines ? $errorLine + static::SOURCE_LINES : $numLines;
 
 		$source = '';
 		for ($i = $beginLine; $i < $endLine; ++$i) {
@@ -472,7 +641,11 @@ class TErrorHandler extends \Prado\TModule
 		return $source;
 	}
 
-	private function addLink($message)
+	/**
+	 * Wraps the first recognized Prado class name in the message with a documentation hyperlink.
+	 * @param string $message
+	 */
+	protected function addLink($message): string
 	{
 		if (null !== ($class = $this->getErrorClassNameSpace($message))) {
 			return str_replace($class['name'], '<a href="' . $class['url'] . '" target="_blank">' . $class['name'] . '</a>', $message);
@@ -480,23 +653,110 @@ class TErrorHandler extends \Prado\TModule
 		return $message;
 	}
 
-	private function getErrorClassNameSpace($message)
+	/**
+	 * Extracts the first Prado class name from a message and returns its documentation URL.
+	 * @param string $message
+	 * @return ?array{url: string, name: string} associative array with 'url' and 'name' keys, or null
+	 */
+	protected function getErrorClassNameSpace($message): ?array
 	{
 		$matches = [];
 		preg_match('/\b(T[A-Z]\w+)\b/', $message, $matches);
-		if (is_array($matches) && count($matches) > 0) {
+		if (count($matches) > 0) {
 			$class = $matches[0];
 			try {
-				$function = new \ReflectionClass($class);
+				$reflection = new \ReflectionClass($class);
 			} catch (\Exception $e) {
 				return null;
 			}
-			$classname = $function->getNamespaceName();
+			$classname = $reflection->getNamespaceName();
 			return [
-				'url' => 'http://pradosoft.github.io/docs/manual/class-' . str_replace('\\', '.', (string) $classname) . '.' . $class . '.html',
+				'url' => 'https://pradosoft.github.io/docs/manual/class-' . str_replace('\\', '.', (string) $classname) . '.' . $class . '.html',
 				'name' => $class,
 			];
 		}
 		return null;
+	}
+
+	// ── PHP global-function wrappers (self-encapsulation) ──────────────────────
+
+	/**
+	 * Writes a message to the PHP error log.
+	 * Extracted to allow subclasses to capture or suppress error-log output in
+	 * tests or custom logging integrations without modifying PHP ini settings.
+	 * @param string $message the message to log
+	 * @since 4.3.3
+	 */
+	protected function errorLog(string $message): void
+	{
+		error_log($message);
+	}
+
+	/**
+	 * Returns whether HTTP headers have already been sent.
+	 * Extracted to allow subclasses to mock header state in test environments.
+	 * @return bool true when headers have already been sent
+	 * @since 4.3.3
+	 */
+	protected function headersSent(): bool
+	{
+		return headers_sent();
+	}
+
+	/**
+	 * Wraps PHP's built-in {@see \header()} as a protected seam for unit testing.
+	 * @param string $header        Raw header string, e.g. `X-Frame-Options: DENY`.
+	 * @param bool   $replace       Replace an existing same-name header. Default: `true`.
+	 * @param int    $response_code HTTP response code to force; `0` leaves it unchanged.
+	 * @since 4.3.3
+	 */
+	protected function header(string $header, bool $replace = true, int $response_code = 0): void
+	{
+		header($header, $replace, $response_code);
+	}
+
+	/**
+	 * Restores the previously installed PHP error handler.
+	 * Extracted to allow subclasses to suppress restoration in test environments.
+	 * @since 4.3.3
+	 */
+	protected function restoreErrorHandler(): void
+	{
+		restore_error_handler();
+	}
+
+	/**
+	 * Restores the previously installed PHP exception handler.
+	 * Extracted to allow subclasses to suppress restoration in test environments.
+	 * @see restoreErrorHandler()
+	 * @since 4.3.3
+	 */
+	protected function restoreExceptionHandler(): void
+	{
+		restore_exception_handler();
+	}
+
+	/**
+	 * Returns the PHP SAPI name for the current process.
+	 * Extracted to allow subclasses to override the SAPI check in test environments.
+	 * @return string the SAPI name (e.g. `'cli'`, `'apache2handler'`, `'fpm-fcgi'`)
+	 * @since 4.3.3
+	 */
+	protected function phpSapiName(): string
+	{
+		return php_sapi_name();
+	}
+
+	/**
+	 * Returns a value from the `$_SERVER` superglobal, or null when the key is absent.
+	 * Extracted to allow subclasses to mock server variables in test environments
+	 * without modifying the real superglobal.
+	 * @param string $key the `$_SERVER` key to retrieve (e.g. `'DOCUMENT_ROOT'`)
+	 * @return mixed the value, or null if the key is not set
+	 * @since 4.3.3
+	 */
+	protected function serverGlobal(string $key): mixed
+	{
+		return $_SERVER[$key] ?? null;
 	}
 }

--- a/framework/Exceptions/TExitException.php
+++ b/framework/Exceptions/TExitException.php
@@ -25,10 +25,8 @@ namespace Prado\Exceptions;
  */
 class TExitException extends TSystemException
 {
-	/**
-	 * @var int The exit code
-	 */
-	protected int $_exitCode;
+	/** @var int The exit code. */
+	private int $_exitCode;
 
 	/**
 	 * Constructor.
@@ -38,7 +36,7 @@ class TExitException extends TSystemException
 	 */
 	public function __construct(int $exitCode = 0, ?string $message = null, ...$args)
 	{
-		$this->_exitCode = $exitCode;
+		$this->setExitCodeDirect($exitCode);
 		parent::__construct($message, ...$args);
 	}
 
@@ -47,6 +45,22 @@ class TExitException extends TSystemException
 	 */
 	public function getExitCode(): int
 	{
+		return $this->getExitCodeDirect();
+	}
+
+	/**
+	 * @return int Get exit code property directly.
+	 */
+	protected function getExitCodeDirect(): int
+	{
 		return $this->_exitCode;
+	}
+
+	/**
+	 * @param int $value Set exit code property directly.
+	 */
+	protected function setExitCodeDirect(int $value)
+	{
+		$this->_exitCode = $value;
 	}
 }

--- a/framework/Exceptions/THttpException.php
+++ b/framework/Exceptions/THttpException.php
@@ -22,7 +22,8 @@ namespace Prado\Exceptions;
  */
 class THttpException extends TSystemException
 {
-	private $_statusCode;
+	/** @var int The status code. */
+	private int $_statusCode;
 
 	/**
 	 * Constructor.
@@ -32,18 +33,35 @@ class THttpException extends TSystemException
 	 * will be used as the error message. Any rest parameters will be used
 	 * to replace placeholders ({0}, {1}, {2}, etc.) in the message.
 	 * @param array $args
+	 * @todo v4.4, add type to $statusCode param
 	 */
 	public function __construct($statusCode, $errorMessage, ...$args)
 	{
-		$this->_statusCode = $statusCode;
+		$this->setStatusCodeDirect((int) $statusCode);
 		parent::__construct($errorMessage, ...$args);
 	}
 
 	/**
 	 * @return int HTTP status code, such as 404, 500, etc.
 	 */
-	public function getStatusCode()
+	public function getStatusCode(): int
+	{
+		return $this->getStatusCodeDirect();
+	}
+
+	/**
+	 * @return int Get HTTP status code property directly.
+	 */
+	protected function getStatusCodeDirect(): int
 	{
 		return $this->_statusCode;
+	}
+
+	/**
+	 * @param int $value Set HTTP status code property directly.
+	 */
+	protected function setStatusCodeDirect(int $value)
+	{
+		$this->_statusCode = $value;
 	}
 }

--- a/tests/unit/Exceptions/TErrorHandlerTest.php
+++ b/tests/unit/Exceptions/TErrorHandlerTest.php
@@ -1,45 +1,1653 @@
 <?php
 
+/**
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
 use Prado\Exceptions\TErrorHandler;
-use Prado\Prado;
 use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\THttpException;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\Exceptions\TPhpErrorException;
+use Prado\Prado;
+use Prado\TApplicationMode;
 
 /**
- * Tests for TErrorHandler small, isolated behaviors.
+ * Global class whose short name matches T[A-Z]\w+ so that
+ * getErrorClassNameSpace() can resolve it via ReflectionClass without a namespace.
+ */
+if (!class_exists('TErrorHandlerTestGlobalClass', false)) {
+	class TErrorHandlerTestGlobalClass
+	{
+	}
+}
+
+/**
+ * Exposes all protected methods of TErrorHandler for unit testing.
+ * All wrappers call the protected methods directly — no reflection needed since
+ * the methods were promoted to protected in 4.3.3.
+ *
+ * Overrides errorLog(), headersSent(), and header() to capture calls and
+ * suppress side-effects (stderr noise, real header emission) during tests.
+ */
+class TErrorHandlerAccessor extends TErrorHandler
+{
+	// ── Captured / fake state for UAP-SE helper overrides ────────────────────
+
+	/** @var string|null the last message passed to errorLog(), or null if not called */
+	public ?string $capturedErrorLog = null;
+
+	/** @var bool|null when non-null, headersSent() returns this value instead of headers_sent() */
+	public ?bool $fakeHeadersSent = null;
+
+	/** @var string[] all values passed to header() calls during the test */
+	public array $capturedHeaders = [];
+
+	/** @var bool tracks whether restoreErrorHandler() was called during the test */
+	public bool $restoreErrorHandlerCalled = false;
+
+	/** @var bool tracks whether restoreExceptionHandler() was called during the test */
+	public bool $restoreExceptionHandlerCalled = false;
+
+	/** @var string|null when non-null, phpSapiName() returns this value instead of php_sapi_name() */
+	public ?string $fakePhpSapiName = null;
+
+	protected function errorLog(string $message): void
+	{
+		$this->capturedErrorLog = $message;
+	}
+
+	protected function headersSent(): bool
+	{
+		return $this->fakeHeadersSent ?? parent::headersSent();
+	}
+
+	protected function header(string $header, bool $replace = true, int $response_code = 0): void
+	{
+		$this->capturedHeaders[] = $header;
+	}
+
+	protected function restoreErrorHandler(): void
+	{
+		$this->restoreErrorHandlerCalled = true;
+	}
+
+	protected function restoreExceptionHandler(): void
+	{
+		$this->restoreExceptionHandlerCalled = true;
+	}
+
+	protected function phpSapiName(): string
+	{
+		return $this->fakePhpSapiName ?? parent::phpSapiName();
+	}
+
+	/**
+	 * Returns null so that handleRecursiveError() always takes the
+	 * `$this->header()` branch rather than `$response->appendHeader()`.
+	 * This prevents the live THttpResponse (which opens output buffers
+	 * for compression) from being touched during recursive-error tests,
+	 * and ensures capturedHeaders is populated by the overridden header().
+	 */
+	public function getResponse(): ?\Prado\Web\THttpResponse
+	{
+		return null;
+	}
+
+	// ── Public wrappers for testing the base helper implementations ──────────
+
+	public function pubErrorLog(string $message): void
+	{
+		// Call the real (parent) implementation — used to verify it delegates to error_log().
+		parent::errorLog($message);
+	}
+
+	public function pubHeadersSent(): bool
+	{
+		return parent::headersSent();
+	}
+
+	public function pubHeader(string $header, bool $replace = true, int $response_code = 0): void
+	{
+		// In CLI tests headers_sent() is always false, so header() would fire.
+		// Call via parent to exercise the real path without the override.
+		parent::header($header, $replace, $response_code);
+	}
+
+	public function pubRestoreErrorHandler(): void
+	{
+		parent::restoreErrorHandler();
+	}
+
+	public function pubRestoreExceptionHandler(): void
+	{
+		parent::restoreExceptionHandler();
+	}
+
+	public function pubPhpSapiName(): string
+	{
+		return parent::phpSapiName();
+	}
+
+	public function pubServerGlobal(string $key): mixed
+	{
+		return parent::serverGlobal($key);
+	}
+
+	// ── Compatibility shims used by template-path tests ──────────────────────
+
+	/** Writes directly to the backing field via the new Direct setter. */
+	public function setRawTemplatePath(?string $path): void
+	{
+		$this->setErrorTemplatePathDirect($path);
+	}
+
+	/** Reads the raw backing field via the new Direct getter. */
+	public function getRawTemplatePath(): ?string
+	{
+		return $this->getErrorTemplatePathDirect();
+	}
+
+	// ── New Direct accessor wrappers (4.3.3) ─────────────────────────────────
+
+	public function pubGetPrivatePathReplacementsDirect(): ?array
+	{
+		return $this->getPrivatePathReplacementsDirect();
+	}
+
+	public function pubSetPrivatePathReplacementsDirect(?array $value): void
+	{
+		$this->setPrivatePathReplacementsDirect($value);
+	}
+
+	public function pubGetPrivatePathReplacements(): array
+	{
+		return $this->getPrivatePathReplacements();
+	}
+
+	public function pubGetErrorTemplatePathDirect(): ?string
+	{
+		return $this->getErrorTemplatePathDirect();
+	}
+
+	public function pubSetErrorTemplatePathDirect(?string $value): void
+	{
+		$this->setErrorTemplatePathDirect($value);
+	}
+
+	public function pubSetAppErrorHandler(): void
+	{
+		$this->setAppErrorHandler();
+	}
+
+	// ── Protected method wrappers (direct calls, no reflection) ──────────────
+
+	public function pubGetDefaultErrorTemplatePath(): string
+	{
+		return $this->getDefaultErrorTemplatePath();
+	}
+
+	public function pubGetSourceCode($lines, int $errorLine): string
+	{
+		return $this->getSourceCode($lines, $errorLine);
+	}
+
+	public function pubGetErrorTemplate(int $statusCode, \Exception $exception): string
+	{
+		return $this->getErrorTemplate($statusCode, $exception);
+	}
+
+	public function pubGetExceptionTemplate(\Exception $exception): string
+	{
+		return $this->getExceptionTemplate($exception);
+	}
+
+	public function pubGetErrorClassNameSpace(string $message): ?array
+	{
+		return $this->getErrorClassNameSpace($message);
+	}
+
+	public function pubAddLink(string $message): string
+	{
+		return $this->addLink($message);
+	}
+
+	public function pubGetPropertyAccessTrace(array $trace, string $pattern): ?array
+	{
+		return $this->getPropertyAccessTrace($trace, $pattern);
+	}
+
+	public function pubHidePrivatePathParts(string $value): string
+	{
+		return $this->hidePrivatePathParts($value);
+	}
+
+	public function pubHideSecurityRelated(string $value, ?\Exception $exception = null): string
+	{
+		return $this->hideSecurityRelated($value, $exception);
+	}
+
+	public function pubGetExactTrace(\Exception $exception): ?array
+	{
+		return $this->getExactTrace($exception);
+	}
+
+	public function pubGetExactTraceAsString(\Exception $exception): string
+	{
+		return $this->getExactTraceAsString($exception);
+	}
+
+	public function pubHandleRecursiveError(\Exception $exception): void
+	{
+		$this->handleRecursiveError($exception);
+	}
+
+	public function pubDisplayException(\Exception $exception): void
+	{
+		parent::displayException($exception);
+	}
+
+	// ── Captured dispatch state — set by no-op overrides used in handleError() tests
+
+	public ?int $capturedExternalErrorStatusCode = null;
+	public bool $displayExceptionCalled = false;
+	public bool $handleExternalErrorEnabled = false; // set true to run real implementation
+	public bool $displayExceptionEnabled = false;    // set true to run real implementation
+
+	protected function handleExternalError($statusCode, $exception): void
+	{
+		$this->capturedExternalErrorStatusCode = $statusCode;
+		if ($this->handleExternalErrorEnabled) {
+			parent::handleExternalError($statusCode, $exception);
+		}
+	}
+
+	protected function displayException($exception): void
+	{
+		$this->displayExceptionCalled = true;
+		if ($this->displayExceptionEnabled) {
+			parent::displayException($exception);
+		}
+	}
+
+	public function pubHandleError(mixed $sender, \Throwable $param): void
+	{
+		$this->handleError($sender, $param);
+	}
+
+	public function pubGetIsHandled(): bool
+	{
+		return $this->getIsHandled();
+	}
+
+	public function pubSetIsHandled(bool $value): void
+	{
+		$this->setIsHandled($value);
+	}
+
+	public function resetHandling(): void
+	{
+		// Resets the instance handling flag so handleError() can be called again in tests.
+		$this->setIsHandled(false);
+	}
+}
+
+/**
+ * Comprehensive tests for {@see TErrorHandler}: constants, module init,
+ * Direct accessor methods, template path lazy-init and validation, source code
+ * formatting, template priority fallbacks, security-related path hiding,
+ * class namespace resolution, link injection, property-access trace filtering,
+ * exact-trace extraction, trace-as-string formatting, CLI display, and
+ * recursive error handling.
  */
 class TErrorHandlerTest extends PHPUnit\Framework\TestCase
 {
-    public function testDefaultErrorTemplatePath()
-    {
-        $handler = new TErrorHandler();
-        $path = $handler->getErrorTemplatePath();
-        $this->assertIsString($path);
-        $this->assertStringEndsWith('/Exceptions/templates', $path);
-    }
+	private TErrorHandlerAccessor $handler;
 
-    public function testSetErrorTemplatePathInvalidThrows()
-    {
-        $handler = new TErrorHandler();
-        $this->expectException(TConfigurationException::class);
-        // Intentionally invalid namespace to trigger exception
-        $handler->setErrorTemplatePath('Prado\NonExistentNamespace\ThatDoesNotExist');
-    }
+	protected function setUp(): void
+	{
+		$this->handler = new TErrorHandlerAccessor();
+	}
 
-    public function testSetErrorTemplatePathValidNoException()
-    {
-        $handler = new TErrorHandler();
-        // Should not throw for a valid framework namespace; this should resolve to a real path
-        $handler->setErrorTemplatePath('Prado\\Exceptions');
-        $expectedPath = Prado::getPathOfNamespace('Prado\\Exceptions');
-        $this->assertEquals($expectedPath, $handler->getErrorTemplatePath());
-    }
+	// ── Constants ─────────────────────────────────────────────────────────────
 
-    public function testErrorTemplatePathGetterAfterSetter()
-    {
-        $handler = new TErrorHandler();
-        // Resolve namespace path using Prado helper
-        $expected = Prado::getPathOfNamespace('Prado\\Exceptions');
-        $handler->setErrorTemplatePath('Prado\\Exceptions');
-        $this->assertEquals($expected, $handler->getErrorTemplatePath());
-    }
+	public function testConstantErrorFileName(): void
+	{
+		$this->assertSame('error', TErrorHandler::ERROR_FILE_NAME);
+	}
+
+	public function testConstantExceptionFileName(): void
+	{
+		$this->assertSame('exception', TErrorHandler::EXCEPTION_FILE_NAME);
+	}
+
+	public function testConstantSourceLines(): void
+	{
+		$this->assertSame(12, TErrorHandler::SOURCE_LINES);
+	}
+
+	public function testConstantFatalErrorTraceDropLines(): void
+	{
+		$this->assertSame(5, TErrorHandler::FATAL_ERROR_TRACE_DROP_LINES);
+	}
+
+	// ── setAppErrorHandler ────────────────────────────────────────────────────
+
+	public function testSetAppErrorHandlerRegistersHandlerWithApplication(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$original = $app->getErrorHandler();
+		$this->handler->pubSetAppErrorHandler();
+		$this->assertSame($this->handler, $app->getErrorHandler());
+		$app->setErrorHandler($original);
+	}
+
+	public function testSetAppErrorHandlerCanBeCalledRepeatedly(): void
+	{
+		// Must not throw regardless of application state
+		$this->handler->pubSetAppErrorHandler();
+		$this->handler->pubSetAppErrorHandler();
+		$this->addToAssertionCount(1);
+	}
+
+	// ── init ──────────────────────────────────────────────────────────────────
+
+	public function testInitRegistersHandlerWithApplication(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$original = $app->getErrorHandler();
+		$fresh = new TErrorHandlerAccessor();
+		$fresh->init(null);
+		$this->assertSame($fresh, $app->getErrorHandler());
+		$app->setErrorHandler($original);
+	}
+
+	// ── getDefaultErrorTemplatePath ───────────────────────────────────────────
+
+	public function testGetDefaultErrorTemplatePath(): void
+	{
+		$expected = Prado::getFrameworkPath() . '/Exceptions/templates';
+		$this->assertSame($expected, $this->handler->pubGetDefaultErrorTemplatePath());
+	}
+
+	public function testGetDefaultErrorTemplatePathPointsToExistingDirectory(): void
+	{
+		$path = $this->handler->pubGetDefaultErrorTemplatePath();
+		$this->assertStringEndsWith('/Exceptions/templates', $path);
+		$this->assertTrue(is_dir($path), 'Default template directory must exist on disk');
+	}
+
+	// ── Direct private-path-replacement accessors (4.3.3) ─────────────────────
+
+	public function testGetPrivatePathReplacementsDirectReturnsNullBeforeFirstBuild(): void
+	{
+		$fresh = new TErrorHandlerAccessor();
+		$this->assertNull($fresh->pubGetPrivatePathReplacementsDirect());
+	}
+
+	public function testSetGetPrivatePathReplacementsDirectRoundTrip(): void
+	{
+		$map = ['/secret/' => '${hidden}/'];
+		$this->handler->pubSetPrivatePathReplacementsDirect($map);
+		$this->assertSame($map, $this->handler->pubGetPrivatePathReplacementsDirect());
+	}
+
+	public function testSetPrivatePathReplacementsDirectAcceptsNull(): void
+	{
+		$this->handler->pubSetPrivatePathReplacementsDirect(['a' => 'b']);
+		$this->handler->pubSetPrivatePathReplacementsDirect(null);
+		$this->assertNull($this->handler->pubGetPrivatePathReplacementsDirect());
+	}
+
+	public function testGetPrivatePathReplacementsBuildsMapOnFirstCall(): void
+	{
+		$fresh = new TErrorHandlerAccessor();
+		$this->assertNull($fresh->pubGetPrivatePathReplacementsDirect());
+		$map = $fresh->pubGetPrivatePathReplacements();
+		$this->assertIsArray($map);
+		$this->assertNotEmpty($map);
+		// After the call the Direct getter must return the built map
+		$this->assertNotNull($fresh->pubGetPrivatePathReplacementsDirect());
+	}
+
+	public function testGetPrivatePathReplacementsIsCachedAcrossCalls(): void
+	{
+		$first  = $this->handler->pubGetPrivatePathReplacements();
+		$second = $this->handler->pubGetPrivatePathReplacements();
+		$this->assertSame($first, $second);
+	}
+
+	public function testGetPrivatePathReplacementsContainsPradoFrameworkEntry(): void
+	{
+		$map = $this->handler->pubGetPrivatePathReplacements();
+		$this->assertContains('${PradoFramework}' . DIRECTORY_SEPARATOR, $map);
+	}
+
+	public function testGetPrivatePathReplacementsContainsDocumentRootEntry(): void
+	{
+		$docRoot = $_SERVER['DOCUMENT_ROOT'] ?? '';
+		if ($docRoot === '') {
+			$this->markTestSkipped('DOCUMENT_ROOT is empty in this environment.');
+		}
+		$map = $this->handler->pubGetPrivatePathReplacements();
+		$this->assertContains('${DocumentRoot}', $map);
+	}
+
+	// ── Direct template-path accessors (4.3.3) ────────────────────────────────
+
+	public function testGetErrorTemplatePathDirectReturnsNullBeforeAnySet(): void
+	{
+		$fresh = new TErrorHandlerAccessor();
+		$this->assertNull($fresh->pubGetErrorTemplatePathDirect());
+	}
+
+	public function testSetGetErrorTemplatePathDirectRoundTrip(): void
+	{
+		$path = sys_get_temp_dir();
+		$this->handler->pubSetErrorTemplatePathDirect($path);
+		$this->assertSame($path, $this->handler->pubGetErrorTemplatePathDirect());
+	}
+
+	public function testSetErrorTemplatePathDirectAcceptsNull(): void
+	{
+		$this->handler->pubSetErrorTemplatePathDirect('/some/path');
+		$this->handler->pubSetErrorTemplatePathDirect(null);
+		$this->assertNull($this->handler->pubGetErrorTemplatePathDirect());
+	}
+
+	// ── getErrorTemplatePath lazy-init ────────────────────────────────────────
+
+	public function testGetErrorTemplatePathRawFieldIsNullBeforeFirstCall(): void
+	{
+		$fresh = new TErrorHandlerAccessor();
+		$this->assertNull($fresh->getRawTemplatePath());
+	}
+
+	public function testGetErrorTemplatePathLazyInitOnFirstCall(): void
+	{
+		$fresh = new TErrorHandlerAccessor();
+		$path = $fresh->getErrorTemplatePath();
+		$this->assertNotNull($fresh->getRawTemplatePath());
+		$this->assertSame($path, $fresh->getRawTemplatePath());
+	}
+
+	public function testGetErrorTemplatePathDefaultsToFrameworkTemplates(): void
+	{
+		$fresh = new TErrorHandlerAccessor();
+		$this->assertStringEndsWith('/Exceptions/templates', $fresh->getErrorTemplatePath());
+	}
+
+	public function testGetErrorTemplatePathReturnsSameValueOnRepeatedCalls(): void
+	{
+		$first  = $this->handler->getErrorTemplatePath();
+		$second = $this->handler->getErrorTemplatePath();
+		$this->assertSame($first, $second);
+	}
+
+	// ── setErrorTemplatePath ──────────────────────────────────────────────────
+
+	public function testSetErrorTemplatePathValidNamespaceUpdatesGetter(): void
+	{
+		$this->handler->setErrorTemplatePath('Prado\\Exceptions');
+		$expected = Prado::getPathOfNamespace('Prado\\Exceptions');
+		$this->assertSame($expected, $this->handler->getErrorTemplatePath());
+	}
+
+	public function testSetErrorTemplatePathStoresResolvedFilesystemPath(): void
+	{
+		$this->handler->setErrorTemplatePath('Prado\\Exceptions');
+		$path = $this->handler->getErrorTemplatePath();
+		$this->assertTrue(is_dir($path), 'Stored path must be an existing directory');
+		$this->assertNotSame('Prado\\Exceptions', $path, 'Path must be resolved to a filesystem path, not stored as a namespace string');
+	}
+
+	public function testSetErrorTemplatePathInvalidNamespaceThrows(): void
+	{
+		$this->expectException(TConfigurationException::class);
+		$this->handler->setErrorTemplatePath('Prado\NonExistentNamespace\ThatDoesNotExist');
+	}
+
+	public function testSetErrorTemplatePathToClassNamespaceThrowsBecauseNotADirectory(): void
+	{
+		// A class-level namespace resolves to a file, not a directory → throws
+		$this->expectException(TConfigurationException::class);
+		$this->handler->setErrorTemplatePath('Prado\\Exceptions\\TErrorHandler');
+	}
+
+	// ── getSourceCode ─────────────────────────────────────────────────────────
+
+	public function testGetSourceCodeNullLinesReturnsEmpty(): void
+	{
+		$this->assertSame('', $this->handler->pubGetSourceCode(null, 5));
+	}
+
+	public function testGetSourceCodeEmptyArrayReturnsEmpty(): void
+	{
+		$this->assertSame('', $this->handler->pubGetSourceCode([], 5));
+	}
+
+	public function testGetSourceCodeZeroErrorLineProducesNoHighlight(): void
+	{
+		// errorLine=0: the highlight condition ($i === $errorLine - 1 = -1) never fires
+		$lines  = ["line1\n", "line2\n", "line3\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 0);
+		$this->assertStringNotContainsString('<div class="error">', $result);
+		$this->assertStringContainsString('line1', $result);
+		$this->assertStringContainsString('line3', $result);
+	}
+
+	public function testGetSourceCodeErrorLineIsHighlighted(): void
+	{
+		$lines  = ["first\n", "second\n", "third\n", "fourth\n", "fifth\n"];
+		// errorLine=3 (1-indexed) → $i=2 receives the error div
+		$result = $this->handler->pubGetSourceCode($lines, 3);
+		$this->assertStringContainsString('<div class="error">', $result);
+		$this->assertMatchesRegularExpression('/<div class="error">[^<]*third[^<]*<\/div>/', $result);
+	}
+
+	public function testGetSourceCodeNonErrorLinesAreNotHighlighted(): void
+	{
+		$lines  = ["first\n", "second\n", "third\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 2);
+		$this->assertMatchesRegularExpression('/<div class="error">[^<]*second[^<]*<\/div>/', $result);
+		$this->assertDoesNotMatchRegularExpression('/<div class="error">[^<]*first[^<]*<\/div>/', $result);
+		$this->assertDoesNotMatchRegularExpression('/<div class="error">[^<]*third[^<]*<\/div>/', $result);
+	}
+
+	public function testGetSourceCodeTabsReplacedWithFourSpaces(): void
+	{
+		$lines  = ["\tindented code\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 1);
+		$this->assertStringContainsString('    indented code', $result);
+		$this->assertStringNotContainsString("\t", $result);
+	}
+
+	public function testGetSourceCodeHtmlSpecialCharsAreEscaped(): void
+	{
+		$lines  = ["<script>alert('xss')</script>\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 1);
+		$this->assertStringNotContainsString('<script>', $result);
+		$this->assertStringContainsString('&lt;script&gt;', $result);
+	}
+
+	public function testGetSourceCodeAmpersandIsEscaped(): void
+	{
+		$lines  = ["foo & bar\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 1);
+		$this->assertStringContainsString('foo &amp; bar', $result);
+	}
+
+	public function testGetSourceCodeLineNumbersAreZeroPadded(): void
+	{
+		$lines  = ["first line\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 1);
+		$this->assertMatchesRegularExpression('/0001:/', $result);
+	}
+
+	public function testGetSourceCodeLargeLineNumbersZeroPadded(): void
+	{
+		// 25 lines; errorLine=14 puts lines 3–25 in the window
+		$lines  = array_map(fn($i) => "line$i\n", range(1, 25));
+		$result = $this->handler->pubGetSourceCode($lines, 14);
+		$this->assertMatchesRegularExpression('/0010:/', $result);
+		$this->assertMatchesRegularExpression('/0003:/', $result);
+	}
+
+	public function testGetSourceCodeWindowClampsAtFileStart(): void
+	{
+		// SOURCE_LINES=12; errorLine=3 → beginLine = max(0, 3-12) = 0 → line 1 included
+		$lines  = array_map(fn($i) => "line$i\n", range(1, 5));
+		$result = $this->handler->pubGetSourceCode($lines, 3);
+		$this->assertStringContainsString('line1', $result);
+	}
+
+	public function testGetSourceCodeWindowClampsAtFileEnd(): void
+	{
+		// SOURCE_LINES=12; 3-line file, errorLine=2 → endLine = min(3, 14) = 3
+		$lines  = array_map(fn($i) => "line$i\n", range(1, 3));
+		$result = $this->handler->pubGetSourceCode($lines, 2);
+		$this->assertStringContainsString('line3', $result);
+	}
+
+	public function testGetSourceCodeLinesOutsideWindowAreExcluded(): void
+	{
+		// SOURCE_LINES=12; errorLine=50 in a 100-line file
+		// beginLine = 50-12 = 38 (0-indexed) → first shown = line 39 (1-indexed)
+		// endLine   = 50+12 = 62             → last shown  = line 62
+		$lines  = array_map(fn($i) => "ln$i\n", range(1, 100));
+		$result = $this->handler->pubGetSourceCode($lines, 50);
+		$this->assertStringNotContainsString('0001: ln1', $result);   // before window
+		$this->assertStringContainsString('0039: ln39', $result);     // first in window
+		$this->assertStringContainsString('0062: ln62', $result);     // last in window
+		$this->assertStringNotContainsString('0063: ln63', $result);  // after window
+	}
+
+	public function testGetSourceCodeErrorLineWayBeyondFileReturnsEmpty(): void
+	{
+		// errorLine=99 in a 1-line file:
+		// beginLine = max(0, 99-12) = 87; endLine = min(1, 111) = 1
+		// 87 > 1 → loop body never executes → empty string
+		$lines  = ["only one line\n"];
+		$result = $this->handler->pubGetSourceCode($lines, 99);
+		$this->assertSame('', $result);
+	}
+
+	public function testGetSourceCodeErrorLineBeyondFileShowsAllLinesWithoutHighlight(): void
+	{
+		// errorLine=10, 5-line file → beginLine=0, endLine=5, $i===9 never fires
+		$lines  = array_map(fn($i) => "line$i\n", range(1, 5));
+		$result = $this->handler->pubGetSourceCode($lines, 10);
+		$this->assertStringContainsString('line1', $result);
+		$this->assertStringContainsString('line5', $result);
+		$this->assertStringNotContainsString('<div class="error">', $result);
+	}
+
+	// ── getErrorTemplate priority ─────────────────────────────────────────────
+
+	/**
+	 * @param array<string,string> $files filename → content map
+	 */
+	private function makeTempTemplateDir(array $files): string
+	{
+		$tmpDir = sys_get_temp_dir() . '/prado_errtest_' . uniqid('', true);
+		mkdir($tmpDir, 0700, true);
+		foreach ($files as $name => $content) {
+			file_put_contents($tmpDir . '/' . $name, $content);
+		}
+		return $tmpDir;
+	}
+
+	private function cleanTempDir(string $dir): void
+	{
+		foreach (glob($dir . '/*') ?: [] as $f) {
+			unlink($f);
+		}
+		rmdir($dir);
+	}
+
+	public function testGetErrorTemplateStatusCodeAndLangHasHighestPriority(): void
+	{
+		$lang   = Prado::getPreferredLanguage();
+		$tmpDir = $this->makeTempTemplateDir([
+			"error404-{$lang}.html" => 'priority1',
+			'error404.html'         => 'priority2',
+			"error-{$lang}.html"    => 'priority3',
+			'error.html'            => 'priority4',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetErrorTemplate(404, new \Exception('test'));
+		$this->assertSame('priority1', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	public function testGetErrorTemplateStatusCodeOnlyFallback(): void
+	{
+		$lang   = Prado::getPreferredLanguage();
+		$tmpDir = $this->makeTempTemplateDir([
+			'error404.html'      => 'priority2',
+			"error-{$lang}.html" => 'priority3',
+			'error.html'         => 'priority4',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetErrorTemplate(404, new \Exception('test'));
+		$this->assertSame('priority2', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	public function testGetErrorTemplateLangOnlyFallback(): void
+	{
+		$lang   = Prado::getPreferredLanguage();
+		$tmpDir = $this->makeTempTemplateDir([
+			"error-{$lang}.html" => 'priority3',
+			'error.html'         => 'priority4',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetErrorTemplate(404, new \Exception('test'));
+		$this->assertSame('priority3', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	public function testGetErrorTemplateDefaultFallback(): void
+	{
+		$tmpDir = $this->makeTempTemplateDir(['error.html' => 'default-content']);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetErrorTemplate(404, new \Exception('test'));
+		$this->assertSame('default-content', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	public function testGetErrorTemplateDifferentStatusCodesSelectDifferentFiles(): void
+	{
+		$tmpDir = $this->makeTempTemplateDir([
+			'error404.html' => 'not-found',
+			'error500.html' => 'server-error',
+			'error.html'    => 'default',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$this->assertSame('not-found',    $this->handler->pubGetErrorTemplate(404, new \Exception()));
+		$this->assertSame('server-error', $this->handler->pubGetErrorTemplate(500, new \Exception()));
+		$this->assertSame('default',      $this->handler->pubGetErrorTemplate(403, new \Exception()));
+		$this->cleanTempDir($tmpDir);
+	}
+
+	// ── getExceptionTemplate ──────────────────────────────────────────────────
+
+	public function testGetExceptionTemplateReturnsNonEmptyString(): void
+	{
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertIsString($content);
+		$this->assertNotEmpty($content);
+	}
+
+	public function testGetExceptionTemplateContainsErrorTypeToken(): void
+	{
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertStringContainsString('%%ErrorType%%', $content);
+	}
+
+	public function testGetExceptionTemplateContainsErrorMessageToken(): void
+	{
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertStringContainsString('%%ErrorMessage%%', $content);
+	}
+
+	public function testGetExceptionTemplateIsHtml(): void
+	{
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertStringContainsString('<html', $content);
+	}
+
+	public function testGetExceptionTemplateRespectsCustomTemplatePath(): void
+	{
+		// After the getExceptionTemplate() bug fix, setErrorTemplatePath() now
+		// affects the exception template as well as the error template.
+		$tmpDir = $this->makeTempTemplateDir([
+			'exception.html' => 'custom-exception-template',
+			'error.html'     => 'custom-error-template',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertSame('custom-exception-template', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	public function testGetExceptionTemplateLanguageSpecificVariantHasPriority(): void
+	{
+		$lang   = Prado::getPreferredLanguage();
+		$tmpDir = $this->makeTempTemplateDir([
+			"exception-{$lang}.html" => 'lang-specific-exception',
+			'exception.html'         => 'default-exception',
+			'error.html'             => 'error-placeholder',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertSame('lang-specific-exception', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	public function testGetExceptionTemplateFallsBackToDefaultWhenNoLanguageVariant(): void
+	{
+		$tmpDir = $this->makeTempTemplateDir([
+			'exception.html' => 'fallback-exception',
+			'error.html'     => 'error-placeholder',
+		]);
+		$this->handler->setRawTemplatePath($tmpDir);
+
+		$content = $this->handler->pubGetExceptionTemplate(new \Exception('test'));
+		$this->assertSame('fallback-exception', $content);
+		$this->cleanTempDir($tmpDir);
+	}
+
+	// ── hideSecurityRelated ──────────────────────────────────────────────────
+
+	public function testHideSecurityRelatedReplacesPradoDir(): void
+	{
+		$value  = 'Framework at ' . PRADO_DIR . DIRECTORY_SEPARATOR . 'TApplication.php';
+		$result = $this->handler->pubHideSecurityRelated($value);
+		$this->assertStringNotContainsString(PRADO_DIR . DIRECTORY_SEPARATOR, $result);
+		$this->assertStringContainsString('${PradoFramework}', $result);
+	}
+
+	public function testHideSecurityRelatedReplacesDocumentRoot(): void
+	{
+		$docRoot = $_SERVER['DOCUMENT_ROOT'] ?? '';
+		if ($docRoot === '') {
+			$this->markTestSkipped('DOCUMENT_ROOT is empty in this environment.');
+		}
+		$value  = 'File: ' . $docRoot . '/index.php';
+		$result = $this->handler->pubHideSecurityRelated($value);
+		$this->assertStringNotContainsString($docRoot, $result);
+		$this->assertStringContainsString('${DocumentRoot}', $result);
+	}
+
+	public function testHideSecurityRelatedReplacesTraceDirs(): void
+	{
+		$exception = new \Exception('test');
+		$trace     = $exception->getTrace();
+		if (empty($trace) || !isset($trace[0]['file'])) {
+			$this->markTestSkipped('Exception trace has no file entries.');
+		}
+		$traceFile = $trace[0]['file'];
+		$traceDir  = dirname($traceFile) . DIRECTORY_SEPARATOR;
+		$value     = 'Occurred in ' . $traceDir . basename($traceFile);
+
+		$result = $this->handler->pubHideSecurityRelated($value, $exception);
+		$this->assertStringNotContainsString($traceDir, $result);
+		$this->assertStringContainsString('<hidden>', $result);
+	}
+
+	public function testHideSecurityRelatedWithNullExceptionSkipsTraceDirs(): void
+	{
+		// No exception → only PRADO_DIR and DOCUMENT_ROOT are replaced
+		$value  = 'plain message with no sensitive paths';
+		$result = $this->handler->pubHideSecurityRelated($value, null);
+		$this->assertSame($value, $result);
+	}
+
+	public function testHideSecurityRelatedWithPlainStringReturnsUnchanged(): void
+	{
+		$value  = 'A plain message with no paths at all';
+		$result = $this->handler->pubHideSecurityRelated($value);
+		$this->assertSame($value, $result);
+	}
+
+	// ── hidePrivatePathParts (instance-cached) ────────────────────────────────
+
+	public function testHidePrivatePathPartsReplacesPradoDir(): void
+	{
+		$value  = 'In ' . PRADO_DIR . DIRECTORY_SEPARATOR . 'TComponent.php';
+		$result = $this->handler->pubHidePrivatePathParts($value);
+		$this->assertStringNotContainsString(PRADO_DIR . DIRECTORY_SEPARATOR, $result);
+		$this->assertStringContainsString('${PradoFramework}', $result);
+	}
+
+	public function testHidePrivatePathPartsReplacesDocumentRoot(): void
+	{
+		$docRoot = $_SERVER['DOCUMENT_ROOT'] ?? '';
+		if ($docRoot === '') {
+			$this->markTestSkipped('DOCUMENT_ROOT is empty in this environment.');
+		}
+		$value  = 'Path: ' . $docRoot . '/index.php';
+		$result = $this->handler->pubHidePrivatePathParts($value);
+		$this->assertStringNotContainsString($docRoot, $result);
+		$this->assertStringContainsString('${DocumentRoot}', $result);
+	}
+
+	public function testHidePrivatePathPartsCacheProducesConsistentResults(): void
+	{
+		// The replacement map is built once and cached on the instance.
+		$value  = PRADO_DIR . DIRECTORY_SEPARATOR . 'framework.php';
+		$first  = $this->handler->pubHidePrivatePathParts($value);
+		$second = $this->handler->pubHidePrivatePathParts($value);
+		$this->assertSame($first, $second);
+	}
+
+	public function testHidePrivatePathPartsPlainStringIsUnchanged(): void
+	{
+		$value  = 'nothing sensitive here';
+		$result = $this->handler->pubHidePrivatePathParts($value);
+		$this->assertSame($value, $result);
+	}
+
+	public function testHidePrivatePathPartsCacheCanBeCleared(): void
+	{
+		// Clearing the cached map via the Direct setter causes a rebuild on next call
+		$this->handler->pubHidePrivatePathParts('warm up');
+		$this->assertNotNull($this->handler->pubGetPrivatePathReplacementsDirect());
+
+		$this->handler->pubSetPrivatePathReplacementsDirect(null);
+		$this->assertNull($this->handler->pubGetPrivatePathReplacementsDirect());
+
+		// Calling hidePrivatePathParts again rebuilds the cache
+		$this->handler->pubHidePrivatePathParts('trigger rebuild');
+		$this->assertNotNull($this->handler->pubGetPrivatePathReplacementsDirect());
+	}
+
+	// ── getErrorClassNameSpace ────────────────────────────────────────────────
+
+	public function testGetErrorClassNameSpaceNoTClassReturnsNull(): void
+	{
+		$this->assertNull($this->handler->pubGetErrorClassNameSpace('No class name here at all'));
+	}
+
+	public function testGetErrorClassNameSpaceNonExistentClassReturnsNull(): void
+	{
+		// TFakeClassThatWillNotExistXyz123 → ReflectionClass throws → returns null
+		$this->assertNull(
+			$this->handler->pubGetErrorClassNameSpace('Error involving TFakeClassThatWillNotExistXyz123')
+		);
+	}
+
+	public function testGetErrorClassNameSpaceRequiresUppercaseTPrefix(): void
+	{
+		// 'tLowercase' does not match \b(T[A-Z]\w+)\b
+		$this->assertNull(
+			$this->handler->pubGetErrorClassNameSpace('problem in tLowercaseClass here')
+		);
+	}
+
+	public function testGetErrorClassNameSpaceResolvesGlobalClass(): void
+	{
+		$result = $this->handler->pubGetErrorClassNameSpace('Error in TErrorHandlerTestGlobalClass was thrown');
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('url', $result);
+		$this->assertArrayHasKey('name', $result);
+		$this->assertSame('TErrorHandlerTestGlobalClass', $result['name']);
+	}
+
+	public function testGetErrorClassNameSpaceUrlHasCorrectFormat(): void
+	{
+		$result = $this->handler->pubGetErrorClassNameSpace('Error in TErrorHandlerTestGlobalClass here');
+		if ($result === null) {
+			$this->markTestSkipped('TErrorHandlerTestGlobalClass not reflectable as a global class.');
+		}
+		$this->assertStringStartsWith('https://pradosoft.github.io/docs/manual/class-', $result['url']);
+		$this->assertStringEndsWith('TErrorHandlerTestGlobalClass.html', $result['url']);
+	}
+
+	public function testGetErrorClassNameSpaceUsesFirstMatchWhenMultipleClassesAppear(): void
+	{
+		// Two T-classes in message; the regex finds the first one; neither exists → null
+		$result = $this->handler->pubGetErrorClassNameSpace(
+			'Both TFakeFirstClass and TFakeSecondClass appear'
+		);
+		$this->assertNull($result);
+	}
+
+	// ── addLink ───────────────────────────────────────────────────────────────
+
+	public function testAddLinkWithNoClassReturnsMessageUnchanged(): void
+	{
+		$message = 'No class name here to link';
+		$this->assertSame($message, $this->handler->pubAddLink($message));
+	}
+
+	public function testAddLinkWithUnknownClassReturnsMessageUnchanged(): void
+	{
+		$message = 'Error in TFakeNonExistentClassAbc occurred';
+		$this->assertSame($message, $this->handler->pubAddLink($message));
+	}
+
+	public function testAddLinkWithKnownGlobalClassInsertsAnchorTag(): void
+	{
+		$message = 'Error in TErrorHandlerTestGlobalClass was thrown';
+		$result  = $this->handler->pubAddLink($message);
+		if ($result === $message) {
+			$this->markTestSkipped('TErrorHandlerTestGlobalClass not reflectable as global.');
+		}
+		$this->assertStringContainsString('<a href=', $result);
+		$this->assertStringContainsString('target="_blank"', $result);
+		$this->assertStringContainsString('TErrorHandlerTestGlobalClass', $result);
+	}
+
+	public function testAddLinkDoesNotThrowOnRepeatedCalls(): void
+	{
+		$message = 'See TErrorHandlerTestGlobalClass for details';
+		$first   = $this->handler->pubAddLink($message);
+		$second  = $this->handler->pubAddLink($first);
+		$this->assertIsString($second);
+	}
+
+	public function testAddLinkWithNamespacedPradoClassInsertsAnchorTag(): void
+	{
+		// Prado's autoloader resolves the short name 'TErrorHandler' to
+		// Prado\Exceptions\TErrorHandler, so addLink() can build a documentation
+		// URL even though the class lives in a namespace.
+		$message = 'Error involving TErrorHandler occurred';
+		$result  = $this->handler->pubAddLink($message);
+		$this->assertStringContainsString('<a href=', $result);
+		$this->assertStringContainsString('TErrorHandler', $result);
+		$this->assertStringContainsString('Prado.Exceptions', $result);
+	}
+
+	public function testGetErrorClassNameSpaceUsesHttpsUrl(): void
+	{
+		$result = $this->handler->pubGetErrorClassNameSpace('Error in TErrorHandlerTestGlobalClass here');
+		if ($result === null) {
+			$this->markTestSkipped('TErrorHandlerTestGlobalClass not reflectable as a global class.');
+		}
+		$this->assertStringStartsWith('https://', $result['url']);
+	}
+
+	// ── getPropertyAccessTrace ────────────────────────────────────────────────
+
+	public function testGetPropertyAccessTraceEmptyTraceReturnsNull(): void
+	{
+		$this->assertNull($this->handler->pubGetPropertyAccessTrace([], '__get'));
+	}
+
+	public function testGetPropertyAccessTraceFrameWithNoFunctionKeyReturnsNull(): void
+	{
+		$trace  = [['file' => 'a.php', 'line' => 1]];
+		$this->assertNull($this->handler->pubGetPropertyAccessTrace($trace, '__get'));
+	}
+
+	public function testGetPropertyAccessTraceNonMatchingFunctionReturnsNull(): void
+	{
+		$trace  = [['function' => '__construct', 'file' => 'a.php', 'line' => 1]];
+		$this->assertNull($this->handler->pubGetPropertyAccessTrace($trace, '__get'));
+	}
+
+	public function testGetPropertyAccessTraceSingleMatchingFrameReturnsIt(): void
+	{
+		$frame  = ['function' => '__get', 'file' => 'a.php', 'line' => 10];
+		$result = $this->handler->pubGetPropertyAccessTrace([$frame], '__get');
+		$this->assertSame($frame, $result);
+	}
+
+	public function testGetPropertyAccessTraceReturnsLastOfConsecutiveMatches(): void
+	{
+		$frame1 = ['function' => '__get', 'file' => 'a.php', 'line' => 1];
+		$frame2 = ['function' => '__get', 'file' => 'b.php', 'line' => 2];
+		$result = $this->handler->pubGetPropertyAccessTrace([$frame1, $frame2], '__get');
+		$this->assertSame($frame2, $result);
+	}
+
+	public function testGetPropertyAccessTraceBreaksAtFirstNonMatch(): void
+	{
+		$frame1 = ['function' => '__get',           'file' => 'a.php', 'line' => 1];
+		$frame2 = ['function' => 'someOtherMethod', 'file' => 'b.php', 'line' => 2];
+		$frame3 = ['function' => '__get',           'file' => 'c.php', 'line' => 3];
+		$result = $this->handler->pubGetPropertyAccessTrace([$frame1, $frame2, $frame3], '__get');
+		// Stops at frame2; frame3 (after the break) is never considered
+		$this->assertSame($frame1, $result);
+	}
+
+	public function testGetPropertyAccessTraceThreeConsecutiveMatchesReturnsLast(): void
+	{
+		$frames = [
+			['function' => '__set', 'file' => 'a.php', 'line' => 1],
+			['function' => '__set', 'file' => 'b.php', 'line' => 2],
+			['function' => '__set', 'file' => 'c.php', 'line' => 3],
+		];
+		$this->assertSame($frames[2], $this->handler->pubGetPropertyAccessTrace($frames, '__set'));
+	}
+
+	public function testGetPropertyAccessTracePatternIsStrictlyMatched(): void
+	{
+		// __set frames do not match when the pattern is __get
+		$trace  = [['function' => '__set', 'file' => 'a.php', 'line' => 1]];
+		$this->assertNull($this->handler->pubGetPropertyAccessTrace($trace, '__get'));
+	}
+
+	public function testGetPropertyAccessTraceMatchFollowedByFrameWithoutFunctionBreaks(): void
+	{
+		// A frame with no 'function' key triggers the else-break, so only the
+		// matching frames before it count.
+		$frame1 = ['function' => '__get', 'file' => 'a.php', 'line' => 1];
+		$frameNoFunc = ['file' => 'b.php', 'line' => 2]; // no 'function' key
+		$frame3 = ['function' => '__get', 'file' => 'c.php', 'line' => 3];
+		$result = $this->handler->pubGetPropertyAccessTrace([$frame1, $frameNoFunc, $frame3], '__get');
+		$this->assertSame($frame1, $result);
+	}
+
+	// ── getExactTrace ─────────────────────────────────────────────────────────
+
+	public function testGetExactTraceGenericExceptionReturnsNull(): void
+	{
+		// A plain RuntimeException is neither TPhpErrorException nor
+		// TInvalidOperationException → the method returns null.
+		$result = $this->handler->pubGetExactTrace(new \RuntimeException('test'));
+		$this->assertNull($result);
+	}
+
+	public function testGetExactTraceTPhpErrorExceptionReturnsFirstFrameWithFile(): void
+	{
+		$ex    = new TPhpErrorException(E_WARNING, 'test warning', __FILE__, __LINE__);
+		$trace = $ex->getTrace();
+		if (empty($trace) || !isset($trace[0]['file'])) {
+			$this->markTestSkipped('Exception trace frame 0 has no file key in this environment.');
+		}
+		$result = $this->handler->pubGetExactTrace($ex);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('file', $result);
+		$this->assertSame($trace[0], $result);
+	}
+
+	public function testGetExactTraceTPhpErrorExceptionEvalFrameReturnsNull(): void
+	{
+		// When the exception is constructed inside eval(), trace[0]['file'] contains
+		// ": eval()'d code" which the method explicitly filters out.
+		$ex = eval('return new \Prado\Exceptions\TPhpErrorException(\E_WARNING, "eval test", "eval.php", 1);');
+		$this->assertNull($this->handler->pubGetExactTrace($ex));
+	}
+
+	public function testGetExactTraceTInvalidOperationExceptionWithNoPropertyFramesReturnsNull(): void
+	{
+		// A directly constructed TInvalidOperationException has no __get or __set
+		// frames in its trace → getPropertyAccessTrace returns null for both →
+		// getExactTrace returns null.
+		$ex     = new TInvalidOperationException('prado_application_singleton_required');
+		$result = $this->handler->pubGetExactTrace($ex);
+		$this->assertNull($result);
+	}
+
+	public function testGetExactTraceNonMatchingExceptionTypeReturnsNull(): void
+	{
+		// TConfigurationException is neither TPhpErrorException nor
+		// TInvalidOperationException → returns null.
+		$ex     = new TConfigurationException('errorhandler_errortemplatepath_invalid', 'x');
+		$result = $this->handler->pubGetExactTrace($ex);
+		$this->assertNull($result);
+	}
+
+	// ── getExactTraceAsString ─────────────────────────────────────────────────
+
+	public function testGetExactTraceAsStringReturnsString(): void
+	{
+		$ex     = new \Exception('trace test');
+		$result = $this->handler->pubGetExactTraceAsString($ex);
+		$this->assertIsString($result);
+	}
+
+	public function testGetExactTraceAsStringContainsHashFrameMarkers(): void
+	{
+		$ex     = new \Exception('trace test');
+		$result = $this->handler->pubGetExactTraceAsString($ex);
+		// Exception::getTraceAsString() always starts with '#0'
+		$this->assertMatchesRegularExpression('/#\d/', $result);
+	}
+
+	public function testGetExactTraceAsStringSanitizesPradoFrameworkPaths(): void
+	{
+		// The string representation of the exception's trace will contain paths
+		// to framework files; hidePrivatePathParts must have replaced PRADO_DIR.
+		$ex     = new \Exception('trace test');
+		$result = $this->handler->pubGetExactTraceAsString($ex);
+		// PRADO_DIR itself must not appear verbatim; if the trace touches framework
+		// files the token replaces it.
+		if (str_contains($ex->getTraceAsString(), PRADO_DIR . DIRECTORY_SEPARATOR)) {
+			$this->assertStringNotContainsString(PRADO_DIR . DIRECTORY_SEPARATOR, $result);
+			$this->assertStringContainsString('${PradoFramework}', $result);
+		} else {
+			// No framework paths in the trace; result is unchanged (no assertion needed)
+			$this->assertIsString($result);
+		}
+	}
+
+	// ── displayException (CLI mode) ───────────────────────────────────────────
+
+	public function testDisplayExceptionCliModeOutputsExceptionMessage(): void
+	{
+		// PHPUnit runs via CLI, so php_sapi_name() === 'cli' is guaranteed.
+		$exception = new \Exception('cli display test message');
+		ob_start();
+		$this->handler->pubDisplayException($exception);
+		$output = ob_get_clean();
+		$this->assertStringContainsString('cli display test message', $output);
+	}
+
+	public function testDisplayExceptionCliModeOutputsTraceString(): void
+	{
+		$exception = new \Exception('trace display test');
+		ob_start();
+		$this->handler->pubDisplayException($exception);
+		$output = ob_get_clean();
+		// Trace output contains '#0' frame marker
+		$this->assertMatchesRegularExpression('/#\d/', $output);
+	}
+
+	// ── displayException (web mode) ──────────────────────────────────────────────
+
+	public function testDisplayExceptionWebModeOutputsExceptionTokens(): void
+	{
+		// Run displayException() in web mode by faking a non-CLI SAPI.
+		$this->handler->fakePhpSapiName = 'apache2handler';
+		$exception = new \Exception('web display test message');
+		ob_start();
+		try {
+			$this->handler->pubDisplayException($exception);
+		} finally {
+			$output = ob_get_clean();
+			$this->handler->fakePhpSapiName = null;
+		}
+		// Build token strings dynamically so they do not appear as literals in the
+		// source-code window rendered by the exception template itself.
+		$tokenErrorType    = '%%' . 'ErrorType'    . '%%';
+		$tokenErrorMessage = '%%' . 'ErrorMessage' . '%%';
+		// The exception template is rendered with token substitution.
+		$this->assertStringNotContainsString($tokenErrorType, $output);
+		$this->assertStringNotContainsString($tokenErrorMessage, $output);
+		$this->assertStringContainsString('Exception', $output);
+		$this->assertStringContainsString('web display test message', $output);
+	}
+
+	public function testDisplayExceptionWebModeSourceFileIsSanitized(): void
+	{
+		$this->handler->fakePhpSapiName = 'apache2handler';
+		$exception = new \Exception('path sanitation test');
+		ob_start();
+		try {
+			$this->handler->pubDisplayException($exception);
+		} finally {
+			$output = ob_get_clean();
+			$this->handler->fakePhpSapiName = null;
+		}
+		// The %%SourceFile%% token must have been replaced; PRADO_DIR must not appear raw.
+		$this->assertStringNotContainsString(PRADO_DIR . DIRECTORY_SEPARATOR, $output);
+	}
+
+	public function testDisplayExceptionWebModeDoesNotOutputRawStackTrace(): void
+	{
+		$this->handler->fakePhpSapiName = 'apache2handler';
+		$exception = new \Exception('stack trace test');
+		ob_start();
+		try {
+			$this->handler->pubDisplayException($exception);
+		} finally {
+			$output = ob_get_clean();
+			$this->handler->fakePhpSapiName = null;
+		}
+		// Build token string dynamically so it does not appear as a literal in
+		// the source-code window rendered by the exception template itself.
+		$tokenStackTrace = '%%' . 'StackTrace' . '%%';
+		$this->assertStringNotContainsString($tokenStackTrace, $output);
+	}
+
+	// ── handleRecursiveError ──────────────────────────────────────────────────
+
+	public function testHandleRecursiveErrorInDebugModeRendersMinimalHtml(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Debug);
+		$exception = new \Exception('Test recursive error message');
+		ob_start();
+		try {
+			$this->handler->pubHandleRecursiveError($exception);
+		} finally {
+			$output = ob_get_clean();
+			$app->setMode($originalMode);
+		}
+		$this->assertStringContainsString('<html>', $output);
+		$this->assertStringContainsString('Recursive Error', $output);
+		$this->assertStringContainsString('Test recursive error message', $output);
+	}
+
+	public function testHandleRecursiveErrorInNonDebugModeProducesNoHtmlOutput(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Normal);
+		$exception = new \Exception('Test recursive error');
+		ob_start();
+		try {
+			$this->handler->pubHandleRecursiveError($exception);
+		} finally {
+			$output = ob_get_clean();
+			$app->setMode($originalMode);
+		}
+		$this->assertSame('', $output);
+	}
+
+	public function testHandleRecursiveErrorInNonDebugModeLogsMessage(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Normal);
+		$this->handler->capturedErrorLog = null;
+		try {
+			$this->handler->pubHandleRecursiveError(new \Exception('logged error'));
+		} finally {
+			$app->setMode($originalMode);
+		}
+		$this->assertNotNull($this->handler->capturedErrorLog);
+		$this->assertStringContainsString('logged error', $this->handler->capturedErrorLog);
+		$this->assertStringContainsString('Error happened while processing an existing error', $this->handler->capturedErrorLog);
+	}
+
+	public function testHandleRecursiveErrorInOffModeProducesNoHtmlOutput(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Off);
+		$exception = new \Exception('Test recursive off error');
+		ob_start();
+		try {
+			$this->handler->pubHandleRecursiveError($exception);
+		} finally {
+			$output = ob_get_clean();
+			$app->setMode($originalMode);
+		}
+		$this->assertSame('', $output);
+	}
+
+	public function testHandleRecursiveErrorInPerformanceModeProducesNoHtmlOutput(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Performance);
+		$exception = new \Exception('Test recursive performance error');
+		ob_start();
+		try {
+			$this->handler->pubHandleRecursiveError($exception);
+		} finally {
+			$output = ob_get_clean();
+			$app->setMode($originalMode);
+		}
+		$this->assertSame('', $output);
+	}
+
+	public function testHandleRecursiveErrorSendsHeaderWhenHeadersNotSent(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Normal);
+		// Simulate headers not yet sent.
+		$this->handler->fakeHeadersSent = false;
+		$this->handler->capturedHeaders = [];
+		ob_start();
+		try {
+			$this->handler->pubHandleRecursiveError(new \Exception('header test'));
+		} finally {
+			ob_end_clean();
+			$this->handler->fakeHeadersSent = null;
+			$app->setMode($originalMode);
+		}
+		$this->assertCount(1, $this->handler->capturedHeaders);
+		$this->assertStringContainsString('500', $this->handler->capturedHeaders[0]);
+	}
+
+	public function testHandleRecursiveErrorSkipsHeaderWhenHeadersAlreadySent(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Normal);
+		// Simulate headers already sent.
+		$this->handler->fakeHeadersSent = true;
+		$this->handler->capturedHeaders = [];
+		try {
+			$this->handler->pubHandleRecursiveError(new \Exception('header skip test'));
+		} finally {
+			$this->handler->fakeHeadersSent = null;
+			$app->setMode($originalMode);
+		}
+		$this->assertCount(0, $this->handler->capturedHeaders);
+	}
+
+	public function testHandleRecursiveErrorDoesNotThrow(): void
+	{
+		// Must not throw regardless of application mode.
+		$exception = new \Exception('Error inside error handler');
+		ob_start();
+		try {
+			$this->handler->pubHandleRecursiveError($exception);
+			$threw = false;
+		} catch (\Throwable $t) {
+			$threw = true;
+		} finally {
+			ob_get_clean();
+		}
+		$this->assertFalse($threw);
+	}
+
+	// ── getIsHandled / setIsHandled ───────────────────────────────────────────────
+
+	public function testGetIsHandledDefaultsToFalse(): void
+	{
+		$this->assertFalse($this->handler->pubGetIsHandled());
+	}
+
+	public function testSetIsHandledToTrueIsReflectedByGetter(): void
+	{
+		$this->handler->pubSetIsHandled(true);
+		$this->assertTrue($this->handler->pubGetIsHandled());
+	}
+
+	public function testSetIsHandledToFalseResetsFlag(): void
+	{
+		$this->handler->pubSetIsHandled(true);
+		$this->handler->pubSetIsHandled(false);
+		$this->assertFalse($this->handler->pubGetIsHandled());
+	}
+
+	public function testResetHandlingClearsFlag(): void
+	{
+		$this->handler->pubSetIsHandled(true);
+		$this->handler->resetHandling();
+		$this->assertFalse($this->handler->pubGetIsHandled());
+	}
+
+	// ── handleError ───────────────────────────────────────────────────────────────
+
+	public function testHandleErrorCallsRestoreErrorHandler(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$this->handler->resetHandling();
+		$this->handler->restoreErrorHandlerCalled = false;
+		$exception = new \Prado\Exceptions\THttpException(404, 'pageservice_page_unknown', 'test');
+		$this->handler->pubHandleError(null, $exception);
+		$this->assertTrue($this->handler->restoreErrorHandlerCalled);
+	}
+
+	public function testHandleErrorCallsRestoreExceptionHandler(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$this->handler->resetHandling();
+		$this->handler->restoreExceptionHandlerCalled = false;
+		$exception = new \Prado\Exceptions\THttpException(404, 'pageservice_page_unknown', 'test');
+		$this->handler->pubHandleError(null, $exception);
+		$this->assertTrue($this->handler->restoreExceptionHandlerCalled);
+	}
+
+	public function testHandleErrorSetsContentTypeHeaderWhenHeadersNotSent(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$this->handler->resetHandling();
+		$this->handler->fakeHeadersSent = false;
+		$this->handler->capturedHeaders = [];
+		$exception = new \Prado\Exceptions\THttpException(404, 'pageservice_page_unknown', 'test');
+		$this->handler->pubHandleError(null, $exception);
+		$this->handler->fakeHeadersSent = null;
+		$found = false;
+		foreach ($this->handler->capturedHeaders as $h) {
+			if (stripos($h, 'Content-Type') !== false && stripos($h, 'text/html') !== false) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue($found, 'handleError() must set a Content-Type: text/html header when headers have not been sent.');
+	}
+
+	public function testHandleErrorDispatchesToHandleExternalErrorForHttpException(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$this->handler->resetHandling();
+		$this->handler->capturedExternalErrorStatusCode = null;
+		$exception = new \Prado\Exceptions\THttpException(403, 'pageservice_page_unknown', 'test');
+		$this->handler->pubHandleError(null, $exception);
+		$this->assertSame(403, $this->handler->capturedExternalErrorStatusCode);
+	}
+
+	public function testHandleErrorDispatchesToDisplayExceptionInDebugMode(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Debug);
+		$this->handler->resetHandling();
+		$this->handler->displayExceptionCalled = false;
+		try {
+			$this->handler->pubHandleError(null, new \RuntimeException('dispatch test'));
+		} finally {
+			$app->setMode($originalMode);
+		}
+		$this->assertTrue($this->handler->displayExceptionCalled);
+	}
+
+	public function testHandleErrorDispatchesToHandleExternalError500ForNonHttpExceptionInNonDebugMode(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Normal);
+		$this->handler->resetHandling();
+		$this->handler->capturedExternalErrorStatusCode = null;
+		try {
+			$this->handler->pubHandleError(null, new \RuntimeException('non-http normal mode dispatch'));
+		} finally {
+			$app->setMode($originalMode);
+		}
+		$this->assertSame(500, $this->handler->capturedExternalErrorStatusCode);
+	}
+
+	public function testHandleErrorRecursiveCallGoesToHandleRecursiveError(): void
+	{
+		$app = Prado::getApplication();
+		if ($app === null) {
+			$this->markTestSkipped('No global TApplication available.');
+		}
+		// Force _handling = true so the next call is treated as recursive.
+		$this->handler->resetHandling();
+		$exception = new \Prado\Exceptions\THttpException(404, 'pageservice_page_unknown', 'test');
+		$this->handler->pubHandleError(null, $exception); // sets _handling = true
+		// Second call — must take the recursive path (handleRecursiveError in non-debug = no output, just log).
+		$originalMode = $app->getMode();
+		$app->setMode(TApplicationMode::Normal);
+		$this->handler->capturedErrorLog = null;
+		ob_start();
+		try {
+			$this->handler->pubHandleError(null, new \RuntimeException('recursive'));
+		} finally {
+			ob_get_clean();
+			$app->setMode($originalMode);
+		}
+		$this->assertNotNull($this->handler->capturedErrorLog,
+			'Second handleError() call must route through handleRecursiveError() and log.');
+	}
+
+	// ── PHP global-function wrappers (self-encapsulation) ──────────────────────
+
+	public function testHeadersSentDelegatesTo_headers_sent(): void
+	{
+		// headers_sent() may or may not be false in the CLI PHPUnit environment
+		// (it returns true once any output has been flushed). The protected
+		// helper must return exactly the same value as the underlying PHP call.
+		$this->assertSame(headers_sent(), $this->handler->pubHeadersSent());
+	}
+
+	public function testErrorLogDelegatesToPhpErrorLog(): void
+	{
+		// Redirect error_log to a temp file to capture the output without
+		// polluting stderr, then verify the message was written.
+		$logFile = tempnam(sys_get_temp_dir(), 'prado_test_errlog_');
+		$originalErrorLog = ini_set('error_log', $logFile);
+		try {
+			$this->handler->pubErrorLog('test error log message');
+		} finally {
+			ini_set('error_log', $originalErrorLog);
+		}
+		$contents = @file_get_contents($logFile) ?: '';
+		@unlink($logFile);
+		$this->assertStringContainsString('test error log message', $contents);
+	}
+
+	public function testPhpSapiNameDelegatesToPhpFunction(): void
+	{
+		$this->assertSame(php_sapi_name(), $this->handler->pubPhpSapiName());
+	}
+
+	public function testRestoreErrorHandlerRestoresPreviousHandler(): void
+	{
+		// Push a sentinel handler onto the PHP error-handler stack.
+		$sentinel = static function (int $no, string $str): bool { return true; };
+		set_error_handler($sentinel);
+		// pubRestoreErrorHandler() wraps restore_error_handler(); the sentinel must be popped.
+		$this->handler->pubRestoreErrorHandler();
+		// Install a probe to read what the current "previous" handler is.
+		$previous = set_error_handler(static function (int $no, string $str): bool { return false; });
+		restore_error_handler(); // remove the probe
+		$this->assertNotSame($sentinel, $previous,
+			'restoreErrorHandler() must pop the sentinel off the error-handler stack.');
+	}
+
+	public function testRestoreExceptionHandlerRestoresPreviousHandler(): void
+	{
+		// Push a sentinel exception handler.
+		$sentinel = static function (\Throwable $e): void {};
+		set_exception_handler($sentinel);
+		// pubRestoreExceptionHandler() wraps restore_exception_handler().
+		$this->handler->pubRestoreExceptionHandler();
+		// Install a probe to read the current "previous" exception handler.
+		$previous = set_exception_handler(static function (\Throwable $e): void {});
+		restore_exception_handler(); // remove the probe
+		$this->assertNotSame($sentinel, $previous,
+			'restoreExceptionHandler() must pop the sentinel off the exception-handler stack.');
+	}
+
+	public function testServerGlobalDelegatesToServerSuperglobal(): void
+	{
+		// serverGlobal() must return the same value as $_SERVER[$key].
+		$key   = 'PATH';
+		$this->assertSame($_SERVER[$key] ?? null, $this->handler->pubServerGlobal($key));
+	}
+
+	public function testServerGlobalReturnsNullForAbsentKey(): void
+	{
+		$this->assertNull($this->handler->pubServerGlobal('__PRADO_TEST_KEY_THAT_DOES_NOT_EXIST__'));
+	}
+
+	public function testServerGlobalReturnsInjectedValue(): void
+	{
+		// serverGlobal() reads from $_SERVER, so injecting a value there is immediately visible.
+		$key   = '__PRADO_TEST_INJECT__';
+		$_SERVER[$key] = 'injected-value';
+		try {
+			$this->assertSame('injected-value', $this->handler->pubServerGlobal($key));
+		} finally {
+			unset($_SERVER[$key]);
+		}
+	}
 }

--- a/tests/unit/Exceptions/TExitExceptionTest.php
+++ b/tests/unit/Exceptions/TExitExceptionTest.php
@@ -1,24 +1,448 @@
 <?php
 
+/**
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
 use Prado\Exceptions\TExitException;
+use Prado\Exceptions\TSystemException;
+use Prado\Exceptions\TException;
 
 /**
- * Tests for TExitException exit code handling and message propagation.
+ * Comprehensive tests for {@see TExitException}: exit code storage and edge values,
+ * message translation, variadic placeholders, getErrorMessage(), setErrorCode(),
+ * throw/catch, exception chaining (getPrevious()), and the full inheritance chain.
  */
 class TExitExceptionTest extends PHPUnit\Framework\TestCase
 {
-    public function testExitCodeAndMessagePropagation()
-    {
-        // Use a known message code so translation occurs consistently
-        $ex = new TExitException(7, 'prado_application_singleton_required');
-        $this->assertSame(7, $ex->getExitCode());
-        // Message should come from translation of the provided code
-        $this->assertStringStartsWith('Prado.Application must only be set once', $ex->getMessage());
-    }
+	// ── Construction and exit code ────────────────────────────────────────────
 
-    public function testExitCodeGetter()
-    {
-        $ex = new \Prado\Exceptions\TExitException(9, 'test');
-        $this->assertEquals(9, $ex->getExitCode());
-    }
+	public function testDefaultExitCodeIsZero()
+	{
+		$ex = new TExitException();
+		$this->assertSame(0, $ex->getExitCode());
+	}
+
+	public function testDefaultMessageIsEmpty()
+	{
+		$ex = new TExitException();
+		// null message → translateErrorMessage('') → ''
+		$this->assertSame('', $ex->getMessage());
+	}
+
+	public function testExitCodeGetter()
+	{
+		$ex = new TExitException(9, 'test');
+		$this->assertSame(9, $ex->getExitCode());
+	}
+
+	public function testExitCodeAndMessagePropagation()
+	{
+		// Use a known message code so translation occurs consistently
+		$ex = new TExitException(7, 'prado_application_singleton_required');
+		$this->assertSame(7, $ex->getExitCode());
+		// Message should come from translation of the provided code
+		$this->assertStringStartsWith('Prado.Application must only be set once', $ex->getMessage());
+	}
+
+	public function testNegativeExitCode()
+	{
+		$ex = new TExitException(-1);
+		$this->assertSame(-1, $ex->getExitCode());
+	}
+
+	public function testLargeExitCode()
+	{
+		$ex = new TExitException(255);
+		$this->assertSame(255, $ex->getExitCode());
+	}
+
+	public function testExitCodeZeroExplicit()
+	{
+		$ex = new TExitException(0, 'test message');
+		$this->assertSame(0, $ex->getExitCode());
+	}
+
+	public function testPhpIntMaxExitCode()
+	{
+		$ex = new TExitException(PHP_INT_MAX);
+		$this->assertSame(PHP_INT_MAX, $ex->getExitCode());
+	}
+
+	public function testPhpIntMinExitCode()
+	{
+		$ex = new TExitException(PHP_INT_MIN);
+		$this->assertSame(PHP_INT_MIN, $ex->getExitCode());
+	}
+
+	// ── Ordering: exitCode stored before parent::__construct ──────────────────
+
+	public function testExitCodeAvailableBeforeMessageTranslation()
+	{
+		// setExitCodeDirect is called before parent::__construct, so the code
+		// is always set even when message construction fails or is null.
+		$ex = new TExitException(42, null);
+		$this->assertSame(42, $ex->getExitCode());
+	}
+
+	public function testExitCodeAvailableWithNonTranslatableMessage()
+	{
+		$ex = new TExitException(3, 'plain string message no translation');
+		$this->assertSame(3, $ex->getExitCode());
+	}
+
+	// ── Message handling ──────────────────────────────────────────────────────
+
+	public function testNullMessageResultsInEmptyMessage()
+	{
+		$ex = new TExitException(1, null);
+		$this->assertSame('', $ex->getMessage());
+	}
+
+	public function testPlainStringMessagePassedThrough()
+	{
+		$ex = new TExitException(1, 'Graceful shutdown');
+		$this->assertStringContainsString('Graceful shutdown', $ex->getMessage());
+	}
+
+	public function testMessageCodeTranslated()
+	{
+		$ex = new TExitException(0, 'prado_application_singleton_required');
+		// Should be translated, not the raw code
+		$this->assertStringNotContainsString('prado_application_singleton_required', $ex->getMessage());
+		$this->assertNotEmpty($ex->getMessage());
+	}
+
+	public function testVariadicPlaceholdersReplacedInMessage()
+	{
+		// prado_component_unknown uses {0} and {1}
+		$ex = new TExitException(2, 'prado_component_unknown', 'MyClass', 'SomeContext');
+		$this->assertStringContainsString('MyClass', $ex->getMessage());
+		$this->assertStringContainsString('SomeContext', $ex->getMessage());
+	}
+
+	public function testErrorCodeHoldsMessageKey()
+	{
+		$ex = new TExitException(5, 'prado_application_singleton_required');
+		$this->assertSame('prado_application_singleton_required', $ex->getErrorCode());
+	}
+
+	public function testErrorCodeForPlainStringIsTheStringItself()
+	{
+		$ex = new TExitException(5, 'some plain text');
+		$this->assertSame('some plain text', $ex->getErrorCode());
+	}
+
+	public function testErrorCodeIsNullStringWhenMessageIsNull()
+	{
+		$ex = new TExitException(1, null);
+		// TException old-style: null errorCode → stored as null
+		$this->assertNull($ex->getErrorCode());
+	}
+
+	public function testPhpExceptionCodeIsZeroForOldStyleMessage()
+	{
+		// TException old-style (string as first arg to parent) → PHP getCode() = 0
+		$ex = new TExitException(7, 'prado_application_singleton_required');
+		$this->assertSame(0, $ex->getCode());
+	}
+
+	public function testPhpExceptionCodeIsZeroEvenForNullMessage()
+	{
+		$ex = new TExitException(5, null);
+		$this->assertSame(0, $ex->getCode());
+	}
+
+	// ── getErrorMessage() alias ────────────────────────────────────────────────
+
+	public function testGetErrorMessageReturnsSameAsGetMessage()
+	{
+		$ex = new TExitException(1, 'prado_application_singleton_required');
+		$this->assertSame($ex->getMessage(), $ex->getErrorMessage());
+	}
+
+	public function testGetErrorMessageWithNullMessage()
+	{
+		$ex = new TExitException(0, null);
+		$this->assertSame('', $ex->getErrorMessage());
+	}
+
+	public function testGetErrorMessageWithPlainString()
+	{
+		$ex = new TExitException(1, 'Shutdown requested');
+		$this->assertStringContainsString('Shutdown requested', $ex->getErrorMessage());
+		$this->assertSame($ex->getMessage(), $ex->getErrorMessage());
+	}
+
+	public function testGetErrorMessageWithTranslatedCode()
+	{
+		$ex = new TExitException(0, 'prado_application_singleton_required');
+		$this->assertNotEmpty($ex->getErrorMessage());
+		$this->assertSame($ex->getMessage(), $ex->getErrorMessage());
+	}
+
+	// ── setErrorCode() mutation ───────────────────────────────────────────────
+
+	public function testSetErrorCodeMutatesGetErrorCode()
+	{
+		$ex = new TExitException(1, 'prado_application_singleton_required');
+		$this->assertSame('prado_application_singleton_required', $ex->getErrorCode());
+		$ex->setErrorCode('new_error_code');
+		$this->assertSame('new_error_code', $ex->getErrorCode());
+	}
+
+	public function testSetErrorCodeDoesNotChangeMessage()
+	{
+		// setErrorCode() only updates the stored code; getMessage() is fixed at construction.
+		$ex = new TExitException(1, 'prado_application_singleton_required');
+		$originalMessage = $ex->getMessage();
+		$ex->setErrorCode('something_else');
+		$this->assertSame($originalMessage, $ex->getMessage());
+	}
+
+	public function testSetErrorCodeToEmptyString()
+	{
+		$ex = new TExitException(1, 'prado_application_singleton_required');
+		$ex->setErrorCode('');
+		$this->assertSame('', $ex->getErrorCode());
+	}
+
+	// ── Throw and catch ───────────────────────────────────────────────────────
+
+	public function testThrowAndCatch()
+	{
+		$this->expectException(TExitException::class);
+		throw new TExitException(1, 'Graceful shutdown');
+	}
+
+	public function testThrowAndCatchPreservesExitCode()
+	{
+		try {
+			throw new TExitException(42, 'test');
+		} catch (TExitException $ex) {
+			$this->assertSame(42, $ex->getExitCode());
+
+			return;
+		}
+		$this->fail('TExitException was not caught');
+	}
+
+	public function testThrowAndCatchPreservesMessage()
+	{
+		try {
+			throw new TExitException(1, 'prado_application_singleton_required');
+		} catch (TExitException $ex) {
+			$this->assertStringStartsWith('Prado.Application must only be set once', $ex->getMessage());
+
+			return;
+		}
+		$this->fail('TExitException was not caught');
+	}
+
+	public function testThrowAndCatchPreservesErrorCode()
+	{
+		try {
+			throw new TExitException(1, 'prado_application_singleton_required');
+		} catch (TExitException $ex) {
+			$this->assertSame('prado_application_singleton_required', $ex->getErrorCode());
+
+			return;
+		}
+		$this->fail('TExitException was not caught');
+	}
+
+	public function testCaughtAsTException()
+	{
+		$caught = null;
+		try {
+			throw new TExitException(5, 'test');
+		} catch (TException $ex) {
+			$caught = $ex;
+		}
+		$this->assertNotNull($caught);
+		$this->assertInstanceOf(TExitException::class, $caught);
+	}
+
+	public function testCaughtAsException()
+	{
+		$caught = null;
+		try {
+			throw new TExitException(3, 'test');
+		} catch (\Exception $ex) {
+			$caught = $ex;
+		}
+		$this->assertNotNull($caught);
+		$this->assertInstanceOf(TExitException::class, $caught);
+	}
+
+	public function testCaughtAsThrowable()
+	{
+		$caught = null;
+		try {
+			throw new TExitException(2, 'test');
+		} catch (\Throwable $ex) {
+			$caught = $ex;
+		}
+		$this->assertNotNull($caught);
+		$this->assertInstanceOf(TExitException::class, $caught);
+	}
+
+	// ── Exception chaining ────────────────────────────────────────────────────
+
+	public function testGetPreviousIsNullWhenNotProvided()
+	{
+		$ex = new TExitException(1, 'test');
+		$this->assertNull($ex->getPrevious());
+	}
+
+	public function testGetPreviousIsNullForDefaultConstructor()
+	{
+		$ex = new TExitException();
+		$this->assertNull($ex->getPrevious());
+	}
+
+	public function testExceptionChainingWithThrowable()
+	{
+		$prev = new \RuntimeException('previous cause');
+		$ex = new TExitException(1, 'prado_application_singleton_required', $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testExceptionChainingPreservesExitCode()
+	{
+		$prev = new \RuntimeException('previous');
+		$ex = new TExitException(7, 'prado_application_singleton_required', $prev);
+		$this->assertSame(7, $ex->getExitCode());
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testExceptionChainingPreservesMessage()
+	{
+		$prev = new \RuntimeException('previous');
+		$ex = new TExitException(1, 'prado_application_singleton_required', $prev);
+		$this->assertStringStartsWith('Prado.Application must only be set once', $ex->getMessage());
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testExceptionChainingWithNullMessage()
+	{
+		$prev = new \RuntimeException('previous');
+		$ex = new TExitException(1, null, $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+		$this->assertSame(1, $ex->getExitCode());
+		$this->assertSame('', $ex->getMessage());
+	}
+
+	public function testExceptionChainingWithPlaceholders()
+	{
+		$prev = new \LogicException('root cause');
+		$ex = new TExitException(2, 'prado_component_unknown', 'CompA', 'CompB', $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+		$this->assertStringContainsString('CompA', $ex->getMessage());
+		$this->assertStringContainsString('CompB', $ex->getMessage());
+	}
+
+	public function testExceptionChainingWithPreviousTException()
+	{
+		$prev = new TException('prado_application_singleton_required');
+		$ex = new TExitException(1, 'prado_application_singleton_required', $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testPreviousChainedExceptionIsAccessibleAfterThrowCatch()
+	{
+		$prev = new \InvalidArgumentException('root');
+		try {
+			throw new TExitException(3, 'test', $prev);
+		} catch (TExitException $ex) {
+			$this->assertSame($prev, $ex->getPrevious());
+			$this->assertSame(3, $ex->getExitCode());
+
+			return;
+		}
+		$this->fail('Exception not caught');
+	}
+
+	// ── instanceof ────────────────────────────────────────────────────────────
+
+	public function testIsInstanceOfTSystemException()
+	{
+		$this->assertInstanceOf(TSystemException::class, new TExitException());
+	}
+
+	public function testIsInstanceOfTException()
+	{
+		$this->assertInstanceOf(TException::class, new TExitException());
+	}
+
+	public function testIsInstanceOfException()
+	{
+		$this->assertInstanceOf(\Exception::class, new TExitException());
+	}
+
+	public function testIsInstanceOfThrowable()
+	{
+		$this->assertInstanceOf(\Throwable::class, new TExitException());
+	}
+
+	// ── Visibility / encapsulation ────────────────────────────────────────────
+
+	public function testGetExitCodeDirectIsProtected()
+	{
+		$ref = new \ReflectionMethod(TExitException::class, 'getExitCodeDirect');
+		$this->assertTrue($ref->isProtected());
+	}
+
+	public function testSetExitCodeDirectIsProtected()
+	{
+		$ref = new \ReflectionMethod(TExitException::class, 'setExitCodeDirect');
+		$this->assertTrue($ref->isProtected());
+	}
+
+	public function testExitCodePropertyIsPrivate()
+	{
+		$ref = new \ReflectionProperty(TExitException::class, '_exitCode');
+		$this->assertTrue($ref->isPrivate());
+	}
+
+	public function testGetExitCodeIsPublic()
+	{
+		$ref = new \ReflectionMethod(TExitException::class, 'getExitCode');
+		$this->assertTrue($ref->isPublic());
+	}
+
+	// ── Multiple instances are independent ────────────────────────────────────
+
+	public function testMultipleInstancesHaveIndependentExitCodes()
+	{
+		$ex1 = new TExitException(1);
+		$ex2 = new TExitException(2);
+		$ex3 = new TExitException(0);
+		$this->assertSame(1, $ex1->getExitCode());
+		$this->assertSame(2, $ex2->getExitCode());
+		$this->assertSame(0, $ex3->getExitCode());
+	}
+
+	public function testMultipleInstancesHaveIndependentPrevious()
+	{
+		$prev1 = new \RuntimeException('first');
+		$prev2 = new \RuntimeException('second');
+		$ex1 = new TExitException(1, 'test', $prev1);
+		$ex2 = new TExitException(2, 'test', $prev2);
+		$ex3 = new TExitException(3, 'test');
+		$this->assertSame($prev1, $ex1->getPrevious());
+		$this->assertSame($prev2, $ex2->getPrevious());
+		$this->assertNull($ex3->getPrevious());
+	}
+
+	public function testMultipleInstancesHaveIndependentErrorCodes()
+	{
+		$ex1 = new TExitException(1, 'prado_application_singleton_required');
+		$ex2 = new TExitException(2, 'prado_component_unknown', 'X', 'Y');
+		$ex1->setErrorCode('modified');
+		$this->assertSame('modified', $ex1->getErrorCode());
+		$this->assertSame('prado_component_unknown', $ex2->getErrorCode());
+	}
 }

--- a/tests/unit/Exceptions/THttpExceptionTest.php
+++ b/tests/unit/Exceptions/THttpExceptionTest.php
@@ -1,29 +1,491 @@
 <?php
 
+/**
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
 use Prado\Exceptions\THttpException;
+use Prado\Exceptions\TSystemException;
+use Prado\Exceptions\TException;
 
 /**
- * Tests for THttpException behavior: status code, translated message, and code.
+ * Comprehensive tests for {@see THttpException}: HTTP status code storage, mixed-type
+ * inputs, message translation, placeholder substitution, getErrorMessage(),
+ * setErrorCode(), getCode() vs getStatusCode() distinction, throw/catch,
+ * exception chaining (getPrevious()), and the full inheritance chain.
  */
 class THttpExceptionTest extends PHPUnit\Framework\TestCase
 {
-    public function testStatusCodeAndMessageTranslation()
-    {
-        $ex = new THttpException(404, 'prado_component_unknown', 'MyComponent', 'Missing');
+	// ── Basic construction and status code ───────────────────────────────────
 
-        // Status code should be preserved
-        $this->assertSame(404, $ex->getStatusCode());
-        // Exception code should be the message code (from translation path)
-        $this->assertEquals('prado_component_unknown', $ex->getErrorCode());
-        // Message should be translated with placeholders replaced
-        $this->assertStringStartsWith('Unknown component type', $ex->getMessage());
-        $this->assertStringContainsString('MyComponent', $ex->getMessage());
-        $this->assertStringContainsString('Missing', $ex->getMessage());
-    }
+	public function testStatusCodeGetterOnly()
+	{
+		$ex = new THttpException(500, 'prado_application_singleton_required');
+		$this->assertSame(500, $ex->getStatusCode());
+	}
 
-    public function testStatusCodeGetterOnly()
-    {
-        $ex = new THttpException(500, 'prado_application_singleton_required');
-        $this->assertEquals(500, $ex->getStatusCode());
-    }
+	public function testIntStatusCode404()
+	{
+		$ex = new THttpException(404, 'test message');
+		$this->assertSame(404, $ex->getStatusCode());
+	}
+
+	public function testIntStatusCode403()
+	{
+		$ex = new THttpException(403, 'test message');
+		$this->assertSame(403, $ex->getStatusCode());
+	}
+
+	// ── Constructor accepts mixed (untyped); converts to int ─────────────────
+
+	public function testStatusCodeStringConvertedToInt()
+	{
+		// setStatusCode($value) has no type hint — accepts any type
+		$ex = new THttpException('404', 'test message');
+		$this->assertSame(404, $ex->getStatusCode());
+	}
+
+	public function testStatusCodeFloatConvertedToInt()
+	{
+		$ex = new THttpException(404.9, 'test message');
+		$this->assertSame(404, $ex->getStatusCode());
+	}
+
+	// ── Status code set before parent::__construct ────────────────────────────
+
+	public function testStatusCodeAvailableWithNullMessage()
+	{
+		// setStatusCodeDirect is invoked before parent::__construct, so the code
+		// is always set even when message construction fails or is null.
+		$ex = new THttpException(503, null);
+		$this->assertSame(503, $ex->getStatusCode());
+	}
+
+	// ── Edge-case status codes ────────────────────────────────────────────────
+
+	public function testStatusCodeZero()
+	{
+		$ex = new THttpException(0, 'test');
+		$this->assertSame(0, $ex->getStatusCode());
+	}
+
+	public function testStatusCode3xxRange()
+	{
+		foreach ([301, 302, 304, 307, 308] as $code) {
+			$ex = new THttpException($code, 'redirect');
+			$this->assertSame($code, $ex->getStatusCode(), "Status code $code not preserved");
+		}
+	}
+
+	public function testStatusCode1xxRange()
+	{
+		foreach ([100, 101] as $code) {
+			$ex = new THttpException($code, 'info');
+			$this->assertSame($code, $ex->getStatusCode(), "Status code $code not preserved");
+		}
+	}
+
+	public function testNonStandardLargeStatusCode()
+	{
+		$ex = new THttpException(999, 'custom error');
+		$this->assertSame(999, $ex->getStatusCode());
+	}
+
+	public function testNegativeStatusCode()
+	{
+		// No lower-bound clamping; stored as-is after int cast
+		$ex = new THttpException(-1, 'test');
+		$this->assertSame(-1, $ex->getStatusCode());
+	}
+
+	// ── Message translation and placeholders ─────────────────────────────────
+
+	public function testStatusCodeAndMessageTranslation()
+	{
+		$ex = new THttpException(404, 'prado_component_unknown', 'MyComponent', 'Missing');
+
+		$this->assertSame(404, $ex->getStatusCode());
+		$this->assertEquals('prado_component_unknown', $ex->getErrorCode());
+		$this->assertStringStartsWith('Unknown component type', $ex->getMessage());
+		$this->assertStringContainsString('MyComponent', $ex->getMessage());
+		$this->assertStringContainsString('Missing', $ex->getMessage());
+	}
+
+	public function testPlainStringMessagePassedThrough()
+	{
+		$ex = new THttpException(500, 'Internal Server Error');
+		$this->assertStringContainsString('Internal Server Error', $ex->getMessage());
+	}
+
+	public function testMessageCodeTranslatedNotRaw()
+	{
+		$ex = new THttpException(500, 'prado_application_singleton_required');
+		$this->assertStringNotContainsString('prado_application_singleton_required', $ex->getMessage());
+		$this->assertNotEmpty($ex->getMessage());
+	}
+
+	public function testMessageWithMultiplePlaceholders()
+	{
+		$ex = new THttpException(400, 'prado_component_unknown', 'CompA', 'CompB');
+		$this->assertStringContainsString('CompA', $ex->getMessage());
+		$this->assertStringContainsString('CompB', $ex->getMessage());
+	}
+
+	public function testNullMessageResultsInEmptyMessage()
+	{
+		$ex = new THttpException(404, null);
+		$this->assertSame('', $ex->getMessage());
+	}
+
+	public function testErrorCodeHoldsMessageKey()
+	{
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		$this->assertSame('prado_application_singleton_required', $ex->getErrorCode());
+	}
+
+	public function testErrorCodeForPlainStringIsTheStringItself()
+	{
+		$ex = new THttpException(500, 'plain error text');
+		$this->assertSame('plain error text', $ex->getErrorCode());
+	}
+
+	// ── getCode() vs getStatusCode() are distinct ─────────────────────────────
+
+	public function testPhpExceptionCodeIsZeroForOldStyleMessage()
+	{
+		// TException old-style (string first arg) → PHP Exception getCode() = 0
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		$this->assertSame(0, $ex->getCode());
+	}
+
+	public function testGetCodeDistinctFromGetStatusCode()
+	{
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		// HTTP status code lives in getStatusCode(), not getCode()
+		$this->assertSame(404, $ex->getStatusCode());
+		$this->assertNotSame($ex->getStatusCode(), $ex->getCode());
+	}
+
+	public function testGetCodeIsZeroAndGetStatusCodeIsZeroWhenStatusCodeIsZero()
+	{
+		// Both happen to be 0 when the HTTP status code is 0, but for
+		// independent reasons: getCode() is 0 because TException old-style
+		// always sets PHP code = 0; getStatusCode() is 0 because that was passed.
+		$ex = new THttpException(0, 'test');
+		$this->assertSame(0, $ex->getCode());
+		$this->assertSame(0, $ex->getStatusCode());
+	}
+
+	public function testGetCodeIsAlwaysZeroForAnyStatusCode()
+	{
+		foreach ([200, 301, 400, 401, 403, 404, 500, 503] as $code) {
+			$ex = new THttpException($code, 'test');
+			$this->assertSame(0, $ex->getCode(), "getCode() should be 0 for status $code");
+		}
+	}
+
+	// ── Broad HTTP status code coverage ──────────────────────────────────────
+
+	public function testVarious4xxStatusCodes()
+	{
+		foreach ([400, 401, 403, 404, 405, 409, 422, 429] as $code) {
+			$ex = new THttpException($code, 'test');
+			$this->assertSame($code, $ex->getStatusCode(), "Status code $code not preserved");
+		}
+	}
+
+	public function testVarious5xxStatusCodes()
+	{
+		foreach ([500, 501, 502, 503, 504] as $code) {
+			$ex = new THttpException($code, 'test');
+			$this->assertSame($code, $ex->getStatusCode(), "Status code $code not preserved");
+		}
+	}
+
+	// ── getErrorMessage() alias ────────────────────────────────────────────────
+
+	public function testGetErrorMessageReturnsSameAsGetMessage()
+	{
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		$this->assertSame($ex->getMessage(), $ex->getErrorMessage());
+	}
+
+	public function testGetErrorMessageWithNullMessage()
+	{
+		$ex = new THttpException(404, null);
+		$this->assertSame('', $ex->getErrorMessage());
+	}
+
+	public function testGetErrorMessageWithTranslatedCode()
+	{
+		$ex = new THttpException(500, 'prado_application_singleton_required');
+		$this->assertNotEmpty($ex->getErrorMessage());
+		$this->assertSame($ex->getMessage(), $ex->getErrorMessage());
+	}
+
+	public function testGetErrorMessageWithPlainString()
+	{
+		$ex = new THttpException(500, 'Service temporarily unavailable');
+		$this->assertStringContainsString('Service temporarily unavailable', $ex->getErrorMessage());
+		$this->assertSame($ex->getMessage(), $ex->getErrorMessage());
+	}
+
+	// ── setErrorCode() mutation ───────────────────────────────────────────────
+
+	public function testSetErrorCodeMutatesGetErrorCode()
+	{
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		$this->assertSame('prado_application_singleton_required', $ex->getErrorCode());
+		$ex->setErrorCode('custom_error_code');
+		$this->assertSame('custom_error_code', $ex->getErrorCode());
+	}
+
+	public function testSetErrorCodeDoesNotChangeMessage()
+	{
+		// setErrorCode() only updates the stored key; getMessage() is fixed at construction.
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		$originalMessage = $ex->getMessage();
+		$ex->setErrorCode('something_else');
+		$this->assertSame($originalMessage, $ex->getMessage());
+	}
+
+	public function testSetErrorCodeToEmptyString()
+	{
+		$ex = new THttpException(404, 'prado_application_singleton_required');
+		$ex->setErrorCode('');
+		$this->assertSame('', $ex->getErrorCode());
+	}
+
+	// ── Throw and catch ───────────────────────────────────────────────────────
+
+	public function testThrowAndCatch()
+	{
+		$this->expectException(THttpException::class);
+		throw new THttpException(404, 'Not Found');
+	}
+
+	public function testThrowAndCatchPreservesStatusCode()
+	{
+		try {
+			throw new THttpException(404, 'prado_application_singleton_required');
+		} catch (THttpException $ex) {
+			$this->assertSame(404, $ex->getStatusCode());
+
+			return;
+		}
+		$this->fail('THttpException was not caught');
+	}
+
+	public function testThrowAndCatchPreservesMessage()
+	{
+		try {
+			throw new THttpException(500, 'prado_application_singleton_required');
+		} catch (THttpException $ex) {
+			$this->assertStringStartsWith('Prado.Application must only be set once', $ex->getMessage());
+
+			return;
+		}
+		$this->fail('THttpException was not caught');
+	}
+
+	public function testThrowAndCatchPreservesErrorCode()
+	{
+		try {
+			throw new THttpException(404, 'prado_application_singleton_required');
+		} catch (THttpException $ex) {
+			$this->assertSame('prado_application_singleton_required', $ex->getErrorCode());
+
+			return;
+		}
+		$this->fail('THttpException was not caught');
+	}
+
+	public function testCaughtAsTException()
+	{
+		$caught = null;
+		try {
+			throw new THttpException(500, 'test');
+		} catch (TException $ex) {
+			$caught = $ex;
+		}
+		$this->assertNotNull($caught);
+		$this->assertInstanceOf(THttpException::class, $caught);
+	}
+
+	public function testCaughtAsException()
+	{
+		$caught = null;
+		try {
+			throw new THttpException(500, 'test');
+		} catch (\Exception $ex) {
+			$caught = $ex;
+		}
+		$this->assertNotNull($caught);
+		$this->assertInstanceOf(THttpException::class, $caught);
+	}
+
+	public function testCaughtAsThrowable()
+	{
+		$caught = null;
+		try {
+			throw new THttpException(500, 'test');
+		} catch (\Throwable $ex) {
+			$caught = $ex;
+		}
+		$this->assertNotNull($caught);
+		$this->assertInstanceOf(THttpException::class, $caught);
+	}
+
+	// ── Exception chaining ────────────────────────────────────────────────────
+
+	public function testGetPreviousIsNullWhenNotProvided()
+	{
+		$ex = new THttpException(404, 'test');
+		$this->assertNull($ex->getPrevious());
+	}
+
+	public function testExceptionChainingWithThrowable()
+	{
+		$prev = new \RuntimeException('previous cause');
+		$ex = new THttpException(404, 'prado_application_singleton_required', $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testExceptionChainingPreservesStatusCode()
+	{
+		$prev = new \RuntimeException('previous');
+		$ex = new THttpException(404, 'prado_application_singleton_required', $prev);
+		$this->assertSame(404, $ex->getStatusCode());
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testExceptionChainingPreservesMessage()
+	{
+		$prev = new \RuntimeException('previous');
+		$ex = new THttpException(404, 'prado_application_singleton_required', $prev);
+		$this->assertStringStartsWith('Prado.Application must only be set once', $ex->getMessage());
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testExceptionChainingWithNullMessage()
+	{
+		$prev = new \RuntimeException('previous');
+		$ex = new THttpException(503, null, $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+		$this->assertSame(503, $ex->getStatusCode());
+		$this->assertSame('', $ex->getMessage());
+	}
+
+	public function testExceptionChainingWithPlaceholders()
+	{
+		$prev = new \LogicException('root cause');
+		$ex = new THttpException(400, 'prado_component_unknown', 'CompA', 'CompB', $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+		$this->assertStringContainsString('CompA', $ex->getMessage());
+		$this->assertStringContainsString('CompB', $ex->getMessage());
+	}
+
+	public function testExceptionChainingWithPreviousTException()
+	{
+		$prev = new TException('prado_application_singleton_required');
+		$ex = new THttpException(500, 'prado_application_singleton_required', $prev);
+		$this->assertSame($prev, $ex->getPrevious());
+	}
+
+	public function testPreviousChainedExceptionIsAccessibleAfterThrowCatch()
+	{
+		$prev = new \InvalidArgumentException('root');
+		try {
+			throw new THttpException(422, 'test', $prev);
+		} catch (THttpException $ex) {
+			$this->assertSame($prev, $ex->getPrevious());
+			$this->assertSame(422, $ex->getStatusCode());
+
+			return;
+		}
+		$this->fail('Exception not caught');
+	}
+
+	// ── instanceof ────────────────────────────────────────────────────────────
+
+	public function testIsInstanceOfTSystemException()
+	{
+		$this->assertInstanceOf(TSystemException::class, new THttpException(500, 'test'));
+	}
+
+	public function testIsInstanceOfTException()
+	{
+		$this->assertInstanceOf(TException::class, new THttpException(500, 'test'));
+	}
+
+	public function testIsInstanceOfException()
+	{
+		$this->assertInstanceOf(\Exception::class, new THttpException(500, 'test'));
+	}
+
+	public function testIsInstanceOfThrowable()
+	{
+		$this->assertInstanceOf(\Throwable::class, new THttpException(500, 'test'));
+	}
+
+	// ── Visibility / encapsulation ────────────────────────────────────────────
+
+	public function testGetStatusCodeDirectIsProtected()
+	{
+		$ref = new \ReflectionMethod(THttpException::class, 'getStatusCodeDirect');
+		$this->assertTrue($ref->isProtected());
+	}
+
+	public function testSetStatusCodeDirectIsProtected()
+	{
+		$ref = new \ReflectionMethod(THttpException::class, 'setStatusCodeDirect');
+		$this->assertTrue($ref->isProtected());
+	}
+
+	public function testStatusCodePropertyIsPrivate()
+	{
+		$ref = new \ReflectionProperty(THttpException::class, '_statusCode');
+		$this->assertTrue($ref->isPrivate());
+	}
+
+	public function testGetStatusCodeIsPublic()
+	{
+		$ref = new \ReflectionMethod(THttpException::class, 'getStatusCode');
+		$this->assertTrue($ref->isPublic());
+	}
+
+	// ── Multiple instances are independent ────────────────────────────────────
+
+	public function testMultipleInstancesHaveIndependentStatusCodes()
+	{
+		$ex1 = new THttpException(404, 'test');
+		$ex2 = new THttpException(500, 'test');
+		$ex3 = new THttpException(403, 'test');
+		$this->assertSame(404, $ex1->getStatusCode());
+		$this->assertSame(500, $ex2->getStatusCode());
+		$this->assertSame(403, $ex3->getStatusCode());
+	}
+
+	public function testMultipleInstancesHaveIndependentPrevious()
+	{
+		$prev1 = new \RuntimeException('first');
+		$prev2 = new \RuntimeException('second');
+		$ex1 = new THttpException(404, 'test', $prev1);
+		$ex2 = new THttpException(500, 'test', $prev2);
+		$ex3 = new THttpException(403, 'test');
+		$this->assertSame($prev1, $ex1->getPrevious());
+		$this->assertSame($prev2, $ex2->getPrevious());
+		$this->assertNull($ex3->getPrevious());
+	}
+
+	public function testMultipleInstancesHaveIndependentErrorCodes()
+	{
+		$ex1 = new THttpException(404, 'prado_application_singleton_required');
+		$ex2 = new THttpException(500, 'prado_component_unknown', 'X', 'Y');
+		$ex1->setErrorCode('modified');
+		$this->assertSame('modified', $ex1->getErrorCode());
+		$this->assertSame('prado_component_unknown', $ex2->getErrorCode());
+	}
 }


### PR DESCRIPTION
THttpException - conforms to Uniform Access Principle - Self Encapsulation (UAP-SE)
TExitException - conforms to Uniform Access Principle - Self Encapsulation (UAP-SE)
TErrorHandler changes
 - uses `static::` rather than `self` in proper places.
 - updated documentation (including xml and php examples).
 - caching of privatePathReplacements.
 - recursive error handling in class, not static.
 - better date-time handling.
 - encapsulate PHP functions for unit testing (like `$_SERVER[$key]` accessed by `$this->serverGlobal($key)`).
 - conforms to UAP-SE.
 - return types for PHP 8.