### PR TITLE
4 Prado Modules with init dependencies

### DIFF
--- a/framework/Data/ActiveRecord/TActiveRecordConfig.php
+++ b/framework/Data/ActiveRecord/TActiveRecordConfig.php
@@ -11,6 +11,7 @@
 namespace Prado\Data\ActiveRecord;
 
 use Prado\Data\TDataSourceConfig;
+use Prado\IModuleDependency;
 use Prado\Prado;
 use Prado\TPropertyValue;
 
@@ -88,7 +89,7 @@ use Prado\TPropertyValue;
  * @author Wei Zhuo <weizho[at]gmail[dot]com>
  * @since 3.1
  */
-class TActiveRecordConfig extends TDataSourceConfig
+class TActiveRecordConfig extends TDataSourceConfig implements IModuleDependency
 {
 	public const DEFAULT_MANAGER_CLASS = \Prado\Data\ActiveRecord\TActiveRecordManager::class;
 	public const DEFAULT_GATEWAY_CLASS = \Prado\Data\ActiveRecord\TActiveRecordGateway::class;
@@ -127,13 +128,28 @@ class TActiveRecordConfig extends TDataSourceConfig
 	public function init($xml)
 	{
 		parent::init($xml);
-		$manager = $this -> getManager();
-		if ($this->getEnableCache()) {
-			$manager->setCache($this->getApplication()->getCache());
+		$manager = $this->getManager();
+		if ($this->getEnableCache() && ($cache = $this->getApplication()?->getCache())) {
+			$manager->setCache($cache);
 		}
 		$manager->setDbConnection($this->getDbConnection());
 		$manager->setInvalidFinderResult($this->getInvalidFinderResult());
 		$manager->setGatewayClass($this->getGatewayClass());
+	}
+
+	/**
+	 * Returns the forwarding ConnectionID that init() depends on, when set.
+	 * init() eagerly materializes the connection via setDbConnection(); a
+	 * forwarded TDataSourceConfig must have applied its <database> element
+	 * first. Empty ConnectionID means the local <database> element configures
+	 * the connection.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string the forwarding ConnectionID (empty if unset), or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->getConnectionID();
 	}
 
 	/**
@@ -142,7 +158,7 @@ class TActiveRecordConfig extends TDataSourceConfig
 	public function getManager()
 	{
 		if ($this->_manager === null) {
-			$this->_manager = Prado::createComponent($this -> getManagerClass());
+			$this->_manager = Prado::createComponent($this->getManagerClass());
 		}
 		return TActiveRecordManager::getInstance($this->_manager);
 	}

--- a/framework/Data/ActiveRecord/TActiveRecordConfig.php
+++ b/framework/Data/ActiveRecord/TActiveRecordConfig.php
@@ -11,6 +11,7 @@
 namespace Prado\Data\ActiveRecord;
 
 use Prado\Data\TDataSourceConfig;
+use Prado\IModuleDependency;
 use Prado\Prado;
 use Prado\TPropertyValue;
 
@@ -88,7 +89,7 @@ use Prado\TPropertyValue;
  * @author Wei Zhuo <weizho[at]gmail[dot]com>
  * @since 3.1
  */
-class TActiveRecordConfig extends TDataSourceConfig
+class TActiveRecordConfig extends TDataSourceConfig implements IModuleDependency
 {
 	public const DEFAULT_MANAGER_CLASS = \Prado\Data\ActiveRecord\TActiveRecordManager::class;
 	public const DEFAULT_GATEWAY_CLASS = \Prado\Data\ActiveRecord\TActiveRecordGateway::class;
@@ -127,7 +128,7 @@ class TActiveRecordConfig extends TDataSourceConfig
 	public function init($xml)
 	{
 		parent::init($xml);
-		$manager = $this -> getManager();
+		$manager = $this->getManager();
 		if ($this->getEnableCache()) {
 			$manager->setCache($this->getApplication()->getCache());
 		}
@@ -137,12 +138,27 @@ class TActiveRecordConfig extends TDataSourceConfig
 	}
 
 	/**
+	 * Returns the forwarding ConnectionID that init() depends on, when set.
+	 * init() eagerly materializes the connection via setDbConnection(); a
+	 * forwarded TDataSourceConfig must have applied its <database> element
+	 * first. Empty ConnectionID means the local <database> element configures
+	 * the connection.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string the forwarding ConnectionID (empty if unset), or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->getConnectionID();
+	}
+
+	/**
 	 * @return TActiveRecordManager
 	 */
 	public function getManager()
 	{
 		if ($this->_manager === null) {
-			$this->_manager = Prado::createComponent($this -> getManagerClass());
+			$this->_manager = Prado::createComponent($this->getManagerClass());
 		}
 		return TActiveRecordManager::getInstance($this->_manager);
 	}

--- a/framework/Data/ActiveRecord/TActiveRecordConfig.php
+++ b/framework/Data/ActiveRecord/TActiveRecordConfig.php
@@ -11,7 +11,6 @@
 namespace Prado\Data\ActiveRecord;
 
 use Prado\Data\TDataSourceConfig;
-use Prado\IModuleDependency;
 use Prado\Prado;
 use Prado\TPropertyValue;
 
@@ -89,7 +88,7 @@ use Prado\TPropertyValue;
  * @author Wei Zhuo <weizho[at]gmail[dot]com>
  * @since 3.1
  */
-class TActiveRecordConfig extends TDataSourceConfig implements IModuleDependency
+class TActiveRecordConfig extends TDataSourceConfig
 {
 	public const DEFAULT_MANAGER_CLASS = \Prado\Data\ActiveRecord\TActiveRecordManager::class;
 	public const DEFAULT_GATEWAY_CLASS = \Prado\Data\ActiveRecord\TActiveRecordGateway::class;
@@ -128,7 +127,7 @@ class TActiveRecordConfig extends TDataSourceConfig implements IModuleDependency
 	public function init($xml)
 	{
 		parent::init($xml);
-		$manager = $this->getManager();
+		$manager = $this -> getManager();
 		if ($this->getEnableCache()) {
 			$manager->setCache($this->getApplication()->getCache());
 		}
@@ -138,27 +137,12 @@ class TActiveRecordConfig extends TDataSourceConfig implements IModuleDependency
 	}
 
 	/**
-	 * Returns the forwarding ConnectionID that init() depends on, when set.
-	 * init() eagerly materializes the connection via setDbConnection(); a
-	 * forwarded TDataSourceConfig must have applied its <database> element
-	 * first. Empty ConnectionID means the local <database> element configures
-	 * the connection.
-	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
-	 * @return null|string the forwarding ConnectionID (empty if unset), or null for pre-init
-	 * @since 4.4.0
-	 */
-	public function getModuleDependencies(bool $isPreInit): null|string|array
-	{
-		return $this->getConnectionID();
-	}
-
-	/**
 	 * @return TActiveRecordManager
 	 */
 	public function getManager()
 	{
 		if ($this->_manager === null) {
-			$this->_manager = Prado::createComponent($this->getManagerClass());
+			$this->_manager = Prado::createComponent($this -> getManagerClass());
 		}
 		return TActiveRecordManager::getInstance($this->_manager);
 	}

--- a/framework/IModuleDependency.php
+++ b/framework/IModuleDependency.php
@@ -52,8 +52,10 @@ namespace Prado;
  *         advisory: it influences order when the referenced module is present
  *         but raises no error when it is absent;
  *   - an associative array whose keys are module IDs and values are the
- *     required flag in any form accepted by {@see TPropertyValue::ensureBoolean}
- *     (bool, int, or string such as `'true'`, `'false'`, `'yes'`, `'no'`).
+ *     required flag, coerced via {@see TPropertyValue::ensureBoolean}: `bool`
+ *     values pass through, the case-insensitive string `'true'` and non-zero
+ *     numeric values (including numeric strings) coerce to `true`, and every
+ *     other value coerces to `false`.
  *     Example: `['db' => true, 'cache' => false]`.
  *
  * **Contract:** {@see getModuleDependencies()} is called before
@@ -83,8 +85,9 @@ interface IModuleDependency
 	 *   - `['a', 'b']` — multiple required dependencies
 	 *   - `[['id' => 'a', 'required' => false]]` — verbose form with required flag;
 	 *     `'id'` may be `null` to represent "no dependency" in a fixed-shape array
-	 *   - `['a' => true, 'b' => false]` — key-value shorthand; value is passed through
-	 *     {@see TPropertyValue::ensureBoolean} so strings like `'true'`/`'false'` are accepted
+	 *   - `['a' => true, 'b' => false]` — key-value shorthand; the value is
+	 *     coerced via {@see TPropertyValue::ensureBoolean} (case-insensitive
+	 *     `'true'` and non-zero numerics become `true`, all else `false`)
 	 *
 	 * @param bool $isPreInit `true` when collecting for the dyPreInit pass,
 	 *   `false` when collecting for the init() pass (default)

--- a/framework/Util/TDbParameterModule.php
+++ b/framework/Util/TDbParameterModule.php
@@ -18,7 +18,6 @@ use Prado\Data\TDbDriver;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
-use Prado\IModuleDependency;
 use Prado\TModule;
 use Prado\TPropertyValue;
 use Prado\Security\Permissions\IPermissions;
@@ -79,7 +78,7 @@ use Prado\Util\Traits\TInitializedTrait;
  * @since 4.2.0
  * @method bool dyRegisterShellAction($returnValue)
  */
-class TDbParameterModule extends TDbModule implements IPermissions, IModuleDependency
+class TDbParameterModule extends TDbModule implements IPermissions
 {
 	use TInitializedTrait;
 
@@ -173,21 +172,6 @@ class TDbParameterModule extends TDbModule implements IPermissions, IModuleDepen
 		$app->attachEventHandler('onAuthenticationComplete', [$this, 'registerShellAction']);
 		parent::init($config);
 		$this->markInitialized();
-	}
-
-	/**
-	 * Returns the ConnectionID that init() depends on, when set.
-	 * init() issues SELECT queries against the parameter table; the upstream
-	 * TDataSourceConfig::init() must have applied its <database> element
-	 * first. Empty ConnectionID means no dependency — TDbPropertiesTrait may
-	 * fall back to a sqlite store.
-	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
-	 * @return null|string the ConnectionID (empty if unset), or null for pre-init
-	 * @since 4.4.0
-	 */
-	public function getModuleDependencies(bool $isPreInit): null|string|array
-	{
-		return $this->getConnectionID();
 	}
 
 	/**

--- a/framework/Util/TDbParameterModule.php
+++ b/framework/Util/TDbParameterModule.php
@@ -18,6 +18,7 @@ use Prado\Data\TDbDriver;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\IModuleDependency;
 use Prado\TModule;
 use Prado\TPropertyValue;
 use Prado\Security\Permissions\IPermissions;
@@ -78,7 +79,7 @@ use Prado\Util\Traits\TInitializedTrait;
  * @since 4.2.0
  * @method bool dyRegisterShellAction($returnValue)
  */
-class TDbParameterModule extends TDbModule implements IPermissions
+class TDbParameterModule extends TDbModule implements IPermissions, IModuleDependency
 {
 	use TInitializedTrait;
 
@@ -162,16 +163,32 @@ class TDbParameterModule extends TDbModule implements IPermissions
 	{
 		$this->loadDbParameters();
 
-		if ($this->_autoLoadField) {
-			$this->getApplication()->getParameters()->attachBehavior(self::APP_PARAMETER_LAZY_BEHAVIOR, new TMapLazyLoadBehavior([$this, 'getFromBehavior']));
+		if ($app = $this->getApplication()) {
+			if ($this->getAutoLoadField()) {
+				$app->getParameters()->attachBehavior(self::APP_PARAMETER_LAZY_BEHAVIOR, new TMapLazyLoadBehavior([$this, 'getFromBehavior']));
+			}
+			if ($this->getCaptureParameterChanges()) {
+				$app->attachEventHandler('onBeginRequest', [$this, 'attachTPageServiceHandler']);
+			}
+			$app->attachEventHandler('onAuthenticationComplete', [$this, 'registerShellAction']);
 		}
-		if ($this->_autoCapture) {
-			$this->getApplication()->attachEventHandler('onBeginRequest', [$this, 'attachTPageServiceHandler']);
-		}
-		$app = $this->getApplication();
-		$app->attachEventHandler('onAuthenticationComplete', [$this, 'registerShellAction']);
 		parent::init($config);
 		$this->markInitialized();
+	}
+
+	/**
+	 * Returns the ConnectionID that init() depends on, when set.
+	 * init() issues SELECT queries against the parameter table; the upstream
+	 * TDataSourceConfig::init() must have applied its <database> element
+	 * first. Empty ConnectionID means no dependency — TDbPropertiesTrait may
+	 * fall back to a sqlite store.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string the ConnectionID (empty if unset), or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->getConnectionID();
 	}
 
 	/**
@@ -195,9 +212,10 @@ class TDbParameterModule extends TDbModule implements IPermissions
 
 		$this->ensureTable();
 
-		$where = ($this->_autoLoadField ? " WHERE {$this->_autoLoadField}={$this->_autoLoadValue}" : '');
+		$autoLoadField = $this->getAutoLoadField();
+		$where = ($autoLoadField ? " WHERE {$autoLoadField}={$this->getAutoLoadValue()}" : '');
 		$cmd = $db->createCommand(
-			"SELECT {$this->_keyField} as keyField, {$this->_valueField}  as valueField FROM {$this->_tableName}{$where}"
+			"SELECT {$this->getKeyField()} as keyField, {$this->getValueField()}  as valueField FROM {$this->getTableName()}{$where}"
 		);
 		$results = $cmd->query();
 
@@ -268,10 +286,11 @@ class TDbParameterModule extends TDbModule implements IPermissions
 	{
 		$db = $this->getDbConnection();
 		$driver = $db->getDriverName();
+		$autoLoadField = $this->getAutoLoadField();
 		$autoidAttributes = '';
 		$autotype = 'INTEGER';
-		$postIndices = '; CREATE UNIQUE INDEX tkey ON ' . $this->_tableName . '(' . $this->_keyField . ');' .
-		($this->_autoLoadField ? ' CREATE INDEX tauto ON ' . $this->_tableName . '(' . $this->_autoLoadField . ');' : '');
+		$postIndices = '; CREATE UNIQUE INDEX tkey ON ' . $this->getTableName() . '(' . $this->getKeyField() . ');' .
+		($autoLoadField ? ' CREATE INDEX tauto ON ' . $this->getTableName() . '(' . $autoLoadField . ');' : '');
 
 		switch ($driver) {
 			case TDbDriver::DRIVER_SQLITE:
@@ -285,11 +304,11 @@ class TDbParameterModule extends TDbModule implements IPermissions
 				break;
 		}
 
-		$sql = 'CREATE TABLE ' . $this->_tableName . ' (
+		$sql = 'CREATE TABLE ' . $this->getTableName() . ' (
 			param_id ' . $autotype . ' PRIMARY KEY ' . $autoidAttributes . ', ' .
-			$this->_keyField . ' VARCHAR(128) NOT NULL,' .
-			$this->_valueField . ' MEDIUMTEXT' .
-			($this->_autoLoadField ? ', ' . $this->_autoLoadField . ' BOOLEAN NOT NULL DEFAULT 1' : '') .
+			$this->getKeyField() . ' VARCHAR(128) NOT NULL,' .
+			$this->getValueField() . ' MEDIUMTEXT' .
+			($autoLoadField ? ', ' . $autoLoadField . ' BOOLEAN NOT NULL DEFAULT 1' : '') .
 			')' . $postIndices;
 		$db->createCommand($sql)->execute();
 	}
@@ -305,7 +324,7 @@ class TDbParameterModule extends TDbModule implements IPermissions
 		}
 		$this->_tableEnsured = true;
 		$db = $this->getDbConnection();
-		$sql = 'SELECT * FROM ' . $this->_tableName . ' WHERE 0=1';
+		$sql = 'SELECT * FROM ' . $this->getTableName() . ' WHERE 0=1';
 		try {
 			$db->createCommand($sql)->query()->close();
 		} catch (Exception $e) {
@@ -313,7 +332,7 @@ class TDbParameterModule extends TDbModule implements IPermissions
 			if ($this->_autoCreate) {
 				$this->createDbTable();
 			} else {
-				throw new TConfigurationException('dbparametermodule_table_nonexistent', $this->_tableName);
+				throw new TConfigurationException('dbparametermodule_table_nonexistent', $this->getTableName());
 			}
 		}
 	}
@@ -344,7 +363,7 @@ class TDbParameterModule extends TDbModule implements IPermissions
 
 		$db = $this->getDbConnection();
 		$cmd = $db->createCommand(
-			"SELECT {$this->_valueField} as valueField FROM {$this->_tableName} WHERE {$this->_keyField}=:key LIMIT 1"
+			"SELECT {$this->getValueField()} as valueField FROM {$this->getTableName()} WHERE {$this->getKeyField()}=:key LIMIT 1"
 		);
 		$cmd->bindParameter(":key", $key, PDO::PARAM_STR);
 		$results = $cmd->queryRow();
@@ -410,21 +429,22 @@ class TDbParameterModule extends TDbModule implements IPermissions
 		$this->ensureTable();
 		$db = $this->getDbConnection();
 		$driver = $db->getDriverName();
+		$autoLoadField = $this->getAutoLoadField();
 		$appendix = '';
 		if ($driver === TDbDriver::DRIVER_MYSQL) {
-			$dupl = ($this->_autoLoadField ? ", {$this->_autoLoadField}=values({$this->_autoLoadField})" : '');
-			$appendix = " ON DUPLICATE KEY UPDATE {$this->_valueField}=values({$this->_valueField}){$dupl}";
+			$dupl = ($autoLoadField ? ", {$autoLoadField}=values({$autoLoadField})" : '');
+			$appendix = " ON DUPLICATE KEY UPDATE {$this->getValueField()}=values({$this->getValueField()}){$dupl}";
 		} else {
 			$this->remove($key);
 		}
-		$field = ($this->_autoLoadField ? ", {$this->_autoLoadField}" : '');
-		$values = ($this->_autoLoadField ? ", :auto" : '');
-		$cmd = $db->createCommand("INSERT INTO {$this->_tableName} ({$this->_keyField}, {$this->_valueField}{$field}) " .
+		$field = ($autoLoadField ? ", {$autoLoadField}" : '');
+		$values = ($autoLoadField ? ", :auto" : '');
+		$cmd = $db->createCommand("INSERT INTO {$this->getTableName()} ({$this->getKeyField()}, {$this->getValueField()}{$field}) " .
 					"VALUES (:key, :value{$values})" . $appendix);
 		$cmd->bindParameter(":key", $key, PDO::PARAM_STR);
 		$cmd->bindParameter(":value", $_value, PDO::PARAM_STR);
-		if ($this->_autoLoadField) {
-			$alv = $autoLoad ? $this->_autoLoadValue : $this->_autoLoadValueFalse;
+		if ($autoLoadField) {
+			$alv = $autoLoad ? $this->getAutoLoadValue() : $this->getAutoLoadValueFalse();
 			$cmd->bindParameter(":auto", $alv, PDO::PARAM_STR);
 		}
 		$cmd->execute();
@@ -464,7 +484,7 @@ class TDbParameterModule extends TDbModule implements IPermissions
 
 		$db = $this->getDbConnection();
 		$cmd = $db->createCommand(
-			"SELECT COUNT(*) AS count FROM {$this->_tableName} WHERE {$this->_keyField}=:key"
+			"SELECT COUNT(*) AS count FROM {$this->getTableName()} WHERE {$this->getKeyField()}=:key"
 		);
 		$cmd->bindParameter(":key", $key, PDO::PARAM_STR);
 		$result = $cmd->queryRow();
@@ -488,7 +508,7 @@ class TDbParameterModule extends TDbModule implements IPermissions
 		if ($driver === TDbDriver::DRIVER_MYSQL) {
 			$appendix = ' LIMIT 1';
 		}
-		$cmd = $db->createCommand("DELETE FROM {$this->_tableName} WHERE {$this->_keyField}=:key" . $appendix);
+		$cmd = $db->createCommand("DELETE FROM {$this->getTableName()} WHERE {$this->getKeyField()}=:key" . $appendix);
 		$cmd->bindParameter(":key", $key, PDO::PARAM_STR);
 		$cmd->execute();
 		return $value;

--- a/framework/Util/TDbParameterModule.php
+++ b/framework/Util/TDbParameterModule.php
@@ -18,6 +18,7 @@ use Prado\Data\TDbDriver;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataTypeException;
 use Prado\Exceptions\TInvalidOperationException;
+use Prado\IModuleDependency;
 use Prado\TModule;
 use Prado\TPropertyValue;
 use Prado\Security\Permissions\IPermissions;
@@ -78,7 +79,7 @@ use Prado\Util\Traits\TInitializedTrait;
  * @since 4.2.0
  * @method bool dyRegisterShellAction($returnValue)
  */
-class TDbParameterModule extends TDbModule implements IPermissions
+class TDbParameterModule extends TDbModule implements IPermissions, IModuleDependency
 {
 	use TInitializedTrait;
 
@@ -172,6 +173,21 @@ class TDbParameterModule extends TDbModule implements IPermissions
 		$app->attachEventHandler('onAuthenticationComplete', [$this, 'registerShellAction']);
 		parent::init($config);
 		$this->markInitialized();
+	}
+
+	/**
+	 * Returns the ConnectionID that init() depends on, when set.
+	 * init() issues SELECT queries against the parameter table; the upstream
+	 * TDataSourceConfig::init() must have applied its <database> element
+	 * first. Empty ConnectionID means no dependency — TDbPropertiesTrait may
+	 * fall back to a sqlite store.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string the ConnectionID (empty if unset), or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->getConnectionID();
 	}
 
 	/**

--- a/framework/Web/TCacheHttpSession.php
+++ b/framework/Web/TCacheHttpSession.php
@@ -14,6 +14,7 @@ namespace Prado\Web;
 
 use Prado\Caching\ICache;
 use Prado\Exceptions\TConfigurationException;
+use Prado\IModuleDependency;
 
 /**
  * TCacheHttpSession class
@@ -41,7 +42,7 @@ use Prado\Exceptions\TConfigurationException;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.1
  */
-class TCacheHttpSession extends THttpSession
+class TCacheHttpSession extends THttpSession implements IModuleDependency
 {
 	private $_prefix = 'session';
 	private $_cacheModuleID = '';
@@ -66,6 +67,20 @@ class TCacheHttpSession extends THttpSession
 		}
 		$this->setUseCustomStorage(true);
 		parent::init($config);
+	}
+
+	/**
+	 * Returns the CacheModuleID that init() depends on, when set.
+	 * init() resolves the cache module then delegates to parent::init(), which
+	 * may touch session storage immediately; concrete caches open their
+	 * connection in their own init(). Empty CacheModuleID means no dependency.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string the cache module ID (empty if unset), or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->getCacheModuleID();
 	}
 
 	/**

--- a/framework/Web/TCacheHttpSession.php
+++ b/framework/Web/TCacheHttpSession.php
@@ -14,6 +14,7 @@ namespace Prado\Web;
 
 use Prado\Caching\ICache;
 use Prado\Exceptions\TConfigurationException;
+use Prado\IModuleDependency;
 
 /**
  * TCacheHttpSession class
@@ -41,7 +42,7 @@ use Prado\Exceptions\TConfigurationException;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.1
  */
-class TCacheHttpSession extends THttpSession
+class TCacheHttpSession extends THttpSession implements IModuleDependency
 {
 	private $_prefix = 'session';
 	private $_cacheModuleID = '';
@@ -55,17 +56,32 @@ class TCacheHttpSession extends THttpSession
 	 */
 	public function init($config)
 	{
-		if ($this->_cacheModuleID === '') {
+		$cacheModuleId = $this->getCacheModuleID();
+		if ($cacheModuleId === '') {
 			throw new TConfigurationException('cachesession_cachemoduleid_required');
-		} elseif (($cache = $this->getApplication()->getModule($this->_cacheModuleID)) === null) {
-			throw new TConfigurationException('cachesession_cachemodule_inexistent', $this->_cacheModuleID);
+		} elseif (($cache = $this->getApplication()->getModule($cacheModuleId)) === null) {
+			throw new TConfigurationException('cachesession_cachemodule_inexistent', $cacheModuleId);
 		} elseif ($cache instanceof ICache) {
 			$this->_cache = $cache;
 		} else {
-			throw new TConfigurationException('cachesession_cachemodule_invalid', $this->_cacheModuleID);
+			throw new TConfigurationException('cachesession_cachemodule_invalid', $cacheModuleId);
 		}
 		$this->setUseCustomStorage(true);
 		parent::init($config);
+	}
+
+	/**
+	 * Returns the CacheModuleID that init() depends on, when set.
+	 * init() resolves the cache module then delegates to parent::init(), which
+	 * may touch session storage immediately; concrete caches open their
+	 * connection in their own init(). Empty CacheModuleID means no dependency.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string the cache module ID (empty if unset), or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->getCacheModuleID();
 	}
 
 	/**
@@ -99,7 +115,7 @@ class TCacheHttpSession extends THttpSession
 	 */
 	public function _read($id)
 	{
-		return (string) $this->_cache->get($this->calculateKey($id));
+		return (string) $this->getCache()->get($this->calculateKey($id));
 	}
 
 	/**
@@ -110,7 +126,7 @@ class TCacheHttpSession extends THttpSession
 	 */
 	public function _write($id, $data)
 	{
-		return $this->_cache->set($this->calculateKey($id), $data, $this->getTimeout());
+		return $this->getCache()->set($this->calculateKey($id), $data, $this->getTimeout());
 	}
 
 	/**
@@ -121,7 +137,7 @@ class TCacheHttpSession extends THttpSession
 	 */
 	public function _destroy($id)
 	{
-		return $this->_cache->delete($this->calculateKey($id));
+		return $this->getCache()->delete($this->calculateKey($id));
 	}
 
 	/**

--- a/framework/Web/TCacheHttpSession.php
+++ b/framework/Web/TCacheHttpSession.php
@@ -14,7 +14,6 @@ namespace Prado\Web;
 
 use Prado\Caching\ICache;
 use Prado\Exceptions\TConfigurationException;
-use Prado\IModuleDependency;
 
 /**
  * TCacheHttpSession class
@@ -42,7 +41,7 @@ use Prado\IModuleDependency;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.1
  */
-class TCacheHttpSession extends THttpSession implements IModuleDependency
+class TCacheHttpSession extends THttpSession
 {
 	private $_prefix = 'session';
 	private $_cacheModuleID = '';
@@ -67,20 +66,6 @@ class TCacheHttpSession extends THttpSession implements IModuleDependency
 		}
 		$this->setUseCustomStorage(true);
 		parent::init($config);
-	}
-
-	/**
-	 * Returns the CacheModuleID that init() depends on, when set.
-	 * init() resolves the cache module then delegates to parent::init(), which
-	 * may touch session storage immediately; concrete caches open their
-	 * connection in their own init(). Empty CacheModuleID means no dependency.
-	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
-	 * @return null|string the cache module ID (empty if unset), or null for pre-init
-	 * @since 4.4.0
-	 */
-	public function getModuleDependencies(bool $isPreInit): null|string|array
-	{
-		return $this->getCacheModuleID();
 	}
 
 	/**

--- a/framework/Web/TUrlMapping.php
+++ b/framework/Web/TUrlMapping.php
@@ -121,11 +121,11 @@ class TUrlMapping extends TUrlManager implements IModuleDependency
 		if ($this->getRequest()->getRequestResolved()) {
 			throw new TConfigurationException('urlmapping_global_required');
 		}
-		if ($this->_configFile !== null) {
+		if ($this->getConfigFile() !== null) {
 			$this->loadConfigFile();
 		}
 		$this->loadUrlMappings($config);
-		if ($this->_urlPrefix === '') {
+		if ($this->getUrlPrefix() === '') {
 			$request = $this->getRequest();
 			if ($request->getUrlFormat() === THttpRequestUrlFormat::HiddenPath) {
 				$this->_urlPrefix = dirname($request->getApplicationUrl());
@@ -133,7 +133,7 @@ class TUrlMapping extends TUrlManager implements IModuleDependency
 				$this->_urlPrefix = $request->getApplicationUrl();
 			}
 		}
-		$this->_urlPrefix = rtrim($this->_urlPrefix, '/');
+		$this->_urlPrefix = rtrim($this->getUrlPrefix(), '/');
 	}
 
 	/**
@@ -157,17 +157,18 @@ class TUrlMapping extends TUrlManager implements IModuleDependency
 	 */
 	protected function loadConfigFile()
 	{
-		if (is_file($this->_configFile)) {
+		$configFile = $this->getConfigFile();
+		if (is_file($configFile)) {
 			if ($this->getApplication()->getConfigurationType() == TApplication::CONFIG_TYPE_PHP) {
-				$config = include $this->_configFile;
+				$config = include $configFile;
 				$this->loadUrlMappings($config);
 			} else {
 				$dom = new TXmlDocument();
-				$dom->loadFromFile($this->_configFile);
+				$dom->loadFromFile($configFile);
 				$this->loadUrlMappings($dom);
 			}
 		} else {
-			throw new TConfigurationException('urlmapping_configfile_inexistent', $this->_configFile);
+			throw new TConfigurationException('urlmapping_configfile_inexistent', $configFile);
 		}
 	}
 
@@ -229,7 +230,7 @@ class TUrlMapping extends TUrlManager implements IModuleDependency
 	 */
 	public function setConfigFile($value)
 	{
-		$configFile = Prado::getPathOfNamespace($value, $this->getApplication()->getConfigurationFileExt());
+		$configFile = Prado::getPathOfNamespace($value, $this->getApplication()?->getConfigurationFileExt());
 		if ($configFile === null) {
 			throw new TConfigurationException('urlmapping_configfile_invalid', $value);
 		}
@@ -379,7 +380,7 @@ class TUrlMapping extends TUrlManager implements IModuleDependency
 	 */
 	public function constructUrl($serviceID, $serviceParam, $getItems, $encodeAmpersand, $encodeGetItems)
 	{
-		if ($this->_customUrl) {
+		if ($this->getEnableCustomUrl()) {
 			if (!(is_array($getItems) || ($getItems instanceof \Traversable))) {
 				$getItems = [];
 			}

--- a/framework/Web/TUrlMapping.php
+++ b/framework/Web/TUrlMapping.php
@@ -11,6 +11,7 @@
 namespace Prado\Web;
 
 use Prado\Exceptions\TConfigurationException;
+use Prado\IModuleDependency;
 use Prado\Prado;
 use Prado\TApplication;
 use Prado\TPropertyValue;
@@ -81,7 +82,7 @@ use Prado\Xml\TXmlElement;
  * @author Wei Zhuo <weizhuo[at]gmail[dot]com>
  * @since 3.0.5
  */
-class TUrlMapping extends TUrlManager
+class TUrlMapping extends TUrlManager implements IModuleDependency
 {
 	/**
 	 * @var TUrlMappingPattern[] list of patterns.
@@ -133,6 +134,21 @@ class TUrlMapping extends TUrlManager
 			}
 		}
 		$this->_urlPrefix = rtrim($this->_urlPrefix, '/');
+	}
+
+	/**
+	 * Returns the configured THttpRequest module IDs that init() depends on.
+	 * init() reads request state right after parent::init(); a configured
+	 * request registers itself with TApplication only after its own init()
+	 * completes. With no configured request, getRequest() lazily instantiates
+	 * a default and no ordering is needed.
+	 * @param bool $isPreInit true for the dyPreInit pass, false for the init() pass
+	 * @return null|string[] configured request module IDs, or null for pre-init
+	 * @since 4.4.0
+	 */
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return array_keys($this->getApplication()?->getModulesByType(THttpRequest::class));
 	}
 
 	/**


### PR DESCRIPTION
Everything else does not have `init` inter-dependencies and operate within Prado phased initialization.

There are only 4 Modules that need module dependencies:
- TActiveRecordConfig - for its getDbConnection - requiring the ConnectionID Db module in `init`. (sets the DbConnection in the Manager)
- TDbParameterModule - `init` uses Db connection to load data.
- TCacheHttpSession - Caching module dependency ensures its caching subsystem has started before it.
- TUrlMapping - uses getRequest, requires any THttpRequest modules to be loaded before it.

There is also some light Self Encapsulation.