### PR TITLE
Module Dependencies - Some load after others

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -68,6 +68,8 @@ application_unavailable					= Application is unavailable at this time.
 application_service_unavailable			= Service '{0}' is unavailable at this time.
 application_moduleid_duplicated			= Application module ID '{0}' is not unique.
 application_runtimepath_failed			= Unable to create runtime path '{0}'. Make sure the parent directory exists and is writable by the Web process.
+application_module_required_dep_missing	= Module '{0}' has a required dependency on module '{1}', which is not registered with the application.
+application_module_dependency_cycle		= A dependency cycle was detected among the following modules: {0}.
 
 appconfig_aliaspath_invalid				= Application configuration <alias id="{0}"> uses an invalid file path "{1}".
 appconfig_alias_invalid					= Application configuration <alias> element must have an "id" attribute and a "path" attribute.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -70,6 +70,7 @@ application_moduleid_duplicated			= Application module ID '{0}' is not unique.
 application_runtimepath_failed			= Unable to create runtime path '{0}'. Make sure the parent directory exists and is writable by the Web process.
 application_module_required_dep_missing	= Module '{0}' has a required dependency on module '{1}', which is not registered with the application.
 application_module_dependency_cycle		= A dependency cycle was detected among the following modules: {0}.
+application_module_dependency_self_reference	= Module '{0}' declares itself as a dependency, which is never valid.
 
 appconfig_aliaspath_invalid				= Application configuration <alias id="{0}"> uses an invalid file path "{1}".
 appconfig_alias_invalid					= Application configuration <alias> element must have an "id" attribute and a "path" attribute.

--- a/framework/IModuleDependency.php
+++ b/framework/IModuleDependency.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * IModuleDependency interface file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado;
+
+/**
+ * IModuleDependency interface.
+ *
+ * Application modules may implement this interface to declare which other
+ * modules must be initialized before they are. The application loader
+ * collects these declarations and uses Kahn's topological sort to determine
+ * a safe initialization order, regardless of the order modules appear in the
+ * configuration file.
+ *
+ * **The `$isPreInit` flag** passed to {@see getModuleDependencies()} identifies
+ * which sort pass is being computed:
+ *
+ * | `$isPreInit` | Used for                   |
+ * |--------------|----------------------------|
+ * | `true`       | dyPreInit pass             |
+ * | `false`      | init() and dyPostInit      |
+ *
+ * `dyPostInit` always runs in the **same order** as `init()` — the framework
+ * reuses the init-pass sort result for post-init without re-sorting.
+ * Implementations may return different lists for the pre-init and init passes:
+ * ```php
+ * public function getModuleDependencies(bool $isPreInit = false): ?array
+ * {
+ *     // Only need 'db' during init; skip in the pre-init pass.
+ *     if ($isPreInit) { return []; }
+ *     return ['db'];
+ * }
+ * ```
+ *
+ * The return value of {@see getModuleDependencies()} is cast to an array
+ * internally (`null|string|array`), so implementations may return any of the following:
+ *   - `null` or `[]` — no dependencies;
+ *   - a single string module ID — required dependency, shorthand for one dep;
+ *   - an indexed array whose elements are either:
+ *       - a plain string module ID — required dependency; or
+ *       - an associative array with keys `'id'` (string|null) and optionally
+ *         `'required'` (bool, default true). When `'id'` is `null` or `''` the
+ *         entry is silently skipped (useful for conditional deps where the ID
+ *         may not yet be known). When `'required'` is false the dependency is
+ *         advisory: it influences order when the referenced module is present
+ *         but raises no error when it is absent;
+ *   - an associative array whose keys are module IDs and values are the
+ *     required flag in any form accepted by {@see TPropertyValue::ensureBoolean}
+ *     (bool, int, or string such as `'true'`, `'false'`, `'yes'`, `'no'`).
+ *     Example: `['db' => true, 'cache' => false]`.
+ *
+ * **Contract:** {@see getModuleDependencies()} is called before
+ * {@see IModule::init()}, after all configuration properties have been
+ * applied via setXxx() calls. Implementations must therefore return their
+ * values from configuration state alone and must not rely on init() having
+ * run.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+interface IModuleDependency
+{
+	/**
+	 * Returns the IDs of modules that must be initialized before this module.
+	 *
+	 * The `$isPreInit` flag identifies which sort pass is being computed:
+	 * `true` for the dyPreInit pass, `false` for the init() pass (dyPostInit
+	 * reuses the init-pass order and does not re-invoke this method).
+	 * Implementations may ignore `$isPreInit` and return the same list for both
+	 * values, or return different lists for the two passes.
+	 *
+	 * The return value is cast to an array by the caller, so a single string
+	 * module ID may be returned as a convenience. Supported forms:
+	 *   - `null` or `[]` — no dependencies
+	 *   - `'moduleId'` — single required dependency
+	 *   - `['a', 'b']` — multiple required dependencies
+	 *   - `[['id' => 'a', 'required' => false]]` — verbose form with required flag;
+	 *     `'id'` may be `null` to represent "no dependency" in a fixed-shape array
+	 *   - `['a' => true, 'b' => false]` — key-value shorthand; value is passed through
+	 *     {@see TPropertyValue::ensureBoolean} so strings like `'true'`/`'false'` are accepted
+	 *
+	 * @param bool $isPreInit `true` when collecting for the dyPreInit pass,
+	 *   `false` when collecting for the init() pass (default)
+	 * @return null|array<array{id:null|string,required?:bool}|string>|array<string,bool|int|string>|string dependency descriptors
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array;
+}

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -122,6 +122,7 @@ use Prado\Xml\TXmlElement;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @author Brad Anderson <belisoful@icloud.com> Self-encapsulation, module dependencies.
  * @since 3.0
+ * @method array dyFilterModuleDependencies(array $moduleRecords, array $pending, bool $isPreInit) Filters the complete module dependency map before topological sorting; the (possibly modified) map is returned.
  */
 class TApplication extends TComponent implements ISingleton
 {
@@ -1395,7 +1396,7 @@ class TApplication extends TComponent implements ISingleton
 					$module[0]->dyPreInit($module[1]);
 				}
 				// Ensure every declared dependency is initialized before this module (init phase).
-				foreach ($this->collectModuleDependencies($module[0], false) as $dep) {
+				foreach ($this->collectModuleDependencies($module[0], false)['deps'] as $dep) {
 					if (!array_key_exists($dep['id'], $this->_modules)) {
 						// Dep not registered at all.
 						if ($dep['required']) {
@@ -2004,118 +2005,40 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Collects all dependencies that `$module` declares for the given lifecycle
-	 * `$phase`, merging two sources in priority order — module first, then
-	 * behaviors — and deduplicating by module ID. When the same ID appears in
-	 * both sources, the module-level declaration wins.
-	 *
-	 * Sources:
-	 * 1. {@see IModuleDependency::getModuleDependencies()} on the module itself —
-	 *    fully dynamic, re-evaluated on every call. The return value is cast to
-	 *    an array, so implementations may return a single string as shorthand.
-	 * 2. Any behavior attached to the module that also implements
-	 *    {@see IModuleDependency} — fully dynamic, the behavior list is re-scanned
-	 *    and each behavior's `getModuleDependencies()` is re-evaluated on every call,
-	 *    because behaviors may be attached or detached between initialization phases.
-	 *    Behavior return values are cast to array by the same rule.
-	 *
-	 * Both sources are re-evaluated on every call with no caching.
-	 *
-	 * Verbose array entries whose `'id'` key is `null` or `''` are silently
-	 * skipped; this lets implementations return a fixed-shape array where a
-	 * dep ID that is not yet known is represented as `null`.
-	 *
-	 * Each returned element is an associative array with keys:
-	 * - `'id'`       (string) — the dependency module ID
-	 * - `'required'` (bool)   — `true` if the dependency is mandatory (default),
-	 *                           `false` if advisory (influences order when present
-	 *                           but raises no error when absent).
-	 *
-	 * @param IModule $module the module to inspect.
-	 * @param bool $isPreInit `true` when collecting for the dyPreInit pass,
-	 *   `false` when collecting for the init() pass (default). Passed verbatim to
-	 *   {@see IModuleDependency::getModuleDependencies()}.
-	 * @return array<array{id:string,required:bool}> unique list of dependency descriptors.
-	 * @since 4.4.0
-	 */
-	protected function collectModuleDependencies(IModule $module, bool $isPreInit = false): array
-	{
-		// Keyed by dep ID so that module-level declarations take priority over
-		// behavior-level ones when the same dep ID appears in both sources.
-		$deps = [];
-
-		// Source 1: IModuleDependency on the module itself.
-		// Processed first so module-level declarations take priority over behaviors.
-		if ($module instanceof IModuleDependency) {
-			foreach ((array) ($module->getModuleDependencies($isPreInit) ?? []) as $key => $dep) {
-				if (is_string($key) && $key !== '') {
-					$deps[$key] = ['id' => $key, 'required' => TPropertyValue::ensureBoolean($dep)];
-				} elseif (is_string($dep) && $dep !== '') {
-					$deps[$dep] = ['id' => $dep, 'required' => true];
-				} elseif (is_array($dep) && array_key_exists('id', $dep) && $dep['id'] !== null && $dep['id'] !== '') {
-					$deps[$dep['id']] = [
-						'id' => $dep['id'],
-						'required' => TPropertyValue::ensureBoolean($dep['required'] ?? true),
-					];
-				}
-			}
-		}
-
-		// Source 2: IModuleDependency behaviors attached to the module.
-		// Re-scanned every call — behaviors may be attached or detached between phases.
-		// Only adds IDs not already contributed by the module (Source 1 takes priority).
-		if ($module instanceof TComponent) {
-			foreach ($module->getBehaviors(IModuleDependency::class) as $behavior) {
-				foreach ((array) ($behavior->getModuleDependencies($isPreInit) ?? []) as $key => $dep) {
-					if (is_string($key) && $key !== '') {
-						if (!isset($deps[$key])) {
-							$deps[$key] = ['id' => $key, 'required' => TPropertyValue::ensureBoolean($dep)];
-						}
-					} elseif (is_string($dep) && $dep !== '') {
-						if (!isset($deps[$dep])) {
-							$deps[$dep] = ['id' => $dep, 'required' => true];
-						}
-					} elseif (is_array($dep) && array_key_exists('id', $dep) && $dep['id'] !== null && $dep['id'] !== '') {
-						if (!isset($deps[$dep['id']])) {
-							$deps[$dep['id']] = [
-								'id' => $dep['id'],
-								'required' => TPropertyValue::ensureBoolean($dep['required'] ?? true),
-							];
-						}
-					}
-				}
-			}
-			$deps = $module->dyFilterDependencies($deps);
-		}
-
-		return array_values($deps);
-	}
-
-	/**
 	 * Sorts a set of pending module entries into initialization order using
 	 * Kahn's topological sort algorithm, respecting declared module dependencies.
 	 *
-	 * Each element of `$pending` must be an associative array with keys:
-	 * - `'id'`     (string)   — the module's registration ID
-	 * - `'module'` (IModule)  — the instantiated, property-configured module
-	 * - `'config'` (mixed)    — the configuration element to pass to `init()`
+	 * Both `$pending` and the return value are arrays of entries with the same
+	 * structure — the output is the input reordered so each module appears after
+	 * all of its in-batch dependencies:
+	 * ```php
+	 * [
+	 *     'id'     => 'moduleA',   // registration ID
+	 *     'module' => $moduleA,    // IModule instance
+	 *     'config' => $config,     // configuration element passed to init()
+	 * ]
+	 * ```
 	 *
 	 * Dependencies that reference module IDs outside of `$pending` (already
 	 * initialized or not present in this configuration batch) are silently
 	 * ignored for ordering purposes. The caller is responsible for ensuring
 	 * those modules are already live.
 	 *
+	 * `$cache` is a sort-result cache passed by reference, keyed by dependency-graph
+	 * fingerprint under {@see DEP_SORT_CACHE_KEY}. Passing the same array across both
+	 * phase-sort calls within a single configuration run avoids redundant sorts when
+	 * the dependency graph is unchanged between phases.
+	 *
+	 * `$isPreInit` is forwarded to {@see collectModuleDependencies()} and from there
+	 * to each module's {@see IModuleDependency::getModuleDependencies()}, allowing
+	 * modules to declare different dependencies for the dyPreInit and init() passes.
+	 *
 	 * @param array  $pending list of pending module entries.
-	 * @param array &$cache  sort-result cache passed by reference. Sort results are
-	 *   stored under {@see DEP_SORT_CACHE_KEY} keyed by dependency-graph fingerprint.
-	 *   Pass the same array across both phase-sort calls within a single configuration
-	 *   run to avoid redundant sorts when the dependency graph is unchanged.
+	 * @param array &$cache  sort-result cache, keyed by graph fingerprint.
 	 * @param bool $isPreInit `true` when sorting the dyPreInit pass,
-	 *   `false` when sorting the init() pass (default). Passed to
-	 *   {@see collectModuleDependencies()} and then to each module's
-	 *   {@see IModuleDependency::getModuleDependencies()}.
+	 *   `false` for the init() pass (default).
 	 * @throws \Prado\Exceptions\TConfigurationException if a dependency cycle is detected.
-	 * @return array the same entries sorted in dependency-first order.
+	 * @return array the entries of `$pending` in dependency-first order.
 	 * @since 4.4.0
 	 */
 	protected function sortModulesByDependency(array $pending, array &$cache = [], bool $isPreInit = false): array
@@ -2131,20 +2054,22 @@ class TApplication extends TComponent implements ISingleton
 		}
 
 		// Collect all dependencies for this phase — fully re-evaluated on every call (no caching).
-		// Each element of $allDeps[$id] is array{id:string, required:bool}.
-		$allDeps = [];
+		$moduleRecords = [];
 		foreach ($byId as $id => $entry) {
-			$allDeps[$id] = $this->collectModuleDependencies($entry['module'], $isPreInit);
+			// $moduleRecords[$id] = ['id' => string, 'module' => IModule, 'deps' => array<depId, array{id:string,required:bool}>].
+			$moduleRecords[$id] = $this->collectModuleDependencies($entry['module'], $isPreInit);
 		}
+
+		$moduleRecords = $this->filterModuleDependencies($moduleRecords, $pending, $isPreInit);
 
 		// Build a fingerprint of the in-batch dependency graph.
 		// Only intra-batch edges influence the sort, so out-of-batch deps are excluded.
 		// The fingerprint is stored under DEP_SORT_CACHE_KEY in $cache.
 		$depGraph = [];
-		foreach ($allDeps as $id => $deps) {
+		foreach ($moduleRecords as $id => $record) {
 			$inBatch = array_values(array_filter(
-				array_column($deps, 'id'),
-				fn (string $d) => isset($byId[$d])
+				array_keys($record['deps']),
+				fn (string $depId) => isset($moduleRecords[$depId])
 			));
 			sort($inBatch);
 			$depGraph[$id] = $inBatch;
@@ -2162,15 +2087,14 @@ class TApplication extends TComponent implements ISingleton
 		$depMap = [];   // id → [dep_id, ...]  (used for cycle reporting)
 		$inDegree = [];   // id → int
 		$successors = [];   // dep_id → [dependent_id, ...]
-		foreach ($byId as $id => $_) {
+		foreach ($moduleRecords as $id => $_) {
 			$inDegree[$id] = 0;
 			$successors[$id] = [];
 			$depMap[$id] = [];
 		}
-		foreach ($allDeps as $id => $deps) {
-			foreach ($deps as $dep) {
-				$depId = $dep['id'];
-				if (!isset($byId[$depId])) {
+		foreach ($moduleRecords as $id => $record) {
+			foreach ($record['deps'] as $depId => $_dep) {
+				if (!isset($moduleRecords[$depId])) {
 					continue; // dep is outside this batch — already satisfied or truly external
 				}
 				$depMap[$id][] = $depId;
@@ -2198,8 +2122,8 @@ class TApplication extends TComponent implements ISingleton
 			}
 		}
 
-		if (count($sorted) < count($byId)) {
-			$cycleIds = array_diff(array_keys($byId), $sorted);
+		if (count($sorted) < count($moduleRecords)) {
+			$cycleIds = array_diff(array_keys($moduleRecords), $sorted);
 			$cyclePath = $this->findCyclePath($cycleIds, $depMap);
 			throw new TConfigurationException(
 				'application_module_dependency_cycle',
@@ -2212,12 +2136,183 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
+	 * Collects all dependencies that `$module` declares for the given lifecycle
+	 * `$isPreInit`, merging two sources in priority order — module first, then
+	 * behaviors — and deduplicating by module ID. When the same ID appears in
+	 * both sources, the module-level declaration wins.
+	 *
+	 * Sources:
+	 * 1. {@see IModuleDependency::getModuleDependencies()} on the module itself —
+	 *    fully dynamic, re-evaluated on every call. The return value is cast to
+	 *    an array, so implementations may return a single string as shorthand.
+	 * 2. Any behavior attached to the module that also implements
+	 *    {@see IModuleDependency} — fully dynamic, the behavior list is re-scanned
+	 *    and each behavior's `getModuleDependencies()` is re-evaluated on every call,
+	 *    because behaviors may be attached or detached between initialization phases.
+	 *    Behavior return values are cast to array by the same rule.
+	 *
+	 * {@see IModuleDependency::getModuleDependencies()} may return dependencies in
+	 * any of four forms, all of which are normalized to the `deps` map format:
+	 *
+	 * - **String return** — a bare `$depId` string: cast to an indexed array before
+	 *   before processing; the dependency ID is the string value; `required`
+	 *   defaults to `true`.
+	 * - **Indexed array** — `[$depId]`: a non-empty string value with an integer key;
+	 *   the dependency ID is the value; `required` defaults to `true`.
+	 * - **Key-value** — `[$depId => $required]`: a non-empty string key is the
+	 *   dependency ID; the value is cast to `bool` via
+	 *   {@see TPropertyValue::ensureBoolean()} as the `required` flag.
+	 * - **Verbose array** — `[['id' => $depId, 'required' => $bool]]`: `'id'` may
+	 *   be any value, but entries where `'id'` is `null`, `''`, or not a string are
+	 *   silently skipped; `'required'` is optional and defaults to `true`.
+	 *
+	 * Entries that resolve to a `null`, `false`, `0`, or empty-string dependency ID
+	 * are silently skipped. This lets implementations return a fixed-shape array
+	 * where a dep ID that is not set or known is represented as `null`.
+	 *
+	 * Both sources are re-evaluated on every call with no caching.
+	 *
+	 * Example return value:
+	 * ```php
+	 * [
+	 *     'id'     => 'moduleA',             // the module's registration ID
+	 *     'module' => $moduleA,              // the IModule instance
+	 *     'deps'   => [                      // keyed by dependency module ID
+	 *         'moduleB' => ['id' => 'moduleB', 'required' => true],
+	 *         'moduleC' => ['id' => 'moduleC', 'required' => false],
+	 *     ],
+	 * ]
+	 * ```
+	 *
+	 * Each returned dependency (`deps`) is an associative array with keys:
+	 * - `'id'`       (string) — the dependency module ID
+	 * - `'required'` (bool)   — `true` if the dependency is mandatory (default),
+	 *                           `false` if advisory (influences order when present
+	 *                           but raises no error when absent).
+	 *
+	 * @param IModule $module the module to inspect.
+	 * @param bool $isPreInit `true` when collecting for the dyPreInit pass,
+	 *   `false` when collecting for the init() pass (default). Passed verbatim to
+	 *   {@see IModuleDependency::getModuleDependencies()}.
+	 * @return array{id:string,module:IModule,deps:array<string,array{id:string,required:bool}>} record containing the module ID, the module instance, and its dependency map keyed by dep ID.
+	 * @since 4.4.0
+	 * @see IModuleDependency
+	 */
+	protected function collectModuleDependencies(IModule $module, bool $isPreInit = false): array
+	{
+		// Keyed by dep ID so that module-level declarations take priority over
+		// behavior-level ones when the same dep ID appears in both sources.
+		$ownId = $module->getID();
+		$deps = [];
+
+		// Source 1: IModuleDependency on the module itself.
+		// Processed first so module-level declarations take priority over behaviors.
+		if ($module instanceof IModuleDependency) {
+			foreach ((array) ($module->getModuleDependencies($isPreInit) ?? []) as $key => $dep) {
+				$required = true;
+				if (is_string($key) && $key !== '') {
+					$required = TPropertyValue::ensureBoolean($dep);
+					$dep = $key;
+				} elseif (is_string($dep) && $dep !== '') {
+					$key = $dep;
+				} elseif (is_array($dep) && is_string($dep['id'] ?? null) && $dep['id'] !== '') {
+					$required = TPropertyValue::ensureBoolean($dep['required'] ?? true);
+					$key = $dep = $dep['id'];
+				} else {
+					continue; // no valid dep ID resolved — silently skip
+				}
+				if ($dep === $ownId) {
+					throw new TConfigurationException('application_module_dependency_self_reference', $ownId);
+				}
+				$deps[$key] = ['id' => $dep, 'required' => $required];
+			}
+		}
+
+		// Source 2: IModuleDependency behaviors attached to the module.
+		// Re-scanned every call — behaviors may be attached or detached between phases.
+		// Only adds IDs not already contributed by the module (Source 1 takes priority).
+		if ($module instanceof TComponent) {
+			foreach ($module->getBehaviors(IModuleDependency::class) as $behavior) {
+				foreach ((array) ($behavior->getModuleDependencies($isPreInit) ?? []) as $key => $dep) {
+					$required = true;
+					if (is_string($key) && $key !== '') {
+						$required = TPropertyValue::ensureBoolean($dep);
+						$dep = $key;
+					} elseif (is_string($dep) && $dep !== '') {
+						$key = $dep;
+					} elseif (is_array($dep) && is_string($dep['id'] ?? null) && $dep['id'] !== '') {
+						$required = TPropertyValue::ensureBoolean($dep['required'] ?? true);
+						$key = $dep = $dep['id'];
+					} else {
+						continue; // no valid dep ID resolved — silently skip
+					}
+					if ($dep === $ownId) {
+						throw new TConfigurationException('application_module_dependency_self_reference', $ownId);
+					}
+					if (!isset($deps[$key])) {
+						$deps[$key] = ['id' => $dep, 'required' => $required];
+					}
+				}
+			}
+			$deps = $module->dyFilterDependencies($deps);
+		}
+
+		return ['id' => $ownId, 'module' => $module, 'deps' => $deps];
+	}
+
+	/**
+	 * Filters the complete dependency map for all pending modules after every
+	 * module's own sources have been collected. Called once per sort pass, so
+	 * implementations can see — and cross-reference — the full set of edges at
+	 * once. Subclasses may override this method to inject configuration-sourced
+	 * edges or apply global ordering policies. Attached behaviors may implement
+	 * {@see dyFilterModuleDependencies()} to participate without subclassing.
+	 *
+	 * This is the application-level counterpart to
+	 * {@see \Prado\TModule::dyFilterDependencies()}, which lets each module's own
+	 * behaviors filter its individual dep list before this method is reached.
+	 *
+	 * The `$moduleRecords` map has the following structure:
+	 * ```php
+	 * [
+	 *     'moduleA' => [
+	 *         'id'     => 'moduleA',         // the module's registration ID
+	 *         'module' => $moduleA,          // the IModule instance
+	 *         'deps'   => [                  // keyed by dependency module ID
+	 *             'moduleB' => ['id' => 'moduleB', 'required' => true],
+	 *             'moduleC' => ['id' => 'moduleC', 'required' => false],
+	 *         ],
+	 *     ],
+	 *     'moduleB' => [
+	 *         'id'     => 'moduleB',
+	 *         'module' => $moduleB,
+	 *         'deps'   => [],
+	 *     ],
+	 * ]
+	 * ```
+	 *
+	 * @param array<string,array{id:string,module:IModule,deps:array<string,array{id:string,required:bool}>}> $moduleRecords map of module ID → record from {@see collectModuleDependencies()}
+	 * @param array $pending the pending module entries being sorted, each with keys
+	 *   `'id'` (string), `'module'` (IModule), and `'config'` (mixed)
+	 * @param bool $isPreInit `true` when sorting the dyPreInit pass,
+	 *   `false` for the init() pass
+	 * @return array<string,array{id:string,module:IModule,deps:array<string,array{id:string,required:bool}>}> the filtered map, keyed by module ID
+	 * @since 4.4.0
+	 */
+	protected function filterModuleDependencies(array $moduleRecords, array $pending, bool $isPreInit = false): array
+	{
+		return $this->dyFilterModuleDependencies($moduleRecords, $pending, $isPreInit);
+	}
+
+	/**
 	 * Finds and returns a representative cycle path within a known set of
 	 * cycle node IDs by following dependency edges via DFS until a node is
 	 * revisited.
 	 *
 	 * Returns a closed-loop array where the first and last elements are the
-	 * same module ID (e.g. `['a', 'b', 'c', 'a']`).
+	 * same module ID (e.g. `['a', 'b', 'c', 'a']`). Self-cycles — where a
+	 * module lists itself as a dependency — produce a two-element path
+	 * (e.g. `['a', 'a']`) and are detected the same way as multi-node cycles.
 	 *
 	 * @param array $cycleIds IDs known to participate in a cycle.
 	 * @param array $depMap   dependency map: id → [dep_id, ...].

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -101,6 +101,17 @@ use Prado\Xml\TXmlElement;
  * in the above order. To terminate an application before the whole lifecycle
  * completes, call {@see completeRequest}.
  *
+ * ## Module Dependency Ordering
+ *
+ * Each configuration batch is sorted into dependency-first initialization order
+ * before initialization phases 2–4 (dyPreInit, init, dyPostInit) run.
+ * Dependencies are declared via the {@see IModuleDependency} interface — either
+ * directly on the module or on any attached behavior that also implements
+ * {@see IModuleDependency}. Kahn's topological sort is used; a
+ * {@see Exceptions\TConfigurationException} is thrown when a dependency cycle
+ * is detected. See {@see TModule} for a full description of all declaration
+ * mechanisms.
+ *
  * Examples:
  * - Create and run a Prado application:
  * ```php
@@ -109,6 +120,7 @@ use Prado\Xml\TXmlElement;
  * ```
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
+ * @author Brad Anderson <belisoful@icloud.com> Self-encapsulation, module dependencies.
  * @since 3.0
  */
 class TApplication extends TComponent implements ISingleton
@@ -163,6 +175,12 @@ class TApplication extends TComponent implements ISingleton
 	 * @since 4.3.3
 	 */
 	public const DEFAULT_PAGE_SERVICE_CLASS = TPageService::class;
+	/**
+	 * Key used within the dependency cache array to store sort results,
+	 * distinct from the integer spl_object_id keys used for per-instance data.
+	 * @since 4.4.0
+	 */
+	public const DEP_SORT_CACHE_KEY = '_sort';
 
 	/**
 	 * @var string[] ordered list of lifecycle method names executed by {@see run()}.
@@ -1350,9 +1368,15 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the module registered under `$id`, or `null` if no module with that ID exists.
-	 * Lazy modules are deferred at startup and loaded on first request via {@see internalLoadModule()}
-	 * and `init()`, then cached for subsequent calls.
+	 * Returns the module registered under `$id`, or `null` if no module with that ID
+	 * exists.
+	 *
+	 * Lazy modules are deferred at startup and loaded on first access. When a lazy
+	 * module is loaded, its full four-phase sequence is run inline:
+	 * {@see TModule::dyPreInit()}, dependency initialization (each declared dependency
+	 * is loaded recursively via a nested `getModule()` call before `init()` runs),
+	 * {@see IModule::init()}, and {@see TModule::dyPostInit()}.
+	 *
 	 * @param string $id module ID
 	 * @return ?TModule the module with the specified ID, null if not found
 	 */
@@ -1365,7 +1389,31 @@ class TApplication extends TComponent implements ISingleton
 		// force loading of a lazy module
 		if ($this->_modules[$id] === null) {
 			$module = $this->internalLoadModule($id, true);
-			$module[0]->init($module[1]);
+			if ($module) {
+				$isComponent = $module[0] instanceof TComponent;
+				if ($isComponent) {
+					$module[0]->dyPreInit($module[1]);
+				}
+				// Ensure every declared dependency is initialized before this module (init phase).
+				foreach ($this->collectModuleDependencies($module[0], false) as $dep) {
+					if (!array_key_exists($dep['id'], $this->_modules)) {
+						// Dep not registered at all.
+						if ($dep['required']) {
+							throw new TConfigurationException(
+								'application_module_required_dep_missing',
+								$module[0]->getID(),
+								$dep['id']
+							);
+						}
+						continue; // advisory dep absent — skip silently
+					}
+					$this->getModule($dep['id']); // force-load if lazy
+				}
+				$module[0]->init($module[1]);
+				if ($isComponent) {
+					$module[0]->dyPostInit($module[1]);
+				}
+			}
 		}
 
 		return $this->_modules[$id];
@@ -1913,19 +1961,20 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Loads and initializes a single module from its lazy-module registration tuple.
+	 * Instantiates a single module from its lazy-module registration tuple and
+	 * applies its configuration properties (Phase 1 of module initialization).
 	 *
 	 * If the module's `lazy` property is `true` and `$force` is `false`, the module
 	 * is registered as a null placeholder in `$_modules` and this method returns `null`.
-	 * Otherwise the module is instantiated, its properties are applied, and it is stored
-	 * in `$_modules`. The lazy-module slot is nullified to prevent ID reuse.
-	 * The caller is responsible for calling `init()` on the returned module.
+	 * Otherwise the module is instantiated, its properties are applied via setXxx()
+	 * calls, and it is stored in `$_modules`. The lazy-module slot is nullified to
+	 * prevent ID reuse.
 	 *
-	 * @param string $id module ID registered with {@see setLazyModule()}.
+	 * @param string $id module ID registered in `$_lazyModules`.
 	 * @param bool $force when `true`, forces loading even if the `lazy` property is set. Defaults to `false`.
 	 * @return null|array{0: IModule, 1: mixed}|false a two-element array `[$module, $configElement]`
-	 *   ready for `$module->init($configElement)`, `null` if the module was deferred, or
-	 *   `false` if `$id` is not registered in `$_lazyModules`.
+	 *   ready for `dyPreInit($configElement)` and `$module->init($configElement)`,
+	 *   `null` if the module was deferred, or `false` if `$id` is not registered in `$_lazyModules`.
 	 */
 	protected function internalLoadModule($id, bool $force = false)
 	{
@@ -1950,9 +1999,259 @@ class TApplication extends TComponent implements ISingleton
 		$this->setModule($id, $module);
 		// keep the key to avoid reuse of the old module id
 		$this->setLazyModule($id, null);
-		$module->dyPreInit($configElement);
 
 		return [$module, $configElement];
+	}
+
+	/**
+	 * Collects all dependencies that `$module` declares for the given lifecycle
+	 * `$phase`, merging two sources in priority order — module first, then
+	 * behaviors — and deduplicating by module ID. When the same ID appears in
+	 * both sources, the module-level declaration wins.
+	 *
+	 * Sources:
+	 * 1. {@see IModuleDependency::getModuleDependencies()} on the module itself —
+	 *    fully dynamic, re-evaluated on every call. The return value is cast to
+	 *    an array, so implementations may return a single string as shorthand.
+	 * 2. Any behavior attached to the module that also implements
+	 *    {@see IModuleDependency} — fully dynamic, the behavior list is re-scanned
+	 *    and each behavior's `getModuleDependencies()` is re-evaluated on every call,
+	 *    because behaviors may be attached or detached between initialization phases.
+	 *    Behavior return values are cast to array by the same rule.
+	 *
+	 * Both sources are re-evaluated on every call with no caching.
+	 *
+	 * Verbose array entries whose `'id'` key is `null` or `''` are silently
+	 * skipped; this lets implementations return a fixed-shape array where a
+	 * dep ID that is not yet known is represented as `null`.
+	 *
+	 * Each returned element is an associative array with keys:
+	 * - `'id'`       (string) — the dependency module ID
+	 * - `'required'` (bool)   — `true` if the dependency is mandatory (default),
+	 *                           `false` if advisory (influences order when present
+	 *                           but raises no error when absent).
+	 *
+	 * @param IModule $module the module to inspect.
+	 * @param bool $isPreInit `true` when collecting for the dyPreInit pass,
+	 *   `false` when collecting for the init() pass (default). Passed verbatim to
+	 *   {@see IModuleDependency::getModuleDependencies()}.
+	 * @return array<array{id:string,required:bool}> unique list of dependency descriptors.
+	 * @since 4.4.0
+	 */
+	protected function collectModuleDependencies(IModule $module, bool $isPreInit = false): array
+	{
+		// Keyed by dep ID so that module-level declarations take priority over
+		// behavior-level ones when the same dep ID appears in both sources.
+		$deps = [];
+
+		// Source 1: IModuleDependency on the module itself.
+		// Processed first so module-level declarations take priority over behaviors.
+		if ($module instanceof IModuleDependency) {
+			foreach ((array) ($module->getModuleDependencies($isPreInit) ?? []) as $key => $dep) {
+				if (is_string($key) && $key !== '') {
+					$deps[$key] = ['id' => $key, 'required' => TPropertyValue::ensureBoolean($dep)];
+				} elseif (is_string($dep) && $dep !== '') {
+					$deps[$dep] = ['id' => $dep, 'required' => true];
+				} elseif (is_array($dep) && array_key_exists('id', $dep) && $dep['id'] !== null && $dep['id'] !== '') {
+					$deps[$dep['id']] = [
+						'id' => $dep['id'],
+						'required' => TPropertyValue::ensureBoolean($dep['required'] ?? true),
+					];
+				}
+			}
+		}
+
+		// Source 2: IModuleDependency behaviors attached to the module.
+		// Re-scanned every call — behaviors may be attached or detached between phases.
+		// Only adds IDs not already contributed by the module (Source 1 takes priority).
+		if ($module instanceof TComponent) {
+			foreach ($module->getBehaviors(IModuleDependency::class) as $behavior) {
+				foreach ((array) ($behavior->getModuleDependencies($isPreInit) ?? []) as $key => $dep) {
+					if (is_string($key) && $key !== '') {
+						if (!isset($deps[$key])) {
+							$deps[$key] = ['id' => $key, 'required' => TPropertyValue::ensureBoolean($dep)];
+						}
+					} elseif (is_string($dep) && $dep !== '') {
+						if (!isset($deps[$dep])) {
+							$deps[$dep] = ['id' => $dep, 'required' => true];
+						}
+					} elseif (is_array($dep) && array_key_exists('id', $dep) && $dep['id'] !== null && $dep['id'] !== '') {
+						if (!isset($deps[$dep['id']])) {
+							$deps[$dep['id']] = [
+								'id' => $dep['id'],
+								'required' => TPropertyValue::ensureBoolean($dep['required'] ?? true),
+							];
+						}
+					}
+				}
+			}
+			$deps = $module->dyFilterDependencies($deps);
+		}
+
+		return array_values($deps);
+	}
+
+	/**
+	 * Sorts a set of pending module entries into initialization order using
+	 * Kahn's topological sort algorithm, respecting declared module dependencies.
+	 *
+	 * Each element of `$pending` must be an associative array with keys:
+	 * - `'id'`     (string)   — the module's registration ID
+	 * - `'module'` (IModule)  — the instantiated, property-configured module
+	 * - `'config'` (mixed)    — the configuration element to pass to `init()`
+	 *
+	 * Dependencies that reference module IDs outside of `$pending` (already
+	 * initialized or not present in this configuration batch) are silently
+	 * ignored for ordering purposes. The caller is responsible for ensuring
+	 * those modules are already live.
+	 *
+	 * @param array  $pending list of pending module entries.
+	 * @param array &$cache  sort-result cache passed by reference. Sort results are
+	 *   stored under {@see DEP_SORT_CACHE_KEY} keyed by dependency-graph fingerprint.
+	 *   Pass the same array across both phase-sort calls within a single configuration
+	 *   run to avoid redundant sorts when the dependency graph is unchanged.
+	 * @param bool $isPreInit `true` when sorting the dyPreInit pass,
+	 *   `false` when sorting the init() pass (default). Passed to
+	 *   {@see collectModuleDependencies()} and then to each module's
+	 *   {@see IModuleDependency::getModuleDependencies()}.
+	 * @throws \Prado\Exceptions\TConfigurationException if a dependency cycle is detected.
+	 * @return array the same entries sorted in dependency-first order.
+	 * @since 4.4.0
+	 */
+	protected function sortModulesByDependency(array $pending, array &$cache = [], bool $isPreInit = false): array
+	{
+		if (count($pending) <= 1) {
+			return $pending;
+		}
+
+		// Build index: id → entry.
+		$byId = [];
+		foreach ($pending as $entry) {
+			$byId[$entry['id']] = $entry;
+		}
+
+		// Collect all dependencies for this phase — fully re-evaluated on every call (no caching).
+		// Each element of $allDeps[$id] is array{id:string, required:bool}.
+		$allDeps = [];
+		foreach ($byId as $id => $entry) {
+			$allDeps[$id] = $this->collectModuleDependencies($entry['module'], $isPreInit);
+		}
+
+		// Build a fingerprint of the in-batch dependency graph.
+		// Only intra-batch edges influence the sort, so out-of-batch deps are excluded.
+		// The fingerprint is stored under DEP_SORT_CACHE_KEY in $cache.
+		$depGraph = [];
+		foreach ($allDeps as $id => $deps) {
+			$inBatch = array_values(array_filter(
+				array_column($deps, 'id'),
+				fn (string $d) => isset($byId[$d])
+			));
+			sort($inBatch);
+			$depGraph[$id] = $inBatch;
+		}
+		ksort($depGraph);
+		$fingerprint = sha1(serialize($depGraph));
+
+		if (isset($cache[self::DEP_SORT_CACHE_KEY][$fingerprint])) {
+			return array_map(fn (string $id) => $byId[$id], $cache[self::DEP_SORT_CACHE_KEY][$fingerprint]);
+		}
+
+		// Build in-degree table and successor adjacency list (intra-batch edges only).
+		// Both required and advisory deps influence ordering when they reference an
+		// in-batch module; the required flag only governs error handling, not sort order.
+		$depMap = [];   // id → [dep_id, ...]  (used for cycle reporting)
+		$inDegree = [];   // id → int
+		$successors = [];   // dep_id → [dependent_id, ...]
+		foreach ($byId as $id => $_) {
+			$inDegree[$id] = 0;
+			$successors[$id] = [];
+			$depMap[$id] = [];
+		}
+		foreach ($allDeps as $id => $deps) {
+			foreach ($deps as $dep) {
+				$depId = $dep['id'];
+				if (!isset($byId[$depId])) {
+					continue; // dep is outside this batch — already satisfied or truly external
+				}
+				$depMap[$id][] = $depId;
+				$inDegree[$id]++;
+				$successors[$depId][] = $id;
+			}
+		}
+
+		// Kahn's algorithm: seed the queue with all zero-in-degree nodes.
+		$queue = [];
+		foreach ($inDegree as $id => $deg) {
+			if ($deg === 0) {
+				$queue[] = $id;
+			}
+		}
+
+		$sorted = [];
+		while ($queue !== []) {
+			$id = array_shift($queue);
+			$sorted[] = $id;
+			foreach ($successors[$id] as $succId) {
+				if (--$inDegree[$succId] === 0) {
+					$queue[] = $succId;
+				}
+			}
+		}
+
+		if (count($sorted) < count($byId)) {
+			$cycleIds = array_diff(array_keys($byId), $sorted);
+			$cyclePath = $this->findCyclePath($cycleIds, $depMap);
+			throw new TConfigurationException(
+				'application_module_dependency_cycle',
+				implode(' -> ', $cyclePath)
+			);
+		}
+
+		$cache[self::DEP_SORT_CACHE_KEY][$fingerprint] = $sorted;
+		return array_map(fn (string $id) => $byId[$id], $sorted);
+	}
+
+	/**
+	 * Finds and returns a representative cycle path within a known set of
+	 * cycle node IDs by following dependency edges via DFS until a node is
+	 * revisited.
+	 *
+	 * Returns a closed-loop array where the first and last elements are the
+	 * same module ID (e.g. `['a', 'b', 'c', 'a']`).
+	 *
+	 * @param array $cycleIds IDs known to participate in a cycle.
+	 * @param array $depMap   dependency map: id → [dep_id, ...].
+	 * @return array the cycle path with the entry node repeated at the end.
+	 * @since 4.4.0
+	 */
+	private function findCyclePath(array $cycleIds, array $depMap): array
+	{
+		$inCycle = array_flip($cycleIds);
+		$start = (string) array_key_first($inCycle);
+		$visited = [];
+		$path = [];
+
+		$current = $start;
+		while (!isset($visited[$current])) {
+			$visited[$current] = count($path);
+			$path[] = $current;
+			$next = null;
+			foreach ($depMap[$current] ?? [] as $depId) {
+				if (isset($inCycle[$depId])) {
+					$next = $depId;
+					break;
+				}
+			}
+			if ($next === null) {
+				break;
+			}
+			$current = $next;
+		}
+
+		$cycleStart = $visited[$current] ?? 0;
+		$loop = array_slice($path, $cycleStart);
+		$loop[] = $current; // close the loop
+		return $loop;
 	}
 
 	/**
@@ -1961,7 +2260,12 @@ class TApplication extends TComponent implements ISingleton
 	 * 2. Application properties (skipped when `$withinService` is true)
 	 * 3. Services
 	 * 4. Parameters
-	 * 5. Modules (instantiated and initialized)
+	 * 5. Modules — four phases:
+	 *    a. Instantiate all modules and apply configuration properties via {@see setSubProperty()}
+	 *    b. Sort by dependency (pre-init pass), then raise {@see TModule::dyPreInit()} in order
+	 *    c. Sort by dependency (init pass), then call {@see IModule::init()} in order
+	 *    d. Raise {@see TModule::dyPostInit()} in the same order as step c — no re-sort
+	 *    Steps b–c share a sort-result cache ({@see DEP_SORT_CACHE_KEY}) if they remain the same.
 	 * 6. External configuration files (evaluated conditionally and applied recursively)
 	 * @param TApplicationConfiguration $config the configuration
 	 * @param bool $withinService whether the configuration is specified within a service.
@@ -2010,19 +2314,38 @@ class TApplication extends TComponent implements ISingleton
 			}
 		}
 
-		// load and init modules specified in app config
-		$modules = [];
+		// Phase 1: Instantiate all modules and apply configuration properties via setXxx().
+		$pending = [];
 		foreach ($config->getModules() as $id => $moduleConfig) {
 			if (!is_string($id)) {
 				$id = '_module' . $this->getLazyModuleCount();
 			}
 			$this->setLazyModule($id, $moduleConfig);
-			if ($module = $this->internalLoadModule($id)) {
-				$modules[] = $module;
+			if ($entry = $this->internalLoadModule($id)) {
+				$pending[] = ['id' => $id, 'module' => $entry[0], 'config' => $entry[1]];
 			}
 		}
-		foreach ($modules as $module) {
-			$module[0]->init($module[1]);
+
+		if ($pending !== []) {
+			// Sort-result cache shared across both sort passes in this config run.
+			// All dependency sources are re-evaluated on every pass.
+			$depCache = [];
+
+			// Phase 2: sort → dyPreInit in dependency order.
+			foreach ($this->sortModulesByDependency($pending, $depCache, true) as $entry) {
+				$entry['module']->dyPreInit($entry['config']);
+			}
+
+			// Phase 3: sort → init() in dependency order; save result for post-init.
+			$initOrder = $this->sortModulesByDependency($pending, $depCache, false);
+			foreach ($initOrder as $entry) {
+				$entry['module']->init($entry['config']);
+			}
+
+			// Phase 4: dyPostInit in the same order as init() — no re-sort.
+			foreach ($initOrder as $entry) {
+				$entry['module']->dyPostInit($entry['config']);
+			}
 		}
 
 		// external configurations

--- a/framework/TModule.php
+++ b/framework/TModule.php
@@ -11,18 +11,73 @@
 namespace Prado;
 
 /**
- * TModule class.
+ * TModule class
  *
- * TModule implements the basic methods required by IModule and may be
- * used as the basic class for application modules.
+ * TModule implements {@see IModule} and is the base class for all application modules.
  *
- * void dyPreInit($config) is raised after loading the module but before
- * init.
+ * ## Initialization Phases
+ *
+ * {@see TApplication} initializes modules in four ordered phases:
+ *
+ * 1. **Instantiate & configure** — module created; configuration properties applied.
+ * 2. **dyPreInit** — dispatched to attached behaviors before `init()`.
+ * 3. **init** — {@see init()} called; the primary initialization point.
+ * 4. **dyPostInit** — dispatched to attached behaviors after `init()` returns.
+ *
+ * To dispatch `dyPreInit` or `dyPostInit` to behaviors from a TModule subclass with
+ * custom `dyPreInit` or `dyPostInit` methods, calling `$this->callBehaviorsMethod(...)`
+ * is required.  If it is not custom dynamic event, the dynamic event is passed
+ * through to behaviors automatically.
+ * For example:
+ * ```php
+ * class MyModule extends TModule {
+ *      public function dyPreInit($config) {
+ *          ...
+ *          $this->callBehaviorsMethod('dyPreInit', $return, $config);
+ *      }
+ *  }
+ * ```
+ *
+ * ## Dependencies
+ *
+ * Implement {@see IModuleDependency} on the module or on an attached behavior to
+ * declare dependencies. Both sources are re-evaluated before each sort pass.
+ *
+ * ```php
+ * class TMyModule extends TModule implements IModuleDependency {
+ *     public function getModuleDependencies(bool $isPreInit = false): ?array {
+ *         return ['db', 'cache'];
+ *     }
+ * }
+ * ```
+ *
+ * After both sources have been collected, {@see TApplication::collectModuleDependencies()}
+ * dispatches `dyFilterDependencies` to all behaviors attached to the module, passing
+ * the accumulated dependency map and returning the (possibly modified) map. Behaviors
+ * may add, remove, or replace entries before the map is used for topological sorting.
+ *
+ * When multiple behaviors implement `dyFilterDependencies`, the `TCallChain` dispatch
+ * calls each behavior with the **original** map and returns the **last** behavior's
+ * return value — unless each behavior accepts the `$callchain` parameter and explicitly
+ * forwards its modified map via `$callchain->dyFilterDependencies($deps)`. Use the
+ * callchain pattern when multiple behaviors must each see the previous behavior's output:
+ *
+ * ```php
+ * class TMyDependencyBehavior extends TBehavior {
+ *     public function dyFilterDependencies(array $deps, \Prado\Util\TCallChain $callchain): array {
+ *         unset($deps['moduleId']);   // drop an optional dependency
+ *         $deps['otherModule'] = ['id' => 'otherModule', 'required' => true];
+ *         return $callchain->dyFilterDependencies($deps);  // forward to next behavior
+ *     }
+ * }
+ * ```
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.0
- * @method void dyPreInit(mixed $config)
- * @method void dyInit(mixed $config)
+ * @method void dyPreInit(mixed $config) Dispatched by {@see TApplication} before {@see init()} runs.
+ * @method void dyInit(mixed $config) Dispatched from within {@see init()} to all attached behaviors.
+ * @method void dyPostInit(mixed $config) Dispatched by {@see TApplication} after {@see init()} returns.
+ * @method array dyFilterDependencies(array $deps) Filters the collected dependency map before topological sorting. Behaviors may add, remove, or replace entries; the (possibly modified) map is returned.
  */
 abstract class TModule extends \Prado\TApplicationComponent implements IModule
 {
@@ -32,10 +87,10 @@ abstract class TModule extends \Prado\TApplicationComponent implements IModule
 	private $_id;
 
 	/**
-	 * Initializes the module.
-	 * This method is required by IModule and is invoked by application.
-	 * This raises dyInit($config) for behaviors.
-	 * @param \Prado\Xml\TXmlElement $config module configuration
+	 * Initializes the module. Required by {@see IModule}; invoked by the application.
+	 * Raises {@see dyInit()} on all attached behaviors.
+	 * @param ?\Prado\Xml\TXmlElement $config module configuration element, or null
+	 *   when invoked without XML configuration
 	 */
 	public function init($config)
 	{
@@ -43,6 +98,7 @@ abstract class TModule extends \Prado\TApplicationComponent implements IModule
 	}
 
 	/**
+	 * Returns the module ID assigned by the application.
 	 * @return string id of this module
 	 */
 	public function getID()
@@ -51,6 +107,7 @@ abstract class TModule extends \Prado\TApplicationComponent implements IModule
 	}
 
 	/**
+	 * Sets the module ID. Called by the application during configuration.
 	 * @param string $value id of this module
 	 */
 	public function setID($value)

--- a/framework/TModule.php
+++ b/framework/TModule.php
@@ -89,8 +89,9 @@ abstract class TModule extends \Prado\TApplicationComponent implements IModule
 	/**
 	 * Initializes the module. Required by {@see IModule}; invoked by the application.
 	 * Raises {@see dyInit()} on all attached behaviors.
-	 * @param ?\Prado\Xml\TXmlElement $config module configuration element, or null
-	 *   when invoked without XML configuration
+	 * @param null|array|\Prado\Xml\TXmlElement $config Module configuration element.
+	 *  `TXmlElement` for XML configuration, `array` for PHP configuration, and null
+	 *   when invoked without configuration.
 	 */
 	public function init($config)
 	{

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -243,6 +243,7 @@ return [
 'IEventCycleParameter' => 'Prado\IEventCycleParameter',
 'IEventParameter' => 'Prado\IEventParameter',
 'IModule' => 'Prado\IModule',
+'IModuleDependency' => 'Prado\IModuleDependency',
 'ITextWriter' => 'Prado\IO\ITextWriter',
 'TOutputWriter' => 'Prado\IO\TOutputWriter',
 'TStdOutWriter' => 'Prado\IO\TStdOutWriter',

--- a/tests/unit/TApplicationDependencyTest.php
+++ b/tests/unit/TApplicationDependencyTest.php
@@ -1,0 +1,2328 @@
+<?php
+
+use Prado\TApplication;
+use Prado\TModule;
+
+// =============================================================================
+// Helper fixtures for TApplicationModuleDependencyTest
+// =============================================================================
+
+/**
+ * Records the order in which test modules call init().
+ */
+class DepOrderTracker
+{
+	public static array $order = [];
+
+	public static function reset(): void
+	{
+		self::$order = [];
+	}
+
+	public static function record(string $id): void
+	{
+		self::$order[] = $id;
+	}
+}
+
+/**
+ * A module that declares dependencies via the IModuleDependency interface.
+ * Its DependencyId property holds the single dependency module ID.
+ * When DependencyId is empty no dependency is declared.
+ */
+class InterfaceDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private string $_dependencyId = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_dependencyId !== '' ? [$this->_dependencyId] : [];
+	}
+
+	public function getDependencyId(): string
+	{
+		return $this->_dependencyId;
+	}
+
+	public function setDependencyId(string $value): void
+	{
+		$this->_dependencyId = $value;
+	}
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * A module with no dependency declarations that still records its init() call.
+ */
+class TrackingModule extends \Prado\TModule
+{
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * A module that implements both IModuleDependency (Source 1) and has an attached
+ * behavior implementing IModuleDependency (Source 2), used to test that both
+ * sources are merged and deduplicated.
+ */
+class BothSourcesDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private string $_primaryDepId = '';
+	private string $_secondDepId  = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		$deps = [];
+		if ($this->_primaryDepId !== '') {
+			$deps[] = $this->_primaryDepId;
+		}
+		if ($this->_secondDepId !== '') {
+			$deps[] = $this->_secondDepId;
+		}
+		return $deps;
+	}
+
+	public function getPrimaryDepId(): string { return $this->_primaryDepId; }
+	public function setPrimaryDepId(string $v): void { $this->_primaryDepId = $v; }
+
+	public function getSecondDepId(): string { return $this->_secondDepId; }
+	public function setSecondDepId(string $v): void { $this->_secondDepId = $v; }
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * A behavior that implements IModuleDependency.  Its single declared dependency
+ * is driven by a settable DepId property so tests can mutate it between calls.
+ */
+class DepBehavior extends \Prado\Util\TBehavior implements \Prado\IModuleDependency
+{
+	private string $_depId = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_depId !== '' ? [$this->_depId] : [];
+	}
+
+	public function getDepId(): string { return $this->_depId; }
+	public function setDepId(string $v): void { $this->_depId = $v; }
+}
+
+/**
+ * An IModuleDependency module whose getModuleDependencies() can return null.
+ */
+class NullReturnDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private bool $_returnNull = false;
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_returnNull ? null : [];
+	}
+
+	public function setReturnNull(bool $v): void
+	{
+		$this->_returnNull = $v;
+	}
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * Exposes the protected dependency methods as public for unit testing, and
+ * adds direct access to internalLoadModule for path-coverage tests.
+ */
+class TApplicationDepAccessor extends TApplication
+{
+
+	/** @return array<array{id:string,required:bool}> */
+	public function pubCollectDeps(\Prado\IModule $module, bool $isPreInit = false): array
+	{
+		return $this->collectModuleDependencies($module, $isPreInit);
+	}
+
+	public function pubSortByDep(array $pending, array &$cache = [], bool $isPreInit = false): array
+	{
+		return $this->sortModulesByDependency($pending, $cache, $isPreInit);
+	}
+
+	public function pubInternalLoadModule(string $id, bool $force = false)
+	{
+		return $this->internalLoadModule($id, $force);
+	}
+
+	public function pubGetLazyModule(string $id): ?array
+	{
+		return $this->getLazyModule($id);
+	}
+}
+
+// =============================================================================
+// New fixtures for extended coverage
+// =============================================================================
+
+/**
+ * Module whose getModuleDependencies() returns a plain string (shorthand for a
+ * single dependency).  Exercises the (array) cast path in collectModuleDependencies.
+ */
+class StringReturnDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private string $_depId = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_depId !== '' ? $this->_depId : null;
+	}
+
+	public function getDepId(): string { return $this->_depId; }
+	public function setDepId(string $v): void { $this->_depId = $v; }
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * A behavior that declares its dep as advisory (required=false) via key-value form.
+ * Used to test that module-source declarations override behavior-source ones.
+ */
+class DepBehaviorAdvisory extends \Prado\Util\TBehavior implements \Prado\IModuleDependency
+{
+	private string $_depId = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_depId !== '' ? [$this->_depId => false] : null;
+	}
+
+	public function getDepId(): string { return $this->_depId; }
+	public function setDepId(string $v): void { $this->_depId = $v; }
+}
+
+/**
+ * A module that always returns a single advisory (required=false) dep via verbose form.
+ * The dep ID is set through setAdvisoryDepId(), which maps cleanly to init-properties
+ * so applyConfiguration / internalLoadModule can configure it.
+ */
+class AdvisoryDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private string $_advisoryDepId = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_advisoryDepId !== ''
+			? [['id' => $this->_advisoryDepId, 'required' => false]]
+			: null;
+	}
+
+	public function getAdvisoryDepId(): string { return $this->_advisoryDepId; }
+	public function setAdvisoryDepId(string $v): void { $this->_advisoryDepId = $v; }
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * Module whose getModuleDependencies() returns the key-value associative form:
+ * ['moduleId' => bool|int|string].  The value is the required flag consumed by
+ * TPropertyValue::ensureBoolean; only the key (module ID) is collected.
+ */
+class KeyValueDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private array $_deps = [];
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_deps !== [] ? $this->_deps : null;
+	}
+
+	/** @param array<string,bool|int|string> $deps e.g. ['db' => true, 'cache' => false] */
+	public function setDepsArray(array $deps): void { $this->_deps = $deps; }
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * Module whose getModuleDependencies() returns the verbose array form:
+ * [['id' => 'moduleId', 'required' => bool], ...].
+ */
+class VerboseArrayDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private array $_deps = [];
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_deps !== [] ? $this->_deps : null;
+	}
+
+	/** @param list<array{id:string,required?:bool}> $deps */
+	public function setDepsArray(array $deps): void { $this->_deps = $deps; }
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+/**
+ * A module that records its own dyPreInit, init, and dyPostInit calls into a
+ * shared static $phases array, in addition to calling the parent implementations.
+ *
+ * Since dyPreInit and dyPostInit are dynamic events (dy-prefix) dispatched through
+ * TComponent::__call, defining them as real PHP methods on the subclass causes
+ * PHP to invoke them directly — allowing phase-order assertions without requiring
+ * a separate tracking behavior.
+ *
+ * Implements IModuleDependency so a single dependency can be configured via
+ * setDependencyId() in applyConfiguration init-properties.
+ */
+class PhaseTrackingModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	/** Ordered log of 'moduleId:phase' strings across all instances. */
+	public static array $phases = [];
+
+	private string $_dependencyId = '';
+
+	public static function reset(): void
+	{
+		self::$phases = [];
+	}
+
+	public function getDependencyId(): string { return $this->_dependencyId; }
+	public function setDependencyId(string $v): void { $this->_dependencyId = $v; }
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_dependencyId !== '' ? $this->_dependencyId : null;
+	}
+
+	public function dyPreInit($config): void
+	{
+		self::$phases[] = $this->getID() . ':pre';
+	}
+
+	public function init($config): void
+	{
+		parent::init($config);
+		self::$phases[] = $this->getID() . ':init';
+		DepOrderTracker::record($this->getID());
+	}
+
+	public function dyPostInit($config): void
+	{
+		self::$phases[] = $this->getID() . ':post';
+	}
+}
+
+/**
+ * A module that returns different deps depending on the `$isPreInit` flag.
+ * Used to verify that the flag is actually threaded from sortModulesByDependency
+ * down to getModuleDependencies().
+ *
+ * Flag mapping:
+ *   $isPreInit=true : returns $_preinitDepId (if set) — dyPreInit pass
+ *   $isPreInit=false: returns $_initDepId    (if set) — init() pass
+ *                     (dyPostInit reuses the init-pass order; no separate dep)
+ */
+class PhaseAwareDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	/** Recorded $isPreInit values from each getModuleDependencies() call. */
+	public array $receivedPhases = [];
+
+	private string $_preinitDepId = '';
+	private string $_initDepId    = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		$this->receivedPhases[] = $isPreInit;
+		$depId = $isPreInit ? $this->_preinitDepId : $this->_initDepId;
+		return $depId !== '' ? [$depId] : [];
+	}
+
+	public function getPreinitDepId(): string { return $this->_preinitDepId; }
+	public function setPreinitDepId(string $v): void { $this->_preinitDepId = $v; }
+
+	public function getInitDepId(): string { return $this->_initDepId; }
+	public function setInitDepId(string $v): void { $this->_initDepId = $v; }
+
+	public function init($config): void
+	{
+		parent::init($config);
+		DepOrderTracker::record($this->getID());
+	}
+}
+
+// =============================================================================
+// Additional fixtures for extended coverage (Part 2)
+// =============================================================================
+
+/**
+ * A behavior implementing IModuleDependency that returns a plain string (shorthand
+ * for a single dependency). Used to verify that string-shorthand returns from
+ * behavior sources are collected correctly.
+ */
+class BehaviorStringDep extends \Prado\Util\TBehavior implements \Prado\IModuleDependency
+{
+	private string $_depId = '';
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_depId !== '' ? $this->_depId : null;
+	}
+
+	public function getDepId(): string { return $this->_depId; }
+	public function setDepId(string $v): void { $this->_depId = $v; }
+}
+
+/**
+ * A behavior implementing IModuleDependency that returns the verbose array form:
+ * [['id' => 'moduleId', 'required' => bool]].
+ */
+class BehaviorVerboseDep extends \Prado\Util\TBehavior implements \Prado\IModuleDependency
+{
+	private array $_deps = [];
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->_deps !== [] ? $this->_deps : null;
+	}
+
+	public function setDepsArray(array $deps): void { $this->_deps = $deps; }
+}
+
+/**
+ * A behavior that implements dyFilterDependencies to inject or remove entries
+ * from the dependency map returned by collectModuleDependencies().
+ * Used to verify the integration between collectModuleDependencies() and the
+ * dyFilterDependencies dynamic event.
+ */
+class AppDyFilterBehavior extends \Prado\Util\TBehavior
+{
+	/** @var array<string,array{id:string,required:bool}> Dep entries to inject. */
+	private array $_additions = [];
+
+	/** @var list<string> Dep IDs to remove. */
+	private array $_removals = [];
+
+	/** @param array<string,array{id:string,required:bool}> $additions */
+	public function setAdditions(array $additions): void { $this->_additions = $additions; }
+
+	/** @param list<string> $removals */
+	public function setRemovals(array $removals): void { $this->_removals = $removals; }
+
+	/**
+	 * @param array<string,array{id:string,required:bool}> $deps
+	 * @return array<string,array{id:string,required:bool}>
+	 */
+	public function dyFilterDependencies(array $deps): array
+	{
+		foreach ($this->_removals as $id) {
+			unset($deps[$id]);
+		}
+		foreach ($this->_additions as $id => $entry) {
+			$deps[$id] = $entry;
+		}
+		return $deps;
+	}
+}
+
+/**
+ * A module that implements IModule and IModuleDependency but does NOT extend
+ * TComponent.  Used to verify that collectModuleDependencies() handles the
+ * non-TComponent branch correctly: Source 1 (module-level IModuleDependency) is
+ * still processed, but Source 2 (behavior scanning) and dyFilterDependencies are
+ * skipped because they require TComponent.
+ */
+class PureIModuleWithDep implements \Prado\IModule, \Prado\IModuleDependency
+{
+	private string $_id = '';
+
+	/** @param list<string> $deps Plain dep IDs. */
+	public function __construct(private readonly array $deps = []) {}
+
+	public function init($config): void {}
+	public function getID(): string { return $this->_id; }
+	public function setID($value): void { $this->_id = $value; }
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return $this->deps !== [] ? $this->deps : null;
+	}
+}
+
+// =============================================================================
+
+/**
+ * Tests for module dependency ordering (Kahn's topological sort) and cycle
+ * detection in TApplication.
+ *
+ * Covers:
+ * - collectModuleDependencies: IModuleDependency on module (Source 1) and on
+ *   behaviors (Source 2); all input forms — indexed-string, string-shorthand,
+ *   key-value, verbose array; null/empty-string/missing-id entries silently
+ *   skipped; deduplication across sources; module-source priority over behavior-
+ *   source for the same dep ID; two behaviors with the same dep ID (first wins);
+ *   non-TComponent module (no behavior scan, no dyFilterDependencies);
+ *   dyFilterDependencies integration (add dep, remove dep, end-to-end with sort).
+ * - sortModulesByDependency: empty / single / no-deps ordering; chain; diamond;
+ *   disjoint groups; external-batch dep silently ignored; advisory dep in batch
+ *   still enforces order; cycle detection (2-node, 3-node, 4-node, self-cycle)
+ *   with meaningful exception message; sort-result cache (hit, miss, new entry
+ *   on changed graph, new entry for different batch); phase flag threaded through.
+ * - internalLoadModule: false / null / success paths; ID set; lazy slot nullified.
+ * - applyConfiguration: init order respects dependencies; no-deps declaration
+ *   order; full four-phase (dyPreInit / init / dyPostInit) ordering for single
+ *   module and for a two-module dependency pair; cycle throws before any init;
+ *   all dep input forms exercised end-to-end; advisory dep in batch sorted; phase
+ *   flag passed to each sort pass.
+ * - getModule() lazy-load: dependency initialized first; dep already live not
+ *   re-initialized; four-phase order per module; three-level chain; advisory dep
+ *   registered as lazy still loaded; required dep absent throws; advisory dep
+ *   absent silently skipped.
+ *
+ * @package System
+ */
+class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
+{
+	// -----------------------------------------------------------------------
+	// Shared helpers
+	// -----------------------------------------------------------------------
+
+	private function newAccessor(): TApplicationDepAccessor
+	{
+		$ref = new \ReflectionClass(TApplicationDepAccessor::class);
+		$app = $ref->newInstanceWithoutConstructor();
+		PradoUnit::setProp($app, '_modules', []);
+		PradoUnit::setProp($app, '_lazyModules', []);
+		PradoUnit::setProp($app, '_parameters', new \Prado\Collections\TMap());
+		PradoUnit::setProp($app, '_configType', TApplication::CONFIG_TYPE_XML);
+		PradoUnit::setProp($app, '_configFileExt', TApplication::CONFIG_FILE_EXT_XML);
+		PradoUnit::setProp($app, '_basePath', sys_get_temp_dir());
+		PradoUnit::setProp($app, '_pageServiceID', 'page');
+		PradoUnit::setProp($app, '_services', []);
+		return $app;
+	}
+
+	/** Build an entry array as sortModulesByDependency() expects. */
+	private function entry(string $id, \Prado\IModule $module): array
+	{
+		return ['id' => $id, 'module' => $module, 'config' => null];
+	}
+
+	/**
+	 * Extract just the dep IDs from a collectModuleDependencies() result.
+	 *
+	 * @param array<array{id:string,required:bool}> $deps
+	 * @return list<string>
+	 */
+	private function depIds(array $deps): array
+	{
+		return array_column($deps, 'id');
+	}
+
+	/**
+	 * Look up the required flag for a specific dep ID in a collectModuleDependencies() result.
+	 * Returns null if the ID is not present.
+	 *
+	 * @param array<array{id:string,required:bool}> $deps
+	 */
+	private function depRequired(array $deps, string $id): ?bool
+	{
+		foreach ($deps as $dep) {
+			if ($dep['id'] === $id) {
+				return $dep['required'];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Build a config mock whose getModules() returns $modules.
+	 *
+	 * Mirrors TApplicationConfiguration which always includes 'id' in the
+	 * init-properties tuple so that internalLoadModule() can call setID() on
+	 * the module via the property system.
+	 */
+	private function moduleConfig(array $modules): \Prado\TApplicationConfiguration
+	{
+		// Inject 'id' into every module's init-properties, matching what the real
+		// config loaders (loadModulesPhp / loadModulesXml) produce.
+		$withId = [];
+		foreach ($modules as $id => $tuple) {
+			$tuple[1]['id'] = $id;
+			$withId[$id] = $tuple;
+		}
+
+		$cfg = $this->createMock(\Prado\TApplicationConfiguration::class);
+		$cfg->method('getIsEmpty')->willReturn(false);
+		$cfg->method('getAliases')->willReturn([]);
+		$cfg->method('getUsings')->willReturn([]);
+		$cfg->method('getProperties')->willReturn([]);
+		$cfg->method('getServices')->willReturn([]);
+		$cfg->method('getParameters')->willReturn([]);
+		$cfg->method('getModules')->willReturn($withId);
+		$cfg->method('getExternalConfigurations')->willReturn([]);
+		return $cfg;
+	}
+
+	protected function setUp(): void
+	{
+		DepOrderTracker::reset();
+		PhaseTrackingModule::reset();
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — Source 1: IModuleDependency on module
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_interfaceNoDep_returnsEmpty(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		// DependencyId is empty → no deps declared.
+		$this->assertSame([], $app->pubCollectDeps($module));
+	}
+
+	public function testCollectDeps_interfaceWithDep_returnsId(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		$module->setDependencyId('db');
+		$deps = $app->pubCollectDeps($module);
+		$this->assertSame(['db'], $this->depIds($deps));
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'plain-string dep must default to required=true');
+	}
+
+	public function testCollectDeps_interfaceDynamic_reevaluatedEachCall(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		$module->setDependencyId('first');
+
+		$first = $app->pubCollectDeps($module);
+		$module->setDependencyId('second');
+		$second = $app->pubCollectDeps($module);
+
+		$this->assertContains('first', $this->depIds($first));
+		$this->assertContains('second', $this->depIds($second),
+			'IModuleDependency result must be re-evaluated on every call');
+		$this->assertNotContains('first', $this->depIds($second));
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — string shorthand return form
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_stringShorthand_singleDepReturned(): void
+	{
+		// getModuleDependencies() returns a plain string — the (array) cast must
+		// convert it to a one-element indexed array so the dep is collected.
+		$app    = $this->newAccessor();
+		$module = new StringReturnDepModule();
+		$module->setDepId('db');
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps),
+			'a string return from getModuleDependencies() must be collected as a single dep');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'a plain-string dep must default to required=true');
+	}
+
+	public function testCollectDeps_stringShorthand_null_returnsEmpty(): void
+	{
+		// When getModuleDependencies() returns null the dep list must be empty.
+		$app    = $this->newAccessor();
+		$module = new StringReturnDepModule();
+		// _depId is '' → returns null
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'null return from getModuleDependencies() must yield an empty dep list');
+	}
+
+	public function testCollectDeps_stringShorthand_sort_depComesBefore(): void
+	{
+		// Verify the string-shorthand dep is actually honoured by the topological sort.
+		// b returns 'a' as a plain string → sorted order must be [a, b].
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new StringReturnDepModule();
+		$b->setDepId('a');
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'a dep declared via string shorthand must be respected by the sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — key-value associative form
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_keyValueForm_boolTrue_depCollected(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['db' => true]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps),
+			'key-value form with bool true value must collect the key as a dep ID');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'key-value true value must yield required=true');
+	}
+
+	public function testCollectDeps_keyValueForm_boolFalse_depCollected(): void
+	{
+		// false means required=false (advisory), but the dep ID is still collected.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['cache' => false]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('cache', $this->depIds($deps),
+			'key-value form with bool false value must still collect the dep ID');
+		$this->assertFalse($this->depRequired($deps, 'cache'),
+			'key-value false value must yield required=false');
+	}
+
+	public function testCollectDeps_keyValueForm_multipleDeps_allCollected(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['db' => true, 'cache' => false]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps));
+		$this->assertContains('cache', $this->depIds($deps));
+		$this->assertCount(2, $deps);
+		$this->assertTrue($this->depRequired($deps, 'db'));
+		$this->assertFalse($this->depRequired($deps, 'cache'));
+	}
+
+	public function testCollectDeps_keyValueForm_stringBoolValue_accepted(): void
+	{
+		// TPropertyValue::ensureBoolean accepts string values such as 'yes'/'no'.
+		// These must not throw and both IDs must appear in the result with the
+		// correct parsed required flag.
+		// ensureBoolean recognises 'true' (case-insensitive) and numeric strings.
+		// Use '1' (truthy) and '0' (falsy) as representative string boolean values.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['db' => '1', 'cache' => '0']);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps),
+			"key-value string value '1' must be accepted by ensureBoolean");
+		$this->assertContains('cache', $this->depIds($deps),
+			"key-value string value '0' must be accepted by ensureBoolean");
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			"'1' must parse to required=true");
+		$this->assertFalse($this->depRequired($deps, 'cache'),
+			"'0' must parse to required=false");
+	}
+
+	public function testCollectDeps_keyValueForm_intValue_accepted(): void
+	{
+		// Integer 1 / 0 are valid boolean representations.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['db' => 1, 'cache' => 0]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps));
+		$this->assertContains('cache', $this->depIds($deps));
+		$this->assertTrue($this->depRequired($deps, 'db'));
+		$this->assertFalse($this->depRequired($deps, 'cache'));
+	}
+
+	public function testCollectDeps_keyValueForm_sort_depComesBefore(): void
+	{
+		// The key-value dep must be honoured in sort order.
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new KeyValueDepModule();
+		$b->setDepsArray(['a' => true]);
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'a dep declared via key-value form must be respected by the sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — verbose array form
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_verboseArrayForm_requiredTrue_depCollected(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['id' => 'db', 'required' => true]]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps),
+			'verbose array entry with required=true must contribute its id as a dep');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'verbose array required=true must yield required=true');
+	}
+
+	public function testCollectDeps_verboseArrayForm_requiredFalse_depCollected(): void
+	{
+		// required=false means advisory; the dep ID is still collected for ordering.
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['id' => 'cache', 'required' => false]]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('cache', $this->depIds($deps),
+			'verbose array entry with required=false must still contribute its id as a dep');
+		$this->assertFalse($this->depRequired($deps, 'cache'),
+			'verbose array required=false must yield required=false');
+	}
+
+	public function testCollectDeps_verboseArrayForm_missingRequiredKey_defaultsToTrue(): void
+	{
+		// When the verbose array entry omits the 'required' key, the default is true.
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['id' => 'db']]);  // no 'required' key
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps));
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'verbose array entry without required key must default to required=true');
+	}
+
+	public function testCollectDeps_verboseArrayForm_multipleDeps_allCollected(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([
+			['id' => 'db',    'required' => true],
+			['id' => 'cache', 'required' => false],
+		]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps));
+		$this->assertContains('cache', $this->depIds($deps));
+		$this->assertCount(2, $deps);
+		$this->assertTrue($this->depRequired($deps, 'db'));
+		$this->assertFalse($this->depRequired($deps, 'cache'));
+	}
+
+	public function testCollectDeps_verboseArrayForm_emptyId_ignored(): void
+	{
+		// An entry with an empty 'id' string must be silently skipped.
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['id' => '', 'required' => true]]);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'verbose array entry with empty id must be silently ignored');
+	}
+
+	public function testCollectDeps_verboseArrayForm_missingId_ignored(): void
+	{
+		// An array entry that has no 'id' key at all must be silently skipped.
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['required' => true]]);   // no 'id' key
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'verbose array entry missing the id key must be silently ignored');
+	}
+
+	public function testCollectDeps_verboseArrayForm_sort_depComesBefore(): void
+	{
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new VerboseArrayDepModule();
+		$b->setDepsArray([['id' => 'a', 'required' => true]]);
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'a dep declared via verbose array form must be respected by the sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — deduplication across forms and sources
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_mixedForms_deduplicatedAcrossForms(): void
+	{
+		// Module returns the same dep ID via two different forms in one call.
+		// The result must contain it only once.
+		$app    = $this->newAccessor();
+		$module = new BothSourcesDepModule();
+		$module->setPrimaryDepId('db');  // plain string in array
+		$module->setSecondDepId('db');   // same ID again
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertCount(1, array_filter($this->depIds($deps), fn($d) => $d === 'db'),
+			'the same dep ID appearing multiple times in one source must be deduplicated');
+	}
+
+	// -----------------------------------------------------------------------
+	// sortModulesByDependency — sort result cache
+	// -----------------------------------------------------------------------
+
+	public function testSort_resultCachedAfterFirstCall(): void
+	{
+		$app   = $this->newAccessor();
+		$cache = [];
+		$a     = new TrackingModule();
+		$b     = new InterfaceDepModule();
+		$b->setDependencyId('a');
+		$pending = [
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		];
+
+		$app->pubSortByDep($pending, $cache);
+
+		$this->assertArrayHasKey(TApplication::DEP_SORT_CACHE_KEY, $cache, 'sort cache sub-key must exist after first call');
+		$this->assertCount(1, $cache[TApplication::DEP_SORT_CACHE_KEY], 'exactly one fingerprint must be stored');
+	}
+
+	public function testSort_sameDepsReturnsCachedOrder(): void
+	{
+		$app   = $this->newAccessor();
+		$cache = [];
+		$a     = new TrackingModule();
+		$b     = new InterfaceDepModule();
+		$b->setDependencyId('a');
+		$pending = [
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		];
+
+		$first  = array_column($app->pubSortByDep($pending, $cache), 'id');
+		$second = array_column($app->pubSortByDep($pending, $cache), 'id');
+
+		$this->assertSame($first, $second, 'repeated call with identical graph must return same order');
+		$this->assertCount(1, $cache[TApplication::DEP_SORT_CACHE_KEY], 'no new fingerprint must be added for identical graph');
+	}
+
+	public function testSort_changedDepsProducesNewCacheEntry(): void
+	{
+		// First call: b depends on a.
+		// Second call: IModuleDependency changes — b depends on nothing.
+		$app   = $this->newAccessor();
+		$cache = [];
+		$a     = new TrackingModule();
+		$b     = new InterfaceDepModule();
+		$b->setDependencyId('a');
+		$pending = [
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		];
+
+		$app->pubSortByDep($pending, $cache);
+
+		// Mutate the dynamic dep (IModuleDependency) — clears the dep.
+		$b->setDependencyId('');
+		$app->pubSortByDep($pending, $cache);
+
+		$this->assertCount(2, $cache[TApplication::DEP_SORT_CACHE_KEY],
+			'a changed dependency graph must produce a new cache entry');
+	}
+
+	// -----------------------------------------------------------------------
+	// sortModulesByDependency — trivial cases
+	// -----------------------------------------------------------------------
+
+	public function testSort_emptyPending_returnsEmpty(): void
+	{
+		$app = $this->newAccessor();
+		$this->assertSame([], $app->pubSortByDep([]));
+	}
+
+	public function testSort_singleModule_returnsUnchanged(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$entry  = $this->entry('a', $module);
+		$result = $app->pubSortByDep([$entry]);
+		$this->assertSame([$entry], $result);
+	}
+
+	public function testSort_noDeps_preservesOrder(): void
+	{
+		$app = $this->newAccessor();
+		$a   = $this->entry('a', new TrackingModule());
+		$b   = $this->entry('b', new TrackingModule());
+		$c   = $this->entry('c', new TrackingModule());
+		$result = $app->pubSortByDep([$a, $b, $c]);
+		$ids = array_column($result, 'id');
+		// No deps — original declaration order is a valid topological order.
+		$this->assertSame(['a', 'b', 'c'], $ids);
+	}
+
+	// -----------------------------------------------------------------------
+	// sortModulesByDependency — dependency ordering
+	// -----------------------------------------------------------------------
+
+	public function testSort_simpleChain_depComesFirst(): void
+	{
+		// b depends on a → sorted order must be [a, b].
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new InterfaceDepModule();
+		$b->setDependencyId('a');
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'));
+	}
+
+	public function testSort_threeChain_correctOrder(): void
+	{
+		// c depends on b, b depends on a → sorted: [a, b, c].
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+
+		$b = new InterfaceDepModule();
+		$b->setDependencyId('a');
+
+		$c = new InterfaceDepModule();
+		$c->setDependencyId('b');
+
+		$result = $app->pubSortByDep([
+			$this->entry('c', $c),
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b', 'c'], array_column($result, 'id'));
+	}
+
+	public function testSort_multipleDepsPerModule_allHonoured(): void
+	{
+		// d depends on both b and c. All four are in the same batch.
+		// Kahn's sort must respect both edges: b and c before d.
+		$app = $this->newAccessor();
+		$b   = new TrackingModule();
+		$c   = new TrackingModule();
+		$d   = new BothSourcesDepModule();
+		$d->setPrimaryDepId('b');
+		$d->setSecondDepId('c');
+
+		$result = $app->pubSortByDep([
+			$this->entry('d', $d),
+			$this->entry('b', $b),
+			$this->entry('c', $c),
+		]);
+		$ids  = array_column($result, 'id');
+		$posB = array_search('b', $ids, true);
+		$posC = array_search('c', $ids, true);
+		$posD = array_search('d', $ids, true);
+
+		$this->assertLessThan($posD, $posB, 'b must come before d');
+		$this->assertLessThan($posD, $posC, 'c must come before d');
+	}
+
+	public function testSort_diamondDependency_correctOrder(): void
+	{
+		// Diamond: d depends on b and c; b and c both depend on a.
+		// Valid topological orders: a, b, c, d  or  a, c, b, d.
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+
+		$b = new InterfaceDepModule();
+		$b->setDependencyId('a');
+
+		$c = new InterfaceDepModule();
+		$c->setDependencyId('a');
+
+		$d = new BothSourcesDepModule();
+		$d->setPrimaryDepId('b');
+		$d->setSecondDepId('c');
+
+		$result = $app->pubSortByDep([
+			$this->entry('d', $d),
+			$this->entry('c', $c),
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$ids = array_column($result, 'id');
+
+		$posA = array_search('a', $ids, true);
+		$posB = array_search('b', $ids, true);
+		$posC = array_search('c', $ids, true);
+		$posD = array_search('d', $ids, true);
+
+		$this->assertLessThan($posB, $posA, 'a must come before b');
+		$this->assertLessThan($posC, $posA, 'a must come before c');
+		$this->assertLessThan($posD, $posB, 'b must come before d');
+		$this->assertLessThan($posD, $posC, 'c must come before d');
+	}
+
+	public function testSort_disjointGroups_allPresent(): void
+	{
+		// Two completely independent chains: a→b and c→d.
+		// Both chains must appear in the result; within each chain the dep comes first.
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new InterfaceDepModule(); $b->setDependencyId('a');
+		$c   = new TrackingModule();
+		$d   = new InterfaceDepModule(); $d->setDependencyId('c');
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+			$this->entry('d', $d),
+			$this->entry('c', $c),
+		]);
+		$ids  = array_column($result, 'id');
+		$posA = array_search('a', $ids, true);
+		$posB = array_search('b', $ids, true);
+		$posC = array_search('c', $ids, true);
+		$posD = array_search('d', $ids, true);
+
+		$this->assertCount(4, $ids);
+		$this->assertLessThan($posB, $posA, 'a must come before b (chain 1)');
+		$this->assertLessThan($posD, $posC, 'c must come before d (chain 2)');
+	}
+
+	public function testSort_depOutsideBatch_ignored(): void
+	{
+		// b declares a dep on 'external' which is not in this batch.
+		// Should not affect order (b has no in-batch deps → treated as in-degree 0).
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new InterfaceDepModule();
+		$b->setDependencyId('external');
+
+		$result = $app->pubSortByDep([
+			$this->entry('a', $a),
+			$this->entry('b', $b),
+		]);
+		// Both valid orders are fine; just ensure no exception and both present.
+		$ids = array_column($result, 'id');
+		$this->assertContains('a', $ids);
+		$this->assertContains('b', $ids);
+		$this->assertCount(2, $ids);
+	}
+
+	// -----------------------------------------------------------------------
+	// sortModulesByDependency — cycle detection
+	// -----------------------------------------------------------------------
+
+	public function testSort_twoCycle_throwsConfigurationException(): void
+	{
+		$app = $this->newAccessor();
+		$a   = new InterfaceDepModule();
+		$a->setDependencyId('b');
+		$b = new InterfaceDepModule();
+		$b->setDependencyId('a');
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$app->pubSortByDep([
+			$this->entry('a', $a),
+			$this->entry('b', $b),
+		]);
+	}
+
+	public function testSort_threeCycle_throwsConfigurationException(): void
+	{
+		$app = $this->newAccessor();
+		$a   = new InterfaceDepModule();
+		$a->setDependencyId('c');
+		$b = new InterfaceDepModule();
+		$b->setDependencyId('a');
+		$c = new InterfaceDepModule();
+		$c->setDependencyId('b');
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$app->pubSortByDep([
+			$this->entry('a', $a),
+			$this->entry('b', $b),
+			$this->entry('c', $c),
+		]);
+	}
+
+	public function testSort_cycle_exceptionMessageNamesInvolvedModules(): void
+	{
+		// 'alpha' depends on 'beta' and 'beta' depends on 'alpha' — a direct cycle.
+		// Dependency IDs must match the registered entry IDs so Kahn's sort
+		// can detect the cycle (IDs that don't appear in pending are silently ignored).
+		$app = $this->newAccessor();
+		$a   = new InterfaceDepModule();
+		$a->setDependencyId('beta');
+		$b = new InterfaceDepModule();
+		$b->setDependencyId('alpha');
+
+		try {
+			$app->pubSortByDep([
+				$this->entry('alpha', $a),
+				$this->entry('beta', $b),
+			]);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertSame('application_module_dependency_cycle', $e->getErrorCode());
+		}
+	}
+
+	public function testSort_selfCycle_throwsConfigurationException(): void
+	{
+		// A module that declares itself as a dependency is a trivial cycle.
+		$app = $this->newAccessor();
+		$a   = new InterfaceDepModule();
+		$a->setDependencyId('a');
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$app->pubSortByDep([
+			$this->entry('a', $a),
+			$this->entry('b', new TrackingModule()),
+		]);
+	}
+
+	public function testSort_fourNodeCycle_throwsConfigurationException(): void
+	{
+		// a→b→c→d→a
+		$app = $this->newAccessor();
+		$a   = new InterfaceDepModule(); $a->setDependencyId('d');
+		$b   = new InterfaceDepModule(); $b->setDependencyId('a');
+		$c   = new InterfaceDepModule(); $c->setDependencyId('b');
+		$d   = new InterfaceDepModule(); $d->setDependencyId('c');
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$app->pubSortByDep([
+			$this->entry('a', $a),
+			$this->entry('b', $b),
+			$this->entry('c', $c),
+			$this->entry('d', $d),
+		]);
+	}
+
+	public function testSort_differentBatchProducesNewCacheEntry(): void
+	{
+		// First call: batch {a, b} with b→a.
+		// Second call: batch {a, b, c} with b→a, c→a.
+		// Different graphs → different fingerprints → two cache entries.
+		$app   = $this->newAccessor();
+		$cache = [];
+
+		$a = new TrackingModule();
+		$b = new InterfaceDepModule(); $b->setDependencyId('a');
+		$app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		], $cache);
+
+		$c = new InterfaceDepModule(); $c->setDependencyId('a');
+		$app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+			$this->entry('c', $c),
+		], $cache);
+
+		$this->assertCount(2, $cache[TApplication::DEP_SORT_CACHE_KEY],
+			'a batch with a different module set must produce a distinct fingerprint entry');
+	}
+
+	// -----------------------------------------------------------------------
+	// sortModulesByDependency — behavior dep respected in ordering
+	// -----------------------------------------------------------------------
+
+	public function testSort_behaviorDep_respected(): void
+	{
+		// b has an attached IModuleDependency behavior that declares dep on a.
+		// Even though b itself has no module-level declaration, the behavior's
+		// dep must be respected: sorted order must be [a, b].
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+
+		$b = new TrackingModule();
+		$bh = new DepBehavior(); $bh->setDepId('a');
+		$b->attachBehavior('depOnA', $bh);
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'a dep declared only by a behavior must be respected by the topological sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// internalLoadModule — all return paths
+	// -----------------------------------------------------------------------
+
+	public function testInternalLoadModule_idNotInLazyModules_returnsFalse(): void
+	{
+		// Requesting an ID that has never been registered in _lazyModules must
+		// return false (the "not known" sentinel).
+		$app = $this->newAccessor();
+		// _lazyModules and _modules are already empty from newAccessor().
+		$result = $app->pubInternalLoadModule('nonexistent');
+		$this->assertFalse($result,
+			'internalLoadModule must return false for an ID not present in _lazyModules');
+	}
+
+	public function testInternalLoadModule_lazyTrue_withoutForce_returnsNull(): void
+	{
+		// A module whose init-properties include 'lazy' => true must be deferred
+		// (returned as null) when force=false.
+		$app = $this->newAccessor();
+		PradoUnit::setProp($app, '_lazyModules', [
+			'mod' => [TrackingModule::class, ['id' => 'mod', 'lazy' => true], null],
+		]);
+		PradoUnit::setProp($app, '_modules', ['mod' => null]);
+
+		$result = $app->pubInternalLoadModule('mod', false);
+
+		$this->assertNull($result,
+			'internalLoadModule must return null (deferred) when lazy=true and force=false');
+	}
+
+	public function testInternalLoadModule_lazyTrue_withForce_returnsModuleArray(): void
+	{
+		// force=true must override the lazy flag and return the module.
+		$app = $this->newAccessor();
+		PradoUnit::setProp($app, '_lazyModules', [
+			'mod' => [TrackingModule::class, ['id' => 'mod', 'lazy' => true], null],
+		]);
+		PradoUnit::setProp($app, '_modules', ['mod' => null]);
+
+		$result = $app->pubInternalLoadModule('mod', true);
+
+		$this->assertIsArray($result,
+			'internalLoadModule must return [$module, $config] when force=true even if lazy=true');
+		$this->assertInstanceOf(TrackingModule::class, $result[0],
+			'first element must be the instantiated module');
+	}
+
+	public function testInternalLoadModule_normalModule_returnsModuleAndConfig(): void
+	{
+		// A regular (non-lazy) module must be instantiated and returned with its config.
+		$app           = $this->newAccessor();
+		$configElement = null;
+		PradoUnit::setProp($app, '_lazyModules', [
+			'mod' => [TrackingModule::class, ['id' => 'mod'], $configElement],
+		]);
+		PradoUnit::setProp($app, '_modules', ['mod' => null]);
+
+		$result = $app->pubInternalLoadModule('mod');
+
+		$this->assertIsArray($result);
+		$this->assertInstanceOf(TrackingModule::class, $result[0]);
+		$this->assertSame($configElement, $result[1],
+			'second element must be the config element from the lazy-module tuple');
+	}
+
+	public function testInternalLoadModule_normalModule_setsModuleId(): void
+	{
+		// After internalLoadModule, the module's ID must have been set via setID().
+		$app = $this->newAccessor();
+		PradoUnit::setProp($app, '_lazyModules', [
+			'mymod' => [TrackingModule::class, ['id' => 'mymod'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', ['mymod' => null]);
+
+		$result = $app->pubInternalLoadModule('mymod');
+
+		$this->assertSame('mymod', $result[0]->getID(),
+			'internalLoadModule must apply the id init-property to the module instance');
+	}
+
+	public function testInternalLoadModule_normalModule_nullifiesLazySlot(): void
+	{
+		// internalLoadModule must nullify the _lazyModules slot to prevent ID reuse
+		// (i.e., calling getLazyModule on the same ID afterwards should return null).
+		$app = $this->newAccessor();
+		PradoUnit::setProp($app, '_lazyModules', [
+			'mod' => [TrackingModule::class, ['id' => 'mod'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', ['mod' => null]);
+
+		$app->pubInternalLoadModule('mod');
+
+		$this->assertNull($app->pubGetLazyModule('mod'),
+			'internalLoadModule must nullify the _lazyModules slot after loading');
+	}
+
+	// -----------------------------------------------------------------------
+	// applyConfiguration() — integration: init() order respects dependencies
+	// -----------------------------------------------------------------------
+
+	public function testApplyConfiguration_initOrderRespectsDependencies(): void
+	{
+		// Config declares modules in order: [dependent, dependency].
+		// dependency declares no deps; dependent declares dep on dependency.
+		// Expected init order: dependency first, then dependent.
+		$app = $this->newAccessor();
+
+		// Modules config: [$class, $initProperties, $configElement]
+		$modules = [
+			'dependent'  => [InterfaceDepModule::class, ['DependencyId' => 'dep'], null],
+			'dep'        => [TrackingModule::class, [], null],
+		];
+
+		$cfg = $this->moduleConfig($modules);
+		$app->applyConfiguration($cfg, false);
+
+		$this->assertSame(['dep', 'dependent'], DepOrderTracker::$order,
+			'dep must be initialized before dependent');
+	}
+
+	public function testApplyConfiguration_noDeps_initInDeclarationOrder(): void
+	{
+		$app     = $this->newAccessor();
+		$modules = [
+			'alpha' => [TrackingModule::class, [], null],
+			'beta'  => [TrackingModule::class, [], null],
+			'gamma' => [TrackingModule::class, [], null],
+		];
+
+		$cfg = $this->moduleConfig($modules);
+		$app->applyConfiguration($cfg, false);
+
+		$this->assertSame(['alpha', 'beta', 'gamma'], DepOrderTracker::$order,
+			'modules with no deps must initialize in declaration order');
+	}
+
+	public function testApplyConfiguration_dyPostInitCalledAfterInit(): void
+	{
+		// All three phases must fire in dependency order; record separately.
+		$modules = [
+			'dep'       => [TrackingModule::class, [], null],
+			'dependent' => [InterfaceDepModule::class, ['DependencyId' => 'dep'], null],
+		];
+
+		$app = $this->newAccessor();
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		// init() fired in dep order — basic sanity that all four phases completed.
+		$this->assertSame(['dep', 'dependent'], DepOrderTracker::$order,
+			'all four phases must complete with modules in dependency order');
+	}
+
+	public function testApplyConfiguration_fourPhaseOrder_singleModule(): void
+	{
+		// For a single PhaseTrackingModule, phases must appear in pre → init → post order.
+		$app     = $this->newAccessor();
+		$modules = [
+			'mod' => [PhaseTrackingModule::class, [], null],
+		];
+
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		$this->assertSame(['mod:pre', 'mod:init', 'mod:post'], PhaseTrackingModule::$phases,
+			'dyPreInit must run before init(), and init() must run before dyPostInit()');
+	}
+
+	public function testApplyConfiguration_fourPhaseOrder_withDependency(): void
+	{
+		// Two PhaseTrackingModules: 'leaf' depends on 'root'.
+		// applyConfiguration runs all dyPreInit first (in dep order), then all init()
+		// (in dep order), then all dyPostInit (in dep order).
+		// Expected: root:pre, leaf:pre, root:init, leaf:init, root:post, leaf:post
+		$app     = $this->newAccessor();
+		$modules = [
+			'leaf' => [PhaseTrackingModule::class, ['DependencyId' => 'root'], null],
+			'root' => [PhaseTrackingModule::class, [], null],
+		];
+
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		$this->assertSame(
+			['root:pre', 'leaf:pre', 'root:init', 'leaf:init', 'root:post', 'leaf:post'],
+			PhaseTrackingModule::$phases,
+			'all dyPreInit must fire (in dep order) before any init(), and all init() before any dyPostInit()'
+		);
+	}
+
+	public function testApplyConfiguration_cycle_throwsBeforeAnyInit(): void
+	{
+		$app     = $this->newAccessor();
+		$modules = [
+			'x' => [InterfaceDepModule::class, ['DependencyId' => 'y'], null],
+			'y' => [InterfaceDepModule::class, ['DependencyId' => 'x'], null],
+		];
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		// No module should have been initialized.
+		$this->assertSame([], DepOrderTracker::$order);
+	}
+
+	public function testApplyConfiguration_stringShorthandDep_initOrder(): void
+	{
+		// StringReturnDepModule returns a plain string dep — must sort correctly.
+		$app     = $this->newAccessor();
+		$modules = [
+			'dependent' => [StringReturnDepModule::class, ['DepId' => 'dep'], null],
+			'dep'       => [TrackingModule::class, [], null],
+		];
+
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		$this->assertSame(['dep', 'dependent'], DepOrderTracker::$order,
+			'string-shorthand dep form must be honoured in applyConfiguration init order');
+	}
+
+	public function testApplyConfiguration_keyValueDep_initOrder(): void
+	{
+		// A key-value dep returned from getModuleDependencies() must be sorted correctly.
+		$app     = $this->newAccessor();
+		$modules = [
+			'dependent' => [KeyValueDepModule::class, [], null],
+			'dep'       => [TrackingModule::class, [], null],
+		];
+
+		// After instantiation via applyConfiguration, setDepsArray cannot be called
+		// via init-properties directly. Verify the empty form (no deps) doesn't crash.
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		$this->assertSame(['dependent', 'dep'], DepOrderTracker::$order,
+			'KeyValueDepModule with no deps must initialize in declaration order');
+	}
+
+	// -----------------------------------------------------------------------
+	// getModule() lazy-load — dependencies initialized first
+	// -----------------------------------------------------------------------
+
+	public function testGetModule_lazyLoad_initsDependencyFirst(): void
+	{
+		$app = $this->newAccessor();
+
+		// Register two lazy modules: 'dependent' depends on 'dep'.
+		// 'id' is included in init-properties to mirror TApplicationConfiguration.
+		PradoUnit::setProp($app, '_lazyModules', [
+			'dep'       => [TrackingModule::class, ['id' => 'dep'], null],
+			'dependent' => [InterfaceDepModule::class, ['id' => 'dependent', 'DependencyId' => 'dep'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'dep'       => null,
+			'dependent' => null,
+		]);
+
+		// Force-load 'dependent'; should trigger 'dep' first.
+		$app->getModule('dependent');
+
+		$this->assertSame(['dep', 'dependent'], DepOrderTracker::$order,
+			'dep must be initialized before dependent when lazy-loading dependent');
+	}
+
+	public function testGetModule_lazyLoad_depAlreadyInitedNotReinited(): void
+	{
+		$app = $this->newAccessor();
+
+		// Pre-initialize 'dep' as a live module object (not null).
+		$depModule = new TrackingModule();
+		$depModule->setID('dep');
+
+		PradoUnit::setProp($app, '_lazyModules', [
+			'dependent' => [InterfaceDepModule::class, ['id' => 'dependent', 'DependencyId' => 'dep'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'dep'       => $depModule,   // already live
+			'dependent' => null,
+		]);
+
+		$app->getModule('dependent');
+
+		// 'dep' was already live — only 'dependent' should appear in the init log.
+		$this->assertSame(['dependent'], DepOrderTracker::$order,
+			'dep must not be re-initialized when it is already live');
+	}
+
+	public function testGetModule_lazyLoad_fourPhaseOrder_singleModule(): void
+	{
+		// For a single lazy PhaseTrackingModule (no deps), the per-module phase order
+		// in getModule() must be: pre → init → post.
+		$app = $this->newAccessor();
+		PradoUnit::setProp($app, '_lazyModules', [
+			'mod' => [PhaseTrackingModule::class, ['id' => 'mod'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', ['mod' => null]);
+
+		$app->getModule('mod');
+
+		$this->assertSame(['mod:pre', 'mod:init', 'mod:post'], PhaseTrackingModule::$phases,
+			'getModule lazy path must call dyPreInit then init then dyPostInit on a single module');
+	}
+
+	public function testGetModule_lazyLoad_chainPhaseOrder(): void
+	{
+		// For a lazy chain: 'top' depends on 'mid', 'mid' depends on 'base'.
+		// getModule() resolves recursively: top.dyPreInit → getModule(mid) →
+		//   mid.dyPreInit → getModule(base) → base.dyPreInit → base.init → base.dyPostInit
+		//   → mid.init → mid.dyPostInit → top.init → top.dyPostInit.
+		$app = $this->newAccessor();
+		PradoUnit::setProp($app, '_lazyModules', [
+			'base' => [PhaseTrackingModule::class, ['id' => 'base'], null],
+			'mid'  => [PhaseTrackingModule::class, ['id' => 'mid',  'DependencyId' => 'base'], null],
+			'top'  => [PhaseTrackingModule::class, ['id' => 'top',  'DependencyId' => 'mid'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'base' => null,
+			'mid'  => null,
+			'top'  => null,
+		]);
+
+		$app->getModule('top');
+
+		$this->assertSame(
+			['top:pre', 'mid:pre', 'base:pre', 'base:init', 'base:post',
+			 'mid:init', 'mid:post', 'top:init', 'top:post'],
+			PhaseTrackingModule::$phases,
+			'lazy chain: outer dyPreInit fires before dep resolution; each dep completes all three phases before the outer init runs'
+		);
+	}
+
+	public function testGetModule_advisoryDepRegisteredNull_loadedFirst(): void
+	{
+		// 'dependent' declares an advisory dep on 'optional' which IS registered
+		// (as a lazy null slot). Even though it is advisory, it must still be
+		// force-loaded before 'dependent' when it is registered.
+		$app = $this->newAccessor();
+
+		PradoUnit::setProp($app, '_lazyModules', [
+			'optional'  => [TrackingModule::class, ['id' => 'optional'], null],
+			'dependent' => [AdvisoryDepModule::class, ['id' => 'dependent', 'AdvisoryDepId' => 'optional'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'optional'  => null,
+			'dependent' => null,
+		]);
+
+		$app->getModule('dependent');
+
+		// 'optional' is present in _modules → must be loaded before 'dependent'.
+		$this->assertSame(['optional', 'dependent'], DepOrderTracker::$order,
+			'advisory dep that IS registered must still be force-loaded before the dependent');
+	}
+
+	public function testGetModule_threeModuleLazyChain_initDeepestFirst(): void
+	{
+		// Chain: 'top' depends on 'mid', 'mid' depends on 'base'. All three are lazy.
+		// Requesting 'top' must resolve the full chain depth-first: base → mid → top.
+		$app = $this->newAccessor();
+
+		PradoUnit::setProp($app, '_lazyModules', [
+			'base' => [TrackingModule::class, ['id' => 'base'], null],
+			'mid'  => [InterfaceDepModule::class, ['id' => 'mid', 'DependencyId' => 'base'], null],
+			'top'  => [InterfaceDepModule::class, ['id' => 'top', 'DependencyId' => 'mid'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'base' => null,
+			'mid'  => null,
+			'top'  => null,
+		]);
+
+		$app->getModule('top');
+
+		$this->assertSame(['base', 'mid', 'top'], DepOrderTracker::$order,
+			'a three-level lazy dependency chain must initialize deepest dep first');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — edge cases
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_interfaceReturnsNull_treatedAsEmpty(): void
+	{
+		// getModuleDependencies() returns null — must not throw and must yield no deps.
+		$app    = $this->newAccessor();
+		$module = new NullReturnDepModule();
+		$module->setReturnNull(true);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'null return from getModuleDependencies() must be treated as an empty dep list');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — Source 2: IModuleDependency on behaviors
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_noBehaviors_returnsEmpty(): void
+	{
+		// A module with no attached behaviors must not crash (tests the
+		// getBehaviors null-$_m guard fix) and must return no deps.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'a module with no behaviors must yield no behavior-sourced deps');
+	}
+
+	public function testCollectDeps_behaviorWithDep_depsCollected(): void
+	{
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b      = new DepBehavior();
+		$b->setDepId('db');
+		$module->attachBehavior('depB', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps),
+			'dep declared by an IModuleDependency behavior must be collected');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'behavior plain-string dep must default to required=true');
+	}
+
+	public function testCollectDeps_behaviorDepDynamic_reevaluatedEachCall(): void
+	{
+		// getModuleDependencies() on the behavior is called on every collect
+		// call — changing the dep ID must be visible immediately.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b      = new DepBehavior();
+		$b->setDepId('first');
+		$module->attachBehavior('depB', $b);
+
+		$first = $app->pubCollectDeps($module);
+
+		$b->setDepId('second');
+		$second = $app->pubCollectDeps($module);
+
+		$this->assertContains('first', $this->depIds($first));
+		$this->assertContains('second', $this->depIds($second),
+			'behavior getModuleDependencies() must be re-evaluated on every call');
+		$this->assertNotContains('first', $this->depIds($second));
+	}
+
+	public function testCollectDeps_behaviorAttachedBetweenCalls_appearsInSubsequentCall(): void
+	{
+		// Behaviors may be attached between initialization phases; the behavior list
+		// is fully re-scanned on every call so newly attached behaviors are included.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b1     = new DepBehavior(); $b1->setDepId('db');
+		$module->attachBehavior('b1', $b1);
+
+		$app->pubCollectDeps($module); // first scan — b1 only
+
+		// Attach a second IModuleDependency behavior between calls.
+		$b2 = new DepBehavior(); $b2->setDepId('late');
+		$module->attachBehavior('b2', $b2);
+
+		$second = $app->pubCollectDeps($module);
+
+		$this->assertContains('late', $this->depIds($second),
+			'behavior attached between calls must appear on the next collect — no behavior-list caching');
+	}
+
+	public function testCollectDeps_multipleBehaviors_allDepsCollected(): void
+	{
+		// Two IModuleDependency behaviors — both must contribute deps.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b1     = new DepBehavior(); $b1->setDepId('db');
+		$b2     = new DepBehavior(); $b2->setDepId('cache');
+		$module->attachBehavior('b1', $b1);
+		$module->attachBehavior('b2', $b2);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps));
+		$this->assertContains('cache', $this->depIds($deps));
+	}
+
+	public function testCollectDeps_behaviorAndModuleSameDep_moduleTakesPriority(): void
+	{
+		// The same dep ID declared by both the module (required=true via plain string)
+		// and a behavior must appear only once; the module-level declaration wins.
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		$module->setDependencyId('db');  // required=true (default for plain string)
+		$b      = new DepBehavior(); $b->setDepId('db');
+		$module->attachBehavior('depB', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$ids = $this->depIds($deps);
+		$this->assertCount(1, array_filter($ids, fn($d) => $d === 'db'),
+			'the same dep ID from both module and behavior must be deduplicated');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'module-level declaration takes priority — required flag must come from the module');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — required flag: module-source priority
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_moduleSrcRequired_behaviorSrcAdvisory_moduleWins(): void
+	{
+		// Module declares 'db' as required (plain string).
+		// A behavior also declares 'db' as advisory (required=false).
+		// The module-level required=true must win because module source takes priority.
+		$app = $this->newAccessor();
+
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['db' => true]);
+
+		$b = new DepBehaviorAdvisory();  // returns ['db' => false]
+		$b->setDepId('db');
+		$module->attachBehavior('advisory', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertCount(1, array_filter($this->depIds($deps), fn($d) => $d === 'db'));
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'module required=true must override behavior required=false for the same dep ID');
+	}
+
+	// -----------------------------------------------------------------------
+	// getModule() lazy-load — required flag enforcement
+	// -----------------------------------------------------------------------
+
+	public function testGetModule_requiredDepNotRegistered_throwsConfigurationException(): void
+	{
+		// 'dependent' declares a required dep on 'missing' which is not registered.
+		// getModule must throw TConfigurationException.
+		$app = $this->newAccessor();
+
+		PradoUnit::setProp($app, '_lazyModules', [
+			'dependent' => [InterfaceDepModule::class, ['id' => 'dependent', 'DependencyId' => 'missing'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'dependent' => null,
+			// 'missing' intentionally absent from _modules
+		]);
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$app->getModule('dependent');
+	}
+
+	public function testGetModule_advisoryDepNotRegistered_noException(): void
+	{
+		// 'dependent' declares an advisory (required=false) dep on 'optional' which
+		// is not registered at all. getModule must load 'dependent' successfully
+		// without throwing — the absent advisory dep is silently skipped.
+		$app = $this->newAccessor();
+
+		PradoUnit::setProp($app, '_lazyModules', [
+			'dependent' => [AdvisoryDepModule::class, ['id' => 'dependent', 'AdvisoryDepId' => 'optional'], null],
+		]);
+		PradoUnit::setProp($app, '_modules', [
+			'dependent' => null,
+			// 'optional' intentionally absent — advisory dep, must not throw
+		]);
+
+		$module = $app->getModule('dependent');
+
+		$this->assertInstanceOf(AdvisoryDepModule::class, $module,
+			'loading a module with an absent advisory dep must succeed without throwing');
+		$this->assertSame(['dependent'], DepOrderTracker::$order,
+			'the module must be initialized even though its advisory dep is absent');
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase parameter — passed to getModuleDependencies()
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_phasePassedToGetModuleDependencies(): void
+	{
+		// collectModuleDependencies() must pass the $isPreInit flag verbatim to
+		// getModuleDependencies() on both the module and its behaviors.
+		$app    = $this->newAccessor();
+		$module = new PhaseAwareDepModule();
+
+		$app->pubCollectDeps($module, true);  // dyPreInit pass
+		$app->pubCollectDeps($module, false); // init() pass
+
+		$this->assertSame(
+			[true, false],
+			$module->receivedPhases,
+			'collectModuleDependencies must pass $isPreInit verbatim to getModuleDependencies()'
+		);
+	}
+
+	public function testCollectDeps_phaseAware_preinitReturnsDifferentDeps(): void
+	{
+		// A module that returns deps only for the dyPreInit pass ($isPreInit=true) must
+		// report those deps when collected with true, and no deps with false.
+		$app    = $this->newAccessor();
+		$module = new PhaseAwareDepModule();
+		$module->setPreinitDepId('earlydb');
+
+		$preinitDeps = $app->pubCollectDeps($module, true);
+		$initDeps    = $app->pubCollectDeps($module, false);
+
+		$this->assertContains('earlydb', $this->depIds($preinitDeps),
+			'a dep declared only for the preinit pass must appear when collected with $isPreInit=true');
+		$this->assertNotContains('earlydb', $this->depIds($initDeps),
+			'a dep declared only for the preinit pass must not appear when collected with $isPreInit=false');
+	}
+
+	public function testCollectDeps_phaseAware_initOnlyReturnsDifferentDeps(): void
+	{
+		// A module that returns deps only for the init() pass ($isPreInit=false) must
+		// report those deps when collected with false, and no deps with true.
+		// (dyPostInit reuses the init-pass order — no separate pass for it.)
+		$app    = $this->newAccessor();
+		$module = new PhaseAwareDepModule();
+		$module->setInitDepId('db');
+
+		$initDeps    = $app->pubCollectDeps($module, false);
+		$preinitDeps = $app->pubCollectDeps($module, true);
+
+		$this->assertContains('db', $this->depIds($initDeps),
+			'a dep declared only for the init pass must appear when collected with $isPreInit=false');
+		$this->assertNotContains('db', $this->depIds($preinitDeps),
+			'a dep declared only for the init pass must not appear when collected with $isPreInit=true');
+	}
+
+	public function testSort_phasePassedToCollectModuleDependencies(): void
+	{
+		// sortModulesByDependency() must pass $isPreInit down to collectModuleDependencies().
+		// Use a PhaseAwareDepModule that only declares a dep for the preinit pass ($isPreInit=true).
+		// When sorted with $isPreInit=false the dep must be absent (no ordering constraint);
+		// when sorted with $isPreInit=true the dep must be honoured (dep-first order).
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new PhaseAwareDepModule();
+		$b->setPreinitDepId('a');   // dep only in the preinit pass
+
+		$cache      = [];
+		$initResult = $app->pubSortByDep(
+			[$this->entry('b', $b), $this->entry('a', $a)],
+			$cache,
+			false  // init() pass: b has no dep → original order preserved
+		);
+		$this->assertSame(['b', 'a'], array_column($initResult, 'id'),
+			'no dep in init pass → original order preserved');
+
+		$cache = [];
+		$preinitResult = $app->pubSortByDep(
+			[$this->entry('b', $b), $this->entry('a', $a)],
+			$cache,
+			true  // dyPreInit pass: b depends on a → [a, b]
+		);
+		$this->assertSame(['a', 'b'], array_column($preinitResult, 'id'),
+			'dep declared only for preinit pass must be honoured when sorted with $isPreInit=true');
+	}
+
+	// -----------------------------------------------------------------------
+	// null id in verbose array form
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_verboseArrayForm_nullId_silentlyIgnored(): void
+	{
+		// An entry with id=null must be silently skipped — useful for conditional deps
+		// where the dep ID is not yet known, expressed as ['id' => null, 'required' => false].
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['id' => null, 'required' => false]]);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			"verbose array entry with id=null must be silently ignored");
+	}
+
+	public function testCollectDeps_verboseArrayForm_nullIdAlongsideRealId_onlyRealCollected(): void
+	{
+		// When a null-id entry appears alongside a valid entry, only the valid one
+		// must be collected.
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([
+			['id' => null,  'required' => false],
+			['id' => 'db',  'required' => true],
+		]);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps),
+			'only the non-null id must be collected when mixed with a null-id entry');
+	}
+
+	// -----------------------------------------------------------------------
+	// applyConfiguration — correct phase passed to each sort pass
+	// -----------------------------------------------------------------------
+
+	public function testApplyConfiguration_phaseAware_preinitDepOnlyInPreinitPass(): void
+	{
+		// PhaseAwareDepModule 'b' declares dep on 'a' only for PHASE_PREINIT.
+		// applyConfiguration must pass PHASE_PREINIT to the first sort, so for the
+		// dyPreInit pass 'a' comes before 'b'.  For the init() pass there is no dep,
+		// so both orderings are valid — but both modules must still be initialized.
+		$app     = $this->newAccessor();
+		$modules = [
+			'b' => [PhaseAwareDepModule::class, ['PreinitDepId' => 'a'], null],
+			'a' => [TrackingModule::class, [], null],
+		];
+
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		// Both modules must have been initialized exactly once.
+		$this->assertContains('a', DepOrderTracker::$order);
+		$this->assertContains('b', DepOrderTracker::$order);
+		$this->assertCount(2, DepOrderTracker::$order);
+	}
+
+	public function testApplyConfiguration_phaseAware_initDepOnlyInInitPass(): void
+	{
+		// PhaseAwareDepModule 'b' declares dep on 'a' only for the init() pass ($isPreInit=false).
+		// The sort for init must place 'a' before 'b'; dyPostInit reuses the same order.
+		// Both modules must complete initialization.
+		$app     = $this->newAccessor();
+		$modules = [
+			'b' => [PhaseAwareDepModule::class, ['InitDepId' => 'a'], null],
+			'a' => [TrackingModule::class, [], null],
+		];
+
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		$this->assertSame(['a', 'b'], DepOrderTracker::$order,
+			'init-pass dep must enforce a-before-b in init() order');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — key-value form: empty string key silently ignored
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_keyValueForm_emptyStringKey_silentlyIgnored(): void
+	{
+		// A key-value entry whose key is the empty string ('') must be silently
+		// skipped because the is_string($key) && $key !== '' guard rejects it.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['' => true]);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			"key-value entry with empty string key '' must be silently ignored");
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — behavior string-shorthand form
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_behaviorStringShorthand_collected(): void
+	{
+		// A behavior implementing IModuleDependency that returns a plain string
+		// (string-shorthand form) must still have its dep collected.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b      = new BehaviorStringDep();
+		$b->setDepId('db');
+		$module->attachBehavior('strDep', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps),
+			'behavior returning a plain string from getModuleDependencies() must be collected as a dep');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'plain-string from behavior must default to required=true');
+	}
+
+	public function testCollectDeps_behaviorStringShorthand_null_returnsNoDepForBehavior(): void
+	{
+		// Behavior returning null via string-shorthand path (when depId is empty)
+		// must contribute no deps.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b      = new BehaviorStringDep(); // depId empty → returns null
+		$module->attachBehavior('strDep', $b);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'behavior returning null must contribute no deps');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — behavior verbose array form
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_behaviorVerboseArrayForm_collected(): void
+	{
+		// A behavior returning the verbose [['id'=>...,'required'=>...]] form must
+		// have its dep collected with the correct required flag.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$b      = new BehaviorVerboseDep();
+		$b->setDepsArray([['id' => 'cache', 'required' => false]]);
+		$module->attachBehavior('verboseDep', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('cache', $this->depIds($deps),
+			'behavior returning verbose array form must have its dep collected');
+		$this->assertFalse($this->depRequired($deps, 'cache'),
+			'verbose array required=false from behavior must yield required=false');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — module dep + behavior dep with different IDs
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_moduleDep_and_behaviorDep_differentIds_bothCollected(): void
+	{
+		// Module declares dep 'db' (via IModuleDependency); a behavior declares dep
+		// 'cache' (distinct ID). Both must appear in the merged result.
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		$module->setDependencyId('db');
+
+		$b = new DepBehavior();
+		$b->setDepId('cache');
+		$module->attachBehavior('bDep', $b);
+
+		$deps = $app->pubCollectDeps($module);
+		$ids  = $this->depIds($deps);
+
+		$this->assertContains('db', $ids,
+			'module-level dep must be present');
+		$this->assertContains('cache', $ids,
+			'behavior-level dep (different ID) must also be present');
+		$this->assertCount(2, $deps);
+		$this->assertTrue($this->depRequired($deps, 'db'));
+		$this->assertTrue($this->depRequired($deps, 'cache'));
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — two behaviors with same dep ID
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_twoBehaviorsSameDep_firstBehaviorWins(): void
+	{
+		// Two IModuleDependency behaviors both declare the same dep ID.
+		// The first behavior attached wins (its entry is not overwritten by the second).
+		// Because both declare the same ID as a plain string (required=true), the result
+		// must contain exactly one entry for that ID.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+
+		$b1 = new DepBehavior();
+		$b1->setDepId('shared');
+		$b2 = new DepBehaviorAdvisory(); // returns ['shared' => false]
+		$b2->setDepId('shared');
+
+		$module->attachBehavior('b1', $b1); // attaches first — required=true
+		$module->attachBehavior('b2', $b2); // attaches second — advisory (required=false)
+
+		$deps = $app->pubCollectDeps($module);
+		$ids  = $this->depIds($deps);
+
+		$this->assertCount(1, array_filter($ids, fn($d) => $d === 'shared'),
+			'the same dep ID from two behaviors must appear exactly once');
+		$this->assertTrue($this->depRequired($deps, 'shared'),
+			'first behavior attached (required=true) takes priority over the second (required=false)');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — dyFilterDependencies integration
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_dyFilterDependencies_canInjectDep(): void
+	{
+		// A behavior implementing dyFilterDependencies that adds a dep entry
+		// must have that dep appear in the final collectModuleDependencies() result.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule(); // no IModuleDependency — empty source 1
+
+		$b = new AppDyFilterBehavior();
+		$b->setAdditions(['injected' => ['id' => 'injected', 'required' => true]]);
+		$module->attachBehavior('filter', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('injected', $this->depIds($deps),
+			'dep injected by dyFilterDependencies must appear in collectModuleDependencies result');
+		$this->assertTrue($this->depRequired($deps, 'injected'));
+	}
+
+	public function testCollectDeps_dyFilterDependencies_canRemoveDep(): void
+	{
+		// A behavior implementing dyFilterDependencies that removes a dep entry
+		// declared at the module level must cause that dep to be absent in the result.
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		$module->setDependencyId('db');  // source 1 adds 'db'
+
+		$b = new AppDyFilterBehavior();
+		$b->setRemovals(['db']); // dyFilterDependencies removes it
+		$module->attachBehavior('filter', $b);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertNotContains('db', $this->depIds($deps),
+			'dep removed by dyFilterDependencies must not appear in collectModuleDependencies result');
+	}
+
+	public function testCollectDeps_dyFilterDependencies_injectedDepSortsCorrectly(): void
+	{
+		// Verify end-to-end: a dep injected via dyFilterDependencies is also honoured
+		// by sortModulesByDependency — the injected dep must come before the dependent.
+		$app = $this->newAccessor();
+		$a   = new TrackingModule(); // 'a' — no deps
+
+		// 'b' has no module-level or behavior-level IModuleDependency dep, but
+		// a dyFilterDependencies behavior injects 'a' into the dep map.
+		$b      = new TrackingModule();
+		$filter = new AppDyFilterBehavior();
+		$filter->setAdditions(['a' => ['id' => 'a', 'required' => true]]);
+		$b->attachBehavior('filter', $filter);
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'dep injected via dyFilterDependencies must be respected by the topological sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — non-TComponent module (no behavior scan, no dyFilterDependencies)
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_nonTComponentModule_depsCollectedFromIModuleDependency(): void
+	{
+		// A module that implements IModule and IModuleDependency but does NOT extend
+		// TComponent must still have its Source 1 deps collected (the module-level
+		// IModuleDependency implementation), even though the TComponent branch
+		// (behavior scanning and dyFilterDependencies) is skipped.
+		$app    = $this->newAccessor();
+		$module = new PureIModuleWithDep(['ext']);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['ext'], $this->depIds($deps),
+			'non-TComponent module must still have its own IModuleDependency deps collected');
+		$this->assertTrue($this->depRequired($deps, 'ext'));
+	}
+
+	public function testCollectDeps_nonTComponentModule_noBehaviorScan(): void
+	{
+		// A non-TComponent module with no deps must produce an empty result;
+		// the TComponent branch (behavior loop and dyFilterDependencies) is never reached.
+		$app    = $this->newAccessor();
+		$module = new PureIModuleWithDep(); // no deps
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'non-TComponent module with no deps must produce an empty dep list');
+	}
+
+	// -----------------------------------------------------------------------
+	// sortModulesByDependency — advisory dep in same batch still enforces order
+	// -----------------------------------------------------------------------
+
+	public function testSort_advisoryDepInBatch_depComesBefore(): void
+	{
+		// An advisory dep (required=false) that IS inside the same batch must still
+		// influence ordering — the required flag governs error handling, not sort order.
+		// b declares an advisory dep on a → sorted order must still be [a, b].
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new AdvisoryDepModule();
+		$b->setAdvisoryDepId('a');
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'advisory dep (required=false) that is inside the batch must still enforce sort order');
+	}
+
+	public function testSort_advisoryDepInBatch_diamondWithAdvisoryEdge_correctOrder(): void
+	{
+		// Diamond where d depends on b (required) and c (advisory), both depend on a.
+		// The advisory edge d→c must still be respected: c before d.
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+
+		$b = new InterfaceDepModule();
+		$b->setDependencyId('a');
+
+		// c is advisory dep on a.
+		$c = new AdvisoryDepModule();
+		$c->setAdvisoryDepId('a');
+
+		// d has required dep on b and advisory dep on c.
+		$d = new VerboseArrayDepModule();
+		$d->setDepsArray([
+			['id' => 'b', 'required' => true],
+			['id' => 'c', 'required' => false],
+		]);
+
+		$result = $app->pubSortByDep([
+			$this->entry('d', $d),
+			$this->entry('c', $c),
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$ids = array_column($result, 'id');
+
+		$posA = array_search('a', $ids, true);
+		$posB = array_search('b', $ids, true);
+		$posC = array_search('c', $ids, true);
+		$posD = array_search('d', $ids, true);
+
+		$this->assertLessThan($posB, $posA, 'a before b (required)');
+		$this->assertLessThan($posC, $posA, 'a before c (advisory)');
+		$this->assertLessThan($posD, $posB, 'b before d (required)');
+		$this->assertLessThan($posD, $posC, 'c before d (advisory) — advisory deps still influence order');
+	}
+
+	// -----------------------------------------------------------------------
+	// applyConfiguration — advisory dep in batch sorts correctly end-to-end
+	// -----------------------------------------------------------------------
+
+	public function testApplyConfiguration_advisoryDepInBatch_initOrderRespected(): void
+	{
+		// 'opt' is declared as advisory (required=false) by 'consumer'.
+		// Both are in the same batch. The advisory dep must still enforce init order:
+		// opt first, then consumer.
+		$app     = $this->newAccessor();
+		$modules = [
+			'consumer' => [AdvisoryDepModule::class, ['AdvisoryDepId' => 'opt'], null],
+			'opt'      => [TrackingModule::class, [], null],
+		];
+
+		$app->applyConfiguration($this->moduleConfig($modules), false);
+
+		$this->assertSame(['opt', 'consumer'], DepOrderTracker::$order,
+			'advisory dep present in the same batch must still be initialized before the dependent');
+	}
+}

--- a/tests/unit/TApplicationDependencyTest.php
+++ b/tests/unit/TApplicationDependencyTest.php
@@ -151,10 +151,10 @@ class NullReturnDepModule extends \Prado\TModule implements \Prado\IModuleDepend
 class TApplicationDepAccessor extends TApplication
 {
 
-	/** @return array<array{id:string,required:bool}> */
+	/** @return array<string,array{id:string,required:bool}> */
 	public function pubCollectDeps(\Prado\IModule $module, bool $isPreInit = false): array
 	{
-		return $this->collectModuleDependencies($module, $isPreInit);
+		return $this->collectModuleDependencies($module, $isPreInit)['deps'];
 	}
 
 	public function pubSortByDep(array $pending, array &$cache = [], bool $isPreInit = false): array
@@ -476,6 +476,33 @@ class PureIModuleWithDep implements \Prado\IModule, \Prado\IModuleDependency
 	}
 }
 
+/**
+ * Module that builds its dependency array dynamically as
+ * `[$id1 => $req1, $id2 => $req2]`, where `$id1` and `$id2` are typed `mixed`
+ * so that null, false, or '' can be passed as keys.  This exercises PHP's
+ * array-key coercion rules (null→'', false→0) at construction time and lets
+ * tests assert on the framework's handling of invalid dependency IDs.
+ */
+class TwoKeyValueDepModule extends \Prado\TModule implements \Prado\IModuleDependency
+{
+	private mixed $_id1 = null;
+	private mixed $_id2 = null;
+	private bool $_req1 = true;
+	private bool $_req2 = false;
+
+	public function getModuleDependencies(bool $isPreInit = false): null|string|array
+	{
+		return [$this->_id1 => $this->_req1, $this->_id2 => $this->_req2];
+	}
+
+	public function getId1(): mixed { return $this->_id1; }
+	public function setId1(mixed $v): void { $this->_id1 = $v; }
+	public function getId2(): mixed { return $this->_id2; }
+	public function setId2(mixed $v): void { $this->_id2 = $v; }
+	public function setReq1(bool $v): void { $this->_req1 = $v; }
+	public function setReq2(bool $v): void { $this->_req2 = $v; }
+}
+
 // =============================================================================
 
 /**
@@ -486,14 +513,17 @@ class PureIModuleWithDep implements \Prado\IModule, \Prado\IModuleDependency
  * - collectModuleDependencies: IModuleDependency on module (Source 1) and on
  *   behaviors (Source 2); all input forms — indexed-string, string-shorthand,
  *   key-value, verbose array; null/empty-string/missing-id entries silently
- *   skipped; deduplication across sources; module-source priority over behavior-
- *   source for the same dep ID; two behaviors with the same dep ID (first wins);
- *   non-TComponent module (no behavior scan, no dyFilterDependencies);
- *   dyFilterDependencies integration (add dep, remove dep, end-to-end with sort).
+ *   skipped; self-dependency in any form or source throws
+ *   application_module_dependency_self_reference immediately; deduplication
+ *   across sources; module-source priority over behavior-source for the same dep
+ *   ID; two behaviors with the same dep ID (first wins); non-TComponent module
+ *   (no behavior scan, no dyFilterDependencies); dyFilterDependencies integration
+ *   (add dep, remove dep, end-to-end with sort).
  * - sortModulesByDependency: empty / single / no-deps ordering; chain; diamond;
  *   disjoint groups; external-batch dep silently ignored; advisory dep in batch
- *   still enforces order; cycle detection (2-node, 3-node, 4-node, self-cycle)
- *   with meaningful exception message; sort-result cache (hit, miss, new entry
+ *   still enforces order; cycle detection (2-node, 3-node, 4-node); self-dep
+ *   propagates through sort as application_module_dependency_self_reference;
+ *   meaningful exception message; sort-result cache (hit, miss, new entry
  *   on changed graph, new entry for different batch); phase flag threaded through.
  * - internalLoadModule: false / null / success paths; ID set; lazy slot nullified.
  * - applyConfiguration: init order respects dependencies; no-deps declaration
@@ -536,9 +566,9 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * Extract just the dep IDs from a collectModuleDependencies() result.
+	 * Extract just the dep IDs from a pubCollectDeps() result.
 	 *
-	 * @param array<array{id:string,required:bool}> $deps
+	 * @param array<string,array{id:string,required:bool}> $deps keyed by dep ID
 	 * @return list<string>
 	 */
 	private function depIds(array $deps): array
@@ -547,19 +577,14 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * Look up the required flag for a specific dep ID in a collectModuleDependencies() result.
+	 * Look up the required flag for a specific dep ID in a pubCollectDeps() result.
 	 * Returns null if the ID is not present.
 	 *
-	 * @param array<array{id:string,required:bool}> $deps
+	 * @param array<string,array{id:string,required:bool}> $deps keyed by dep ID
 	 */
 	private function depRequired(array $deps, string $id): ?bool
 	{
-		foreach ($deps as $dep) {
-			if ($dep['id'] === $id) {
-				return $dep['required'];
-			}
-		}
-		return null;
+		return isset($deps[$id]) ? $deps[$id]['required'] : null;
 	}
 
 	/**
@@ -637,10 +662,10 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// collectModuleDependencies — string shorthand return form
+	// collectModuleDependencies — string return form (bare scalar)
 	// -----------------------------------------------------------------------
 
-	public function testCollectDeps_stringShorthand_singleDepReturned(): void
+	public function testCollectDeps_stringReturn_singleDepReturned(): void
 	{
 		// getModuleDependencies() returns a plain string — the (array) cast must
 		// convert it to a one-element indexed array so the dep is collected.
@@ -656,7 +681,7 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 			'a plain-string dep must default to required=true');
 	}
 
-	public function testCollectDeps_stringShorthand_null_returnsEmpty(): void
+	public function testCollectDeps_stringReturn_null_returnsEmpty(): void
 	{
 		// When getModuleDependencies() returns null the dep list must be empty.
 		$app    = $this->newAccessor();
@@ -667,9 +692,9 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 			'null return from getModuleDependencies() must yield an empty dep list');
 	}
 
-	public function testCollectDeps_stringShorthand_sort_depComesBefore(): void
+	public function testCollectDeps_stringReturn_sort_depComesBefore(): void
 	{
-		// Verify the string-shorthand dep is actually honoured by the topological sort.
+		// Verify the string-return dep is actually honoured by the topological sort.
 		// b returns 'a' as a plain string → sorted order must be [a, b].
 		$app = $this->newAccessor();
 		$a   = new TrackingModule();
@@ -681,7 +706,64 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 			$this->entry('a', $a),
 		]);
 		$this->assertSame(['a', 'b'], array_column($result, 'id'),
-			'a dep declared via string shorthand must be respected by the sort');
+			'a dep declared via string return must be respected by the sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — indexed array form ([$depId])
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_indexedArray_singleDepReturned(): void
+	{
+		// getModuleDependencies() returns [$depId] — an indexed array with an integer
+		// key and a string value.  The dep must be collected with required=true.
+		$app    = $this->newAccessor();
+		$module = new InterfaceDepModule();
+		$module->setDependencyId('db');
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps),
+			'an indexed-array dep entry must be collected as a single dep');
+		$this->assertTrue($this->depRequired($deps, 'db'),
+			'indexed-array dep must default to required=true');
+	}
+
+	public function testCollectDeps_indexedArray_multipleDepReturned(): void
+	{
+		// getModuleDependencies() returns ['db', 'cache'] — two integer-keyed string
+		// values.  Both must be collected with required=true.
+		$app    = $this->newAccessor();
+		$module = new BothSourcesDepModule();
+		$module->setPrimaryDepId('db');
+		$module->setSecondDepId('cache');
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertContains('db', $this->depIds($deps),
+			'first indexed-array dep entry must be collected');
+		$this->assertContains('cache', $this->depIds($deps),
+			'second indexed-array dep entry must be collected');
+		$this->assertCount(2, $deps);
+		$this->assertTrue($this->depRequired($deps, 'db'));
+		$this->assertTrue($this->depRequired($deps, 'cache'));
+	}
+
+	public function testCollectDeps_indexedArray_sort_depComesBefore(): void
+	{
+		// b declares dep on a via the indexed-array form ['a'] →
+		// the topological sort must place a before b.
+		$app = $this->newAccessor();
+		$a   = new TrackingModule();
+		$b   = new InterfaceDepModule();
+		$b->setDependencyId('a');
+
+		$result = $app->pubSortByDep([
+			$this->entry('b', $b),
+			$this->entry('a', $a),
+		]);
+		$this->assertSame(['a', 'b'], array_column($result, 'id'),
+			'a dep declared via indexed-array form must be respected by the sort');
 	}
 
 	// -----------------------------------------------------------------------
@@ -786,6 +868,116 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 			'a dep declared via key-value form must be respected by the sort');
 	}
 
+	public function testCollectDeps_keyValueForm_emptyStringKey_silentlyIgnored(): void
+	{
+		// An empty-string key fails the `$key !== ''` guard and must be silently skipped.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['' => true]);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'key-value entry with empty-string key must be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_nullKey_silentlyIgnored(): void
+	{
+		// PHP coerces a null array key to '' at array-construction time.
+		// The resulting '' key must be silently skipped by the framework.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		// setDepsArray([null => true]) — PHP coerces null key to '' on assignment.
+		$module->setDepsArray([null => true]);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'key-value entry whose key is null (coerced to empty string by PHP) must be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_falseKey_silentlyIgnored(): void
+	{
+		// PHP coerces a false array key to 0 (integer) at array-construction time.
+		// The integer 0 fails is_string() and must be silently skipped.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		// setDepsArray([false => true]) — PHP coerces false key to 0 on assignment.
+		$module->setDepsArray([false => true]);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'key-value entry whose key is false (coerced to 0 by PHP) must be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_bothIdsNull_collapseAndIgnored(): void
+	{
+		// When both module ID getters return null, PHP coerces both keys to '' and
+		// the second entry silently overwrites the first (same key).  The surviving
+		// '' entry is then skipped by the framework's `$key !== ''` guard.
+		// This models the real pattern: [$this->getDepId1() => true, $this->getDepId2() => false]
+		// where both getters have not yet been configured.
+		$app    = $this->newAccessor();
+		$module = new TwoKeyValueDepModule();
+		// _id1 = null, _id2 = null (defaults) → [null=>true, null=>false] → [''=> false]
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'both null dep IDs must collapse to a single empty-string key and be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_bothIdsFalse_collapseAndIgnored(): void
+	{
+		// false keys are coerced to integer 0 — both entries collapse to [0 => false].
+		// The integer key fails is_string() and is silently skipped.
+		$app    = $this->newAccessor();
+		$module = new TwoKeyValueDepModule();
+		$module->setId1(false);
+		$module->setId2(false);
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'both false dep IDs must collapse to integer key 0 and be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_bothIdsEmptyString_collapseAndIgnored(): void
+	{
+		// Both IDs are already '' — the array is ['' => true, '' => false] → ['' => false].
+		// The '' key fails `$key !== ''` and is silently skipped.
+		$app    = $this->newAccessor();
+		$module = new TwoKeyValueDepModule();
+		$module->setId1('');
+		$module->setId2('');
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'both empty-string dep IDs must be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_nullAndEmptyString_collapseAndIgnored(): void
+	{
+		// null and '' both coerce to '': [null=>'', ''=> false] → ['' => false].
+		// The surviving '' entry is silently skipped.
+		$app    = $this->newAccessor();
+		$module = new TwoKeyValueDepModule();
+		$module->setId1(null);
+		$module->setId2('');
+
+		$this->assertSame([], $app->pubCollectDeps($module),
+			'null and empty-string dep IDs must both collapse to empty string and be silently ignored');
+	}
+
+	public function testCollectDeps_keyValueForm_oneNullOneValid_validCollectedNullIgnored(): void
+	{
+		// When one ID is null (→ '') and the other is a real module ID, the null
+		// entry gets its own '' key (different from the real key) and is skipped,
+		// leaving only the valid dep in the result.
+		$app    = $this->newAccessor();
+		$module = new TwoKeyValueDepModule();
+		$module->setId1(null);   // → '' key — skipped
+		$module->setId2('db');   // → 'db' key — collected
+		$module->setReq1(true);
+		$module->setReq2(true);
+
+		$deps = $app->pubCollectDeps($module);
+
+		$this->assertSame(['db'], $this->depIds($deps),
+			'the valid dep ID must be collected even when the other ID is null');
+		$this->assertTrue($this->depRequired($deps, 'db'));
+	}
+
 	// -----------------------------------------------------------------------
 	// collectModuleDependencies — verbose array form
 	// -----------------------------------------------------------------------
@@ -886,6 +1078,96 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 		]);
 		$this->assertSame(['a', 'b'], array_column($result, 'id'),
 			'a dep declared via verbose array form must be respected by the sort');
+	}
+
+	// -----------------------------------------------------------------------
+	// collectModuleDependencies — self-dependency detection
+	// -----------------------------------------------------------------------
+
+	public function testCollectDeps_selfDep_stringShorthand_throws(): void
+	{
+		// A module returning its own ID as a plain string dep must throw immediately.
+		$app    = $this->newAccessor();
+		$module = new StringReturnDepModule();
+		$module->setDepId('myModule');
+		$module->setID('myModule');
+
+		try {
+			$app->pubCollectDeps($module);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertSame('application_module_dependency_self_reference', $e->getErrorCode());
+		}
+	}
+
+	public function testCollectDeps_selfDep_keyValueForm_throws(): void
+	{
+		// A module returning its own ID as a key-value key must throw immediately.
+		$app    = $this->newAccessor();
+		$module = new KeyValueDepModule();
+		$module->setDepsArray(['myModule' => true]);
+		$module->setID('myModule');
+
+		try {
+			$app->pubCollectDeps($module);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertSame('application_module_dependency_self_reference', $e->getErrorCode());
+		}
+	}
+
+	public function testCollectDeps_selfDep_verboseArrayForm_throws(): void
+	{
+		// A module returning its own ID in the verbose array form must throw immediately.
+		$app    = $this->newAccessor();
+		$module = new VerboseArrayDepModule();
+		$module->setDepsArray([['id' => 'myModule', 'required' => true]]);
+		$module->setID('myModule');
+
+		try {
+			$app->pubCollectDeps($module);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertSame('application_module_dependency_self_reference', $e->getErrorCode());
+		}
+	}
+
+	public function testCollectDeps_selfDep_behaviorSource_throws(): void
+	{
+		// A self-dep declared by an attached behavior must also throw.
+		$app    = $this->newAccessor();
+		$module = new TrackingModule();
+		$module->setID('myModule');
+
+		$behavior = new DepBehaviorAdvisory();
+		$behavior->setDepId('myModule');
+		$module->attachBehavior('selfDep', $behavior);
+
+		try {
+			$app->pubCollectDeps($module);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertSame('application_module_dependency_self_reference', $e->getErrorCode());
+		} finally {
+			$module->detachBehavior('selfDep');
+		}
+	}
+
+	public function testCollectDeps_selfDep_exceptionMessageContainsModuleId(): void
+	{
+		// The exception message must name the offending module so developers can
+		// identify the misconfiguration without reading a stack trace.
+		$app    = $this->newAccessor();
+		$module = new StringReturnDepModule();
+		$module->setDepId('offender');
+		$module->setID('offender');
+
+		try {
+			$app->pubCollectDeps($module);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertStringContainsString('offender', $e->getMessage());
+		}
 	}
 
 	// -----------------------------------------------------------------------
@@ -1209,18 +1491,28 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 		}
 	}
 
-	public function testSort_selfCycle_throwsConfigurationException(): void
+	public function testSort_selfDep_throwsViaCollect(): void
 	{
-		// A module that declares itself as a dependency is a trivial cycle.
+		// A self-dependency is caught by collectModuleDependencies before the sort
+		// runs; the exception propagates through pubSortByDep unchanged.
+		// setID() must be called so collectModuleDependencies sees the module's own ID
+		// when checking $dep === $ownId; without it getID() returns '' and the check
+		// would miss, falling through to Kahn's sort which throws cycle instead.
 		$app = $this->newAccessor();
 		$a   = new InterfaceDepModule();
+		$a->setID('a');
 		$a->setDependencyId('a');
 
-		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
-		$app->pubSortByDep([
-			$this->entry('a', $a),
-			$this->entry('b', new TrackingModule()),
-		]);
+		try {
+			$app->pubSortByDep([
+				$this->entry('a', $a),
+				$this->entry('b', new TrackingModule()),
+			]);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			$this->assertSame('application_module_dependency_self_reference', $e->getErrorCode(),
+				'self-dep propagated through sort must carry the self_reference error code');
+		}
 	}
 
 	public function testSort_fourNodeCycle_throwsConfigurationException(): void
@@ -1487,11 +1779,16 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 			'y' => [InterfaceDepModule::class, ['DependencyId' => 'x'], null],
 		];
 
-		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
-		$app->applyConfiguration($this->moduleConfig($modules), false);
+		try {
+			$app->applyConfiguration($this->moduleConfig($modules), false);
+			$this->fail('Expected TConfigurationException was not thrown');
+		} catch (\Prado\Exceptions\TConfigurationException $e) {
+			// exception thrown as expected
+		}
 
-		// No module should have been initialized.
-		$this->assertSame([], DepOrderTracker::$order);
+		// No module must have been initialized before the cycle exception is thrown.
+		$this->assertSame([], DepOrderTracker::$order,
+			'no module must be initialized when a dependency cycle is detected');
 	}
 
 	public function testApplyConfiguration_stringShorthandDep_initOrder(): void
@@ -1509,17 +1806,18 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 			'string-shorthand dep form must be honoured in applyConfiguration init order');
 	}
 
-	public function testApplyConfiguration_keyValueDep_initOrder(): void
+	public function testApplyConfiguration_keyValueDepModule_noDeps_declarationOrder(): void
 	{
-		// A key-value dep returned from getModuleDependencies() must be sorted correctly.
+		// KeyValueDepModule's dep array is driven by setDepsArray(), which cannot be
+		// supplied via init-properties (it takes an array, not a scalar). This test
+		// verifies that when no deps are configured the module loads without error and
+		// declaration order is preserved — a smoke-test of the class in applyConfiguration.
 		$app     = $this->newAccessor();
 		$modules = [
 			'dependent' => [KeyValueDepModule::class, [], null],
 			'dep'       => [TrackingModule::class, [], null],
 		];
 
-		// After instantiation via applyConfiguration, setDepsArray cannot be called
-		// via init-properties directly. Verify the empty form (no deps) doesn't crash.
 		$app->applyConfiguration($this->moduleConfig($modules), false);
 
 		$this->assertSame(['dependent', 'dep'], DepOrderTracker::$order,
@@ -2016,22 +2314,6 @@ class TApplicationDependencyTest extends PHPUnit\Framework\TestCase
 
 		$this->assertSame(['a', 'b'], DepOrderTracker::$order,
 			'init-pass dep must enforce a-before-b in init() order');
-	}
-
-	// -----------------------------------------------------------------------
-	// collectModuleDependencies — key-value form: empty string key silently ignored
-	// -----------------------------------------------------------------------
-
-	public function testCollectDeps_keyValueForm_emptyStringKey_silentlyIgnored(): void
-	{
-		// A key-value entry whose key is the empty string ('') must be silently
-		// skipped because the is_string($key) && $key !== '' guard rejects it.
-		$app    = $this->newAccessor();
-		$module = new KeyValueDepModule();
-		$module->setDepsArray(['' => true]);
-
-		$this->assertSame([], $app->pubCollectDeps($module),
-			"key-value entry with empty string key '' must be silently ignored");
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/TModuleTest.php
+++ b/tests/unit/TModuleTest.php
@@ -1,0 +1,440 @@
+<?php
+
+use Prado\TModule;
+use Prado\Util\TBehavior;
+
+// =============================================================================
+// Helper fixtures
+// =============================================================================
+
+/**
+ * Minimal concrete TModule for testing — no additional logic.
+ */
+class ConcreteModule extends TModule
+{
+	public function init($config): void
+	{
+		parent::init($config);
+	}
+}
+
+/**
+ * A behavior that implements dyFilterDependencies.
+ * Removes any dep whose ID appears in $removals and appends any deps in $additions.
+ */
+class FilterDepsBehavior extends TBehavior
+{
+	/** @var string[] IDs to remove from the dependency map. */
+	private array $_removals = [];
+
+	/** @var array<string,array{id:string,required:bool}> Entries to add. */
+	private array $_additions = [];
+
+	/** Records every $deps array the behavior receives. */
+	public array $receivedDeps = [];
+
+	public function setRemovals(array $removals): void
+	{
+		$this->_removals = $removals;
+	}
+
+	public function setAdditions(array $additions): void
+	{
+		$this->_additions = $additions;
+	}
+
+	/**
+	 * @param array<string,array{id:string,required:bool}> $deps
+	 * @return array<string,array{id:string,required:bool}>
+	 */
+	public function dyFilterDependencies(array $deps): array
+	{
+		$this->receivedDeps[] = $deps;
+		foreach ($this->_removals as $id) {
+			unset($deps[$id]);
+		}
+		foreach ($this->_additions as $id => $entry) {
+			$deps[$id] = $entry;
+		}
+		return $deps;
+	}
+}
+
+/**
+ * A behavior that does NOT implement dyFilterDependencies.
+ * Used to confirm that unrelated behaviors are left alone.
+ */
+class NoOpBehavior extends TBehavior
+{
+	public bool $called = false;
+}
+
+/**
+ * A callchain-aware behavior that implements dyFilterDependencies using the
+ * TCallChain parameter for true sequential filtering.
+ * It applies its own removals/additions and then forwards the modified map to
+ * the next behavior in the chain via $callchain->dyFilterDependencies($deps).
+ */
+class CallChainFilterDepsBehavior extends TBehavior
+{
+	/** @var string[] IDs to remove before forwarding to the next behavior. */
+	private array $_removals = [];
+
+	/** @var array<string,array{id:string,required:bool}> Entries to add before forwarding. */
+	private array $_additions = [];
+
+	/** Records the $deps this behavior received. */
+	public array $receivedDeps = [];
+
+	public function setRemovals(array $removals): void
+	{
+		$this->_removals = $removals;
+	}
+
+	public function setAdditions(array $additions): void
+	{
+		$this->_additions = $additions;
+	}
+
+	/**
+	 * @param array<string,array{id:string,required:bool}> $deps
+	 * @param \Prado\Util\TCallChain $callchain
+	 * @return array<string,array{id:string,required:bool}>
+	 */
+	public function dyFilterDependencies(array $deps, \Prado\Util\TCallChain $callchain): array
+	{
+		$this->receivedDeps[] = $deps;
+		foreach ($this->_removals as $id) {
+			unset($deps[$id]);
+		}
+		foreach ($this->_additions as $id => $entry) {
+			$deps[$id] = $entry;
+		}
+		return $callchain->dyFilterDependencies($deps);
+	}
+}
+
+/**
+ * A behavior that records whether dyInit was dispatched to it.
+ */
+class SpyInitBehavior extends TBehavior
+{
+	public bool $initCalled = false;
+
+	public function dyInit(mixed $config): mixed
+	{
+		$this->initCalled = true;
+		return $config;
+	}
+}
+
+// =============================================================================
+// TModuleTest
+// =============================================================================
+
+/**
+ * Unit tests for TModule, focused on the dyFilterDependencies dy-event contract.
+ */
+class TModuleTest extends PHPUnit\Framework\TestCase
+{
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	private function makeModule(): ConcreteModule
+	{
+		$m = new ConcreteModule();
+		$m->setID('testModule');
+		return $m;
+	}
+
+	/**
+	 * Build a dep-map entry identical to the format TApplication produces.
+	 *
+	 * @return array{id:string,required:bool}
+	 */
+	private function entry(string $id, bool $required = true): array
+	{
+		return ['id' => $id, 'required' => $required];
+	}
+
+	// ── getID / setID ─────────────────────────────────────────────────────────
+
+	public function testGetIdReturnsValueSetBySetId(): void
+	{
+		$m = new ConcreteModule();
+		$m->setID('my-module');
+		$this->assertSame('my-module', $m->getID());
+	}
+
+	public function testGetIdDefaultsToNull(): void
+	{
+		$m = new ConcreteModule();
+		$this->assertNull($m->getID());
+	}
+
+	// ── dyFilterDependencies — no behaviors ───────────────────────────────────
+
+	public function testDyFilterDependencies_noBehaviors_returnsInputUnchanged(): void
+	{
+		$m    = $this->makeModule();
+		$deps = ['db' => $this->entry('db'), 'cache' => $this->entry('cache', false)];
+
+		$result = $m->dyFilterDependencies($deps);
+
+		$this->assertSame($deps, $result,
+			'With no behaviors attached the dep map must be returned as-is.');
+	}
+
+	public function testDyFilterDependencies_noBehaviors_emptyMap_returnsEmpty(): void
+	{
+		$m      = $this->makeModule();
+		$result = $m->dyFilterDependencies([]);
+		$this->assertSame([], $result);
+	}
+
+	// ── dyFilterDependencies — single behavior ────────────────────────────────
+
+	public function testDyFilterDependencies_behaviorReceivesOriginalMap(): void
+	{
+		$m    = $this->makeModule();
+		$b    = new FilterDepsBehavior();
+		$m->attachBehavior('filter', $b);
+
+		$deps = ['db' => $this->entry('db')];
+		$m->dyFilterDependencies($deps);
+
+		$this->assertCount(1, $b->receivedDeps,
+			'The behavior must be called exactly once.');
+		$this->assertSame($deps, $b->receivedDeps[0],
+			'The behavior must receive the full original dep map.');
+	}
+
+	public function testDyFilterDependencies_behaviorCanRemoveDep(): void
+	{
+		$m = $this->makeModule();
+		$b = new FilterDepsBehavior();
+		$b->setRemovals(['optional']);
+		$m->attachBehavior('filter', $b);
+
+		$deps = [
+			'db'       => $this->entry('db'),
+			'optional' => $this->entry('optional', false),
+		];
+
+		$result = $m->dyFilterDependencies($deps);
+
+		$this->assertArrayHasKey('db', $result);
+		$this->assertArrayNotHasKey('optional', $result,
+			'The behavior must be able to remove a dep by unsetting it.');
+	}
+
+	public function testDyFilterDependencies_behaviorCanAddDep(): void
+	{
+		$m = $this->makeModule();
+		$b = new FilterDepsBehavior();
+		$b->setAdditions(['extra' => $this->entry('extra')]);
+		$m->attachBehavior('filter', $b);
+
+		$result = $m->dyFilterDependencies(['db' => $this->entry('db')]);
+
+		$this->assertArrayHasKey('extra', $result,
+			'The behavior must be able to inject a new dependency.');
+		$this->assertSame('extra', $result['extra']['id']);
+		$this->assertTrue($result['extra']['required']);
+	}
+
+	public function testDyFilterDependencies_behaviorReturningInputUnchanged_preservesMap(): void
+	{
+		$m = $this->makeModule();
+		$b = new FilterDepsBehavior(); // no removals or additions → returns unchanged
+		$m->attachBehavior('filter', $b);
+
+		$deps   = ['db' => $this->entry('db'), 'cache' => $this->entry('cache')];
+		$result = $m->dyFilterDependencies($deps);
+
+		$this->assertSame($deps, $result);
+	}
+
+	// ── dyFilterDependencies — multiple behaviors ─────────────────────────────
+
+	public function testDyFilterDependencies_twoBehaviors_bothCalled(): void
+	{
+		$m  = $this->makeModule();
+		$b1 = new FilterDepsBehavior();
+		$b2 = new FilterDepsBehavior();
+		$m->attachBehavior('filter1', $b1);
+		$m->attachBehavior('filter2', $b2);
+
+		$deps = ['db' => $this->entry('db')];
+		$m->dyFilterDependencies($deps);
+
+		$this->assertCount(1, $b1->receivedDeps, 'First behavior must be called.');
+		$this->assertCount(1, $b2->receivedDeps, 'Second behavior must be called.');
+	}
+
+	public function testDyFilterDependencies_twoBehaviors_lastReturnWins(): void
+	{
+		// Without explicit callchain forwarding, TCallChain calls all behaviors with
+		// the same original args and returns the LAST behavior's return value.
+		// b1 removes 'cache' but its return is overwritten by b2.
+		// b2 removes 'optional' and its return is what the caller receives.
+		// So the result keeps 'cache' (b2 never saw b1's output) but drops 'optional'.
+		$m  = $this->makeModule();
+		$b1 = new FilterDepsBehavior();
+		$b1->setRemovals(['cache']);
+		$b2 = new FilterDepsBehavior();
+		$b2->setRemovals(['optional']);
+		$m->attachBehavior('filter1', $b1);
+		$m->attachBehavior('filter2', $b2);
+
+		$deps = [
+			'db'       => $this->entry('db'),
+			'cache'    => $this->entry('cache'),
+			'optional' => $this->entry('optional', false),
+		];
+
+		$result = $m->dyFilterDependencies($deps);
+
+		$this->assertArrayHasKey('db', $result);
+		// b2 is last and does not remove 'cache', so 'cache' survives.
+		$this->assertArrayHasKey('cache', $result,
+			'Without callchain forwarding, b1\'s return is discarded; b2 wins.');
+		// b2 removed 'optional' from its (unfiltered) view of the original map.
+		$this->assertArrayNotHasKey('optional', $result,
+			'b2 (last behavior) must have removed optional from the result.');
+	}
+
+	public function testDyFilterDependencies_secondBehaviorReceivesOriginalMap(): void
+	{
+		// Without explicit callchain forwarding, each behavior is called with the
+		// original args — not with the previous behavior's return value.
+		$m  = $this->makeModule();
+		$b1 = new FilterDepsBehavior();
+		$b1->setRemovals(['cache']);
+		$b2 = new FilterDepsBehavior();
+		$m->attachBehavior('filter1', $b1);
+		$m->attachBehavior('filter2', $b2);
+
+		$deps = ['db' => $this->entry('db'), 'cache' => $this->entry('cache')];
+		$m->dyFilterDependencies($deps);
+
+		$this->assertCount(1, $b2->receivedDeps);
+		$this->assertArrayHasKey('cache', $b2->receivedDeps[0],
+			'b2 must receive the original map, not b1\'s filtered output.');
+	}
+
+	// ── dyFilterDependencies — callchain-aware behaviors (true sequential filter) ─
+
+	public function testDyFilterDependencies_callchainBehavior_singleBehavior_filtersCorrectly(): void
+	{
+		$m = $this->makeModule();
+		$b = new CallChainFilterDepsBehavior();
+		$b->setRemovals(['cache']);
+		$m->attachBehavior('filter', $b);
+
+		$deps   = ['db' => $this->entry('db'), 'cache' => $this->entry('cache')];
+		$result = $m->dyFilterDependencies($deps);
+
+		$this->assertArrayHasKey('db', $result);
+		$this->assertArrayNotHasKey('cache', $result);
+	}
+
+	public function testDyFilterDependencies_callchainBehaviors_chainOutput(): void
+	{
+		// Callchain-aware behaviors forward modified deps to the next behavior.
+		// b1 removes 'cache'; b2 receives b1's output and removes 'optional'.
+		// Final result should have only 'db'.
+		$m  = $this->makeModule();
+		$b1 = new CallChainFilterDepsBehavior();
+		$b1->setRemovals(['cache']);
+		$b2 = new CallChainFilterDepsBehavior();
+		$b2->setRemovals(['optional']);
+		$m->attachBehavior('filter1', $b1);
+		$m->attachBehavior('filter2', $b2);
+
+		$deps = [
+			'db'       => $this->entry('db'),
+			'cache'    => $this->entry('cache'),
+			'optional' => $this->entry('optional', false),
+		];
+
+		$result = $m->dyFilterDependencies($deps);
+
+		$this->assertArrayHasKey('db', $result);
+		$this->assertArrayNotHasKey('cache', $result,
+			'b2 must not see cache because b1 removed it via callchain forwarding.');
+		$this->assertArrayNotHasKey('optional', $result,
+			'b2 must have removed optional.');
+	}
+
+	public function testDyFilterDependencies_callchainBehaviors_secondReceivesFirstOutput(): void
+	{
+		// b1 removes 'cache' and forwards via callchain → b2 receives map without 'cache'.
+		$m  = $this->makeModule();
+		$b1 = new CallChainFilterDepsBehavior();
+		$b1->setRemovals(['cache']);
+		$b2 = new CallChainFilterDepsBehavior();
+		$m->attachBehavior('filter1', $b1);
+		$m->attachBehavior('filter2', $b2);
+
+		$deps = ['db' => $this->entry('db'), 'cache' => $this->entry('cache')];
+		$m->dyFilterDependencies($deps);
+
+		$this->assertCount(1, $b2->receivedDeps);
+		$this->assertArrayNotHasKey('cache', $b2->receivedDeps[0],
+			'Callchain-aware b2 must receive b1\'s filtered output.');
+	}
+
+	// ── dyFilterDependencies — unrelated behavior not involved ────────────────
+
+	public function testDyFilterDependencies_unrelatedBehavior_doesNotInterfere(): void
+	{
+		$m  = $this->makeModule();
+		$nb = new NoOpBehavior();
+		$m->attachBehavior('noop', $nb);
+
+		$deps   = ['db' => $this->entry('db')];
+		$result = $m->dyFilterDependencies($deps);
+
+		// The NoOpBehavior has no dyFilterDependencies method; the dep map
+		// must pass through the dy-dispatch unchanged.
+		$this->assertSame($deps, $result);
+		$this->assertFalse($nb->called);
+	}
+
+	// ── dyFilterDependencies — empty map edge cases ───────────────────────────
+
+	public function testDyFilterDependencies_behaviorWithEmptyInput_canAddDeps(): void
+	{
+		$m = $this->makeModule();
+		$b = new FilterDepsBehavior();
+		$b->setAdditions(['injected' => $this->entry('injected')]);
+		$m->attachBehavior('filter', $b);
+
+		$result = $m->dyFilterDependencies([]);
+
+		$this->assertArrayHasKey('injected', $result,
+			'Behavior must be able to inject deps even when the input map is empty.');
+	}
+
+	public function testDyFilterDependencies_behaviorWithEmptyInput_returnsEmpty(): void
+	{
+		$m = $this->makeModule();
+		$b = new FilterDepsBehavior(); // no-op behavior
+		$m->attachBehavior('filter', $b);
+
+		$result = $m->dyFilterDependencies([]);
+
+		$this->assertSame([], $result);
+	}
+
+	// ── init ──────────────────────────────────────────────────────────────────
+
+	public function testInitCallsDyInit(): void
+	{
+		$m = $this->makeModule();
+		$b = new SpyInitBehavior();
+		$m->attachBehavior('spy', $b);
+		$m->init(null);
+		$this->assertTrue($b->initCalled, 'init() must dispatch dyInit to attached behaviors.');
+	}
+}


### PR DESCRIPTION
Prado has always had to order the modules _by hand_.  Any modules that depend on other modules to be initialized had to be strictly ordered in the configuration.

We handled this by initializing the modules in phases.  Dependencies only works when there are "post initialization" processes, eg executed in onConfiguration, onInitComplete, or onBeginRequest.

`IModuleDependency` can be implemented by a class to tell the application what modules it depends upon to ensure they are loaded first.  This allows for Prado to configure an application without concern for module load order during initialization.