### PR TITLE
Prado-wide use of cached TComponentReflection::getReflectionClassForType

### DIFF
--- a/framework/Data/ActiveRecord/TActiveRecord.php
+++ b/framework/Data/ActiveRecord/TActiveRecord.php
@@ -17,7 +17,7 @@ use Prado\Data\ActiveRecord\Relations\TActiveRecordRelationContext;
 use Prado\Data\DataGateway\TSqlCriteria;
 use Prado\Prado;
 use Prado\TPropertyValue;
-use ReflectionClass;
+use Prado\Util\Traits\TReflectionClassTrait;
 
 /**
  * Base class for active records.
@@ -148,6 +148,8 @@ use ReflectionClass;
  */
 abstract class TActiveRecord extends \Prado\TComponent
 {
+	use TReflectionClassTrait;
+
 	public const BELONGS_TO = 'BELONGS_TO';
 	public const HAS_ONE = 'HAS_ONE';
 	public const HAS_MANY = 'HAS_MANY';
@@ -282,7 +284,7 @@ abstract class TActiveRecord extends \Prado\TComponent
 	{
 		$className = $this::class;
 		if (!isset(self::$_columnMapping[$className])) {
-			$class = new ReflectionClass($className);
+			$class = static::getReflectionClass();
 			self::$_columnMapping[$className] = $class->getStaticPropertyValue('COLUMN_MAPPING');
 		}
 	}
@@ -294,7 +296,7 @@ abstract class TActiveRecord extends \Prado\TComponent
 	{
 		$className = $this::class;
 		if (!isset(self::$_relations[$className])) {
-			$class = new ReflectionClass($className);
+			$class = static::getReflectionClass();
 			$relations = [];
 			foreach ($class->getStaticPropertyValue('RELATIONS') as $key => $value) {
 				$relations[strtolower($key)] = [$key, $value];

--- a/framework/Data/ActiveRecord/TActiveRecordGateway.php
+++ b/framework/Data/ActiveRecord/TActiveRecordGateway.php
@@ -20,7 +20,7 @@ use Prado\Data\DataGateway\TSqlCriteria;
 use Prado\Data\IDataConnection;
 use Prado\Data\TDbConnection;
 use Prado\Prado;
-use ReflectionClass;
+use Prado\TComponentReflection;
 
 /**
  * TActiveRecordGateway excutes the SQL command queries and returns the data
@@ -79,7 +79,7 @@ class TActiveRecordGateway extends \Prado\TComponent
 	 */
 	protected function getRecordTableName(TActiveRecord $record)
 	{
-		$class = new ReflectionClass($record);
+		$class = TComponentReflection::getReflectionClassForType($record::class);
 		if ($class->hasConstant(self::TABLE_CONST)) {
 			$value = $class->getConstant(self::TABLE_CONST);
 			if (empty($value)) {

--- a/framework/Data/SqlMap/Configuration/TResultProperty.php
+++ b/framework/Data/SqlMap/Configuration/TResultProperty.php
@@ -13,8 +13,8 @@ namespace Prado\Data\SqlMap\Configuration;
 use Prado\Collections\TList;
 use Prado\Data\SqlMap\DataMapper\TPropertyAccess;
 use Prado\Prado;
+use Prado\TComponentReflection;
 use Prado\TPropertyValue;
-use ReflectionClass;
 
 /**
  * TResultProperty corresponds a <property> tags inside a <resultMap> tag.
@@ -294,7 +294,7 @@ class TResultProperty extends \Prado\TComponent
 			if (is_a($type, TList::class, true)) {
 				return self::LIST_TYPE;
 			}
-			$class = new ReflectionClass($type);
+			$class = TComponentReflection::getReflectionClassForType($type);
 			if ($class->implementsInterface('ArrayAccess')) {
 				return self::ARRAY_TYPE;
 			}

--- a/framework/Exceptions/TErrorHandler.php
+++ b/framework/Exceptions/TErrorHandler.php
@@ -12,6 +12,7 @@ namespace Prado\Exceptions;
 
 use Prado\TApplicationMode;
 use Prado\Prado;
+use Prado\TComponentReflection;
 
 /**
  * TErrorHandler class
@@ -665,9 +666,8 @@ class TErrorHandler extends \Prado\TModule
 		preg_match('/\b(T[A-Z]\w+)\b/', $message, $matches);
 		if (count($matches) > 0) {
 			$class = $matches[0];
-			try {
-				$reflection = new \ReflectionClass($class);
-			} catch (\Exception $e) {
+			$reflection = TComponentReflection::getReflectionClassForType($class);
+			if ($reflection === null) {
 				return null;
 			}
 			$classname = $reflection->getNamespaceName();

--- a/framework/TApplicationComponent.php
+++ b/framework/TApplicationComponent.php
@@ -160,7 +160,7 @@ class TApplicationComponent extends \Prado\TComponent
 		if ($className === null) {
 			$className = $this::class;
 		}
-		$class = new \ReflectionClass($className);
+		$class = TComponentReflection::getReflectionClassForType($className);
 		$fullPath = dirname($class->getFileName()) . DIRECTORY_SEPARATOR . $assetPath;
 		return $this->publishFilePath($fullPath);
 	}

--- a/framework/TPropertyValue.php
+++ b/framework/TPropertyValue.php
@@ -12,6 +12,7 @@ namespace Prado;
 
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Web\Javascripts\TJavaScript;
+use Prado\Web\UI\TWebColor;
 
 /**
  * TPropertyValue class
@@ -160,7 +161,7 @@ class TPropertyValue
 				return $enums::hasConstant($value);
 			}
 			if (!isset($types[$enums])) {
-				$types[$enums] = new \ReflectionClass($enums);
+				$types[$enums] = TComponentReflection::getReflectionClassForType($enums);
 			}
 			if ($types[$enums]->hasConstant($value)) {
 				return $value;
@@ -238,7 +239,7 @@ class TPropertyValue
 		if ($green && $len > 0 && $value[0] !== '#') {
 			static $colors;
 			if (!$colors) {
-				$reflect = new \ReflectionClass(\Prado\Web\UI\TWebColor::class);
+				$reflect = TComponentReflection::getReflectionClassForType(TWebColor::class);
 				$colors = $reflect->getConstants();
 				$colors = array_change_key_case($colors);
 			}

--- a/framework/Util/TPluginModule.php
+++ b/framework/Util/TPluginModule.php
@@ -13,7 +13,7 @@ namespace Prado\Util;
 use Prado\Exceptions\TException;
 use Prado\TPropertyValue;
 use Prado\Util\Behaviors\TPageServiceExtraPathsBehavior;
-use ReflectionClass;
+use Prado\Util\Traits\TReflectionClassTrait;
 
 /**
  * TPluginModule class.
@@ -66,6 +66,8 @@ use ReflectionClass;
  */
 class TPluginModule extends \Prado\TModule implements IPluginModule
 {
+	use TReflectionClassTrait;
+
 	/** Module pages directory for finding pages of a module	 */
 	public const PAGES_DIRECTORY = 'Pages';
 
@@ -136,7 +138,7 @@ class TPluginModule extends \Prado\TModule implements IPluginModule
 	public function getPluginPath()
 	{
 		if ($this->_pluginPath === null) {
-			$reflect = new ReflectionClass($this::class);
+			$reflect = static::getReflectionClass();
 			$this->_pluginPath = dirname($reflect->getFileName());
 		}
 		return $this->_pluginPath;

--- a/framework/Web/UI/TControl.php
+++ b/framework/Web/UI/TControl.php
@@ -22,7 +22,7 @@ use Prado\TEventParameter;
 use Prado\TPropertyValue;
 use Prado\Web\UI\ActiveControls\IActiveControl;
 use Prado\Web\UI\Traits\TFilterRenderableTrait;
-use ReflectionClass;
+use Prado\Util\Traits\TReflectionClassTrait;
 
 /**
  * TControl class
@@ -108,6 +108,7 @@ use ReflectionClass;
 class TControl extends \Prado\TApplicationComponent implements IAdapterControl, IFilterRenderable, IBindable
 {
 	use TFilterRenderableTrait;
+	use TReflectionClassTrait;
 
 	/**
 	 * format of control ID
@@ -408,7 +409,7 @@ class TControl extends \Prado\TApplicationComponent implements IAdapterControl, 
 		if ($this->_pluginmodule === false) {
 			$this->_pluginmodule = null;
 
-			$reflect = new ReflectionClass($this::class);
+			$reflect = static::getReflectionClass();
 			$folder = $reflect->getFileName();
 
 			foreach ($this->getApplication()->getModulesByType(\Prado\Util\IPluginModule::class) as $id => $module) {

--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -15,6 +15,7 @@ use Prado\Exceptions\TException;
 use Prado\Exceptions\TTemplateException;
 use Prado\Prado;
 use Prado\TComponent;
+use Prado\TComponentReflection;
 use Prado\Web\Javascripts\TJavaScriptLiteral;
 use Prado\Web\Services\TPageService;
 
@@ -870,7 +871,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 		if (!is_string($className)) {
 			throw new TConfigurationException('template_component_required', $type);
 		}
-		$class = new \ReflectionClass($className);
+		$class = TComponentReflection::getReflectionClassForType($className);
 		if (!$this->_attributevalidation) {
 			return $class->getName();	//	Skins don't validate.
 		}
@@ -1059,7 +1060,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 	 */
 	protected function isClassBehaviorMethod(\ReflectionClass $class, $method)
 	{
-		$component = new \ReflectionClass(TComponent::class);
+		$component = TComponentReflection::getReflectionClassForType(TComponent::class);
 		$behaviors = $component->getStaticProperties();
 		if (!isset($behaviors['_um'])) {
 			return false;

--- a/framework/Web/UI/TTemplateManager.php
+++ b/framework/Web/UI/TTemplateManager.php
@@ -12,6 +12,7 @@ namespace Prado\Web\UI;
 
 use Prado\Prado;
 use Prado\TApplicationMode;
+use Prado\TComponentReflection;
 use Prado\TPropertyValue;
 
 /**
@@ -106,7 +107,7 @@ class TTemplateManager extends \Prado\TModule
 	 */
 	public function getTemplateByClassName($className)
 	{
-		$class = new \ReflectionClass($className);
+		$class = TComponentReflection::getReflectionClassForType($className);
 		$tplFile = dirname($class->getFileName()) . DIRECTORY_SEPARATOR . $class->getShortName() . self::TEMPLATE_FILE_EXT;
 		return $this->getTemplateByFileName($tplFile);
 	}

--- a/framework/Web/UI/WebControls/TBaseValidator.php
+++ b/framework/Web/UI/WebControls/TBaseValidator.php
@@ -12,6 +12,7 @@ namespace Prado\Web\UI\WebControls;
 
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TNotSupportedException;
+use Prado\TComponentReflection;
 use Prado\TPropertyValue;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Web\Javascripts\TJavaScript;
@@ -207,7 +208,7 @@ abstract class TBaseValidator extends TLabel implements IValidator
 				return $shortName;
 			}
 		}
-		$reflectionClass = new \ReflectionClass($control);
+		$reflectionClass = TComponentReflection::getReflectionClassForType($control::class);
 		return $reflectionClass->getShortName();
 	}
 


### PR DESCRIPTION
This puts in to practice the prior change to cache ReflectionCache in TComponentReflection.

for large templates this could be a very minor speed bump.