### PR TITLE
TApplication::runModuleLifecycle - adds bootstrapped default managers to modules.

### DIFF
--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -185,7 +185,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Canonical IDs assigned to lazily-created default-core modules by
-	 * {@see bootstrapDefaultModule()}, and the registry keys
+	 * {@see bootstrapModule()}, and the registry keys
 	 * {@see bootstrapDefaultModules()} writes into `$_modules`.
 	 * @since 4.4.0
 	 */
@@ -201,7 +201,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Set by {@see bootstrapDefaultModules()} on completion; while set,
-	 * {@see bootstrapDefaultModule()} also registers late-arrival defaults
+	 * {@see bootstrapModule()} also registers late-arrival defaults
 	 * in `$_modules`.
 	 * @since 4.4.0
 	 */
@@ -1534,14 +1534,18 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Runs the four post-construction lifecycle phases on `$module`:
-	 * `dyPreInit`, dependency resolution (force-loading lazy deps via
-	 * {@see getModule()}; missing required deps throw
-	 * {@see TConfigurationException}), `init($config)`, and `dyPostInit`.
+	 *  - `dyPreInit($config)`
+	 *  - dependency resolution — force-loads lazy deps via
+	 *    {@see getModule()}; missing required deps throw
+	 *    {@see TConfigurationException}
+	 *  - `init($config)`
+	 *  - `dyPostInit($config)`
+	 *
 	 * Single source of truth for both the lazy-load path in
-	 * {@see getModule()} and {@see bootstrapDefaultModule()}.
+	 * {@see getModule()} and {@see bootstrapModule()}.
 	 * @param IModule $module the module to bring online.
-	 * @param mixed   $config configuration forwarded to `dyPreInit`, `init`,
-	 *   and `dyPostInit`; `null` for default-bootstrapped modules.
+	 * @param mixed   $config configuration forwarded to every phase; `null`
+	 *   for default-bootstrapped modules.
 	 * @throws TConfigurationException when a required dependency is missing.
 	 * @since 4.4.0
 	 */
@@ -1571,34 +1575,43 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Brings a freshly-constructed default-core module online: assigns its
-	 * canonical ID and runs its lifecycle via {@see runModuleLifecycle()}.
-	 * Once {@see bootstrapDefaultModules()} has run, also registers the
-	 * module in `$_modules` under `$module->getID()` unless a configured
-	 * same-type module is already present.
-	 * @param IModule $module freshly-constructed default-module instance.
-	 * @param string  $id     canonical default ID (see `DEFAULT_*_ID`).
+	 * Assigns the module's ID, runs its lifecycle via
+	 * {@see runModuleLifecycle()}, and — when `$register` is true —
+	 * enrolls it in `$_modules` under `$module->getID()`.
+	 * @param IModule $module   freshly-constructed module instance.
+	 * @param string  $id       ID to assign.
+	 * @param bool    $register write to `$_modules` after the lifecycle; `true` by default.
 	 * @throws TConfigurationException when a required dependency is missing.
 	 * @since 4.4.0
 	 */
-	protected function bootstrapDefaultModule(IModule $module, string $id): void
+	protected function bootstrapModule(IModule $module, string $id, bool $register = true): void
 	{
 		$module->setID($id);
 		$this->runModuleLifecycle($module, null);
-		if ($this->hasStateFlag(static::STATE_DEFAULT_MODULES_BOOTSTRAPPED)
-			&& empty($this->getModulesByType($module::class))) {
+		if ($register) {
 			$this->_modules[$module->getID()] = $module;
 		}
 	}
 
 	/**
-	 * Registers each already-instanced default-core module under its
-	 * canonical ID, unless a module of the same type is already in
-	 * `$_modules` under any ID. Never instantiates — unset slots stay
-	 * unset, type-collisions leave the configured module in place. Sets
-	 * the {@see STATE_DEFAULT_MODULES_BOOTSTRAPPED} flag on completion so any default that
-	 * is lazily created after this sweep (via a `getX()` accessor) is
-	 * registered immediately by {@see bootstrapDefaultModule()}.
+	 * Returns true when {@see bootstrapModule()} should register a
+	 * default-core module of `$type`: the
+	 * {@see STATE_DEFAULT_MODULES_BOOTSTRAPPED} flag is set AND no
+	 * same-type module is already in `$_modules`.
+	 * @param string $type FQN of the default's canonical class.
+	 * @since 4.4.0
+	 */
+	protected function shouldRegisterDefault(string $type): bool
+	{
+		return $this->hasStateFlag(static::STATE_DEFAULT_MODULES_BOOTSTRAPPED)
+			&& empty($this->getModulesByType($type));
+	}
+
+	/**
+	 * Enrols each instanced default-core module in `$_modules` unless a
+	 * same-type module is already registered; never instantiates. Sets
+	 * {@see STATE_DEFAULT_MODULES_BOOTSTRAPPED} on completion so later
+	 * defaults register immediately via {@see bootstrapModule()}.
 	 * @since 4.4.0
 	 */
 	protected function bootstrapDefaultModules(): void
@@ -1658,7 +1671,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the request module, lazily bootstrapping a default via
-	 * {@see newRequest()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newRequest()} + {@see bootstrapModule()} when not yet set.
 	 * @return THttpRequest the request module
 	 */
 	public function getRequest()
@@ -1666,7 +1679,11 @@ class TApplication extends TComponent implements ISingleton
 		$request = $this->getRequestDirect();
 		if (!$request && ($request = $this->newRequest())) {
 			$this->setRequest($request);
-			$this->bootstrapDefaultModule($request, static::DEFAULT_REQUEST_ID);
+			$this->bootstrapModule(
+				$request,
+				static::DEFAULT_REQUEST_ID,
+				$this->shouldRegisterDefault(THttpRequest::class)
+			);
 			$request = $this->getRequestDirect();
 		}
 		return $request;
@@ -1696,7 +1713,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the response module, lazily bootstrapping a default via
-	 * {@see newResponse()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newResponse()} + {@see bootstrapModule()} when not yet set.
 	 * @return THttpResponse the response module
 	 */
 	public function getResponse()
@@ -1704,7 +1721,11 @@ class TApplication extends TComponent implements ISingleton
 		$response = $this->getResponseDirect();
 		if (!$response && ($response = $this->newResponse())) {
 			$this->setResponse($response);
-			$this->bootstrapDefaultModule($response, static::DEFAULT_RESPONSE_ID);
+			$this->bootstrapModule(
+				$response,
+				static::DEFAULT_RESPONSE_ID,
+				$this->shouldRegisterDefault(THttpResponse::class)
+			);
 			$response = $this->getResponseDirect();
 		}
 		return $response;
@@ -1742,7 +1763,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the session module, lazily bootstrapping a default via
-	 * {@see newSession()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newSession()} + {@see bootstrapModule()} when not yet set.
 	 * @return THttpSession the session module, null if session module is not installed
 	 */
 	public function getSession()
@@ -1750,7 +1771,11 @@ class TApplication extends TComponent implements ISingleton
 		$session = $this->getSessionDirect();
 		if (!$session && ($session = $this->newSession())) {
 			$this->setSession($session);
-			$this->bootstrapDefaultModule($session, static::DEFAULT_SESSION_ID);
+			$this->bootstrapModule(
+				$session,
+				static::DEFAULT_SESSION_ID,
+				$this->shouldRegisterDefault(THttpSession::class)
+			);
 			$session = $this->getSessionDirect();
 		}
 		return $session;
@@ -1788,7 +1813,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the error handler module, lazily bootstrapping a default via
-	 * {@see newErrorHandler()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newErrorHandler()} + {@see bootstrapModule()} when not yet set.
 	 * @return TErrorHandler the error handler module
 	 */
 	public function getErrorHandler()
@@ -1796,7 +1821,11 @@ class TApplication extends TComponent implements ISingleton
 		$errorHandler = $this->getErrorHandlerDirect();
 		if (!$errorHandler && ($errorHandler = $this->newErrorHandler())) {
 			$this->setErrorHandler($errorHandler);
-			$this->bootstrapDefaultModule($errorHandler, static::DEFAULT_ERROR_HANDLER_ID);
+			$this->bootstrapModule(
+				$errorHandler,
+				static::DEFAULT_ERROR_HANDLER_ID,
+				$this->shouldRegisterDefault(TErrorHandler::class)
+			);
 			$errorHandler = $this->getErrorHandlerDirect();
 		}
 		return $errorHandler;
@@ -1834,7 +1863,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the security manager module, lazily bootstrapping a default via
-	 * {@see newSecurityManager()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newSecurityManager()} + {@see bootstrapModule()} when not yet set.
 	 * @return TSecurityManager the security manager module
 	 */
 	public function getSecurityManager()
@@ -1842,7 +1871,11 @@ class TApplication extends TComponent implements ISingleton
 		$securityManager = $this->getSecurityManagerDirect();
 		if (!$securityManager && ($securityManager = $this->newSecurityManager())) {
 			$this->setSecurityManager($securityManager);
-			$this->bootstrapDefaultModule($securityManager, static::DEFAULT_SECURITY_MANAGER_ID);
+			$this->bootstrapModule(
+				$securityManager,
+				static::DEFAULT_SECURITY_MANAGER_ID,
+				$this->shouldRegisterDefault(TSecurityManager::class)
+			);
 			$securityManager = $this->getSecurityManagerDirect();
 		}
 		return $securityManager;
@@ -1880,7 +1913,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the asset manager module, lazily bootstrapping a default via
-	 * {@see newAssetManager()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newAssetManager()} + {@see bootstrapModule()} when not yet set.
 	 * @return TAssetManager asset manager
 	 */
 	public function getAssetManager()
@@ -1888,7 +1921,11 @@ class TApplication extends TComponent implements ISingleton
 		$assetManager = $this->getAssetManagerDirect();
 		if (!$assetManager && ($assetManager = $this->newAssetManager())) {
 			$this->setAssetManager($assetManager);
-			$this->bootstrapDefaultModule($assetManager, static::DEFAULT_ASSET_MANAGER_ID);
+			$this->bootstrapModule(
+				$assetManager,
+				static::DEFAULT_ASSET_MANAGER_ID,
+				$this->shouldRegisterDefault(TAssetManager::class)
+			);
 			$assetManager = $this->getAssetManagerDirect();
 		}
 		return $assetManager;
@@ -1926,7 +1963,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the template manager module, lazily bootstrapping a default via
-	 * {@see newTemplateManager()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newTemplateManager()} + {@see bootstrapModule()} when not yet set.
 	 * @return TTemplateManager template manager
 	 */
 	public function getTemplateManager()
@@ -1934,7 +1971,11 @@ class TApplication extends TComponent implements ISingleton
 		$templateManager = $this->getTemplateManagerDirect();
 		if (!$templateManager && ($templateManager = $this->newTemplateManager())) {
 			$this->setTemplateManager($templateManager);
-			$this->bootstrapDefaultModule($templateManager, static::DEFAULT_TEMPLATE_MANAGER_ID);
+			$this->bootstrapModule(
+				$templateManager,
+				static::DEFAULT_TEMPLATE_MANAGER_ID,
+				$this->shouldRegisterDefault(TTemplateManager::class)
+			);
 			$templateManager = $this->getTemplateManagerDirect();
 		}
 		return $templateManager;
@@ -1972,7 +2013,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the theme manager module, lazily bootstrapping a default via
-	 * {@see newThemeManager()} + {@see bootstrapDefaultModule()} when not yet set.
+	 * {@see newThemeManager()} + {@see bootstrapModule()} when not yet set.
 	 * @return TThemeManager theme manager
 	 */
 	public function getThemeManager()
@@ -1980,7 +2021,11 @@ class TApplication extends TComponent implements ISingleton
 		$themeManager = $this->getThemeManagerDirect();
 		if (!$themeManager && ($themeManager = $this->newThemeManager())) {
 			$this->setThemeManager($themeManager);
-			$this->bootstrapDefaultModule($themeManager, static::DEFAULT_THEME_MANAGER_ID);
+			$this->bootstrapModule(
+				$themeManager,
+				static::DEFAULT_THEME_MANAGER_ID,
+				$this->shouldRegisterDefault(TThemeManager::class)
+			);
 			$themeManager = $this->getThemeManagerDirect();
 		}
 		return $themeManager;
@@ -2020,7 +2065,7 @@ class TApplication extends TComponent implements ISingleton
 	 * Returns the application state persister, auto-creating it via
 	 * {@see newApplicationStatePersister()} when not yet set. The persister
 	 * is an `IStatePersister` rather than an application module, so it is
-	 * not routed through {@see bootstrapDefaultModule()}; a direct
+	 * not routed through {@see bootstrapModule()}; a direct
 	 * `init(null)` is invoked when the implementation also happens to be an
 	 * {@see IModule} (the default `TApplicationStatePersister` is).
 	 * @return IStatePersister application state persister
@@ -2070,7 +2115,7 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Returns the globalization module, lazily bootstrapping a default via
-	 * {@see newGlobalization()} + {@see bootstrapDefaultModule()} when not yet set
+	 * {@see newGlobalization()} + {@see bootstrapModule()} when not yet set
 	 * and `$createIfNotExists` is true; otherwise returns `null`.
 	 * @param bool $createIfNotExists whether to create on first access.
 	 * @return ?TGlobalization globalization module, or null when none exists and creation is disabled.
@@ -2080,7 +2125,11 @@ class TApplication extends TComponent implements ISingleton
 		$globalization = $this->getGlobalizationDirect();
 		if (!$globalization && $createIfNotExists && ($globalization = $this->newGlobalization())) {
 			$this->setGlobalization($globalization);
-			$this->bootstrapDefaultModule($globalization, static::DEFAULT_GLOBALIZATION_ID);
+			$this->bootstrapModule(
+				$globalization,
+				static::DEFAULT_GLOBALIZATION_ID,
+				$this->shouldRegisterDefault(TGlobalization::class)
+			);
 			$globalization = $this->getGlobalizationDirect();
 		}
 		return $globalization;

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -184,6 +184,25 @@ class TApplication extends TComponent implements ISingleton
 	public const DEP_SORT_CACHE_KEY = '_sort';
 
 	/**
+	 * Canonical IDs under which the default-created core modules are
+	 * registered in `$_modules` when {@see bootstrapDefaultModules()} runs
+	 * at the start of {@see onConfiguration()}. Applications may pre-register
+	 * a module under any of these IDs to replace the corresponding default —
+	 * `bootstrapDefaultModules()` detects the existing registration and
+	 * leaves it untouched.
+	 * @since 4.4.0
+	 */
+	public const DEFAULT_REQUEST_ID = 'request';
+	public const DEFAULT_RESPONSE_ID = 'response';
+	public const DEFAULT_SESSION_ID = 'session';
+	public const DEFAULT_ERROR_HANDLER_ID = 'errorHandler';
+	public const DEFAULT_SECURITY_MANAGER_ID = 'securityManager';
+	public const DEFAULT_ASSET_MANAGER_ID = 'assetManager';
+	public const DEFAULT_GLOBALIZATION_ID = 'globalization';
+	public const DEFAULT_TEMPLATE_MANAGER_ID = 'templateManager';
+	public const DEFAULT_THEME_MANAGER_ID = 'themeManager';
+
+	/**
 	 * @var string[] ordered list of lifecycle method names executed by {@see run()}.
 	 *   Override {@see getSteps()} to customize the lifecycle in subclasses.
 	 */
@@ -1391,29 +1410,7 @@ class TApplication extends TComponent implements ISingleton
 		if ($this->_modules[$id] === null) {
 			$module = $this->internalLoadModule($id, true);
 			if ($module) {
-				$isComponent = $module[0] instanceof TComponent;
-				if ($isComponent) {
-					$module[0]->dyPreInit($module[1]);
-				}
-				// Ensure every declared dependency is initialized before this module (init phase).
-				foreach ($this->collectModuleDependencies($module[0], false)['deps'] as $dep) {
-					if (!array_key_exists($dep['id'], $this->_modules)) {
-						// Dep not registered at all.
-						if ($dep['required']) {
-							throw new TConfigurationException(
-								'application_module_required_dep_missing',
-								$module[0]->getID(),
-								$dep['id']
-							);
-						}
-						continue; // advisory dep absent — skip silently
-					}
-					$this->getModule($dep['id']); // force-load if lazy
-				}
-				$module[0]->init($module[1]);
-				if ($isComponent) {
-					$module[0]->dyPostInit($module[1]);
-				}
+				$this->runModuleLifecycle($module[0], $module[1]);
 			}
 		}
 
@@ -1478,6 +1475,92 @@ class TApplication extends TComponent implements ISingleton
 		return $m;
 	}
 
+	/**
+	 * Runs the four post-construction lifecycle phases on `$module`:
+	 * `dyPreInit`, dependency resolution (force-loading lazy deps via
+	 * {@see getModule()}; missing required deps throw
+	 * {@see TConfigurationException}), `init($config)`, and `dyPostInit`.
+	 * Single source of truth for both the lazy-load path in
+	 * {@see getModule()} and {@see bootstrapDefaultModule()}.
+	 * @param IModule $module the module to bring online.
+	 * @param mixed   $config configuration forwarded to `dyPreInit`, `init`,
+	 *   and `dyPostInit`; `null` for default-bootstrapped modules.
+	 * @throws TConfigurationException when a required dependency is missing.
+	 * @since 4.4.0
+	 */
+	protected function runModuleLifecycle(IModule $module, mixed $config): void
+	{
+		$isComponent = $module instanceof TComponent;
+		if ($isComponent) {
+			$module->dyPreInit($config);
+		}
+		foreach ($this->collectModuleDependencies($module, false)['deps'] as $dep) {
+			if (!array_key_exists($dep['id'], $this->_modules)) {
+				if ($dep['required']) {
+					throw new TConfigurationException(
+						'application_module_required_dep_missing',
+						$module->getID(),
+						$dep['id']
+					);
+				}
+				continue; // advisory dep absent — skip silently
+			}
+			$this->getModule($dep['id']); // force-load if lazy
+		}
+		$module->init($config);
+		if ($isComponent) {
+			$module->dyPostInit($config);
+		}
+	}
+
+	/**
+	 * Brings a freshly-constructed default-core module online: assigns its
+	 * canonical ID and runs the full lifecycle via
+	 * {@see runModuleLifecycle()}. Registration in `$_modules` is deferred
+	 * to {@see bootstrapDefaultModules()} at {@see onConfiguration()} time.
+	 * @param IModule $module freshly-constructed default-module instance.
+	 * @param string  $id     canonical default ID (see `DEFAULT_*_ID`).
+	 * @throws TConfigurationException when a required dependency is missing.
+	 * @since 4.4.0
+	 */
+	protected function bootstrapDefaultModule(IModule $module, string $id): void
+	{
+		$module->setID($id);
+		$this->runModuleLifecycle($module, null);
+	}
+
+	/**
+	 * Registers each already-instanced default-core module under its
+	 * canonical ID, unless a module of the same type is already in
+	 * `$_modules` under any ID. Never instantiates: unset slots stay
+	 * unset, type-collisions leave the configured module in place.
+	 * Called once from {@see onConfiguration()} before the event raises.
+	 * @since 4.4.0
+	 */
+	protected function bootstrapDefaultModules(): void
+	{
+		$defaults = [
+			static::DEFAULT_REQUEST_ID => [THttpRequest::class,    $this->getRequestDirect()],
+			static::DEFAULT_RESPONSE_ID => [THttpResponse::class,   $this->getResponseDirect()],
+			static::DEFAULT_SESSION_ID => [THttpSession::class,    $this->getSessionDirect()],
+			static::DEFAULT_ERROR_HANDLER_ID => [TErrorHandler::class,   $this->getErrorHandlerDirect()],
+			static::DEFAULT_SECURITY_MANAGER_ID => [TSecurityManager::class, $this->getSecurityManagerDirect()],
+			static::DEFAULT_ASSET_MANAGER_ID => [TAssetManager::class,   $this->getAssetManagerDirect()],
+			static::DEFAULT_GLOBALIZATION_ID => [TGlobalization::class,  $this->getGlobalizationDirect()],
+			static::DEFAULT_TEMPLATE_MANAGER_ID => [TTemplateManager::class, $this->getTemplateManagerDirect()],
+			static::DEFAULT_THEME_MANAGER_ID => [TThemeManager::class,   $this->getThemeManagerDirect()],
+		];
+		foreach ($defaults as $id => [$type, $module]) {
+			if ($module === null) {
+				continue;
+			}
+			if (!empty($this->getModulesByType($type))) {
+				continue;
+			}
+			$this->_modules[$module->getID()] = $module;
+		}
+	}
+
 	// =========================================================================
 	// Request API
 	// =========================================================================
@@ -1509,7 +1592,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the request module, auto-creating it via {@see newRequest()} and calling `init(null)` if not yet set.
+	 * Returns the request module, auto-creating it via {@see newRequest()} and
+	 * running it through {@see bootstrapDefaultModule()} when not yet set so
+	 * the default receives the full module lifecycle (setID, dyPreInit,
+	 * dependency resolution, init, dyPostInit). The instance is enrolled in
+	 * `$_modules` under {@see DEFAULT_REQUEST_ID} by {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return THttpRequest the request module
 	 */
 	public function getRequest()
@@ -1517,7 +1605,7 @@ class TApplication extends TComponent implements ISingleton
 		$request = $this->getRequestDirect();
 		if (!$request && ($request = $this->newRequest())) {
 			$this->setRequest($request);
-			$request->init(null);
+			$this->bootstrapDefaultModule($request, static::DEFAULT_REQUEST_ID);
 			$request = $this->getRequestDirect();
 		}
 		return $request;
@@ -1546,7 +1634,11 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the response module, auto-creating it via {@see newResponse()} and calling `init(null)` if not yet set.
+	 * Returns the response module, auto-creating it via {@see newResponse()}
+	 * and running it through {@see bootstrapDefaultModule()} when not yet
+	 * set so the default receives the full module lifecycle. Registration
+	 * under {@see DEFAULT_RESPONSE_ID} happens via {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return THttpResponse the response module
 	 */
 	public function getResponse()
@@ -1554,7 +1646,7 @@ class TApplication extends TComponent implements ISingleton
 		$response = $this->getResponseDirect();
 		if (!$response && ($response = $this->newResponse())) {
 			$this->setResponse($response);
-			$response->init(null);
+			$this->bootstrapDefaultModule($response, static::DEFAULT_RESPONSE_ID);
 			$response = $this->getResponseDirect();
 		}
 		return $response;
@@ -1591,7 +1683,11 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the session module, auto-creating it via {@see newSession()} and calling `init(null)` if not yet set.
+	 * Returns the session module, auto-creating it via {@see newSession()} and
+	 * running it through {@see bootstrapDefaultModule()} when not yet set so
+	 * the default receives the full module lifecycle. Registration under
+	 * {@see DEFAULT_SESSION_ID} happens via {@see bootstrapDefaultModules()} at
+	 * {@see onConfiguration()} time.
 	 * @return THttpSession the session module, null if session module is not installed
 	 */
 	public function getSession()
@@ -1599,7 +1695,7 @@ class TApplication extends TComponent implements ISingleton
 		$session = $this->getSessionDirect();
 		if (!$session && ($session = $this->newSession())) {
 			$this->setSession($session);
-			$session->init(null);
+			$this->bootstrapDefaultModule($session, static::DEFAULT_SESSION_ID);
 			$session = $this->getSessionDirect();
 		}
 		return $session;
@@ -1636,7 +1732,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the error handler module, auto-creating it via {@see newErrorHandler()} and calling `init(null)` if not yet set.
+	 * Returns the error handler module, auto-creating it via
+	 * {@see newErrorHandler()} and running it through
+	 * {@see bootstrapDefaultModule()} when not yet set so the default
+	 * receives the full module lifecycle. Registration under
+	 * {@see DEFAULT_ERROR_HANDLER_ID} happens via {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return TErrorHandler the error handler module
 	 */
 	public function getErrorHandler()
@@ -1644,7 +1745,7 @@ class TApplication extends TComponent implements ISingleton
 		$errorHandler = $this->getErrorHandlerDirect();
 		if (!$errorHandler && ($errorHandler = $this->newErrorHandler())) {
 			$this->setErrorHandler($errorHandler);
-			$errorHandler->init(null);
+			$this->bootstrapDefaultModule($errorHandler, static::DEFAULT_ERROR_HANDLER_ID);
 			$errorHandler = $this->getErrorHandlerDirect();
 		}
 		return $errorHandler;
@@ -1681,7 +1782,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the security manager module, auto-creating it via {@see newSecurityManager()} and calling `init(null)` if not yet set.
+	 * Returns the security manager module, auto-creating it via
+	 * {@see newSecurityManager()} and running it through
+	 * {@see bootstrapDefaultModule()} when not yet set so the default
+	 * receives the full module lifecycle. Registration under
+	 * {@see DEFAULT_SECURITY_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return TSecurityManager the security manager module
 	 */
 	public function getSecurityManager()
@@ -1689,7 +1795,7 @@ class TApplication extends TComponent implements ISingleton
 		$securityManager = $this->getSecurityManagerDirect();
 		if (!$securityManager && ($securityManager = $this->newSecurityManager())) {
 			$this->setSecurityManager($securityManager);
-			$securityManager->init(null);
+			$this->bootstrapDefaultModule($securityManager, static::DEFAULT_SECURITY_MANAGER_ID);
 			$securityManager = $this->getSecurityManagerDirect();
 		}
 		return $securityManager;
@@ -1726,7 +1832,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the asset manager module, auto-creating it via {@see newAssetManager()} and calling `init(null)` if not yet set.
+	 * Returns the asset manager module, auto-creating it via
+	 * {@see newAssetManager()} and running it through
+	 * {@see bootstrapDefaultModule()} when not yet set so the default
+	 * receives the full module lifecycle. Registration under
+	 * {@see DEFAULT_ASSET_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return TAssetManager asset manager
 	 */
 	public function getAssetManager()
@@ -1734,7 +1845,7 @@ class TApplication extends TComponent implements ISingleton
 		$assetManager = $this->getAssetManagerDirect();
 		if (!$assetManager && ($assetManager = $this->newAssetManager())) {
 			$this->setAssetManager($assetManager);
-			$assetManager->init(null);
+			$this->bootstrapDefaultModule($assetManager, static::DEFAULT_ASSET_MANAGER_ID);
 			$assetManager = $this->getAssetManagerDirect();
 		}
 		return $assetManager;
@@ -1771,7 +1882,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the template manager module, auto-creating it via {@see newTemplateManager()} and calling `init(null)` if not yet set.
+	 * Returns the template manager module, auto-creating it via
+	 * {@see newTemplateManager()} and running it through
+	 * {@see bootstrapDefaultModule()} when not yet set so the default
+	 * receives the full module lifecycle. Registration under
+	 * {@see DEFAULT_TEMPLATE_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return TTemplateManager template manager
 	 */
 	public function getTemplateManager()
@@ -1779,7 +1895,7 @@ class TApplication extends TComponent implements ISingleton
 		$templateManager = $this->getTemplateManagerDirect();
 		if (!$templateManager && ($templateManager = $this->newTemplateManager())) {
 			$this->setTemplateManager($templateManager);
-			$templateManager->init(null);
+			$this->bootstrapDefaultModule($templateManager, static::DEFAULT_TEMPLATE_MANAGER_ID);
 			$templateManager = $this->getTemplateManagerDirect();
 		}
 		return $templateManager;
@@ -1816,7 +1932,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the theme manager module, auto-creating it via {@see newThemeManager()} and calling `init(null)` if not yet set.
+	 * Returns the theme manager module, auto-creating it via
+	 * {@see newThemeManager()} and running it through
+	 * {@see bootstrapDefaultModule()} when not yet set so the default
+	 * receives the full module lifecycle. Registration under
+	 * {@see DEFAULT_THEME_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
+	 * at {@see onConfiguration()} time.
 	 * @return TThemeManager theme manager
 	 */
 	public function getThemeManager()
@@ -1824,7 +1945,7 @@ class TApplication extends TComponent implements ISingleton
 		$themeManager = $this->getThemeManagerDirect();
 		if (!$themeManager && ($themeManager = $this->newThemeManager())) {
 			$this->setThemeManager($themeManager);
-			$themeManager->init(null);
+			$this->bootstrapDefaultModule($themeManager, static::DEFAULT_THEME_MANAGER_ID);
 			$themeManager = $this->getThemeManagerDirect();
 		}
 		return $themeManager;
@@ -1861,7 +1982,12 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the application state persister, auto-creating it via {@see newApplicationStatePersister()} and calling `init(null)` if not yet set.
+	 * Returns the application state persister, auto-creating it via
+	 * {@see newApplicationStatePersister()} when not yet set. The persister
+	 * is an `IStatePersister` rather than an application module, so it is
+	 * not routed through {@see bootstrapDefaultModule()}; a direct
+	 * `init(null)` is invoked when the implementation also happens to be an
+	 * {@see IModule} (the default `TApplicationStatePersister` is).
 	 * @return IStatePersister application state persister
 	 */
 	public function getApplicationStatePersister()
@@ -1908,9 +2034,15 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the globalization module, auto-creating and initialising it via {@see newGlobalization()} when
-	 * `$createIfNotExists` is `true` (the default) and no module has been set yet. Pass `false` to return
-	 * `null` rather than auto-creating.
+	 * Returns the globalization module, auto-creating and bootstrapping it via
+	 * {@see newGlobalization()} + {@see bootstrapDefaultModule()} when
+	 * `$createIfNotExists` is `true` (the default) and no module has been set
+	 * yet. The bootstrap runs the full module lifecycle (setID, dyPreInit,
+	 * dependency resolution, init, dyPostInit) so the default is
+	 * indistinguishable from a configured `<module>` entry; registration in
+	 * `$_modules` under {@see DEFAULT_GLOBALIZATION_ID} is performed by
+	 * {@see bootstrapDefaultModules()} at {@see onConfiguration()} time. Pass
+	 * `false` to return `null` rather than auto-creating.
 	 * @param bool $createIfNotExists whether to create globalization if it does not exist
 	 * @return ?TGlobalization globalization module
 	 */
@@ -1919,7 +2051,7 @@ class TApplication extends TComponent implements ISingleton
 		$globalization = $this->getGlobalizationDirect();
 		if (!$globalization && $createIfNotExists && ($globalization = $this->newGlobalization())) {
 			$this->setGlobalization($globalization);
-			$globalization->init(null);
+			$this->bootstrapDefaultModule($globalization, static::DEFAULT_GLOBALIZATION_ID);
 			$globalization = $this->getGlobalizationDirect();
 		}
 		return $globalization;
@@ -2465,14 +2597,16 @@ class TApplication extends TComponent implements ISingleton
 	// =========================================================================
 
 	/**
-	 * Loads configuration and initializes application.
-	 * Configuration file will be read and parsed (if a valid cached version exists,
-	 * it will be used instead). Then, modules are created and initialized;
-	 * Afterwards, the requested service is created and initialized.
-	 * After all configuration is applied, the onConfiguration event is
-	 * raised so that listeners may register additional services before the
-	 * request is resolved. Lastly, the onInitComplete event is raised.
-	 * @throws TConfigurationException if module is redefined of invalid type, or service not defined or of invalid type
+	 * Loads configuration and initializes the application. Reads the
+	 * configuration file (or its cached form when current), applies it via
+	 * {@see applyConfiguration()} so configured modules are created and
+	 * initialized, then runs {@see bootstrapDefaultModules()} to register
+	 * any lazily-created default-core modules under their canonical IDs,
+	 * raises {@see onConfiguration} for late-stage service registration,
+	 * runs {@see initService()} to resolve and start the requested service,
+	 * and finally raises {@see onInitComplete}.
+	 * @throws TConfigurationException when a module is redefined or
+	 *   invalid, or when the requested service is undefined or invalid.
 	 * @see onConfiguration
 	 * @see onInitComplete
 	 */
@@ -2497,6 +2631,7 @@ class TApplication extends TComponent implements ISingleton
 			$this->applyConfiguration($config, false);
 		}
 
+		$this->bootstrapDefaultModules();
 		$this->onConfiguration();
 		$this->initService();
 		$this->onInitComplete();

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -184,12 +184,9 @@ class TApplication extends TComponent implements ISingleton
 	public const DEP_SORT_CACHE_KEY = '_sort';
 
 	/**
-	 * Canonical IDs under which the default-created core modules are
-	 * registered in `$_modules` when {@see bootstrapDefaultModules()} runs
-	 * at the start of {@see onConfiguration()}. Applications may pre-register
-	 * a module under any of these IDs to replace the corresponding default —
-	 * `bootstrapDefaultModules()` detects the existing registration and
-	 * leaves it untouched.
+	 * Canonical IDs assigned to lazily-created default-core modules by
+	 * {@see bootstrapDefaultModule()}, and the registry keys
+	 * {@see bootstrapDefaultModules()} writes into `$_modules`.
 	 * @since 4.4.0
 	 */
 	public const DEFAULT_REQUEST_ID = 'request';
@@ -201,6 +198,20 @@ class TApplication extends TComponent implements ISingleton
 	public const DEFAULT_GLOBALIZATION_ID = 'globalization';
 	public const DEFAULT_TEMPLATE_MANAGER_ID = 'templateManager';
 	public const DEFAULT_THEME_MANAGER_ID = 'themeManager';
+
+	/**
+	 * Set by {@see bootstrapDefaultModules()} on completion; while set,
+	 * {@see bootstrapDefaultModule()} also registers late-arrival defaults
+	 * in `$_modules`.
+	 * @since 4.4.0
+	 */
+	public const STATE_DEFAULT_MODULES_BOOTSTRAPPED = (1 << 0);
+
+	/**
+	 * Set by {@see initApplication()} after {@see onInitComplete} returns.
+	 * @since 4.4.0
+	 */
+	public const STATE_INITIALIZED = (1 << 1);
 
 	/**
 	 * @var string[] ordered list of lifecycle method names executed by {@see run()}.
@@ -237,7 +248,7 @@ class TApplication extends TComponent implements ISingleton
 	/**
 	 * @var int application state
 	 */
-	private $_step;
+	private $_step = 0;
 	/**
 	 * @var array available services and their configurations indexed by service IDs
 	 */
@@ -358,6 +369,14 @@ class TApplication extends TComponent implements ISingleton
 	private $_pageServiceID;
 
 	/**
+	 * @var int Bit field of TApplication internal state flags. Set via
+	 *   {@see setStateFlag()}, queried via {@see hasStateFlag()} or
+	 *   {@see getStateFlags()}. See the `STATE_*` constants for valid bits.
+	 * @since 4.4.0
+	 */
+	private int $_stateFlags = 0;
+
+	/**
 	 * Constructor.
 	 * Sets application base path and initializes the application singleton.
 	 * Application base path refers to the root directory storing application
@@ -453,6 +472,44 @@ class TApplication extends TComponent implements ISingleton
 	private function setStep(int $value): void
 	{
 		$this->_step = $value;
+	}
+
+	/**
+	 * Returns the raw `$_stateFlags` bit field. See the `STATE_*` constants
+	 * for which bits are defined.
+	 * @return int the raw bit field of internal state flags.
+	 * @since 4.4.0
+	 */
+	public function getStateFlags(): int
+	{
+		return $this->_stateFlags;
+	}
+
+	/**
+	 * Returns true when every bit in `$flag` is set on `$_stateFlags`.
+	 * @param int $flag one or more `STATE_*` bits to test for.
+	 * @return bool true when all of `$flag`'s bits are currently set.
+	 * @since 4.4.0
+	 */
+	public function hasStateFlag(int $flag): bool
+	{
+		return ($this->_stateFlags & $flag) === $flag;
+	}
+
+	/**
+	 * Sets (`$on = true`) or clears (`$on = false`) every bit in `$flag` on
+	 * `$_stateFlags`.
+	 * @param int  $flag one or more `STATE_*` bits to mutate.
+	 * @param bool $on   true to set the bits, false to clear them.
+	 * @since 4.4.0
+	 */
+	protected function setStateFlag(int $flag, bool $on = true): void
+	{
+		if ($on) {
+			$this->_stateFlags |= $flag;
+		} else {
+			$this->_stateFlags &= ~$flag;
+		}
 	}
 
 	/**
@@ -1515,9 +1572,10 @@ class TApplication extends TComponent implements ISingleton
 
 	/**
 	 * Brings a freshly-constructed default-core module online: assigns its
-	 * canonical ID and runs the full lifecycle via
-	 * {@see runModuleLifecycle()}. Registration in `$_modules` is deferred
-	 * to {@see bootstrapDefaultModules()} at {@see onConfiguration()} time.
+	 * canonical ID and runs its lifecycle via {@see runModuleLifecycle()}.
+	 * Once {@see bootstrapDefaultModules()} has run, also registers the
+	 * module in `$_modules` under `$module->getID()` unless a configured
+	 * same-type module is already present.
 	 * @param IModule $module freshly-constructed default-module instance.
 	 * @param string  $id     canonical default ID (see `DEFAULT_*_ID`).
 	 * @throws TConfigurationException when a required dependency is missing.
@@ -1527,14 +1585,20 @@ class TApplication extends TComponent implements ISingleton
 	{
 		$module->setID($id);
 		$this->runModuleLifecycle($module, null);
+		if ($this->hasStateFlag(static::STATE_DEFAULT_MODULES_BOOTSTRAPPED)
+			&& empty($this->getModulesByType($module::class))) {
+			$this->_modules[$module->getID()] = $module;
+		}
 	}
 
 	/**
 	 * Registers each already-instanced default-core module under its
 	 * canonical ID, unless a module of the same type is already in
-	 * `$_modules` under any ID. Never instantiates: unset slots stay
-	 * unset, type-collisions leave the configured module in place.
-	 * Called once from {@see onConfiguration()} before the event raises.
+	 * `$_modules` under any ID. Never instantiates — unset slots stay
+	 * unset, type-collisions leave the configured module in place. Sets
+	 * the {@see STATE_DEFAULT_MODULES_BOOTSTRAPPED} flag on completion so any default that
+	 * is lazily created after this sweep (via a `getX()` accessor) is
+	 * registered immediately by {@see bootstrapDefaultModule()}.
 	 * @since 4.4.0
 	 */
 	protected function bootstrapDefaultModules(): void
@@ -1559,6 +1623,7 @@ class TApplication extends TComponent implements ISingleton
 			}
 			$this->_modules[$module->getID()] = $module;
 		}
+		$this->setStateFlag(static::STATE_DEFAULT_MODULES_BOOTSTRAPPED);
 	}
 
 	// =========================================================================
@@ -1592,12 +1657,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the request module, auto-creating it via {@see newRequest()} and
-	 * running it through {@see bootstrapDefaultModule()} when not yet set so
-	 * the default receives the full module lifecycle (setID, dyPreInit,
-	 * dependency resolution, init, dyPostInit). The instance is enrolled in
-	 * `$_modules` under {@see DEFAULT_REQUEST_ID} by {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the request module, lazily bootstrapping a default via
+	 * {@see newRequest()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return THttpRequest the request module
 	 */
 	public function getRequest()
@@ -1634,11 +1695,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the response module, auto-creating it via {@see newResponse()}
-	 * and running it through {@see bootstrapDefaultModule()} when not yet
-	 * set so the default receives the full module lifecycle. Registration
-	 * under {@see DEFAULT_RESPONSE_ID} happens via {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the response module, lazily bootstrapping a default via
+	 * {@see newResponse()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return THttpResponse the response module
 	 */
 	public function getResponse()
@@ -1683,11 +1741,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the session module, auto-creating it via {@see newSession()} and
-	 * running it through {@see bootstrapDefaultModule()} when not yet set so
-	 * the default receives the full module lifecycle. Registration under
-	 * {@see DEFAULT_SESSION_ID} happens via {@see bootstrapDefaultModules()} at
-	 * {@see onConfiguration()} time.
+	 * Returns the session module, lazily bootstrapping a default via
+	 * {@see newSession()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return THttpSession the session module, null if session module is not installed
 	 */
 	public function getSession()
@@ -1732,12 +1787,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the error handler module, auto-creating it via
-	 * {@see newErrorHandler()} and running it through
-	 * {@see bootstrapDefaultModule()} when not yet set so the default
-	 * receives the full module lifecycle. Registration under
-	 * {@see DEFAULT_ERROR_HANDLER_ID} happens via {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the error handler module, lazily bootstrapping a default via
+	 * {@see newErrorHandler()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return TErrorHandler the error handler module
 	 */
 	public function getErrorHandler()
@@ -1782,12 +1833,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the security manager module, auto-creating it via
-	 * {@see newSecurityManager()} and running it through
-	 * {@see bootstrapDefaultModule()} when not yet set so the default
-	 * receives the full module lifecycle. Registration under
-	 * {@see DEFAULT_SECURITY_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the security manager module, lazily bootstrapping a default via
+	 * {@see newSecurityManager()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return TSecurityManager the security manager module
 	 */
 	public function getSecurityManager()
@@ -1832,12 +1879,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the asset manager module, auto-creating it via
-	 * {@see newAssetManager()} and running it through
-	 * {@see bootstrapDefaultModule()} when not yet set so the default
-	 * receives the full module lifecycle. Registration under
-	 * {@see DEFAULT_ASSET_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the asset manager module, lazily bootstrapping a default via
+	 * {@see newAssetManager()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return TAssetManager asset manager
 	 */
 	public function getAssetManager()
@@ -1882,12 +1925,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the template manager module, auto-creating it via
-	 * {@see newTemplateManager()} and running it through
-	 * {@see bootstrapDefaultModule()} when not yet set so the default
-	 * receives the full module lifecycle. Registration under
-	 * {@see DEFAULT_TEMPLATE_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the template manager module, lazily bootstrapping a default via
+	 * {@see newTemplateManager()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return TTemplateManager template manager
 	 */
 	public function getTemplateManager()
@@ -1932,12 +1971,8 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the theme manager module, auto-creating it via
-	 * {@see newThemeManager()} and running it through
-	 * {@see bootstrapDefaultModule()} when not yet set so the default
-	 * receives the full module lifecycle. Registration under
-	 * {@see DEFAULT_THEME_MANAGER_ID} happens via {@see bootstrapDefaultModules()}
-	 * at {@see onConfiguration()} time.
+	 * Returns the theme manager module, lazily bootstrapping a default via
+	 * {@see newThemeManager()} + {@see bootstrapDefaultModule()} when not yet set.
 	 * @return TThemeManager theme manager
 	 */
 	public function getThemeManager()
@@ -2034,17 +2069,11 @@ class TApplication extends TComponent implements ISingleton
 	}
 
 	/**
-	 * Returns the globalization module, auto-creating and bootstrapping it via
-	 * {@see newGlobalization()} + {@see bootstrapDefaultModule()} when
-	 * `$createIfNotExists` is `true` (the default) and no module has been set
-	 * yet. The bootstrap runs the full module lifecycle (setID, dyPreInit,
-	 * dependency resolution, init, dyPostInit) so the default is
-	 * indistinguishable from a configured `<module>` entry; registration in
-	 * `$_modules` under {@see DEFAULT_GLOBALIZATION_ID} is performed by
-	 * {@see bootstrapDefaultModules()} at {@see onConfiguration()} time. Pass
-	 * `false` to return `null` rather than auto-creating.
-	 * @param bool $createIfNotExists whether to create globalization if it does not exist
-	 * @return ?TGlobalization globalization module
+	 * Returns the globalization module, lazily bootstrapping a default via
+	 * {@see newGlobalization()} + {@see bootstrapDefaultModule()} when not yet set
+	 * and `$createIfNotExists` is true; otherwise returns `null`.
+	 * @param bool $createIfNotExists whether to create on first access.
+	 * @return ?TGlobalization globalization module, or null when none exists and creation is disabled.
 	 */
 	public function getGlobalization($createIfNotExists = true)
 	{
@@ -2600,10 +2629,10 @@ class TApplication extends TComponent implements ISingleton
 	 * Loads configuration and initializes the application. Reads the
 	 * configuration file (or its cached form when current), applies it via
 	 * {@see applyConfiguration()} so configured modules are created and
-	 * initialized, then runs {@see bootstrapDefaultModules()} to register
-	 * any lazily-created default-core modules under their canonical IDs,
-	 * raises {@see onConfiguration} for late-stage service registration,
-	 * runs {@see initService()} to resolve and start the requested service,
+	 * initialized, raises {@see onConfiguration} for late-stage service
+	 * registration, runs {@see bootstrapDefaultModules()} to enroll any
+	 * lazily-created default-core modules in `$_modules`, runs
+	 * {@see initService()} to resolve and start the requested service,
 	 * and finally raises {@see onInitComplete}.
 	 * @throws TConfigurationException when a module is redefined or
 	 *   invalid, or when the requested service is undefined or invalid.
@@ -2635,6 +2664,7 @@ class TApplication extends TComponent implements ISingleton
 		$this->onConfiguration();
 		$this->initService();
 		$this->onInitComplete();
+		$this->setStateFlag(static::STATE_INITIALIZED);
 
 		Prado::trace('Initializing application complete', TApplication::class);
 	}

--- a/tests/unit/TApplicationBootstrapTest.php
+++ b/tests/unit/TApplicationBootstrapTest.php
@@ -8,16 +8,20 @@
  *
  *  - the nine `DEFAULT_*_ID` constants and their late-static-binding override
  *  - {@see TApplication::runModuleLifecycle} — the extracted four-phase
- *    runner shared by `getModule` (lazy load) and `bootstrapDefaultModule`
- *  - {@see TApplication::bootstrapDefaultModule} — assigns canonical ID +
- *    runs lifecycle without registering in `$_modules`
+ *    runner shared by `getModule` (lazy load) and `bootstrapModule`
+ *  - {@see TApplication::bootstrapModule} — assigns the module's ID and
+ *    runs its lifecycle; `$register` (bool, default true) toggles
+ *    whether the module is added to `$_modules`
+ *  - {@see TApplication::shouldRegisterDefault} — the framework
+ *    predicate the lazy default accessors pass as `$register`: true
+ *    only after the sweep flag is set and no same-type collision
  *  - {@see TApplication::bootstrapDefaultModules} — sweep that enrols
  *    each instanced default in `$_modules` (type-collision suppression
  *    keeps configured same-type modules in place) and flips the
- *    STATE_DEFAULT_MODULES_BOOTSTRAPPED flag so subsequent late-arrival defaults
- *    are registered immediately by `bootstrapDefaultModule`
+ *    STATE_DEFAULT_MODULES_BOOTSTRAPPED flag so subsequent late-arrival
+ *    defaults are registered automatically
  *  - the nine lazy default-module accessors and their canonical-ID
- *    assignment via `bootstrapDefaultModule`
+ *    assignment via `bootstrapModule(..., shouldRegisterDefault(...))`
  *
  * @author Brad Anderson <belisoful@icloud.com>
  * @link https://github.com/pradosoft/prado
@@ -44,9 +48,14 @@ use Prado\TModule;
  */
 class TApplicationBootstrapAccessor extends TApplication
 {
-	public function pubBootstrapDefaultModule(IModule $module, string $id): void
+	public function pubBootstrapModule(IModule $module, string $id, bool $register = true): void
 	{
-		$this->bootstrapDefaultModule($module, $id);
+		$this->bootstrapModule($module, $id, $register);
+	}
+
+	public function pubShouldRegisterDefault(string $type): bool
+	{
+		return $this->shouldRegisterDefault($type);
 	}
 
 	public function pubBootstrapDefaultModules(): void
@@ -497,25 +506,25 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 	}
 
 	// =======================================================================
-	// bootstrapDefaultModule — setID + lifecycle, no $_modules write
+	// bootstrapModule — setID + lifecycle; $register toggles registry write
 	// =======================================================================
 
-	public function testBootstrapDefaultModule_assignsCanonicalId(): void
+	public function testBootstrapModule_assignsCanonicalId(): void
 	{
 		$acc = $this->newAccessor();
 		$module = new AppBootstrapSpyModule();
 
-		$acc->pubBootstrapDefaultModule($module, 'my_canon_id');
+		$acc->pubBootstrapModule($module, 'my_canon_id');
 
 		$this->assertSame('my_canon_id', $module->getID());
 	}
 
-	public function testBootstrapDefaultModule_runsFullLifecycle_withNullConfig(): void
+	public function testBootstrapModule_runsFullLifecycle_withNullConfig(): void
 	{
 		$acc = $this->newAccessor();
 		$module = new AppBootstrapSpyModule();
 
-		$acc->pubBootstrapDefaultModule($module, 'spy');
+		$acc->pubBootstrapModule($module, 'spy');
 
 		// All three phases ran (TComponent module) with null config.
 		$this->assertSame(['dyPreInit', 'init', 'dyPostInit'], array_column($module->calls, 'phase'));
@@ -524,28 +533,108 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 		}
 	}
 
-	public function testBootstrapDefaultModule_doesNotRegisterIn_modules(): void
+	public function testBootstrapModule_registerTrue_addsToModules(): void
 	{
 		$acc = $this->newAccessor();
 		$module = new AppBootstrapSpyModule();
 
-		$acc->pubBootstrapDefaultModule($module, 'spy_id');
+		$acc->pubBootstrapModule($module, 'spy_id', true);
 
-		$this->assertSame(
-			[],
-			$acc->getModules(),
-			'bootstrapDefaultModule must not write to $_modules — the module\'s own init() is expected to self-register if needed'
-		);
+		$this->assertSame($module, $acc->getModules()['spy_id'] ?? null);
 	}
 
-	public function testBootstrapDefaultModule_requiredDepMissing_propagates(): void
+	public function testBootstrapModule_registerFalse_doesNotAddToModules(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubBootstrapModule($module, 'spy_id', false);
+
+		$this->assertArrayNotHasKey('spy_id', $acc->getModules());
+	}
+
+	public function testBootstrapModule_registerDefaultsToTrue(): void
+	{
+		// Omit the third argument; the parameter default is true so the
+		// module is added to $_modules.
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubBootstrapModule($module, 'spy_id');
+
+		$this->assertSame($module, $acc->getModules()['spy_id'] ?? null);
+	}
+
+	public function testBootstrapModule_registry_keyedByModuleGetId(): void
+	{
+		// Registration always keys on the module's own getID() — which is
+		// what bootstrapModule just set via setID($id) — so renaming via a
+		// post-init setID call wins over the id passed to bootstrapModule.
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubBootstrapModule($module, 'initial_id', true);
+
+		$this->assertArrayHasKey('initial_id', $acc->getModules());
+		$this->assertSame($module, $acc->getModules()['initial_id']);
+	}
+
+	public function testBootstrapModule_requiredDepMissing_propagates(): void
 	{
 		$acc = $this->newAccessor();
 		$module = new AppBootstrapDepSpyModule();
 		$module->declaredDeps = ['ghost_required'];
 
 		$this->expectException(TConfigurationException::class);
-		$acc->pubBootstrapDefaultModule($module, 'spy_id');
+		$acc->pubBootstrapModule($module, 'spy_id');
+	}
+
+	// =======================================================================
+	// shouldRegisterDefault — predicate the lazy default accessors call
+	// =======================================================================
+
+	public function testShouldRegisterDefault_falseBeforeSweep(): void
+	{
+		$acc = $this->newAccessor();
+		// Flag clear → no default registration is appropriate.
+		$this->assertFalse($acc->pubShouldRegisterDefault(\Prado\Web\THttpRequest::class));
+	}
+
+	public function testShouldRegisterDefault_trueAfterSweepWithNoTypeCollision(): void
+	{
+		$acc = $this->newAccessor();
+		$acc->pubBootstrapDefaultModules();  // sweep flips the flag
+
+		$this->assertTrue($acc->pubShouldRegisterDefault(\Prado\Web\THttpRequest::class));
+	}
+
+	public function testShouldRegisterDefault_falseAfterSweepWhenSameTypeAlreadyRegistered(): void
+	{
+		$acc = $this->newAccessor();
+		// Pre-register a configured same-type module under SOME id.
+		$configured = new \Prado\Web\THttpRequest();
+		$configured->setID('configured_request');
+		PradoUnit::setProp($acc, '_modules', ['configured_request' => $configured]);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertFalse(
+			$acc->pubShouldRegisterDefault(\Prado\Web\THttpRequest::class),
+			'Predicate must defer to a configured same-type module'
+		);
+	}
+
+	public function testShouldRegisterDefault_falseAfterSweepWhenSubclassAlreadyRegistered(): void
+	{
+		// Non-strict type match: a subclass of the target type also suppresses.
+		$acc = $this->newAccessor();
+		$configured = new class extends \Prado\Web\THttpRequest {};
+		$configured->setID('subclass_request');
+		PradoUnit::setProp($acc, '_modules', ['subclass_request' => $configured]);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertFalse($acc->pubShouldRegisterDefault(\Prado\Web\THttpRequest::class));
 	}
 
 	// =======================================================================
@@ -684,7 +773,7 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 
 		// Registry keys on the module's own getID(), not on the canonical
 		// DEFAULT_REQUEST_ID literal — so a module that's been renamed via
-		// setID after bootstrapDefaultModule still lands under its own name.
+		// setID after bootstrapModule still lands under its own name.
 		$this->assertArrayHasKey('my_custom_req_id', $acc->getModules());
 		$this->assertSame($req, $acc->getModules()['my_custom_req_id']);
 	}
@@ -756,56 +845,61 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 	}
 
 	// =======================================================================
-	// Late-bootstrap flag — bootstrapDefaultModule registers if the sweep ran
+	// Late-arrival default-module integration — bootstrapModule + shouldRegisterDefault
 	// =======================================================================
+	//
+	// The lazy default-module accessors all call:
+	//   $this->bootstrapModule($mod, ID, $this->shouldRegisterDefault(Type::class));
+	// These tests exercise that combination end-to-end.
 
-	public function testBootstrapDefaultModule_beforeSweep_doesNotRegister(): void
+	public function testLateDefault_beforeSweep_doesNotRegister(): void
 	{
 		$acc = $this->newAccessor();
 		$module = new \Prado\Web\THttpRequest();
 
-		// Sweep has NOT been called → bootstrapDefaultModule must leave
-		// $_modules pristine.
-		$acc->pubBootstrapDefaultModule($module, 'pre_sweep_id');
+		$acc->pubBootstrapModule(
+			$module,
+			'pre_sweep_id',
+			$acc->pubShouldRegisterDefault(\Prado\Web\THttpRequest::class)
+		);
 
 		$this->assertArrayNotHasKey('pre_sweep_id', $acc->getModules());
 	}
 
-	public function testBootstrapDefaultModule_afterSweep_registersLateArrival(): void
+	public function testLateDefault_afterSweep_registers(): void
 	{
 		$acc = $this->newAccessor();
-		// Run the sweep with nothing instanced — the flag flips even on an
-		// empty registry.
-		$acc->pubBootstrapDefaultModules();
+		$acc->pubBootstrapDefaultModules();  // sweep flips the flag
 
-		// A new default is bootstrapped late (e.g. someone calls getSession()
-		// for the first time after onConfiguration). It MUST be registered.
 		$module = new \Prado\Web\THttpSession();
-		$acc->pubBootstrapDefaultModule($module, TApplication::DEFAULT_SESSION_ID);
+		$acc->pubBootstrapModule(
+			$module,
+			TApplication::DEFAULT_SESSION_ID,
+			$acc->pubShouldRegisterDefault(\Prado\Web\THttpSession::class)
+		);
 
 		$this->assertSame(
 			$module,
 			$acc->getModules()[TApplication::DEFAULT_SESSION_ID] ?? null,
-			'Late-bootstrap default must be registered when the sweep has already completed'
+			'Late-arrival default must register when the sweep has completed'
 		);
 	}
 
-	public function testBootstrapDefaultModule_afterSweep_typeCollisionStillSuppresses(): void
+	public function testLateDefault_afterSweep_typeCollisionSuppresses(): void
 	{
 		$acc = $this->newAccessor();
-
-		// A configured same-type module is already in the registry before
-		// the sweep runs.
 		$configured = new \Prado\Web\THttpRequest();
 		$configured->setID('configured_request');
 		PradoUnit::setProp($acc, '_modules', ['configured_request' => $configured]);
 
 		$acc->pubBootstrapDefaultModules();
 
-		// Now a late default-request bootstrap arrives. It must NOT be
-		// registered — the configured same-type module takes precedence.
 		$lateDefault = new \Prado\Web\THttpRequest();
-		$acc->pubBootstrapDefaultModule($lateDefault, TApplication::DEFAULT_REQUEST_ID);
+		$acc->pubBootstrapModule(
+			$lateDefault,
+			TApplication::DEFAULT_REQUEST_ID,
+			$acc->pubShouldRegisterDefault(\Prado\Web\THttpRequest::class)
+		);
 
 		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
 		$this->assertSame($configured, $acc->getModules()['configured_request']);

--- a/tests/unit/TApplicationBootstrapTest.php
+++ b/tests/unit/TApplicationBootstrapTest.php
@@ -11,12 +11,13 @@
  *    runner shared by `getModule` (lazy load) and `bootstrapDefaultModule`
  *  - {@see TApplication::bootstrapDefaultModule} — assigns canonical ID +
  *    runs lifecycle without registering in `$_modules`
- *  - {@see TApplication::bootstrapDefaultModules} — registers each
- *    instanced default under its self-reported ID, with type-collision
- *    suppression and no auto-instantiation
+ *  - {@see TApplication::bootstrapDefaultModules} — sweep that enrols
+ *    each instanced default in `$_modules` (type-collision suppression
+ *    keeps configured same-type modules in place) and flips the
+ *    STATE_DEFAULT_MODULES_BOOTSTRAPPED flag so subsequent late-arrival defaults
+ *    are registered immediately by `bootstrapDefaultModule`
  *  - the nine lazy default-module accessors and their canonical-ID
  *    assignment via `bootstrapDefaultModule`
- *  - `initApplication`'s ordering of bootstrap → onConfiguration
  *
  * @author Brad Anderson <belisoful@icloud.com>
  * @link https://github.com/pradosoft/prado
@@ -66,6 +67,26 @@ class TApplicationBootstrapAccessor extends TApplication
 class TApplicationBootstrapAccessorCustomRequestId extends TApplicationBootstrapAccessor
 {
 	public const DEFAULT_REQUEST_ID = 'custom_http_request';
+}
+
+/**
+ * Subclass exposing {@see TApplication::initApplication} as public and
+ * stubbing {@see TApplication::initService} to a no-op so the full
+ * initialization sequence can be driven from a test without HTTP setup
+ * or registered services.
+ */
+class TApplicationBootstrapInitAccessor extends TApplicationBootstrapAccessor
+{
+	public function pubInitApplication(): void
+	{
+		$this->initApplication();
+	}
+
+	protected function initService(): void
+	{
+		// No-op: bypass service resolution so initApplication() can
+		// reach setStateFlag(STATE_INITIALIZED) without a configured service.
+	}
 }
 
 /**
@@ -227,6 +248,139 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 	}
 
 	// =======================================================================
+	// STATE_* bit constants
+	// =======================================================================
+
+	public function testConstant_stateDefaultModulesBootstrapped(): void
+	{
+		$this->assertSame(1 << 0, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED);
+	}
+
+	public function testConstant_stateInitialized(): void
+	{
+		$this->assertSame(1 << 1, TApplication::STATE_INITIALIZED);
+	}
+
+	public function testConstant_stateBitsAreDistinct(): void
+	{
+		// No two STATE_* bits may share a position.
+		$this->assertSame(
+			0,
+			TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED & TApplication::STATE_INITIALIZED,
+			'STATE_* bits must occupy distinct positions in $_stateFlags'
+		);
+	}
+
+	// =======================================================================
+	// State-flag helpers — getStateFlags / hasStateFlag / setStateFlag
+	// =======================================================================
+
+	public function testStateFlags_initialValueIsZero(): void
+	{
+		$acc = $this->newAccessor();
+		$this->assertSame(0, $acc->getStateFlags());
+	}
+
+	public function testHasStateFlag_falseWhenNotSet(): void
+	{
+		$acc = $this->newAccessor();
+		$this->assertFalse($acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED));
+		$this->assertFalse($acc->hasStateFlag(TApplication::STATE_INITIALIZED));
+	}
+
+	public function testSetStateFlag_setsBit_thenHasStateFlagReportsTrue(): void
+	{
+		$acc = $this->newAccessor();
+
+		// setStateFlag is protected; drive it via reflection so we test the
+		// helper itself, not through bootstrapDefaultModules.
+		$rm = new \ReflectionMethod(TApplication::class, 'setStateFlag');
+		$rm->setAccessible(true);
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED);
+
+		$this->assertTrue($acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED));
+		$this->assertSame(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED, $acc->getStateFlags());
+	}
+
+	public function testSetStateFlag_clearsBitWhenOnIsFalse(): void
+	{
+		$acc = $this->newAccessor();
+		$rm = new \ReflectionMethod(TApplication::class, 'setStateFlag');
+		$rm->setAccessible(true);
+
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED, true);
+		$this->assertTrue($acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED));
+
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED, false);
+		$this->assertFalse($acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED));
+		$this->assertSame(0, $acc->getStateFlags());
+	}
+
+	public function testSetStateFlag_idempotentOnAlreadySetBit(): void
+	{
+		$acc = $this->newAccessor();
+		$rm = new \ReflectionMethod(TApplication::class, 'setStateFlag');
+		$rm->setAccessible(true);
+
+		$rm->invoke($acc, TApplication::STATE_INITIALIZED);
+		$rm->invoke($acc, TApplication::STATE_INITIALIZED);
+
+		$this->assertTrue($acc->hasStateFlag(TApplication::STATE_INITIALIZED));
+		$this->assertSame(TApplication::STATE_INITIALIZED, $acc->getStateFlags());
+	}
+
+	public function testSetStateFlag_multipleBitsCoexist(): void
+	{
+		$acc = $this->newAccessor();
+		$rm = new \ReflectionMethod(TApplication::class, 'setStateFlag');
+		$rm->setAccessible(true);
+
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED);
+		$rm->invoke($acc, TApplication::STATE_INITIALIZED);
+
+		$this->assertTrue($acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED));
+		$this->assertTrue($acc->hasStateFlag(TApplication::STATE_INITIALIZED));
+		$this->assertSame(
+			TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED | TApplication::STATE_INITIALIZED,
+			$acc->getStateFlags()
+		);
+	}
+
+	public function testHasStateFlag_multiBitRequiresAllBitsSet(): void
+	{
+		$acc = $this->newAccessor();
+		$rm = new \ReflectionMethod(TApplication::class, 'setStateFlag');
+		$rm->setAccessible(true);
+
+		// Only set one of two bits.
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED);
+
+		// Combined check must report false when any requested bit is missing.
+		$combined = TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED | TApplication::STATE_INITIALIZED;
+		$this->assertFalse($acc->hasStateFlag($combined));
+
+		// After setting the second bit, the combined check passes.
+		$rm->invoke($acc, TApplication::STATE_INITIALIZED);
+		$this->assertTrue($acc->hasStateFlag($combined));
+	}
+
+	public function testSetStateFlag_clearOnlyAffectsRequestedBits(): void
+	{
+		$acc = $this->newAccessor();
+		$rm = new \ReflectionMethod(TApplication::class, 'setStateFlag');
+		$rm->setAccessible(true);
+
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED);
+		$rm->invoke($acc, TApplication::STATE_INITIALIZED);
+
+		// Clear only one bit.
+		$rm->invoke($acc, TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED, false);
+
+		$this->assertFalse($acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED));
+		$this->assertTrue($acc->hasStateFlag(TApplication::STATE_INITIALIZED));
+	}
+
+	// =======================================================================
 	// runModuleLifecycle — TComponent vs bare IModule, config passthrough
 	// =======================================================================
 
@@ -380,7 +534,7 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 		$this->assertSame(
 			[],
 			$acc->getModules(),
-			'bootstrapDefaultModule must not write to $_modules; registration is bootstrapDefaultModules() time'
+			'bootstrapDefaultModule must not write to $_modules — the module\'s own init() is expected to self-register if needed'
 		);
 	}
 
@@ -392,168 +546,6 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 
 		$this->expectException(TConfigurationException::class);
 		$acc->pubBootstrapDefaultModule($module, 'spy_id');
-	}
-
-	// =======================================================================
-	// bootstrapDefaultModules — registry sweep with type-collision suppression
-	// =======================================================================
-
-	public function testBootstrapDefaultModules_emptyApp_registersNothing(): void
-	{
-		$acc = $this->newAccessor();
-		// All nine slots already null after newAccessor (no constructor ran).
-
-		$acc->pubBootstrapDefaultModules();
-
-		$this->assertSame([], $acc->getModules());
-	}
-
-	public function testBootstrapDefaultModules_instancedRequest_registered(): void
-	{
-		$acc = $this->newAccessor();
-		$req = new \Prado\Web\THttpRequest();
-		$req->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $req);
-
-		$acc->pubBootstrapDefaultModules();
-
-		$this->assertSame(
-			$req,
-			$acc->getModules()[TApplication::DEFAULT_REQUEST_ID] ?? null,
-			'Instanced default request must be registered under its canonical ID'
-		);
-	}
-
-	public function testBootstrapDefaultModules_registersUnderModuleSelfReportedId(): void
-	{
-		$acc = $this->newAccessor();
-		$req = new \Prado\Web\THttpRequest();
-		// Deliberately give it a non-canonical ID — the registry must follow
-		// the module's own getID(), not the canonical DEFAULT_REQUEST_ID literal.
-		$req->setID('my_custom_req_id');
-		PradoUnit::setProp($acc, '_request', $req);
-
-		$acc->pubBootstrapDefaultModules();
-
-		$this->assertArrayHasKey('my_custom_req_id', $acc->getModules());
-		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
-		$this->assertSame($req, $acc->getModules()['my_custom_req_id']);
-	}
-
-	public function testBootstrapDefaultModules_typeCollision_suppressesDefault(): void
-	{
-		$acc = $this->newAccessor();
-
-		// A configured THttpRequest already registered under SOME id.
-		$configured = new \Prado\Web\THttpRequest();
-		$configured->setID('configured_request');
-		PradoUnit::setProp($acc, '_modules', ['configured_request' => $configured]);
-
-		// A lazy default-request instance also exists in the slot.
-		$defaultReq = new \Prado\Web\THttpRequest();
-		$defaultReq->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $defaultReq);
-
-		$acc->pubBootstrapDefaultModules();
-
-		// The default must not be registered — configured one stays sole.
-		$this->assertSame($configured, $acc->getModules()['configured_request']);
-		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
-		$this->assertCount(1, $acc->getModules());
-	}
-
-	public function testBootstrapDefaultModules_typeCollision_subclassAlsoSuppressesDefault(): void
-	{
-		$acc = $this->newAccessor();
-
-		// Subclass of THttpRequest pre-registered.
-		$configured = new class extends \Prado\Web\THttpRequest {};
-		$configured->setID('my_subclassed_request');
-		PradoUnit::setProp($acc, '_modules', ['my_subclassed_request' => $configured]);
-
-		$defaultReq = new \Prado\Web\THttpRequest();
-		$defaultReq->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $defaultReq);
-
-		$acc->pubBootstrapDefaultModules();
-
-		// Non-strict type match: subclass is-a THttpRequest so the default is
-		// still suppressed.
-		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
-		$this->assertCount(1, $acc->getModules());
-	}
-
-	public function testBootstrapDefaultModules_neverInstantiatesAbsentSlot(): void
-	{
-		$acc = $this->newAccessor();
-
-		$acc->pubBootstrapDefaultModules();
-
-		// None of the nine backing fields should have been touched.
-		foreach (['_request', '_response', '_session', '_errorHandler',
-			'_security', '_assetManager', '_globalization',
-			'_templateManager', '_themeManager'] as $field) {
-			$this->assertNull(
-				PradoUnit::getProp($acc, $field),
-				"Backing field $field must remain null — bootstrapDefaultModules must never instantiate"
-			);
-		}
-	}
-
-	public function testBootstrapDefaultModules_idempotent_secondCallIsNoOp(): void
-	{
-		$acc = $this->newAccessor();
-		$req = new \Prado\Web\THttpRequest();
-		$req->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $req);
-
-		$acc->pubBootstrapDefaultModules();
-		$first = $acc->getModules();
-
-		$acc->pubBootstrapDefaultModules();
-		$second = $acc->getModules();
-
-		$this->assertSame($first, $second);
-		$this->assertSame($req, $second[TApplication::DEFAULT_REQUEST_ID]);
-	}
-
-	public function testBootstrapDefaultModules_multipleInstancedSlots_allRegistered(): void
-	{
-		$acc = $this->newAccessor();
-
-		$req  = new \Prado\Web\THttpRequest();
-		$req->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $req);
-
-		$sec  = new \Prado\Security\TSecurityManager();
-		$sec->setID(TApplication::DEFAULT_SECURITY_MANAGER_ID);
-		PradoUnit::setProp($acc, '_security', $sec);
-
-		$acc->pubBootstrapDefaultModules();
-
-		$this->assertArrayHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
-		$this->assertArrayHasKey(TApplication::DEFAULT_SECURITY_MANAGER_ID, $acc->getModules());
-		$this->assertCount(2, $acc->getModules());
-	}
-
-	public function testBootstrapDefaultModules_preservesUnrelatedModules(): void
-	{
-		$acc = $this->newAccessor();
-
-		// An unrelated configured module of a different type.
-		$unrelated = new AppTestModule();
-		$unrelated->setID('my_unrelated');
-		PradoUnit::setProp($acc, '_modules', ['my_unrelated' => $unrelated]);
-
-		$req = new \Prado\Web\THttpRequest();
-		$req->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $req);
-
-		$acc->pubBootstrapDefaultModules();
-
-		$this->assertSame($unrelated, $acc->getModules()['my_unrelated']);
-		$this->assertSame($req, $acc->getModules()[TApplication::DEFAULT_REQUEST_ID]);
-		$this->assertCount(2, $acc->getModules());
 	}
 
 	// =======================================================================
@@ -671,66 +663,224 @@ class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
 	}
 
 	// =======================================================================
-	// initApplication ordering — bootstrap fires BEFORE onConfiguration
+	// bootstrapDefaultModules — registry sweep with type-collision suppression
 	// =======================================================================
-	//
-	// We can't run initApplication() against the bootstrap singleton without
-	// extensive setup (config file, service registration, etc.), but we CAN
-	// verify the call ordering by inspecting source: bootstrapDefaultModules
-	// must be invoked before onConfiguration. The earlier integration check
-	// via grep proves the order; here we test the observable effect — an
-	// onConfiguration handler attached BEFORE initApplication runs sees the
-	// default modules already registered.
 
-	public function testInitApplication_bootstrapDefaultModulesIsCalledBeforeOnConfiguration(): void
+	public function testBootstrapDefaultModules_emptyApp_registersNothing(): void
 	{
-		// Use the accessor; instantiate without constructor so initApplication's
-		// internal calls don't try to load a config file or start services.
 		$acc = $this->newAccessor();
+		$acc->pubBootstrapDefaultModules();
+		$this->assertSame([], $acc->getModules());
+	}
 
-		// Seed an instanced default so bootstrapDefaultModules has something
-		// to register, and confirm the registration happens before the event.
+	public function testBootstrapDefaultModules_registersInstancedDefaultUnderModuleSelfReportedId(): void
+	{
+		$acc = $this->newAccessor();
+		$req = new \Prado\Web\THttpRequest();
+		$req->setID('my_custom_req_id');  // NOT the canonical literal
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$acc->pubBootstrapDefaultModules();
+
+		// Registry keys on the module's own getID(), not on the canonical
+		// DEFAULT_REQUEST_ID literal — so a module that's been renamed via
+		// setID after bootstrapDefaultModule still lands under its own name.
+		$this->assertArrayHasKey('my_custom_req_id', $acc->getModules());
+		$this->assertSame($req, $acc->getModules()['my_custom_req_id']);
+	}
+
+	public function testBootstrapDefaultModules_typeCollision_suppressesDefault(): void
+	{
+		$acc = $this->newAccessor();
+		// A configured THttpRequest already registered under SOME id.
+		$configured = new \Prado\Web\THttpRequest();
+		$configured->setID('configured_request');
+		PradoUnit::setProp($acc, '_modules', ['configured_request' => $configured]);
+
+		// A lazy default-request instance also exists.
+		$defaultReq = new \Prado\Web\THttpRequest();
+		$defaultReq->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $defaultReq);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertSame($configured, $acc->getModules()['configured_request']);
+		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
+		$this->assertCount(1, $acc->getModules());
+	}
+
+	public function testBootstrapDefaultModules_neverInstantiatesAbsentSlot(): void
+	{
+		$acc = $this->newAccessor();
+		$acc->pubBootstrapDefaultModules();
+
+		foreach (['_request', '_response', '_session', '_errorHandler',
+			'_security', '_assetManager', '_globalization',
+			'_templateManager', '_themeManager'] as $field) {
+			$this->assertNull(
+				PradoUnit::getProp($acc, $field),
+				"Backing field $field must remain null — bootstrapDefaultModules must never instantiate"
+			);
+		}
+	}
+
+	public function testBootstrapDefaultModules_idempotent_secondCallIsNoOp(): void
+	{
+		$acc = $this->newAccessor();
 		$req = new \Prado\Web\THttpRequest();
 		$req->setID(TApplication::DEFAULT_REQUEST_ID);
 		PradoUnit::setProp($acc, '_request', $req);
 
-		// Subscribe a handler that snapshots _modules at event time.
-		$snapAtEvent = null;
-		$acc->attachEventHandler('onConfiguration', function () use ($acc, &$snapAtEvent) {
-			$snapAtEvent = $acc->getModules();
+		$acc->pubBootstrapDefaultModules();
+		$first = $acc->getModules();
+		$acc->pubBootstrapDefaultModules();
+		$second = $acc->getModules();
+
+		$this->assertSame($first, $second);
+	}
+
+	public function testBootstrapDefaultModules_setsStateDefaultModulesBootstrappedFlag(): void
+	{
+		$acc = $this->newAccessor();
+		$this->assertFalse(
+			$acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED),
+			'Sanity: flag should start clear'
+		);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertTrue(
+			$acc->hasStateFlag(TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED),
+			'bootstrapDefaultModules() must flip STATE_DEFAULT_MODULES_BOOTSTRAPPED on completion'
+		);
+	}
+
+	// =======================================================================
+	// Late-bootstrap flag — bootstrapDefaultModule registers if the sweep ran
+	// =======================================================================
+
+	public function testBootstrapDefaultModule_beforeSweep_doesNotRegister(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new \Prado\Web\THttpRequest();
+
+		// Sweep has NOT been called → bootstrapDefaultModule must leave
+		// $_modules pristine.
+		$acc->pubBootstrapDefaultModule($module, 'pre_sweep_id');
+
+		$this->assertArrayNotHasKey('pre_sweep_id', $acc->getModules());
+	}
+
+	public function testBootstrapDefaultModule_afterSweep_registersLateArrival(): void
+	{
+		$acc = $this->newAccessor();
+		// Run the sweep with nothing instanced — the flag flips even on an
+		// empty registry.
+		$acc->pubBootstrapDefaultModules();
+
+		// A new default is bootstrapped late (e.g. someone calls getSession()
+		// for the first time after onConfiguration). It MUST be registered.
+		$module = new \Prado\Web\THttpSession();
+		$acc->pubBootstrapDefaultModule($module, TApplication::DEFAULT_SESSION_ID);
+
+		$this->assertSame(
+			$module,
+			$acc->getModules()[TApplication::DEFAULT_SESSION_ID] ?? null,
+			'Late-bootstrap default must be registered when the sweep has already completed'
+		);
+	}
+
+	public function testBootstrapDefaultModule_afterSweep_typeCollisionStillSuppresses(): void
+	{
+		$acc = $this->newAccessor();
+
+		// A configured same-type module is already in the registry before
+		// the sweep runs.
+		$configured = new \Prado\Web\THttpRequest();
+		$configured->setID('configured_request');
+		PradoUnit::setProp($acc, '_modules', ['configured_request' => $configured]);
+
+		$acc->pubBootstrapDefaultModules();
+
+		// Now a late default-request bootstrap arrives. It must NOT be
+		// registered — the configured same-type module takes precedence.
+		$lateDefault = new \Prado\Web\THttpRequest();
+		$acc->pubBootstrapDefaultModule($lateDefault, TApplication::DEFAULT_REQUEST_ID);
+
+		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
+		$this->assertSame($configured, $acc->getModules()['configured_request']);
+		$this->assertCount(1, $acc->getModules());
+	}
+
+	// =======================================================================
+	// initApplication — STATE_INITIALIZED set after onInitComplete
+	// =======================================================================
+
+	private function newInitAccessor(): TApplicationBootstrapInitAccessor
+	{
+		$ref = new \ReflectionClass(TApplicationBootstrapInitAccessor::class);
+		$acc = $ref->newInstanceWithoutConstructor();
+		PradoUnit::setProp($acc, '_modules', []);
+		PradoUnit::setProp($acc, '_lazyModules', []);
+		return $acc;
+	}
+
+	public function testInitApplication_setsStateInitializedFlagOnCompletion(): void
+	{
+		$acc = $this->newInitAccessor();
+		$this->assertFalse(
+			$acc->hasStateFlag(TApplication::STATE_INITIALIZED),
+			'Sanity: STATE_INITIALIZED should start clear'
+		);
+
+		$acc->pubInitApplication();
+
+		$this->assertTrue(
+			$acc->hasStateFlag(TApplication::STATE_INITIALIZED),
+			'initApplication() must set STATE_INITIALIZED after onInitComplete returns'
+		);
+	}
+
+	public function testInitApplication_setsBothBootstrapAndInitializedFlags(): void
+	{
+		$acc = $this->newInitAccessor();
+
+		$acc->pubInitApplication();
+
+		// bootstrapDefaultModules is part of the initApplication sequence,
+		// so both bits should be set when initApplication returns.
+		$combined = TApplication::STATE_DEFAULT_MODULES_BOOTSTRAPPED
+			| TApplication::STATE_INITIALIZED;
+		$this->assertTrue($acc->hasStateFlag($combined));
+		$this->assertSame($combined, $acc->getStateFlags());
+	}
+
+	public function testInitApplication_initializedFlagSetAfterOnInitComplete(): void
+	{
+		$acc = $this->newInitAccessor();
+
+		// Capture the flag value INSIDE the onInitComplete handler: must be
+		// false there (the flag is set AFTER onInitComplete returns).
+		$flagDuringOnInitComplete = null;
+		$acc->attachEventHandler('onInitComplete', function () use ($acc, &$flagDuringOnInitComplete) {
+			$flagDuringOnInitComplete = $acc->hasStateFlag(TApplication::STATE_INITIALIZED);
 		});
 
-		// Drive the two steps in the order initApplication uses.
-		$acc->pubBootstrapDefaultModules();
-		$acc->onConfiguration();
+		$acc->pubInitApplication();
 
-		$this->assertIsArray($snapAtEvent);
-		$this->assertArrayHasKey(
-			TApplication::DEFAULT_REQUEST_ID,
-			$snapAtEvent,
-			'onConfiguration handlers must see default modules already registered'
+		$this->assertFalse(
+			$flagDuringOnInitComplete,
+			'STATE_INITIALIZED must NOT be set yet while onInitComplete handlers are running'
+		);
+		$this->assertTrue(
+			$acc->hasStateFlag(TApplication::STATE_INITIALIZED),
+			'STATE_INITIALIZED must be set once initApplication returns'
 		);
 	}
 
-	public function testOnConfiguration_isThinEventRaise_doesNotItselfBootstrap(): void
-	{
-		$acc = $this->newAccessor();
-
-		// Seed an instanced default. If onConfiguration is doing the
-		// bootstrapping (the old design), calling it alone would register
-		// the default — that would be wrong now.
-		$req = new \Prado\Web\THttpRequest();
-		$req->setID(TApplication::DEFAULT_REQUEST_ID);
-		PradoUnit::setProp($acc, '_request', $req);
-
-		$acc->onConfiguration();
-
-		$this->assertArrayNotHasKey(
-			TApplication::DEFAULT_REQUEST_ID,
-			$acc->getModules(),
-			'onConfiguration must not itself bootstrap; that is initApplication\'s job before raising the event'
-		);
-	}
+	// =======================================================================
+	// onConfiguration — thin event raise
+	// =======================================================================
 
 	public function testOnConfiguration_raisesEventToAttachedHandlers(): void
 	{

--- a/tests/unit/TApplicationBootstrapTest.php
+++ b/tests/unit/TApplicationBootstrapTest.php
@@ -1,0 +1,748 @@
+<?php
+
+/**
+ * TApplicationBootstrapTest class file.
+ *
+ * Comprehensive coverage for the 4.4.0 default-module bootstrap surface
+ * on {@see \Prado\TApplication}:
+ *
+ *  - the nine `DEFAULT_*_ID` constants and their late-static-binding override
+ *  - {@see TApplication::runModuleLifecycle} — the extracted four-phase
+ *    runner shared by `getModule` (lazy load) and `bootstrapDefaultModule`
+ *  - {@see TApplication::bootstrapDefaultModule} — assigns canonical ID +
+ *    runs lifecycle without registering in `$_modules`
+ *  - {@see TApplication::bootstrapDefaultModules} — registers each
+ *    instanced default under its self-reported ID, with type-collision
+ *    suppression and no auto-instantiation
+ *  - the nine lazy default-module accessors and their canonical-ID
+ *    assignment via `bootstrapDefaultModule`
+ *  - `initApplication`'s ordering of bootstrap → onConfiguration
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Exceptions\TConfigurationException;
+use Prado\IModule;
+use Prado\IModuleDependency;
+use Prado\Prado;
+use Prado\TApplication;
+use Prado\TComponent;
+use Prado\TModule;
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/**
+ * Public-wrapper subclass of TApplication exposing the protected bootstrap
+ * surface and the related test helpers. Instantiated via
+ * {@see \ReflectionClass::newInstanceWithoutConstructor()} so each test starts
+ * from a clean, fully-controllable instance — no Prado singleton swap.
+ */
+class TApplicationBootstrapAccessor extends TApplication
+{
+	public function pubBootstrapDefaultModule(IModule $module, string $id): void
+	{
+		$this->bootstrapDefaultModule($module, $id);
+	}
+
+	public function pubBootstrapDefaultModules(): void
+	{
+		$this->bootstrapDefaultModules();
+	}
+
+	public function pubRunModuleLifecycle(IModule $module, mixed $config): void
+	{
+		$this->runModuleLifecycle($module, $config);
+	}
+}
+
+/**
+ * Subclass that overrides one canonical-ID constant to verify the bootstrap
+ * surface reads `static::DEFAULT_*_ID` (late static binding).
+ */
+class TApplicationBootstrapAccessorCustomRequestId extends TApplicationBootstrapAccessor
+{
+	public const DEFAULT_REQUEST_ID = 'custom_http_request';
+}
+
+/**
+ * `TComponent`-rooted module that records every lifecycle dispatch in order.
+ * Overriding the `dy*` methods as concrete instance methods short-circuits
+ * `TComponent::__call`'s behavior-chain dispatch — which is what we want for
+ * tests that need to observe the call deterministically.
+ */
+class AppBootstrapSpyModule extends TModule
+{
+	/** @var array<int, array{phase: string, config: mixed}> */
+	public array $calls = [];
+
+	public function dyPreInit($config = null, $chain = null): void
+	{
+		$this->calls[] = ['phase' => 'dyPreInit', 'config' => $config];
+	}
+
+	public function init($config)
+	{
+		$this->calls[] = ['phase' => 'init', 'config' => $config];
+	}
+
+	public function dyPostInit($config = null, $chain = null): void
+	{
+		$this->calls[] = ['phase' => 'dyPostInit', 'config' => $config];
+	}
+}
+
+/**
+ * Bare `IModule` implementation that intentionally does NOT extend `TComponent`.
+ * Used to confirm `runModuleLifecycle` skips `dyPreInit`/`dyPostInit` for
+ * non-component modules without erroring on the missing methods.
+ */
+class AppBootstrapBareIModule implements IModule
+{
+	public int $initCount = 0;
+	public mixed $lastConfig = 'NOT_SET';
+	private string $_id = '';
+
+	public function init($config)
+	{
+		$this->initCount++;
+		$this->lastConfig = $config;
+	}
+
+	public function getID()
+	{
+		return $this->_id;
+	}
+
+	public function setID($id)
+	{
+		$this->_id = (string) $id;
+	}
+}
+
+/**
+ * Spy module with configurable {@see IModuleDependency} output, used to
+ * exercise the required/advisory/lazy-load branches in `runModuleLifecycle`.
+ */
+class AppBootstrapDepSpyModule extends AppBootstrapSpyModule implements IModuleDependency
+{
+	/** What `getModuleDependencies` returns; mirrors the documented shapes. */
+	public null|string|array $declaredDeps = null;
+
+	public function getModuleDependencies(bool $isPreInit): null|string|array
+	{
+		return $this->declaredDeps;
+	}
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/**
+ * Coverage for the bootstrap surface added to TApplication in 4.4.0.
+ *
+ * Each test instantiates a {@see TApplicationBootstrapAccessor} via
+ * `newInstanceWithoutConstructor()` so the global Prado singleton is never
+ * touched. Where the accessor needs initialised collections (`_modules`,
+ * `_lazyModules`), `PradoUnit::setProp` sets them explicitly.
+ *
+ * @package System
+ */
+class TApplicationBootstrapTest extends PHPUnit\Framework\TestCase
+{
+	private function newAccessor(string $class = TApplicationBootstrapAccessor::class): TApplicationBootstrapAccessor
+	{
+		$ref = new \ReflectionClass($class);
+		$acc = $ref->newInstanceWithoutConstructor();
+		PradoUnit::setProp($acc, '_modules', []);
+		PradoUnit::setProp($acc, '_lazyModules', []);
+		return $acc;
+	}
+
+	// =======================================================================
+	// DEFAULT_*_ID canonical default-module ID constants
+	// =======================================================================
+
+	public function testConstant_defaultRequestId(): void
+	{
+		$this->assertSame('request', TApplication::DEFAULT_REQUEST_ID);
+	}
+
+	public function testConstant_defaultResponseId(): void
+	{
+		$this->assertSame('response', TApplication::DEFAULT_RESPONSE_ID);
+	}
+
+	public function testConstant_defaultSessionId(): void
+	{
+		$this->assertSame('session', TApplication::DEFAULT_SESSION_ID);
+	}
+
+	public function testConstant_defaultErrorHandlerId(): void
+	{
+		$this->assertSame('errorHandler', TApplication::DEFAULT_ERROR_HANDLER_ID);
+	}
+
+	public function testConstant_defaultSecurityManagerId(): void
+	{
+		$this->assertSame('securityManager', TApplication::DEFAULT_SECURITY_MANAGER_ID);
+	}
+
+	public function testConstant_defaultAssetManagerId(): void
+	{
+		$this->assertSame('assetManager', TApplication::DEFAULT_ASSET_MANAGER_ID);
+	}
+
+	public function testConstant_defaultGlobalizationId(): void
+	{
+		$this->assertSame('globalization', TApplication::DEFAULT_GLOBALIZATION_ID);
+	}
+
+	public function testConstant_defaultTemplateManagerId(): void
+	{
+		$this->assertSame('templateManager', TApplication::DEFAULT_TEMPLATE_MANAGER_ID);
+	}
+
+	public function testConstant_defaultThemeManagerId(): void
+	{
+		$this->assertSame('themeManager', TApplication::DEFAULT_THEME_MANAGER_ID);
+	}
+
+	public function testConstant_subclassOverrideHonored(): void
+	{
+		$this->assertSame(
+			'custom_http_request',
+			TApplicationBootstrapAccessorCustomRequestId::DEFAULT_REQUEST_ID
+		);
+	}
+
+	public function testConstant_baseClassUnaffectedBySubclassOverride(): void
+	{
+		// Sanity: subclass override must not bleed into the parent constant.
+		$this->assertSame('request', TApplication::DEFAULT_REQUEST_ID);
+	}
+
+	// =======================================================================
+	// runModuleLifecycle — TComponent vs bare IModule, config passthrough
+	// =======================================================================
+
+	public function testRunModuleLifecycle_tComponentModule_callsAllPhasesInOrder(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubRunModuleLifecycle($module, 'cfg');
+
+		$this->assertSame(
+			['dyPreInit', 'init', 'dyPostInit'],
+			array_column($module->calls, 'phase'),
+			'TComponent module must receive dyPreInit, init, dyPostInit in order'
+		);
+	}
+
+	public function testRunModuleLifecycle_configForwardedToEveryPhase(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubRunModuleLifecycle($module, 'shared_cfg');
+
+		foreach ($module->calls as $call) {
+			$this->assertSame(
+				'shared_cfg',
+				$call['config'],
+				"Phase {$call['phase']} did not receive the supplied config"
+			);
+		}
+	}
+
+	public function testRunModuleLifecycle_nullConfigForwarded(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubRunModuleLifecycle($module, null);
+
+		foreach ($module->calls as $call) {
+			$this->assertNull($call['config'], "Phase {$call['phase']} should receive null config");
+		}
+	}
+
+	public function testRunModuleLifecycle_bareIModule_skipsDyPhases_butStillCallsInit(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapBareIModule();
+
+		// If runModuleLifecycle attempted dyPreInit/dyPostInit on a class that
+		// has no such methods, PHP would throw. Reaching the assertion proves
+		// the isComponent guard correctly skipped both.
+		$acc->pubRunModuleLifecycle($module, 'cfg');
+
+		$this->assertSame(1, $module->initCount, 'init must be called exactly once');
+		$this->assertSame('cfg', $module->lastConfig, 'init must receive the config');
+	}
+
+	public function testRunModuleLifecycle_requiredDepMissing_throws(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapDepSpyModule();
+		$module->declaredDeps = ['ghost_required'];
+
+		$this->expectException(TConfigurationException::class);
+		$acc->pubRunModuleLifecycle($module, null);
+	}
+
+	public function testRunModuleLifecycle_advisoryDepMissing_silentlySkipped(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapDepSpyModule();
+		$module->declaredDeps = ['ghost_advisory' => false];
+
+		// Must not throw; init still runs.
+		$acc->pubRunModuleLifecycle($module, null);
+
+		$initCount = count(array_filter($module->calls, fn($c) => $c['phase'] === 'init'));
+		$this->assertSame(1, $initCount, 'init must run even when advisory dep is missing');
+	}
+
+	public function testRunModuleLifecycle_presentDepForceLoaded(): void
+	{
+		$acc = $this->newAccessor();
+
+		// Register a lazy module slot keyed 'lazyDep' that, when force-loaded,
+		// instantiates AppTestModule. setLazyModule is protected so we bypass
+		// it and write _lazyModules / _modules directly via reflection.
+		PradoUnit::setProp($acc, '_lazyModules', [
+			'lazyDep' => [AppTestModule::class, [], null],
+		]);
+		PradoUnit::setProp($acc, '_modules', ['lazyDep' => null]);
+
+		$module = new AppBootstrapDepSpyModule();
+		$module->declaredDeps = ['lazyDep'];
+
+		$acc->pubRunModuleLifecycle($module, null);
+
+		// After force-load, _modules['lazyDep'] is a concrete AppTestModule.
+		$loaded = $acc->getModule('lazyDep');
+		$this->assertInstanceOf(AppTestModule::class, $loaded);
+	}
+
+	public function testRunModuleLifecycle_noIModuleDependency_noDepLoop(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();  // does NOT implement IModuleDependency
+
+		// Should run cleanly with no deps to resolve.
+		$acc->pubRunModuleLifecycle($module, null);
+
+		$this->assertContains('init', array_column($module->calls, 'phase'));
+	}
+
+	// =======================================================================
+	// bootstrapDefaultModule — setID + lifecycle, no $_modules write
+	// =======================================================================
+
+	public function testBootstrapDefaultModule_assignsCanonicalId(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubBootstrapDefaultModule($module, 'my_canon_id');
+
+		$this->assertSame('my_canon_id', $module->getID());
+	}
+
+	public function testBootstrapDefaultModule_runsFullLifecycle_withNullConfig(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubBootstrapDefaultModule($module, 'spy');
+
+		// All three phases ran (TComponent module) with null config.
+		$this->assertSame(['dyPreInit', 'init', 'dyPostInit'], array_column($module->calls, 'phase'));
+		foreach ($module->calls as $call) {
+			$this->assertNull($call['config']);
+		}
+	}
+
+	public function testBootstrapDefaultModule_doesNotRegisterIn_modules(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapSpyModule();
+
+		$acc->pubBootstrapDefaultModule($module, 'spy_id');
+
+		$this->assertSame(
+			[],
+			$acc->getModules(),
+			'bootstrapDefaultModule must not write to $_modules; registration is bootstrapDefaultModules() time'
+		);
+	}
+
+	public function testBootstrapDefaultModule_requiredDepMissing_propagates(): void
+	{
+		$acc = $this->newAccessor();
+		$module = new AppBootstrapDepSpyModule();
+		$module->declaredDeps = ['ghost_required'];
+
+		$this->expectException(TConfigurationException::class);
+		$acc->pubBootstrapDefaultModule($module, 'spy_id');
+	}
+
+	// =======================================================================
+	// bootstrapDefaultModules — registry sweep with type-collision suppression
+	// =======================================================================
+
+	public function testBootstrapDefaultModules_emptyApp_registersNothing(): void
+	{
+		$acc = $this->newAccessor();
+		// All nine slots already null after newAccessor (no constructor ran).
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertSame([], $acc->getModules());
+	}
+
+	public function testBootstrapDefaultModules_instancedRequest_registered(): void
+	{
+		$acc = $this->newAccessor();
+		$req = new \Prado\Web\THttpRequest();
+		$req->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertSame(
+			$req,
+			$acc->getModules()[TApplication::DEFAULT_REQUEST_ID] ?? null,
+			'Instanced default request must be registered under its canonical ID'
+		);
+	}
+
+	public function testBootstrapDefaultModules_registersUnderModuleSelfReportedId(): void
+	{
+		$acc = $this->newAccessor();
+		$req = new \Prado\Web\THttpRequest();
+		// Deliberately give it a non-canonical ID — the registry must follow
+		// the module's own getID(), not the canonical DEFAULT_REQUEST_ID literal.
+		$req->setID('my_custom_req_id');
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertArrayHasKey('my_custom_req_id', $acc->getModules());
+		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
+		$this->assertSame($req, $acc->getModules()['my_custom_req_id']);
+	}
+
+	public function testBootstrapDefaultModules_typeCollision_suppressesDefault(): void
+	{
+		$acc = $this->newAccessor();
+
+		// A configured THttpRequest already registered under SOME id.
+		$configured = new \Prado\Web\THttpRequest();
+		$configured->setID('configured_request');
+		PradoUnit::setProp($acc, '_modules', ['configured_request' => $configured]);
+
+		// A lazy default-request instance also exists in the slot.
+		$defaultReq = new \Prado\Web\THttpRequest();
+		$defaultReq->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $defaultReq);
+
+		$acc->pubBootstrapDefaultModules();
+
+		// The default must not be registered — configured one stays sole.
+		$this->assertSame($configured, $acc->getModules()['configured_request']);
+		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
+		$this->assertCount(1, $acc->getModules());
+	}
+
+	public function testBootstrapDefaultModules_typeCollision_subclassAlsoSuppressesDefault(): void
+	{
+		$acc = $this->newAccessor();
+
+		// Subclass of THttpRequest pre-registered.
+		$configured = new class extends \Prado\Web\THttpRequest {};
+		$configured->setID('my_subclassed_request');
+		PradoUnit::setProp($acc, '_modules', ['my_subclassed_request' => $configured]);
+
+		$defaultReq = new \Prado\Web\THttpRequest();
+		$defaultReq->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $defaultReq);
+
+		$acc->pubBootstrapDefaultModules();
+
+		// Non-strict type match: subclass is-a THttpRequest so the default is
+		// still suppressed.
+		$this->assertArrayNotHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
+		$this->assertCount(1, $acc->getModules());
+	}
+
+	public function testBootstrapDefaultModules_neverInstantiatesAbsentSlot(): void
+	{
+		$acc = $this->newAccessor();
+
+		$acc->pubBootstrapDefaultModules();
+
+		// None of the nine backing fields should have been touched.
+		foreach (['_request', '_response', '_session', '_errorHandler',
+			'_security', '_assetManager', '_globalization',
+			'_templateManager', '_themeManager'] as $field) {
+			$this->assertNull(
+				PradoUnit::getProp($acc, $field),
+				"Backing field $field must remain null — bootstrapDefaultModules must never instantiate"
+			);
+		}
+	}
+
+	public function testBootstrapDefaultModules_idempotent_secondCallIsNoOp(): void
+	{
+		$acc = $this->newAccessor();
+		$req = new \Prado\Web\THttpRequest();
+		$req->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$acc->pubBootstrapDefaultModules();
+		$first = $acc->getModules();
+
+		$acc->pubBootstrapDefaultModules();
+		$second = $acc->getModules();
+
+		$this->assertSame($first, $second);
+		$this->assertSame($req, $second[TApplication::DEFAULT_REQUEST_ID]);
+	}
+
+	public function testBootstrapDefaultModules_multipleInstancedSlots_allRegistered(): void
+	{
+		$acc = $this->newAccessor();
+
+		$req  = new \Prado\Web\THttpRequest();
+		$req->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$sec  = new \Prado\Security\TSecurityManager();
+		$sec->setID(TApplication::DEFAULT_SECURITY_MANAGER_ID);
+		PradoUnit::setProp($acc, '_security', $sec);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertArrayHasKey(TApplication::DEFAULT_REQUEST_ID, $acc->getModules());
+		$this->assertArrayHasKey(TApplication::DEFAULT_SECURITY_MANAGER_ID, $acc->getModules());
+		$this->assertCount(2, $acc->getModules());
+	}
+
+	public function testBootstrapDefaultModules_preservesUnrelatedModules(): void
+	{
+		$acc = $this->newAccessor();
+
+		// An unrelated configured module of a different type.
+		$unrelated = new AppTestModule();
+		$unrelated->setID('my_unrelated');
+		PradoUnit::setProp($acc, '_modules', ['my_unrelated' => $unrelated]);
+
+		$req = new \Prado\Web\THttpRequest();
+		$req->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$acc->pubBootstrapDefaultModules();
+
+		$this->assertSame($unrelated, $acc->getModules()['my_unrelated']);
+		$this->assertSame($req, $acc->getModules()[TApplication::DEFAULT_REQUEST_ID]);
+		$this->assertCount(2, $acc->getModules());
+	}
+
+	// =======================================================================
+	// Lazy default-module accessors — canonical ID assigned on creation
+	// =======================================================================
+	//
+	// Each accessor is tested via the bootstrap singleton (Prado::getApplication).
+	// The state is snapshotted in setUp and restored in tearDown so per-test
+	// nullification doesn't leak. For each accessor: null the backing field,
+	// call the accessor, observe (a) returned instance type, (b) ID equals
+	// canonical, (c) subsequent call returns the same instance.
+
+	/** @var TApplication The bootstrap singleton. */
+	private TApplication $_app;
+	private array $_snap = [];
+
+	protected function setUp(): void
+	{
+		$this->_app = Prado::getApplication();
+		$this->_snap = TTestApplication::snapshotApp($this->_app);
+	}
+
+	protected function tearDown(): void
+	{
+		TTestApplication::restoreApp($this->_snap, $this->_app);
+	}
+
+	public function testLazyAccessor_request_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_request', null);
+		$instance = $this->_app->getRequest();
+		$this->assertInstanceOf(\Prado\Web\THttpRequest::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_REQUEST_ID, $instance->getID());
+		$this->assertSame($instance, $this->_app->getRequest(), 'Second call returns same instance');
+	}
+
+	public function testLazyAccessor_response_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_response', null);
+		$levelBefore = ob_get_level();
+		$instance = $this->_app->getResponse();
+		while (ob_get_level() > $levelBefore) {
+			ob_end_clean();
+		}
+		$this->assertInstanceOf(\Prado\Web\THttpResponse::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_RESPONSE_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_session_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_session', null);
+		$instance = $this->_app->getSession();
+		$this->assertInstanceOf(\Prado\Web\THttpSession::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_SESSION_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_errorHandler_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_errorHandler', null);
+		$instance = $this->_app->getErrorHandler();
+		$this->assertInstanceOf(\Prado\Exceptions\TErrorHandler::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_ERROR_HANDLER_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_securityManager_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_security', null);
+		$instance = $this->_app->getSecurityManager();
+		$this->assertInstanceOf(\Prado\Security\TSecurityManager::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_SECURITY_MANAGER_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_globalization_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_globalization', null);
+		$instance = $this->_app->getGlobalization(true);
+		$this->assertInstanceOf(\Prado\I18N\TGlobalization::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_GLOBALIZATION_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_globalization_createFalse_returnsNull(): void
+	{
+		PradoUnit::setProp($this->_app, '_globalization', null);
+		$this->assertNull(
+			$this->_app->getGlobalization(false),
+			'getGlobalization(false) must NOT auto-create'
+		);
+	}
+
+	public function testLazyAccessor_templateManager_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_templateManager', null);
+		$instance = $this->_app->getTemplateManager();
+		$this->assertInstanceOf(\Prado\Web\UI\TTemplateManager::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_TEMPLATE_MANAGER_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_themeManager_assignsCanonicalId(): void
+	{
+		PradoUnit::setProp($this->_app, '_themeManager', null);
+		$instance = $this->_app->getThemeManager();
+		$this->assertInstanceOf(\Prado\Web\UI\TThemeManager::class, $instance);
+		$this->assertSame(TApplication::DEFAULT_THEME_MANAGER_ID, $instance->getID());
+	}
+
+	public function testLazyAccessor_setterBypassesBootstrap(): void
+	{
+		// When the setter is called directly with a fully-constructed instance,
+		// no bootstrap fires and the ID stays whatever the setter passed-in
+		// instance had.
+		$pre = new \Prado\Web\THttpRequest();
+		$pre->setID('prebuilt');
+		$this->_app->setRequest($pre);
+		$this->assertSame('prebuilt', $this->_app->getRequest()->getID());
+	}
+
+	// =======================================================================
+	// initApplication ordering — bootstrap fires BEFORE onConfiguration
+	// =======================================================================
+	//
+	// We can't run initApplication() against the bootstrap singleton without
+	// extensive setup (config file, service registration, etc.), but we CAN
+	// verify the call ordering by inspecting source: bootstrapDefaultModules
+	// must be invoked before onConfiguration. The earlier integration check
+	// via grep proves the order; here we test the observable effect — an
+	// onConfiguration handler attached BEFORE initApplication runs sees the
+	// default modules already registered.
+
+	public function testInitApplication_bootstrapDefaultModulesIsCalledBeforeOnConfiguration(): void
+	{
+		// Use the accessor; instantiate without constructor so initApplication's
+		// internal calls don't try to load a config file or start services.
+		$acc = $this->newAccessor();
+
+		// Seed an instanced default so bootstrapDefaultModules has something
+		// to register, and confirm the registration happens before the event.
+		$req = new \Prado\Web\THttpRequest();
+		$req->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $req);
+
+		// Subscribe a handler that snapshots _modules at event time.
+		$snapAtEvent = null;
+		$acc->attachEventHandler('onConfiguration', function () use ($acc, &$snapAtEvent) {
+			$snapAtEvent = $acc->getModules();
+		});
+
+		// Drive the two steps in the order initApplication uses.
+		$acc->pubBootstrapDefaultModules();
+		$acc->onConfiguration();
+
+		$this->assertIsArray($snapAtEvent);
+		$this->assertArrayHasKey(
+			TApplication::DEFAULT_REQUEST_ID,
+			$snapAtEvent,
+			'onConfiguration handlers must see default modules already registered'
+		);
+	}
+
+	public function testOnConfiguration_isThinEventRaise_doesNotItselfBootstrap(): void
+	{
+		$acc = $this->newAccessor();
+
+		// Seed an instanced default. If onConfiguration is doing the
+		// bootstrapping (the old design), calling it alone would register
+		// the default — that would be wrong now.
+		$req = new \Prado\Web\THttpRequest();
+		$req->setID(TApplication::DEFAULT_REQUEST_ID);
+		PradoUnit::setProp($acc, '_request', $req);
+
+		$acc->onConfiguration();
+
+		$this->assertArrayNotHasKey(
+			TApplication::DEFAULT_REQUEST_ID,
+			$acc->getModules(),
+			'onConfiguration must not itself bootstrap; that is initApplication\'s job before raising the event'
+		);
+	}
+
+	public function testOnConfiguration_raisesEventToAttachedHandlers(): void
+	{
+		$acc = $this->newAccessor();
+
+		$fired = false;
+		$acc->attachEventHandler('onConfiguration', function () use (&$fired) {
+			$fired = true;
+		});
+
+		$acc->onConfiguration();
+
+		$this->assertTrue($fired);
+	}
+}


### PR DESCRIPTION
This ensures that the default bootstrap TApplication Modules get full bootstrap and promoted to official application modules.