### PR TITLE
TErrorHandler correction for prior methods staying the same.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,4 @@
-# Upgrading Instructions for PRADO Framework v4.3.2
+# Upgrading Instructions for PRADO Framework v4.3.3
 
 ### !!!IMPORTANT!!!
 
@@ -6,6 +6,10 @@ The following upgrading instructions are cumulative. That is,
 if you want to upgrade from version A to version C and there is
 version B between A and C, you need to following the instructions
 for both A and B.
+
+Upgrading from v4.3.2
+---------------------
+- Prado\TEventParameter adds a second constructor $readOnly
 
 Upgrading from v4.2.2
 ---------------------

--- a/framework/Exceptions/TErrorHandler.php
+++ b/framework/Exceptions/TErrorHandler.php
@@ -300,7 +300,7 @@ class TErrorHandler extends \Prado\TModule
 	 * @param ?\Exception $exception
 	 * @since 3.1.6
 	 */
-	protected function hideSecurityRelated($value, $exception = null): string
+	protected function hideSecurityRelated($value, $exception = null)
 	{
 		$aRpl = [];
 		if ($exception !== null && $exception instanceof \Exception) {
@@ -338,7 +338,7 @@ class TErrorHandler extends \Prado\TModule
 	 * @param int $statusCode
 	 * @param \Exception $exception
 	 */
-	protected function handleExternalError($statusCode, $exception): void
+	protected function handleExternalError($statusCode, $exception)
 	{
 		if (!($exception instanceof THttpException)) {
 			$this->errorLog($exception->__toString());
@@ -380,7 +380,7 @@ class TErrorHandler extends \Prado\TModule
 	 * Bypasses templates to avoid triggering further errors.
 	 * @param \Exception $exception
 	 */
-	protected function handleRecursiveError($exception): void
+	protected function handleRecursiveError($exception)
 	{
 		if ($this->getApplication()->getMode() === TApplicationMode::Debug) {
 			echo "<html><head><title>Recursive Error</title></head>\n";
@@ -408,7 +408,7 @@ class TErrorHandler extends \Prado\TModule
 	 * Replaces private filesystem paths in a string using the instance replacement map.
 	 * @param string $value
 	 */
-	protected function hidePrivatePathParts($value): string
+	protected function hidePrivatePathParts($value)
 	{
 		$aRpl = $this->getPrivatePathReplacements();
 		return str_replace(array_keys($aRpl), $aRpl, $value);
@@ -476,7 +476,7 @@ class TErrorHandler extends \Prado\TModule
 	 * falling back to `exception.html`.
 	 * @param \Exception $exception
 	 */
-	protected function getExceptionTemplate($exception): string
+	protected function getExceptionTemplate($exception)
 	{
 		$lang = Prado::getPreferredLanguage();
 		$templatePath = $this->getErrorTemplatePath();
@@ -506,7 +506,7 @@ class TErrorHandler extends \Prado\TModule
 	 * @param int $statusCode
 	 * @param \Exception $exception
 	 */
-	protected function getErrorTemplate($statusCode, $exception): string
+	protected function getErrorTemplate($statusCode, $exception)
 	{
 		$base = $this->getErrorTemplatePath() . DIRECTORY_SEPARATOR . static::ERROR_FILE_NAME;
 		$lang = Prado::getPreferredLanguage();
@@ -534,7 +534,7 @@ class TErrorHandler extends \Prado\TModule
 	 * on PHP 8+).
 	 * @param \Exception $exception
 	 */
-	protected function getExactTrace($exception): ?array
+	protected function getExactTrace($exception)
 	{
 		$result = null;
 		if ($exception instanceof TPhpFatalErrorException &&
@@ -573,7 +573,7 @@ class TErrorHandler extends \Prado\TModule
 	 * When xdebug is active and the exception is a fatal error, uses the xdebug stack.
 	 * @param \Exception $exception
 	 */
-	protected function getExactTraceAsString($exception): string
+	protected function getExactTraceAsString($exception)
 	{
 		if ($exception instanceof TPhpFatalErrorException &&
 			function_exists('xdebug_get_function_stack')) {
@@ -604,7 +604,7 @@ class TErrorHandler extends \Prado\TModule
 	 * @param array $trace
 	 * @param string $pattern
 	 */
-	protected function getPropertyAccessTrace($trace, $pattern): ?array
+	protected function getPropertyAccessTrace($trace, $pattern)
 	{
 		$result = null;
 		foreach ($trace as $t) {
@@ -624,7 +624,7 @@ class TErrorHandler extends \Prado\TModule
 	 * @param null|array $lines
 	 * @param int $errorLine
 	 */
-	protected function getSourceCode($lines, $errorLine): string
+	protected function getSourceCode($lines, $errorLine)
 	{
 		$numLines = is_countable($lines) ? count($lines) : 0;
 		$beginLine = $errorLine - static::SOURCE_LINES >= 0 ? $errorLine - static::SOURCE_LINES : 0;
@@ -646,7 +646,7 @@ class TErrorHandler extends \Prado\TModule
 	 * Wraps the first recognized Prado class name in the message with a documentation hyperlink.
 	 * @param string $message
 	 */
-	protected function addLink($message): string
+	protected function addLink($message)
 	{
 		if (null !== ($class = $this->getErrorClassNameSpace($message))) {
 			return str_replace($class['name'], '<a href="' . $class['url'] . '" target="_blank">' . $class['name'] . '</a>', $message);
@@ -659,7 +659,7 @@ class TErrorHandler extends \Prado\TModule
 	 * @param string $message
 	 * @return ?array{url: string, name: string} associative array with 'url' and 'name' keys, or null
 	 */
-	protected function getErrorClassNameSpace($message): ?array
+	protected function getErrorClassNameSpace($message)
 	{
 		$matches = [];
 		preg_match('/\b(T[A-Z]\w+)\b/', $message, $matches);

--- a/framework/Exceptions/THttpException.php
+++ b/framework/Exceptions/THttpException.php
@@ -44,7 +44,7 @@ class THttpException extends TSystemException
 	/**
 	 * @return int HTTP status code, such as 404, 500, etc.
 	 */
-	public function getStatusCode(): int
+	public function getStatusCode()
 	{
 		return $this->getStatusCodeDirect();
 	}

--- a/framework/IO/TTarFileExtractor.php
+++ b/framework/IO/TTarFileExtractor.php
@@ -2791,8 +2791,9 @@ class TTarFileExtractor
 	 *
 	 * @param string $p_message
 	 * @throws \Exception
+	 * @return never
 	 */
-	protected function _error(string $p_message): never
+	protected function _error($p_message)
 	{
 		$cls = $this->getExceptionClass();
 		if (!empty($cls) && $cls !== '\Exception' && $cls !== 'Exception') {
@@ -3197,7 +3198,7 @@ class TTarFileExtractor
 	 * @param ?int $p_len Number of blocks to skip (default 1).
 	 * @return bool
 	 */
-	private function _jumpBlock(?int $p_len = null): bool
+	private function _jumpBlock($p_len = null)
 	{
 		if ($this->_file === null) {
 			return true;
@@ -3288,7 +3289,7 @@ class TTarFileExtractor
 	 * @param array  &$v_header     Receives parsed fields.
 	 * @return bool True on success; false on checksum mismatch or format error.
 	 */
-	private function _readHeader(string $v_binary_data, array &$v_header): bool
+	private function _readHeader($v_binary_data, &$v_header)
 	{
 		if (strlen($v_binary_data) === 0) {
 			$v_header['filepath'] = '';

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -430,7 +430,7 @@ class TApplication extends TComponent implements ISingleton
 	 * @see setConfigurationFile
 	 * @see resolveRuntimePath
 	 */
-	protected function resolvePaths($basePath): void
+	protected function resolvePaths($basePath)
 	{
 		// determine configuration path and file
 		if (empty($errValue = $basePath) || ($basePath = realpath($basePath)) === false) {
@@ -1927,7 +1927,7 @@ class TApplication extends TComponent implements ISingleton
 	 *   ready for `$module->init($configElement)`, `null` if the module was deferred, or
 	 *   `false` if `$id` is not registered in `$_lazyModules`.
 	 */
-	protected function internalLoadModule($id, bool $force = false)
+	protected function internalLoadModule($id, $force = false)
 	{
 		if (($lazy = $this->getLazyModule($id)) === null) {
 			return false;

--- a/framework/Xml/TXmlDocument.php
+++ b/framework/Xml/TXmlDocument.php
@@ -86,7 +86,7 @@ class TXmlDocument extends TXmlElement
 	 * @param ?string $version Version of this XML document
 	 * @param ?string $encoding Encoding of this XML document
 	 */
-	public function __construct(?string $version = '1.0', ?string $encoding = '')
+	public function __construct($version = '1.0', $encoding = '')
 	{
 		$this->setVersion($version);
 		$this->setEncoding($encoding);
@@ -108,7 +108,7 @@ class TXmlDocument extends TXmlElement
 	 * Gets the version of this XML document.
 	 * @return ?string Version of this XML document
 	 */
-	public function getVersion(): ?string
+	public function getVersion()
 	{
 		return $this->_version;
 	}
@@ -117,7 +117,7 @@ class TXmlDocument extends TXmlElement
 	 * Sets the version of this XML document.
 	 * @param ?string $version Version of this XML document
 	 */
-	public function setVersion(?string $version): void
+	public function setVersion($version)
 	{
 		$this->_version = $version;
 	}
@@ -126,7 +126,7 @@ class TXmlDocument extends TXmlElement
 	 * Gets the encoding of this XML document.
 	 * @return ?string Encoding of this XML document
 	 */
-	public function getEncoding(): ?string
+	public function getEncoding()
 	{
 		return $this->_encoding;
 	}
@@ -135,7 +135,7 @@ class TXmlDocument extends TXmlElement
 	 * Sets the encoding of this XML document.
 	 * @param ?string $encoding Encoding of this XML document
 	 */
-	public function setEncoding(?string $encoding): void
+	public function setEncoding($encoding)
 	{
 		$this->_encoding = $encoding;
 	}
@@ -146,7 +146,7 @@ class TXmlDocument extends TXmlElement
 	 * @throws TIOException if the file fails to be opened.
 	 * @return bool Whether the XML file was parsed successfully
 	 */
-	public function loadFromFile(string $file): bool
+	public function loadFromFile($file)
 	{
 		if (($str = @file_get_contents($file)) !== false) {
 			return $this->loadFromString($str);
@@ -161,7 +161,7 @@ class TXmlDocument extends TXmlElement
 	 * @param ?string $string The XML string
 	 * @return bool Whether the XML string was parsed successfully
 	 */
-	public function loadFromString(?string $string): bool
+	public function loadFromString($string)
 	{
 		if (empty($string)) {
 			return false;
@@ -240,7 +240,7 @@ class TXmlDocument extends TXmlElement
 	 * @param string $file The name of the file to be stored with XML output
 	 * @throws TIOException if the file cannot be written
 	 */
-	public function saveToFile(string $file): void
+	public function saveToFile($file)
 	{
 		if (($fw = fopen($file, 'w')) !== false) {
 			fwrite($fw, $this->saveToString());
@@ -254,7 +254,7 @@ class TXmlDocument extends TXmlElement
 	 * Saves this XML document as an XML string.
 	 * @return string The XML string of this XML document
 	 */
-	public function saveToString(): string
+	public function saveToString()
 	{
 		$version = empty($this->_version) ? ' version="1.0"' : ' version="' . $this->_version . '"';
 		$encoding = empty($this->_encoding) ? '' : ' encoding="' . $this->_encoding . '"';
@@ -276,7 +276,7 @@ class TXmlDocument extends TXmlElement
 	 * ```
 	 * @return string String representation of this document
 	 */
-	public function __toString(): string
+	public function __toString()
 	{
 		return $this->saveToString();
 	}

--- a/framework/Xml/TXmlElement.php
+++ b/framework/Xml/TXmlElement.php
@@ -116,7 +116,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * @throws TInvalidDataTypeException when $tagName is null
 	 * @throws TInvalidDataValueException when $tagName is empty
 	 */
-	public function __construct(string $tagName)
+	public function __construct($tagName)
 	{
 		$this->setTagName($tagName);
 		parent::__construct();
@@ -136,7 +136,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Gets the parent element of this element.
 	 * @return ?TXmlElement Parent element of this element, or null if none
 	 */
-	public function getParent(): ?TXmlElement
+	public function getParent()
 	{
 		return $this->_parent;
 	}
@@ -145,7 +145,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Sets the parent element of this element.
 	 * @param ?TXmlElement $parent Parent element of this element
 	 */
-	public function setParent(?TXmlElement $parent): void
+	public function setParent($parent)
 	{
 		$this->_parent = $parent;
 	}
@@ -154,7 +154,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Gets the tag name of this element.
 	 * @return string Tag name of this element
 	 */
-	public function getTagName(): string
+	public function getTagName()
 	{
 		return $this->_tagName;
 	}
@@ -165,7 +165,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * @throws TInvalidDataTypeException when $tagName is null
 	 * @throws TInvalidDataValueException when $tagName is empty
 	 */
-	public function setTagName(string $tagName): void
+	public function setTagName($tagName)
 	{
 		if ($tagName === null) {
 			throw new TInvalidDataTypeException('xmlelement_null_tag');
@@ -180,7 +180,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Gets the text content enclosed between opening and closing tags of this element.
 	 * @return ?string Text content of this element, or null if none
 	 */
-	public function getValue(): ?string
+	public function getValue()
 	{
 		return $this->_value;
 	}
@@ -189,7 +189,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Sets the text content enclosed between opening and closing tags of this element.
 	 * @param ?string $value Text content of this element
 	 */
-	public function setValue($value): void
+	public function setValue($value)
 	{
 		if ($value !== null) {
 			$this->_value = TPropertyValue::ensureString($value);
@@ -202,7 +202,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Gets the list of attributes for this element.
 	 * @return TMap List of attributes for this element
 	 */
-	public function getAttributes(): TMap
+	public function getAttributes()
 	{
 		if (!$this->_attributes) {
 			$this->_attributes = new TMap();
@@ -214,7 +214,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Determines whether this element has any attributes.
 	 * @return bool True if this element has attributes, false otherwise
 	 */
-	public function getHasAttribute(): bool
+	public function getHasAttribute()
 	{
 		return $this->_attributes !== null && $this->_attributes->getCount() > 0;
 	}
@@ -238,7 +238,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * @param string $name Attribute name
 	 * @return ?string Attribute value, or null if no such attribute exists
 	 */
-	public function getAttribute(string $name): ?string
+	public function getAttribute($name)
 	{
 		if ($this->_attributes !== null) {
 			return $this->_attributes->itemAt($name);
@@ -253,7 +253,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * @param mixed $value Attribute value
 	 * @throws TInvalidDataTypeException if an invalid attribute value is provided
 	 */
-	public function setAttribute(string $name, $value)
+	public function setAttribute($name, $value)
 	{
 		$this->getAttributes()->add($name, TPropertyValue::ensureString($value));
 	}
@@ -274,7 +274,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Gets the list of child elements of this element.
 	 * @return TXmlElementList List of child elements
 	 */
-	public function getElements(): TXmlElementList
+	public function getElements()
 	{
 		if (!$this->_elements) {
 			$this->_elements = new TXmlElementList($this);
@@ -286,7 +286,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * Determines whether this element has any child elements.
 	 * @return bool True if this element has child elements, false otherwise
 	 */
-	public function getHasElement(): bool
+	public function getHasElement()
 	{
 		return $this->_elements !== null && $this->_elements->getCount() > 0;
 	}
@@ -659,7 +659,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * ```
 	 * @return string string representation of this element
 	 */
-	public function __toString(): string
+	public function __toString()
 	{
 		return $this->toString();
 	}
@@ -670,7 +670,7 @@ class TXmlElement extends \Prado\TComponent implements \IteratorAggregate, \Arra
 	 * @param string $str The string to encode
 	 * @return string The encoded character.
 	 */
-	private function xmlEncode(string $str): string
+	private function xmlEncode($str)
 	{
 		return strtr($str, [
 			'>' => '&gt;',

--- a/framework/Xml/TXmlElementList.php
+++ b/framework/Xml/TXmlElementList.php
@@ -38,7 +38,7 @@ class TXmlElementList extends \Prado\Collections\TList
 	/**
 	 * Constructor.
 	 * Initializes a new TXmlElementList with the specified owner.
-	 * @param TXmlElement $owner Owner of this list
+	 * @param ?TXmlElement $owner Owner of this list
 	 */
 	public function __construct(?TXmlElement $owner)
 	{
@@ -50,7 +50,7 @@ class TXmlElementList extends \Prado\Collections\TList
 	 * Gets the owner of this list.
 	 * @return TXmlElement Owner of this list
 	 */
-	protected function getOwner(): ?TXmlElement
+	protected function getOwner()
 	{
 		return $this->_o;
 	}
@@ -92,7 +92,7 @@ class TXmlElementList extends \Prado\Collections\TList
 	 * @param int $index The index of the item to be removed.
 	 * @return mixed The removed item.
 	 */
-	public function removeAt($index): mixed
+	public function removeAt($index)
 	{
 		$item = parent::removeAt($index);
 		if ($item instanceof TXmlElement) {


### PR DESCRIPTION
My apologies for mucking this.  I'm glad you called this error out @ctrlaltca.  My intention was to keep it the same in 4.3.3.

For v4.4 we should embrace method parameter and return  types.  I think we can do the whole project pretty easily with these automated "AI" tools.  

I think we can do a conversion of the value based on the setter parameter type in TComponent::setSubProperty. via Reflection.  This is the method everything is routed through (though I'll need to do an audit to be sure).  TTemplate was one of the few places that it was not centralized.

We can also discuss doing a "return $this;" at the end of property setters for chaining.  Again, I think we can just convert the whole project with the AI tools.