### PR TITLE
TComponent::setSubProperty coercion, ensureArray regex refactor

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -20,6 +20,7 @@ component_no_class_provided_nor_late_binding = Adding or Removing Class Behavior
 
 propertyvalue_enumvalue_invalid			= Value '{0}' is a not valid enumeration value ({1}).
 propertyvalue_invalid_hex_color			= Value '{0}' is a not valid hex color value.  eg. "#112233"
+propertyvalue_invalid_array_literal		= Value '{0}' is not a valid array literal.
 
 eventhandler_lost_weak_ref				= TEventHandler cannot invoke the event handler because the callable object WeakReference was lost.
 eventhandler_no_set_handler				= TEventHandler cannot set the event handler, index "{0}".

--- a/framework/ICoercible.php
+++ b/framework/ICoercible.php
@@ -11,45 +11,55 @@
 namespace Prado;
 
 /**
- * ICoercible interface.
+ * ICoercible interface
  *
- * ICoercible lets a class participate in {@see \Prado\TPropertyValue::coerceToType}
- * as a self-constructing target for a typed property's union member.  When the
- * coercion chain reaches a union member that implements this interface,
- * {@see coerceFromValue()} is given the incoming value and may return either a
- * fully-constructed instance of the class or `null` to decline.
+ * ICoercible lets any class act as a self-constructing target inside
+ * {@see \Prado\TPropertyValue::coerceToType}'s coercion chain.  When that
+ * chain reaches a non-builtin union member implementing this interface,
+ * `TPropertyValue` first checks whether `$value` already is an instance of
+ * the member and, if so, returns it untouched; otherwise it calls
+ * {@see coerceFromValue()}, which constructs and returns an instance from a
+ * richer input form — a config array, a parsed string, an int code — or
+ * returns `null` to decline.  The two halves of that contract — when to
+ * decline and how decliners coexist in a union — are detailed below.
  *
  * ## Declining vs. throwing
  *
- * `coerceFromValue()` returns `null` to decline an input it cannot interpret;
- * the coercion chain then tries the next union member.  A returned `null` is
- * *not* a failure — it is the contract for "this is not my input."  Throw a
- * {@see \Prado\Exceptions\TInvalidDataValueException} only when the input is
- * shape-recognized but semantically broken (for example, the right array keys
- * but values out of range).  Never let a foreign exception escape.
+ * A `null` return is not failure; it tells the chain "this is not my input"
+ * and lets the next union member have a turn.  That is how a `TPoint|string`
+ * property, or a union of several coercibles, can share one setter without
+ * fighting over inputs.  An implementation should throw
+ * {@see \Prado\Exceptions\TInvalidDataValueException} only when an input is
+ * shape-recognized but semantically broken — the right array keys with
+ * out-of-range values, a parseable string whose numbers are nonsensical —
+ * and should never let an unrelated exception escape.
  *
  * ## Union member ordering
  *
- * Inside a union type the implementers are tried in PHP reflection order (the
- * declaration order on the property).  The first non-`null` result wins, so a
- * class can be placed earlier in the union to claim ambiguous inputs ahead of
- * later members.  Classes that also implement {@see \Prado\IEnumerable},
- * `\UnitEnum`, or `\BackedEnum` are tried *before* the enum-name validation
- * step, so a coercer can override pure name matching when it has a richer
- * understanding of the input.
+ * When several coercibles share a union, they are tried in PHP reflection
+ * (declaration) order, and the first identity match or non-`null` factory
+ * return wins.  Placing a class earlier in the union therefore lets it claim
+ * ambiguous inputs ahead of later members.  The pass runs *before* enum-name
+ * validation, so a class that also implements {@see \Prado\IEnumerable},
+ * `\UnitEnum`, or `\BackedEnum` can override pure name matching with richer
+ * logic when it has it.
  *
  * ## Example
  *
  * ```php
  * class TPoint implements \Prado\ICoercible
  * {
- *     public function __construct(int $x, int $y) {}
+ *     public int $x;
+ *     public int $y;
+ *
+ *     public function __construct(int $x, int $y)
+ *     {
+ *         $this->x = $x;
+ *         $this->y = $y;
+ *     }
  *
  *     public static function coerceFromValue(mixed $value): ?static
  *     {
- *         if ($value instanceof static) {
- *             return $value;
- *         }
  *         if (is_array($value) && isset($value['x'], $value['y'])) {
  *             return new static((int) $value['x'], (int) $value['y']);
  *         }
@@ -60,7 +70,8 @@ namespace Prado;
  *     }
  * }
  *
- * // Property typed as `TPoint|string` accepts '3,4', ['x'=>3,'y'=>4], or a TPoint.
+ * // A property typed `TPoint|string` accepts '3,4', ['x'=>3,'y'=>4], or a
+ * // TPoint instance (identity pass-through, no factory call).
  * ```
  *
  * @author Brad Anderson <belisoful@icloud.com>
@@ -70,17 +81,13 @@ interface ICoercible
 {
 	/**
 	 * Constructs an instance of the implementing class from `$value`, or
-	 * returns `null` to decline.
+	 * returns `null` to decline so the coercion chain can try the next union
+	 * member.  See the class docblock for the decline-vs-throw contract.
 	 *
-	 * Returning `null` lets {@see \Prado\TPropertyValue::coerceToType} fall
-	 * through to the next union member.  Throw
-	 * {@see \Prado\Exceptions\TInvalidDataValueException} only for inputs that
-	 * are recognized but semantically invalid (range, parse, etc.); never
-	 * leak unrelated exceptions.
-	 *
-	 * Implementations should accept an instance of `static` as a pass-through
-	 * so a property of this type accepts both freshly-coerced inputs and
-	 * already-constructed instances uniformly.
+	 * Because {@see \Prado\TPropertyValue} short-circuits the identity
+	 * pass-through before invoking this method, `$value` is guaranteed not
+	 * to be an instance of the implementing class — no `instanceof static`
+	 * guard is needed.
 	 *
 	 * @param mixed $value the incoming value to coerce.
 	 * @return ?static an instance of the implementing class on success, or

--- a/framework/ICoercible.php
+++ b/framework/ICoercible.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * ICoercible interface file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado;
+
+/**
+ * ICoercible interface.
+ *
+ * ICoercible lets a class participate in {@see \Prado\TPropertyValue::coerceToType}
+ * as a self-constructing target for a typed property's union member.  When the
+ * coercion chain reaches a union member that implements this interface,
+ * {@see coerceFromValue()} is given the incoming value and may return either a
+ * fully-constructed instance of the class or `null` to decline.
+ *
+ * ## Declining vs. throwing
+ *
+ * `coerceFromValue()` returns `null` to decline an input it cannot interpret;
+ * the coercion chain then tries the next union member.  A returned `null` is
+ * *not* a failure — it is the contract for "this is not my input."  Throw a
+ * {@see \Prado\Exceptions\TInvalidDataValueException} only when the input is
+ * shape-recognized but semantically broken (for example, the right array keys
+ * but values out of range).  Never let a foreign exception escape.
+ *
+ * ## Union member ordering
+ *
+ * Inside a union type the implementers are tried in PHP reflection order (the
+ * declaration order on the property).  The first non-`null` result wins, so a
+ * class can be placed earlier in the union to claim ambiguous inputs ahead of
+ * later members.  Classes that also implement {@see \Prado\IEnumerable},
+ * `\UnitEnum`, or `\BackedEnum` are tried *before* the enum-name validation
+ * step, so a coercer can override pure name matching when it has a richer
+ * understanding of the input.
+ *
+ * ## Example
+ *
+ * ```php
+ * class TPoint implements \Prado\ICoercible
+ * {
+ *     public function __construct(int $x, int $y) {}
+ *
+ *     public static function coerceFromValue(mixed $value): ?static
+ *     {
+ *         if ($value instanceof static) {
+ *             return $value;
+ *         }
+ *         if (is_array($value) && isset($value['x'], $value['y'])) {
+ *             return new static((int) $value['x'], (int) $value['y']);
+ *         }
+ *         if (is_string($value) && preg_match('/^(-?\d+),\s*(-?\d+)$/', $value, $m)) {
+ *             return new static((int) $m[1], (int) $m[2]);
+ *         }
+ *         return null; // decline — let the chain try the next member
+ *     }
+ * }
+ *
+ * // Property typed as `TPoint|string` accepts '3,4', ['x'=>3,'y'=>4], or a TPoint.
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+interface ICoercible
+{
+	/**
+	 * Constructs an instance of the implementing class from `$value`, or
+	 * returns `null` to decline.
+	 *
+	 * Returning `null` lets {@see \Prado\TPropertyValue::coerceToType} fall
+	 * through to the next union member.  Throw
+	 * {@see \Prado\Exceptions\TInvalidDataValueException} only for inputs that
+	 * are recognized but semantically invalid (range, parse, etc.); never
+	 * leak unrelated exceptions.
+	 *
+	 * Implementations should accept an instance of `static` as a pass-through
+	 * so a property of this type accepts both freshly-coerced inputs and
+	 * already-constructed instances uniformly.
+	 *
+	 * @param mixed $value the incoming value to coerce.
+	 * @return ?static an instance of the implementing class on success, or
+	 *   `null` to decline.
+	 */
+	public static function coerceFromValue(mixed $value): ?static;
+}

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1102,7 +1102,7 @@ class TComponent
 			$object = $this->getSubProperty(substr($path, 0, $pos));
 			$property = substr($path, $pos + 1);
 		}
-		$object->$property = $value;
+		TPropertyValue::applyProperty($object, $property, $value);
 	}
 
 	/**

--- a/framework/TPropertyValue.php
+++ b/framework/TPropertyValue.php
@@ -311,7 +311,7 @@ class TPropertyValue
 			throw new TInvalidDataValueException(
 				'propertyvalue_enumvalue_invalid',
 				$errVal,
-				implode(' | ', $constants)
+				implode(' | ', array_keys($constants))
 			);
 		} elseif (!is_array($enums)) {
 			$enums = func_get_args();

--- a/framework/TPropertyValue.php
+++ b/framework/TPropertyValue.php
@@ -1392,8 +1392,9 @@ class TPropertyValue
 	 * Resolution order parallels {@see _coerceUnionType()}:
 	 *
 	 * 1. **ICoercible** — when `$className` implements {@see \Prado\ICoercible},
-	 *    `coerceFromValue($value)` runs first.  A non-`null` return wins; a
-	 *    `null` return continues to the enum paths below.
+	 *    an existing instance of the class passes through unchanged; otherwise
+	 *    `coerceFromValue($value)` runs and a non-`null` return wins.  A `null`
+	 *    return continues to the enum paths below.
 	 * 2. **BackedEnum + int** — `tryFrom($value)` resolves an int input to
 	 *    its backing value's case.
 	 * 3. **String + enum** — {@see _tryMatchEnum()} performs a case-insensitive
@@ -1410,6 +1411,9 @@ class TPropertyValue
 	private static function _coerceToClass(mixed $value, string $className): mixed
 	{
 		if (is_a($className, ICoercible::class, true)) {
+			if ($value instanceof $className) {
+				return $value;
+			}
 			$coerced = $className::coerceFromValue($value);
 			if ($coerced !== null) {
 				return $coerced;
@@ -1505,12 +1509,10 @@ class TPropertyValue
 	 * selects the most appropriate type:
 	 *
 	 * 1. `null` / empty string → `null` (when `null` is in the union)
-	 * 2. **ICoercible** — each non-builtin union member implementing
-	 *    {@see \Prado\ICoercible} is given a chance via its
-	 *    `coerceFromValue()` factory; members are tried in declaration order
-	 *    and the first non-`null` result wins.  Runs before enum validation
-	 *    so a class that both validates names *and* coerces richer inputs
-	 *    can stake its claim first.
+	 * 2. **ICoercible** — non-builtin union members implementing
+	 *    {@see \Prado\ICoercible} are tried in declaration order; an existing
+	 *    instance passes through, otherwise `coerceFromValue()` runs and the
+	 *    first non-`null` result wins.
 	 * 3. Enumerable validation — for string `$value`, case-insensitive
 	 *    constant-name lookup via {@see _tryMatchEnum()} against each
 	 *    enum-like (UnitEnum / IEnumerable) union member; the first match
@@ -1561,19 +1563,18 @@ class TPropertyValue
 			return self::coerceToType($value, $nonNull[0]);
 		}
 
-		// 2. ICoercible.  Each non-builtin union member that implements
-		// {@see \Prado\ICoercible} gets a chance to coerce the value via its
-		// `coerceFromValue()` factory.  Members are tried in PHP reflection
-		// (declaration) order; the first non-`null` result wins.  Runs before
-		// enum validation so an IEnumerable / UnitEnum class that also
-		// implements ICoercible can claim inputs richer than pure name
-		// matching.
+		// 2. ICoercible.  Each non-builtin {@see ICoercible} member, in
+		// declaration order, claims an identity match or the first non-`null`
+		// `coerceFromValue()` return.
 		foreach ($nonNull as $t) {
 			if ($t->isBuiltin()) {
 				continue;
 			}
 			$n = $t->getName();
 			if (is_a($n, ICoercible::class, true)) {
+				if ($value instanceof $n) {
+					return $value;
+				}
 				$coerced = $n::coerceFromValue($value);
 				if ($coerced !== null) {
 					return $coerced;

--- a/framework/TPropertyValue.php
+++ b/framework/TPropertyValue.php
@@ -156,7 +156,7 @@ class TPropertyValue
 	public const ARRAY_STRICT_ERRORS = (1 << 2);
 
 	/**
-	 * Step-10 fallback order for {@see _coerceUnionType}: non-null union members are tried in this
+	 * Step-11 fallback order for {@see _coerceUnionType}: non-null union members are tried in this
 	 * sequence — int → float → string → bool → aggregate/catch-all — so resolution is deterministic
 	 * regardless of reflection order.  `null` is absent; step 1 handles it before any fallback.
 	 * @var string[]
@@ -1346,6 +1346,7 @@ class TPropertyValue
 	 * | `mixed` / `null`      | pass-through / `null`                              |
 	 * | Backed enum class     | `tryFrom()` exact backing value, then case-insensitive case-name scan |
 	 * | {@see IEnumerable}    | case-insensitive `valueOfConstant()` name→value; unknown → pass-through |
+	 * | {@see ICoercible}     | `coerceFromValue()` factory; `null` return → pass-through |
 	 * | Union type            | heuristic chain — see {@see _coerceUnionType}      |
 	 * | Nullable (`?T`)       | empty string / `null` input → `null`               |
 	 *
@@ -1384,15 +1385,22 @@ class TPropertyValue
 	}
 
 	/**
-	 * Has coerced a value toward a non-builtin class type that Prado has
-	 * recognized as an enumerable domain.  All other class types have been
+	 * Coerces a value toward a non-builtin class type that Prado recognizes
+	 * as a coercible or enumerable domain.  All other class types are
 	 * returned unchanged.
 	 *
-	 * String inputs delegate to {@see _tryMatchEnum()} for case-insensitive
-	 * name lookup (and, for BackedEnum, value-based `tryFrom` first).  An int
-	 * input against a BackedEnum has been resolved through `tryFrom` directly.
-	 * On any miss, `$value` has been returned unchanged so the TypeError has
-	 * surfaced at the setter boundary.
+	 * Resolution order parallels {@see _coerceUnionType()}:
+	 *
+	 * 1. **ICoercible** — when `$className` implements {@see \Prado\ICoercible},
+	 *    `coerceFromValue($value)` runs first.  A non-`null` return wins; a
+	 *    `null` return continues to the enum paths below.
+	 * 2. **BackedEnum + int** — `tryFrom($value)` resolves an int input to
+	 *    its backing value's case.
+	 * 3. **String + enum** — {@see _tryMatchEnum()} performs a case-insensitive
+	 *    name lookup (and, for BackedEnum, value-based `tryFrom` first).
+	 *
+	 * On any miss, `$value` is returned unchanged so the TypeError surfaces
+	 * at the setter boundary.
 	 *
 	 * @param mixed $value the value to coerce.
 	 * @param string $className the target class or interface name.
@@ -1401,6 +1409,12 @@ class TPropertyValue
 	 */
 	private static function _coerceToClass(mixed $value, string $className): mixed
 	{
+		if (is_a($className, ICoercible::class, true)) {
+			$coerced = $className::coerceFromValue($value);
+			if ($coerced !== null) {
+				return $coerced;
+			}
+		}
 		if (is_a($className, \BackedEnum::class, true) && is_int($value)) {
 			try {
 				return $className::tryFrom($value) ?? $value;
@@ -1491,27 +1505,33 @@ class TPropertyValue
 	 * selects the most appropriate type:
 	 *
 	 * 1. `null` / empty string → `null` (when `null` is in the union)
-	 * 2. Enumerable validation — for string `$value`, case-insensitive
+	 * 2. **ICoercible** — each non-builtin union member implementing
+	 *    {@see \Prado\ICoercible} is given a chance via its
+	 *    `coerceFromValue()` factory; members are tried in declaration order
+	 *    and the first non-`null` result wins.  Runs before enum validation
+	 *    so a class that both validates names *and* coerces richer inputs
+	 *    can stake its claim first.
+	 * 3. Enumerable validation — for string `$value`, case-insensitive
 	 *    constant-name lookup via {@see _tryMatchEnum()} against each
 	 *    enum-like (UnitEnum / IEnumerable) union member; the first match
 	 *    wins.  Return shape per {@see _tryMatchEnum()}'s contract.
-	 * 3. `array` / typed object value whose type appears in the union → use it
-	 *    (pre-empts step 4 to prevent `(string)$array = "Array"` and
+	 * 4. `array` / typed object value whose type appears in the union → use it
+	 *    (pre-empts step 5 to prevent `(string)$array = "Array"` and
 	 *    `(string)$object` TypeError when the value has a native match)
-	 * 4. `string` in union → pass through / `ensureString` if not already a string
+	 * 5. `string` in union → pass through / `ensureString` if not already a string
 	 *    (scalar non-string values such as `int` and `bool` are coerced to their
 	 *    string representation here when `string` is present in the union)
-	 * 5. Non-string typed value whose PHP type directly matches a union member → use it
+	 * 6. Non-string typed value whose PHP type directly matches a union member → use it
 	 *    (only reached when `string` is NOT in the union); then PHP-compatible
 	 *    widening: `bool` → `int`/`float`, `int` → `float`
-	 * 6. `(a,b,c)` / `[a,b,c]` / `array(a,b,c)` notation + `array`/`iterable` in union → {@see ensureArray}
-	 * 7. `'true'`/`'false'` literal + `bool` in union → {@see ensureBoolean}
-	 * 8. Numeric value + `int`/`float` in union → float when `.` or `e`/`E` (scientific notation)
+	 * 7. `(a,b,c)` / `[a,b,c]` / `array(a,b,c)` notation + `array`/`iterable` in union → {@see ensureArray}
+	 * 8. `'true'`/`'false'` literal + `bool` in union → {@see ensureBoolean}
+	 * 9. Numeric value + `int`/`float` in union → float when `.` or `e`/`E` (scientific notation)
 	 *    is present, int otherwise; matching PHP non-strict behavior
-	 * 9. Non-builtin class types — value-based lookup via {@see _coerceToClass}
-	 *    catches inputs that match an enum's *backing value* (e.g. `100` for an
-	 *    int-backed enum) where step 2's *name* lookup did not apply
-	 * 10. Fallback: first non-`null` type sorted by {@see TYPE_COERCE_ORDER}
+	 * 10. Non-builtin class types — value-based lookup via {@see _coerceToClass}
+	 *     catches inputs that match an enum's *backing value* (e.g. `100` for an
+	 *     int-backed enum) where step 3's *name* lookup did not apply
+	 * 11. Fallback: first non-`null` type sorted by {@see TYPE_COERCE_ORDER}
 	 *
 	 * @param mixed $value the value to coerce.
 	 * @param \ReflectionUnionType $type the union type.
@@ -1541,7 +1561,27 @@ class TPropertyValue
 			return self::coerceToType($value, $nonNull[0]);
 		}
 
-		// 2. Enum validation.  Case-insensitive constant-name lookup against
+		// 2. ICoercible.  Each non-builtin union member that implements
+		// {@see \Prado\ICoercible} gets a chance to coerce the value via its
+		// `coerceFromValue()` factory.  Members are tried in PHP reflection
+		// (declaration) order; the first non-`null` result wins.  Runs before
+		// enum validation so an IEnumerable / UnitEnum class that also
+		// implements ICoercible can claim inputs richer than pure name
+		// matching.
+		foreach ($nonNull as $t) {
+			if ($t->isBuiltin()) {
+				continue;
+			}
+			$n = $t->getName();
+			if (is_a($n, ICoercible::class, true)) {
+				$coerced = $n::coerceFromValue($value);
+				if ($coerced !== null) {
+					return $coerced;
+				}
+			}
+		}
+
+		// 3. Enum validation.  Case-insensitive constant-name lookup against
 		// any enum-like (UnitEnum / IEnumerable) union member via
 		// {@see _tryMatchEnum()}, which returns `null` for non-enum classes;
 		// the first match wins.
@@ -1557,8 +1597,8 @@ class TPropertyValue
 			}
 		}
 
-		// 3. Non-stringable native short-circuit.  Arrays and typed-object
-		// instances have claimed a native union match before step 4 —
+		// 4. Non-stringable native short-circuit.  Arrays and typed-object
+		// instances claim a native union match before step 5 —
 		// `(string)$arr` would be the useless `"Array"` and `(string)$obj`
 		// TypeErrors without `__toString()`.
 		if (!is_string($value)) {
@@ -1580,15 +1620,15 @@ class TPropertyValue
 			}
 		}
 
-		// 4. String member.  Strings have passed through; non-string scalars
-		// (bool, int, float) have been coerced via {@see ensureString()}.
-		// Step 3 has already claimed any array or typed object with a
+		// 5. String member.  Strings pass through; non-string scalars
+		// (bool, int, float) are coerced via {@see ensureString()}.
+		// Step 4 has already claimed any array or typed object with a
 		// native union match.
 		if (in_array(self::TYPE_STRING, $names, true)) {
 			return is_string($value) ? $value : self::ensureString($value);
 		}
 
-		// 5. Native-type short-circuit: only reached when string is NOT in the union.
+		// 6. Native-type short-circuit: only reached when string is NOT in the union.
 		// First try an exact match (Pass A), then apply PHP non-strict widening
 		// coercions: bool → int/float (true=1, false=0) and int → float (Pass B).
 		if (!is_string($value)) {
@@ -1627,7 +1667,7 @@ class TPropertyValue
 		$hasInt = in_array(self::TYPE_INT, $names, true);
 		$hasFloat = in_array(self::TYPE_FLOAT, $names, true);
 
-		// 6. Array notation — unambiguous regardless of other types present.
+		// 7. Array notation — unambiguous regardless of other types present.
 		// Three delimiter forms are accepted: the Prado `(...)` convention,
 		// the PHP 8 short `[...]` form, and the PHP `array(...)` keyword form.
 		if ($hasArray) {
@@ -1642,12 +1682,12 @@ class TPropertyValue
 			}
 		}
 
-		// 7. Boolean literals — 'true'/'false' only, not generic truthy strings
+		// 8. Boolean literals — 'true'/'false' only, not generic truthy strings
 		if ($hasBool && in_array(strtolower($strValue), [self::BOOL_TRUE, self::BOOL_FALSE], true)) {
 			return self::ensureBoolean($strValue);
 		}
 
-		// 8. Numeric shape
+		// 9. Numeric shape
 		if (is_numeric($strValue)) {
 			if ($hasInt && $hasFloat) {
 				// Treat as float when: (a) a decimal point or scientific-notation exponent is
@@ -1669,7 +1709,7 @@ class TPropertyValue
 			}
 		}
 
-		// 9. Non-builtin class value-based lookup.  Tries the original $value
+		// 10. Non-builtin class value-based lookup.  Tries the original $value
 		// first so a PHP int reaches an int-backed enum's tryFrom() before
 		// stringification; retries with $strValue only when the original
 		// attempt produced no change.  `isBuiltin()` excludes the `null`
@@ -1690,7 +1730,7 @@ class TPropertyValue
 			}
 		}
 
-		// 10. Fallback.  Sorts non-null members by {@see TYPE_COERCE_ORDER}
+		// 11. Fallback.  Sorts non-null members by {@see TYPE_COERCE_ORDER}
 		// (non-builtin class names sort after every builtin, preserving
 		// reflection order among themselves) and coerces $strValue toward
 		// the winner.  $nonNull has ≥ 2 members here — single-non-null

--- a/framework/TPropertyValue.php
+++ b/framework/TPropertyValue.php
@@ -13,52 +13,180 @@ namespace Prado;
 use Prado\Exceptions\TInvalidDataValueException;
 use Prado\Web\Javascripts\TJavaScript;
 use Prado\Web\UI\TWebColor;
+use Prado\TComponentReflection;
 
 /**
  * TPropertyValue class
  *
- * TPropertyValue is a utility class that provides static methods
- * to convert component property values to specific types.
- *
- * TPropertyValue is commonly used in component setter methods to ensure
- * the new property value is of specific type.
- * For example, a boolean-typed property setter method would be as follows,
+ * TPropertyValue is a utility class that provides static methods to convert component
+ * property values to specific types.  It is commonly used in setter methods:
  * ```php
- * function setPropertyName($value) {
- *     $value=TPropertyValue::ensureBoolean($value);
- *     // $value is now of boolean type
+ * public function setFoo($value): void {
+ *     $this->_foo = TPropertyValue::ensureBoolean($value);
  * }
  * ```
  *
- * Properties can be of the following types with specific type conversion rules:
- * - string: a boolean value will be converted to 'true' or 'false'.
- * - boolean: string 'true' (case-insensitive) will be converted to true,
- *            string 'false' (case-insensitive) will be converted to false.
- * - integer
- * - float
- * - array: string starting with '(' and ending with ')' will be considered as
- *          as an array expression and will be evaluated. Otherwise, an array
- *          with the value to be ensured is returned.
- * - object
- * - enum: enumerable type, represented by an array of strings.
+ * **Conversion rules by type**
+ *
+ * | Type | Rule |
+ * |---|---|
+ * | `string` | `bool` → `'true'`/`'false'`; `TJavaScriptLiteral` passed through; everything else via `(string)` cast |
+ * | `bool` | `'true'` (case-insensitive) or numeric string `!= 0` (loose) → `true`; all else → `false` |
+ * | `int` | `(int)` cast |
+ * | `float` | `(float)` cast |
+ * | `array` | String parsed as PHP array literal; non-string via `(array)` cast |
+ * | `object` | `(object)` cast |
+ * | `enum` | PHP `\BackedEnum` exact backing value or case-insensitive case name; {@see IEnumerable} case-insensitive constant name → value |
+ *
+ * **Constants**
+ *
+ * *PHP type-name strings* — used by {@see coerceToType} and {@see coerceForSetter}:
+ *
+ * |   Constant      |    Value     |
+ * |-----------------|--------------|
+ * | `TYPE_NULL`     | `'null'`     |
+ * | `TYPE_BOOL`     | `'bool'`     |
+ * | `TYPE_INT`      | `'int'`      |
+ * | `TYPE_FLOAT`    | `'float'`    |
+ * | `TYPE_STRING`   | `'string'`   |
+ * | `TYPE_ARRAY`    | `'array'`    |
+ * | `TYPE_ITERABLE` | `'iterable'` |
+ * | `TYPE_OBJECT`   | `'object'`   |
+ * | `TYPE_MIXED`    | `'mixed'`    |
+ *
+ * *Boolean string representations* — canonical values produced by {@see ensureString} and
+ * recognized by {@see ensureBoolean}:
+ *
+ * |   Constant   |    Value  |
+ * |--------------|-----------|
+ * | `BOOL_TRUE`  | `'true'`  |
+ * | `BOOL_FALSE` | `'false'` |
+ *
+ * *Color channel keys* — array keys accepted by {@see ensureHexColor}:
+ *
+ * |   Constant    |    Value  |
+ * |---------------|-----------|
+ * | `COLOR_RED`   | `'red'`   |
+ * | `COLOR_GREEN` | `'green'` |
+ * | `COLOR_BLUE`  | `'blue'`  |
+ *
+ * *Array parser flags* — composable bit flags for {@see ensureArray}:
+ *
+ * | Constant | Bit | Effect |
+ * |---|---|---|
+ * | `ARRAY_STRICT_GRAMMAR` | 0 | Restrict to `[...]` / `array(...)` — no bare `(...)`, no bare words, no legacy octal, no auto-wrap |
+ * | `ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN` | 1 | Also accept Prado `(...)` form; requires `ARRAY_STRICT_GRAMMAR` |
+ * | `ARRAY_STRICT_ERRORS` | 2 | Throw {@see TInvalidDataValueException} on parse failure instead of wrapping |
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.0
  */
 class TPropertyValue
 {
+	/** PHP type name for `null`. @since 4.4.0 */
+	public const TYPE_NULL = 'null';
+
+	/** PHP type name for `bool`. @since 4.4.0 */
+	public const TYPE_BOOL = 'bool';
+
+	/** PHP type name for `int`. @since 4.4.0 */
+	public const TYPE_INT = 'int';
+
+	/** PHP type name for `float`. @since 4.4.0 */
+	public const TYPE_FLOAT = 'float';
+
+	/** PHP type name for `string`. @since 4.4.0 */
+	public const TYPE_STRING = 'string';
+
+	/** PHP type name for `array`. @since 4.4.0 */
+	public const TYPE_ARRAY = 'array';
+
+	/** PHP type name for `iterable`. @since 4.4.0 */
+	public const TYPE_ITERABLE = 'iterable';
+
+	/** PHP type name for `object`. @since 4.4.0 */
+	public const TYPE_OBJECT = 'object';
+
+	/** PHP type name for `mixed`. @since 4.4.0 */
+	public const TYPE_MIXED = 'mixed';
+
+	/** Array key / channel name for the red component in color arrays. @since 4.4.0 */
+	public const COLOR_RED = 'red';
+
+	/** Array key / channel name for the green component in color arrays. @since 4.4.0 */
+	public const COLOR_GREEN = 'green';
+
+	/** Array key / channel name for the blue component in color arrays. @since 4.4.0 */
+	public const COLOR_BLUE = 'blue';
+
+	/**
+	 * The string representation of PHP `true` produced by {@see ensureString} and
+	 * recognized (case-insensitively) by {@see ensureBoolean}.
+	 * @since 4.4.0
+	 */
+	public const BOOL_TRUE = 'true';
+
+	/**
+	 * The string representation of PHP `false` produced by {@see ensureString} and
+	 * recognized (case-insensitively) by {@see ensureBoolean}.
+	 * @since 4.4.0
+	 */
+	public const BOOL_FALSE = 'false';
+
+	/**
+	 * Flag for {@see ensureArray()} that has restricted the parser to PHP-literal grammar:
+	 * `[...]` or `array(...)` only — no bare `(...)`, no unquoted strings, no legacy octal, no auto-wrap.
+	 * @since 4.4.0
+	 */
+	public const ARRAY_STRICT_GRAMMAR = (1 << 0);
+
+	/**
+	 * Flag for {@see ensureArray()} that has extended {@see ARRAY_STRICT_GRAMMAR} to also accept
+	 * the Prado `(...)` bare-paren form alongside `[...]` and `array(...)`.  Has no effect without
+	 * {@see ARRAY_STRICT_GRAMMAR}.
+	 * @since 4.4.0
+	 */
+	public const ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN = (1 << 1);
+
+	/**
+	 * Flag for {@see ensureArray()} that has converted a parse failure from the silent
+	 * single-element wrap into a thrown {@see TInvalidDataValueException}.
+	 * @since 4.4.0
+	 */
+	public const ARRAY_STRICT_ERRORS = (1 << 2);
+
+	/**
+	 * Step-9 fallback order for {@see _coerceUnionType}: non-null union members are tried in this
+	 * sequence — int → float → string → bool → aggregate/catch-all — so resolution is deterministic
+	 * regardless of reflection order.  `null` is absent; step 1 handles it before any fallback.
+	 * @var string[]
+	 * @since 4.4.0
+	 */
+	private const TYPE_COERCE_ORDER = [
+		self::TYPE_INT,
+		self::TYPE_FLOAT,
+		self::TYPE_STRING,
+		self::TYPE_BOOL,
+		self::TYPE_ARRAY,
+		self::TYPE_ITERABLE,
+		self::TYPE_OBJECT,
+		self::TYPE_MIXED,
+	];
+
 	/**
 	 * Converts a value to boolean type.
-	 * Note, string 'true' (case-insensitive) will be converted to true,
-	 * string 'false' (case-insensitive) will be converted to false.
-	 * If a string represents a non-zero number, it will be treated as true.
+	 *
+	 * Strings: `'true'` (case-insensitive) or a numeric string whose value is `!= 0` (loose
+	 * comparison) returns `true`; everything else — including `'false'`, `'yes'`, `'no'`,
+	 * `'on'`, `'off'`, `'0.0'`, `'0e0'` — returns `false`.
+	 * Non-strings: PHP's `(bool)` cast is applied directly.
 	 * @param mixed $value the value to be converted.
 	 * @return bool
 	 */
 	public static function ensureBoolean($value): bool
 	{
 		if (is_string($value)) {
-			return strcasecmp($value, 'true') == 0 || (is_numeric($value) && $value != 0);
+			return strcasecmp($value, self::BOOL_TRUE) === 0 || (is_numeric($value) && $value != 0);
 		} else {
 			return (bool) $value;
 		}
@@ -66,18 +194,21 @@ class TPropertyValue
 
 	/**
 	 * Converts a value to string type.
-	 * Note, a boolean value will be converted to 'true' if it is true
-	 * and 'false' if it is false.
+	 *
+	 * `bool` is converted to `'true'` or `'false'`.  A {@see TJavaScriptLiteral} is returned
+	 * as-is (pass-through) because it carries an opaque JavaScript expression that must not
+	 * be re-encoded; callers that consume it as a plain string rely on its `__toString` cast.
+	 * All other values are cast via `(string)`.
 	 * @param mixed $value the value to be converted.
-	 * @return string
+	 * @return string|\Stringable
 	 */
-	public static function ensureString($value): string
+	public static function ensureString($value): string|\Stringable
 	{
 		if (TJavaScript::isJsLiteral($value)) {
 			return $value;
 		}
 		if (is_bool($value)) {
-			return $value ? 'true' : 'false';
+			return $value ? self::BOOL_TRUE : self::BOOL_FALSE;
 		} else {
 			return (string) $value;
 		}
@@ -104,30 +235,6 @@ class TPropertyValue
 	}
 
 	/**
-	 * Converts a value to array type. If the value is a string and it is
-	 * in the form (a,b,c) then an array consisting of each of the elements
-	 * will be returned. If the value is a string and it is not in this form
-	 * then an array consisting of just the string will be returned. If the value
-	 * is not a string then
-	 * @param mixed $value the value to be converted.
-	 * @return array
-	 */
-	public static function ensureArray($value): array
-	{
-		if (is_string($value)) {
-			$value = trim($value);
-			$len = strlen($value);
-			if ($len >= 2 && $value[0] == '(' && $value[$len - 1] == ')') {
-				return eval('return array' . $value . ';');
-			} else {
-				return $len > 0 ? [$value] : [];
-			}
-		} else {
-			return (array) $value;
-		}
-	}
-
-	/**
 	 * Converts a value to object type.
 	 * @param mixed $value the value to be converted.
 	 * @return object
@@ -140,38 +247,72 @@ class TPropertyValue
 	/**
 	 * Converts a value to enum type.
 	 *
-	 * This method checks if the value is of the specified enumerable type.
-	 * A value is a valid enumerable value if it is equal to the name of a constant
-	 * in the specified enumerable type (class).
-	 * For more details about enumerable, see {@see \Prado\TEnumerable}.
+	 * When `$enums` is a class name, three styles are supported:
 	 *
-	 * For backward compatibility, this method also supports sanity
-	 * check of a string value to see if it is among the given list of strings.
+	 * - **PHP native `\BackedEnum`** *(4.4.0+)*: accepts an existing instance of the class,
+	 *   an exact backing value (via `tryFrom()`), or a case name (case-insensitive scan over
+	 *   `cases()`).  Returns the matching `\BackedEnum` instance; throws
+	 *   {@see TInvalidDataValueException} if none match.
+	 * - **{@see IEnumerable}** (including {@see TEnumerable}): accepts a constant name
+	 *   (case-insensitive); returns the canonical constant *value* (not the input string).
+	 * - **Any other class**: accepts any constant name present on the class; returns the value.
+	 *
+	 * When `$enums` is an array (or extra variadic arguments), the value is checked for strict
+	 * membership in the list; the matching element is returned unchanged.
 	 * @param mixed $value the value to be converted.
 	 * @param mixed $enums class name of the enumerable type, or array of valid enumeration values. If this is not an array,
 	 * the method considers its parameters are of variable length, and the second till the last parameters are enumeration values.
-	 * @throws TInvalidDataValueException if the original value is not in the string array.
-	 * @return string the valid enumeration value
+	 * @throws TInvalidDataValueException if the value does not match any valid enumeration entry.
+	 * @return \BackedEnum|string the valid enumeration value or instance.
 	 */
-	public static function ensureEnum($value, $enums): string
+	public static function ensureEnum($value, $enums): string|\BackedEnum
 	{
-		static $types = [];
 		if (func_num_args() === 2 && is_string($enums)) {
-			if ($enums instanceof TEnumerable) {
-				return $enums::hasConstant($value);
-			}
-			if (!isset($types[$enums])) {
-				$types[$enums] = TComponentReflection::getReflectionClassByType($enums);
-			}
-			if ($types[$enums]->hasConstant($value)) {
-				return $value;
+			if (is_a($enums, \BackedEnum::class, true)) {
+				if ($value instanceof $enums) {
+					return $value;
+				}
+				// Guard backing-type before tryFrom: float (and other non-scalar) would cause
+				// a native TypeError from tryFrom rather than a clean TInvalidDataValueException.
+				if (is_string($value) || is_int($value)) {
+					$case = $enums::tryFrom($value);
+					if ($case !== null) {
+						return $case;
+					}
+				}
+				if (is_string($value)) {
+					foreach ($enums::cases() as $case) {
+						if (strcasecmp($case->name, $value) === 0) {
+							return $case;
+						}
+					}
+				}
+				$labels = implode(' | ', array_map(fn (\BackedEnum $c) => $c->name . '=' . $c->value, $enums::cases()));
+				$errVal = is_scalar($value) || $value === null ? $value : get_debug_type($value);
+				throw new TInvalidDataValueException('propertyvalue_enumvalue_invalid', $errVal, $labels);
+			} elseif (is_a($enums, IEnumerable::class, true)) {
+				if (is_string($value)) {
+					$resolved = $enums::valueOfConstant($value, false);
+					if ($resolved !== null) {
+						return $resolved;
+					}
+				}
+				$constants = is_a($enums, TEnumerable::class, true)
+					? $enums::getReflectionClass()->getConstants()
+					: (TComponentReflection::getReflectionClassByType($enums)?->getConstants() ?? []);
 			} else {
-				throw new TInvalidDataValueException(
-					'propertyvalue_enumvalue_invalid',
-					$value,
-					implode(' | ', $types[$enums]->getConstants())
-				);
+				$ref = TComponentReflection::getReflectionClassByType($enums);
+				if ($ref?->hasConstant($value)) {
+					return $value;
+				}
+				$constants = $ref?->getConstants() ?? [];
 			}
+			$errVal = is_scalar($value) || $value === null ? $value : get_debug_type($value);
+			throw new TInvalidDataValueException(
+				'propertyvalue_enumvalue_invalid',
+				$errVal,
+				implode(' | ', $constants)
+			);
 		} elseif (!is_array($enums)) {
 			$enums = func_get_args();
 			array_shift($enums);
@@ -188,7 +329,7 @@ class TPropertyValue
 	 * @param mixed $value value to be converted
 	 * @return mixed input or NULL if input is empty
 	 */
-	public static function ensureNullIfEmpty($value)
+	public static function ensureNullIfEmpty($value): mixed
 	{
 		return empty($value) ? null : $value;
 	}
@@ -200,23 +341,23 @@ class TPropertyValue
 	 * an array of red, green, and blue, and index 0, 1, 2 or 'red', 'green', 'blue'.
 	 * In instance (A), $green is treated as a boolean flag for whether to convert
 	 * any web colors to their # hex color.  When red, green, or blue colors are specified
-	 * they are assumed be be bound [0...255], inclusive.
-	 * @param array|float|int|string $value String Web Color name or Hex Color (eg. '#336699'),
-	 *   array of [$r, $g, $b] or ['red' => $red, 'green' => $green, 'blue' = $blue], or
+	 * they are assumed to be bound [0...255], inclusive.
+	 * @param null|array|float|int|string $value String Web Color name or Hex Color (eg. '#336699'),
+	 *   array of [$r, $g, $b] or ['red' => $red, 'green' => $green, 'blue' => $blue], or
 	 *   int color (0x00RRGGBB [$blue is null]), or int red [0..255] when $blue is not null.
-	 * @param bool|float|int $green When $blue !== null, $green is an int color, otherwise its
+	 * @param bool|float|int $green When $blue !== null, $green is an int color; otherwise it's
 	 *   the flag to allow converting Web Color names to their web colors. Default true,
-	 *	 for allow web colors to translate into their # hex color.
+	 *   to allow web colors to translate into their # hex color.
 	 * @param null|float|int $blue The blue color. Default null for (A) or (B)
 	 * @return string The valid # hex color.
 	 * @since 4.3.0
 	 */
-	public static function ensureHexColor($value, $green = true, $blue = null)
+	public static function ensureHexColor(array|float|int|null|string $value, bool|float|int $green = true, float|int|null $blue = null): string
 	{
 		if (is_array($value)) {
-			$blue = array_key_exists('blue', $value) ? $value['blue'] : (array_key_exists(2, $value) ? $value[2] : null);
-			$green = array_key_exists('green', $value) ? $value['green'] : (array_key_exists(1, $value) ? $value[1] : true);
-			$value = array_key_exists('red', $value) ? $value['red'] : (array_key_exists(0, $value) ? $value[0] : null);
+			$blue = array_key_exists(self::COLOR_BLUE, $value) ? $value[self::COLOR_BLUE] : (array_key_exists(2, $value) ? $value[2] : null);
+			$green = array_key_exists(self::COLOR_GREEN, $value) ? $value[self::COLOR_GREEN] : (array_key_exists(1, $value) ? $value[1] : true);
+			$value = array_key_exists(self::COLOR_RED, $value) ? $value[self::COLOR_RED] : (array_key_exists(0, $value) ? $value[0] : null);
 		}
 		if (is_numeric($value)) {
 			$value = (int) $value;
@@ -237,23 +378,1087 @@ class TPropertyValue
 		$value = self::ensureString($value);
 		$len = strlen($value);
 		if ($green && $len > 0 && $value[0] !== '#') {
-			static $colors;
-			if (!$colors) {
-				$reflect = TComponentReflection::getReflectionClassByType(TWebColor::class);
-				$colors = $reflect->getConstants();
-				$colors = array_change_key_case($colors);
-			}
-			if (array_key_exists($lvalue = strtolower($value), $colors)) {
-				$value = $colors[$lvalue];
+			$hex = TWebColor::valueOfConstant($value, false);
+			if ($hex !== null) {
+				$value = $hex;
 				$len = strlen($value);
 			}
 		}
-		if ($len == 0 || $value[0] !== '#' || ($len !== 4 && $len !== 7) || !preg_match('/^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$/', $value)) {
+		if ($len === 0 || $value[0] !== '#' || ($len !== 4 && $len !== 7) || !preg_match('/^#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?$/', $value)) {
 			throw new TInvalidDataValueException('propertyvalue_invalid_hex_color', $value);
 		}
 		if ($len === 4) {
 			$value = preg_replace('/^#(.)(.)(.)$/', '#${1}${1}${2}${2}${3}${3}', $value);
 		}
 		return strtoupper($value);
+	}
+
+	// =========================================================================
+	// ensureArray() + Helpers
+	// =========================================================================
+
+	/**
+	 * Has converted a value to array type.
+	 *
+	 * Non-string values have been cast via PHP's `(array)` coercion.  String
+	 * values have been parsed as PHP-style array literals.  The behavior has
+	 * been controlled by two flag bits:
+	 *
+	 * - {@see ARRAY_STRICT_GRAMMAR} — has restricted the parser to the
+	 *   PHP-literal grammar (`[...]` short syntax or `array(...)` keyword
+	 *   form, no bare `(...)` array, no bare-word strings, no legacy octal,
+	 *   no auto-wrap of unbracketed input).
+	 * - {@see ARRAY_STRICT_ERRORS} — has converted the silent
+	 *   single-element fallback into a thrown
+	 *   {@see TInvalidDataValueException}.  Composable with the grammar flag.
+	 *
+	 * With `$flags === 0` (the default) the loose grammar has applied:
+	 * a trimmed string that has begun with `(` or `[` has been parsed in
+	 * place; anything else has been re-parsed as if wrapped in `(...)`, so
+	 * bare element lists like `red, green, blue` have resolved to
+	 * `['red', 'green', 'blue']`.  Loose grammar has accepted PHP-style
+	 * integers (decimal, hex `0xFF`, binary `0b101`, modern octal `0o17`,
+	 * with optional underscored separators; PHP 7's leading-zero octal form
+	 * has been dropped so `017` has read as decimal 17), floats
+	 * (`1.5`, `.5`, `1e10`, `1_000.5_5`), single- or double-quoted strings
+	 * with the common backslash escapes, the keywords `true`/`false`/`null`
+	 * (case-insensitive), unquoted bare-word strings, and nested arrays in
+	 * `(...)`, `[...]`, or `array(...)` form freely mixed.  Each element has
+	 * supported an optional `key => ` prefix (int or string literal); a
+	 * trailing comma has been accepted.  The bare-word rule has supported
+	 * template-attribute conventions like
+	 * `<com:TControl colors="red, green, blue"/>`.
+	 *
+	 * The parser has been regex-driven — no `eval()` — and the empty string
+	 * has always returned the empty array.
+	 *
+	 * @param mixed $value the value to be converted.
+	 * @param int $flags zero or more of {@see ARRAY_STRICT_GRAMMAR},
+	 *   {@see ARRAY_STRICT_ERRORS} combined with `|`.  Defaults to `0`
+	 *   (loose grammar, silent fallback).
+	 * @throws TInvalidDataValueException when {@see ARRAY_STRICT_ERRORS} has
+	 *   been set and the input has not parsed.
+	 * @return array
+	 */
+	public static function ensureArray($value, int $flags = 0): array
+	{
+		if (!is_string($value)) {
+			return (array) $value;
+		}
+		$value = trim($value);
+		$len = strlen($value);
+		if ($len === 0) {
+			return [];
+		}
+		$strict = ($flags & self::ARRAY_STRICT_GRAMMAR) !== 0;
+		$allowBareParen = $strict && ($flags & self::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN) !== 0;
+		$parsed = self::_parseArrayLiteral($value, $strict, $allowBareParen);
+		if ($parsed === null && !$strict) {
+			$parsed = self::_parseArrayLiteral('(' . $value . ')', false, false);
+		}
+		if ($parsed !== null) {
+			return $parsed;
+		}
+		if (($flags & self::ARRAY_STRICT_ERRORS) !== 0) {
+			throw new TInvalidDataValueException('propertyvalue_invalid_array_literal', $value);
+		}
+		return [$value];
+	}
+
+	/**
+	 * Recursive PCRE grammar that has matched a single PHP-style array
+	 * literal: `(...)` or `[...]` at every depth, comma-separated elements
+	 * with optional `key => ` prefixes and trailing comma, and the scalar
+	 * subset (int, float, quoted string, `true`/`false`, `null`, and the
+	 * bare-word fallback for unquoted strings).  Named subpatterns have
+	 * lived in a `(?(DEFINE) ... )` block and participated only via
+	 * `(?&name)` references.  {@see _parseArrayLiteral()} has used it as a
+	 * one-shot validator before the extraction pass.
+	 *
+	 * @since 4.4.0
+	 */
+	private const ARRAY_LITERAL_PATTERN = <<<'REGEX'
+		/\A
+		(?(DEFINE)
+			(?<ws>      \s* )
+			(?<sqstr>   ' (?: \\. | [^'\\] )* ' )
+			(?<dqstr>   " (?: \\. | [^"\\] )* " )
+			(?<str>     (?&sqstr) | (?&dqstr) )
+			(?<digits>  \d (?: _? \d )* )
+			(?<float>   [+-]? (?:
+							(?&digits) \. (?&digits)? (?: [eE] [+-]? (?&digits) )?
+						  | \. (?&digits)             (?: [eE] [+-]? (?&digits) )?
+						  | (?&digits) [eE] [+-]? (?&digits)
+						) )
+			(?<int>     [+-]? (?:
+							0[xX] [0-9a-fA-F] (?: _? [0-9a-fA-F] )*
+						  | 0[bB] [01]        (?: _? [01]        )*
+						  | 0[oO] [0-7]       (?: _? [0-7]       )*
+						  | (?&digits)
+						) )
+			(?<bool>    (?i: true | false ) \b )
+			(?<null>    (?i: null ) \b )
+			(?<bare>    [^,()[\]=\s] [^,()[\]=]* )
+			(?<scalar>  (?&float) | (?&int) | (?&str) | (?&bool) | (?&null) | (?&bare) )
+			(?<key>     (?&int) | (?&str) | (?&bare) )
+			(?<value>   (?&scalar) | (?&arr) )
+			(?<elem>    (?: (?&key) (?&ws) => (?&ws) )? (?&value) )
+			(?<elist>   (?&elem) (?: (?&ws) , (?&ws) (?&elem) )* (?: (?&ws) , )? )
+			(?<arr>     \( (?&ws) (?: (?&elist) (?&ws) )? \)
+					  | \[ (?&ws) (?: (?&elist) (?&ws) )? \]
+					  | (?i:array) (?&ws) \( (?&ws) (?: (?&elist) (?&ws) )? \) )
+		)
+		(?&ws) (?&arr) (?&ws)
+		\z/sx
+		REGEX;
+
+	/**
+	 * Strict variant of {@see ARRAY_LITERAL_PATTERN} that has matched only
+	 * what PHP itself has accepted as an array literal: `[...]` short syntax
+	 * or `array(...)` keyword form at every depth, and no bare-word strings,
+	 * no legacy `0[0-7]+` octal, no bare `(...)` array form.  Selected by
+	 * {@see _parseArrayLiteral()} when the caller has set
+	 * {@see ARRAY_STRICT_GRAMMAR}.
+	 *
+	 * @since 4.4.0
+	 */
+	private const ARRAY_LITERAL_PATTERN_STRICT = <<<'REGEX'
+		/\A
+		(?(DEFINE)
+			(?<ws>      \s* )
+			(?<sqstr>   ' (?: \\. | [^'\\] )* ' )
+			(?<dqstr>   " (?: \\. | [^"\\] )* " )
+			(?<str>     (?&sqstr) | (?&dqstr) )
+			(?<digits>  \d (?: _? \d )* )
+			(?<float>   [+-]? (?:
+							(?&digits) \. (?&digits)? (?: [eE] [+-]? (?&digits) )?
+						  | \. (?&digits)             (?: [eE] [+-]? (?&digits) )?
+						  | (?&digits) [eE] [+-]? (?&digits)
+						) )
+			(?<int>     [+-]? (?:
+							0[xX] [0-9a-fA-F] (?: _? [0-9a-fA-F] )*
+						  | 0[bB] [01]        (?: _? [01]        )*
+						  | 0[oO] [0-7]       (?: _? [0-7]       )*
+						  | 0 (?! [0-9_] )
+						  | [1-9] (?: _? \d )*
+						) )
+			(?<bool>    (?i: true | false ) \b )
+			(?<null>    (?i: null ) \b )
+			(?<scalar>  (?&float) | (?&int) | (?&str) | (?&bool) | (?&null) )
+			(?<key>     (?&int) | (?&str) )
+			(?<value>   (?&scalar) | (?&arr) )
+			(?<elem>    (?: (?&key) (?&ws) => (?&ws) )? (?&value) )
+			(?<elist>   (?&elem) (?: (?&ws) , (?&ws) (?&elem) )* (?: (?&ws) , )? )
+			(?<arr>     \[ (?&ws) (?: (?&elist) (?&ws) )? \]
+					  | (?i:array) (?&ws) \( (?&ws) (?: (?&elist) (?&ws) )? \) )
+		)
+		(?&ws) (?&arr) (?&ws)
+		\z/sx
+		REGEX;
+
+	/**
+	 * Extension of {@see ARRAY_LITERAL_PATTERN_STRICT} that has additionally
+	 * accepted the Prado bare-paren `(...)` array form alongside `[...]` and
+	 * `array(...)`.  The scalar subset has remained strict — no bare-word
+	 * strings, no legacy octal.  Selected by {@see _parseArrayLiteral()} when
+	 * the caller has set both {@see ARRAY_STRICT_GRAMMAR} and
+	 * {@see ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN}.
+	 *
+	 * @since 4.4.0
+	 */
+	private const ARRAY_LITERAL_PATTERN_STRICT_WITH_PAREN = <<<'REGEX'
+		/\A
+		(?(DEFINE)
+			(?<ws>      \s* )
+			(?<sqstr>   ' (?: \\. | [^'\\] )* ' )
+			(?<dqstr>   " (?: \\. | [^"\\] )* " )
+			(?<str>     (?&sqstr) | (?&dqstr) )
+			(?<digits>  \d (?: _? \d )* )
+			(?<float>   [+-]? (?:
+							(?&digits) \. (?&digits)? (?: [eE] [+-]? (?&digits) )?
+						  | \. (?&digits)             (?: [eE] [+-]? (?&digits) )?
+						  | (?&digits) [eE] [+-]? (?&digits)
+						) )
+			(?<int>     [+-]? (?:
+							0[xX] [0-9a-fA-F] (?: _? [0-9a-fA-F] )*
+						  | 0[bB] [01]        (?: _? [01]        )*
+						  | 0[oO] [0-7]       (?: _? [0-7]       )*
+						  | 0 (?! [0-9_] )
+						  | [1-9] (?: _? \d )*
+						) )
+			(?<bool>    (?i: true | false ) \b )
+			(?<null>    (?i: null ) \b )
+			(?<scalar>  (?&float) | (?&int) | (?&str) | (?&bool) | (?&null) )
+			(?<key>     (?&int) | (?&str) )
+			(?<value>   (?&scalar) | (?&arr) )
+			(?<elem>    (?: (?&key) (?&ws) => (?&ws) )? (?&value) )
+			(?<elist>   (?&elem) (?: (?&ws) , (?&ws) (?&elem) )* (?: (?&ws) , )? )
+			(?<arr>     \( (?&ws) (?: (?&elist) (?&ws) )? \)
+					  | \[ (?&ws) (?: (?&elist) (?&ws) )? \]
+					  | (?i:array) (?&ws) \( (?&ws) (?: (?&elist) (?&ws) )? \) )
+		)
+		(?&ws) (?&arr) (?&ws)
+		\z/sx
+		REGEX;
+
+	/**
+	 * Anchored PCRE pattern that has matched a single PHP-style integer
+	 * literal at the current position: decimal (`123`, `-7`, `1_000`), hex
+	 * (`0xFF`, `0xFF_FF`), binary (`0b101`, `0b1010_0011`), and modern octal
+	 * (`0o17`, `0O17`).  PHP 7's leading-zero octal form (`017` reading as
+	 * 15, not 17) has been intentionally dropped — the silent meaning-shift
+	 * has been a long-standing footgun and PHP 8.1 has introduced the
+	 * explicit `0o` prefix specifically to disambiguate.  An input like
+	 * `017` has therefore been read as decimal 17 here.  PHP's "underscores
+	 * between digits only" rule has been enforced by the pattern shape, so
+	 * `0x_FF`, `1_`, and `1__0` have all been rejected.
+	 *
+	 * @since 4.4.0
+	 */
+	private const INT_LITERAL_PATTERN = '/\G[+-]?(?:0[xX][0-9a-fA-F](?:_?[0-9a-fA-F])*|0[bB][01](?:_?[01])*|0[oO][0-7](?:_?[0-7])*|\d(?:_?\d)*)/A';
+
+	/**
+	 * Anchored PCRE pattern that has matched a single PHP-style float literal
+	 * at the current position: `1.5`, `.5`, `1.`, `1e3`, `-1.5E-3`, with
+	 * optional underscored digit separators in any of the integer,
+	 * fractional, and exponent parts.  Float has been attempted before int
+	 * so that `1.5` and `1e3` have resolved to PHP `float`.
+	 *
+	 * @since 4.4.0
+	 */
+	private const FLOAT_LITERAL_PATTERN = '/\G[+-]?(?:\d(?:_?\d)*\.(?:\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|\.\d(?:_?\d)*(?:[eE][+-]?\d(?:_?\d)*)?|\d(?:_?\d)*[eE][+-]?\d(?:_?\d)*)/A';
+
+	/**
+	 * Has parsed a validated PHP-style array literal into the corresponding
+	 * PHP array, returning `null` on parse failure so {@see ensureArray()}
+	 * has fallen back to the single-element wrapping.  Both `(...)` and
+	 * `[...]` delimiters have been accepted at every depth and freely mixed.
+	 * {@see ARRAY_LITERAL_PATTERN} has performed the one-shot validation;
+	 * once it has matched, the extraction pass has been written without
+	 * error handling.
+	 *
+	 * @param string $s the trimmed input.  Under loose grammar it may begin
+	 *   with `(`, `[`, `array(`, or — when wrapped by {@see ensureArray()} —
+	 *   any bare element list.  Under strict grammar it must begin with `[`
+	 *   or `array(` (or `(` when `$allowBareParen` is `true`).
+	 * @param bool $strict when `true`, select {@see ARRAY_LITERAL_PATTERN_STRICT}
+	 *   (or {@see ARRAY_LITERAL_PATTERN_STRICT_WITH_PAREN} when `$allowBareParen`
+	 *   is also `true`) and disable the bare-word fallback inside the parser helpers.
+	 * @param bool $allowBareParen when `true` and `$strict` is also `true`, select
+	 *   {@see ARRAY_LITERAL_PATTERN_STRICT_WITH_PAREN} so the Prado `(...)` form
+	 *   is accepted alongside `[...]` and `array(...)`.  Has no effect when
+	 *   `$strict` is `false` because the loose grammar already accepts `(...)`.
+	 * @return ?array the parsed array, or `null` on syntax error.
+	 * @since 4.4.0
+	 */
+	private static function _parseArrayLiteral(string $s, bool $strict = false, bool $allowBareParen = false): ?array
+	{
+		if ($strict) {
+			$pattern = $allowBareParen
+				? self::ARRAY_LITERAL_PATTERN_STRICT_WITH_PAREN
+				: self::ARRAY_LITERAL_PATTERN_STRICT;
+		} else {
+			$pattern = self::ARRAY_LITERAL_PATTERN;
+		}
+		if (!preg_match($pattern, $s)) {
+			return null;
+		}
+		$pos = 0;
+		self::_skipWs($s, $pos);
+		// Both grammars have accepted the `array(...)` keyword form at the
+		// top level; the helper has advanced `$pos` past the keyword when
+		// present so {@see _consumeArray()} has found `(` directly.
+		self::_skipArrayKeyword($s, $pos);
+		return self::_consumeArray($s, $pos, $strict);
+	}
+
+	/**
+	 * Has advanced `$pos` past the optional `array` keyword (case-insensitive)
+	 * and any whitespace between it and the following `(`, so callers have
+	 * been able to treat `array(1, 2)` and `(1, 2)` uniformly from there on.
+	 * When `$pos` has not pointed at `array` followed by `(`, the cursor has
+	 * been left unchanged.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @since 4.4.0
+	 */
+	private static function _skipArrayKeyword(string $s, int &$pos): void
+	{
+		$len = strlen($s);
+		if ($pos + 5 > $len || strncasecmp(substr($s, $pos, 5), 'array', 5) !== 0) {
+			return;
+		}
+		$look = $pos + 5;
+		while ($look < $len && ($s[$look] === ' ' || $s[$look] === "\t"
+			|| $s[$look] === "\n" || $s[$look] === "\r"
+			|| $s[$look] === "\f" || $s[$look] === "\v")
+		) {
+			$look++;
+		}
+		if ($look < $len && $s[$look] === '(') {
+			$pos = $look;
+		}
+	}
+
+	/**
+	 * Has advanced `$pos` past any ASCII whitespace.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor.
+	 * @since 4.4.0
+	 */
+	private static function _skipWs(string $s, int &$pos): void
+	{
+		$len = strlen($s);
+		while ($pos < $len && ($s[$pos] === ' ' || $s[$pos] === "\t"
+			|| $s[$pos] === "\n" || $s[$pos] === "\r"
+			|| $s[$pos] === "\f" || $s[$pos] === "\v")
+		) {
+			$pos++;
+		}
+	}
+
+	/**
+	 * Has consumed an array literal at `$pos` (which has pointed at `(` or
+	 * `[`) and returned the parsed array.  Mixed delimiters at deeper nesting
+	 * have been handled by recursive calls.  Auto-numbered keys have followed
+	 * PHP's "next integer greater than the largest int key seen so far" rule.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @param bool $strict propagated to nested {@see _consumeValue()} /
+	 *   {@see _consumeKey()} calls so they have skipped the bare-word
+	 *   fallback under strict grammar.
+	 * @return array the parsed array.
+	 * @since 4.4.0
+	 */
+	private static function _consumeArray(string $s, int &$pos, bool $strict = false): array
+	{
+		$len = strlen($s);
+		$close = $s[$pos] === '(' ? ')' : ']';
+		$pos++;
+		$result = [];
+		$nextAutoKey = 0;
+		self::_skipWs($s, $pos);
+		// The validator guarantees a matching close bracket exists; the
+		// `$pos < $len` guard has only protected against a validator-parser
+		// drift turning into an infinite loop on PHP 8.x's out-of-bounds
+		// string access returning the empty string.
+		while ($pos < $len && $s[$pos] !== $close) {
+			$saved = $pos;
+			$key = self::_consumeKey($s, $pos, $strict);
+			self::_skipWs($s, $pos);
+			if ($key !== null && isset($s[$pos + 1]) && $s[$pos] === '=' && $s[$pos + 1] === '>') {
+				$pos += 2;
+				self::_skipWs($s, $pos);
+				$result[$key] = self::_consumeValue($s, $pos, $strict);
+				if (is_int($key) && $key >= $nextAutoKey) {
+					$nextAutoKey = $key + 1;
+				}
+			} else {
+				$pos = $saved;
+				$result[$nextAutoKey++] = self::_consumeValue($s, $pos, $strict);
+			}
+			self::_skipWs($s, $pos);
+			if ($pos < $len && $s[$pos] === ',') {
+				$pos++;
+				self::_skipWs($s, $pos);
+			}
+		}
+		if ($pos < $len) {
+			$pos++;
+		}
+		return $result;
+	}
+
+	/**
+	 * Has consumed a value (scalar or nested array) at `$pos`.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @param bool $strict propagated to {@see _consumeArray()} and
+	 *   {@see _consumeScalar()} so the bare-word fallback has been disabled
+	 *   under strict grammar.
+	 * @return mixed the parsed value.
+	 * @since 4.4.0
+	 */
+	private static function _consumeValue(string $s, int &$pos, bool $strict = false): mixed
+	{
+		$c = $s[$pos];
+		if ($c === '(' || $c === '[') {
+			return self::_consumeArray($s, $pos, $strict);
+		}
+		// The `array(...)` keyword form has been recognized at every depth in
+		// both grammars; the helper has advanced `$pos` past `array` and the
+		// following whitespace so the array body has been consumed normally.
+		if (($c === 'a' || $c === 'A')
+			&& $pos + 5 <= strlen($s)
+			&& strncasecmp(substr($s, $pos, 5), 'array', 5) === 0
+		) {
+			$saved = $pos;
+			self::_skipArrayKeyword($s, $pos);
+			if ($pos !== $saved) {
+				return self::_consumeArray($s, $pos, $strict);
+			}
+		}
+		return self::_consumeScalar($s, $pos, $strict);
+	}
+
+	/**
+	 * Has tentatively consumed a key (quoted string, integer literal, or
+	 * bare-word string) at `$pos`.  An int key has committed only when
+	 * directly followed by `=>` (after optional whitespace) so the bare-word
+	 * fallback can still claim the same span when the element has turned out
+	 * not to be a key⇒value pair.  Returns `null` without advancing `$pos`
+	 * when no key form has matched at all.
+	 *
+	 * The caller has decided whether to commit (when `=>` has followed) or
+	 * restore `$pos` and reparse the span as a value.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @param bool $strict when `true`, the bare-word key fallback has been
+	 *   skipped so non-int / non-string spans have returned `null` and the
+	 *   caller has reparsed the span as a value.
+	 * @return null|int|string the key, or `null` if no key has been present.
+	 * @since 4.4.0
+	 */
+	private static function _consumeKey(string $s, int &$pos, bool $strict = false): null|int|string
+	{
+		if ($s[$pos] === '"' || $s[$pos] === "'") {
+			$str = self::_tryConsumeString($s, $pos);
+			if ($str !== null) {
+				return $str;
+			}
+		}
+		if (preg_match(self::INT_LITERAL_PATTERN, $s, $m, 0, $pos)) {
+			$end = $pos + strlen($m[0]);
+			$body = ($m[0][0] === '+' || $m[0][0] === '-') ? substr($m[0], 1) : $m[0];
+			$isPrefixed = strlen($body) >= 2 && $body[0] === '0'
+				&& ($body[1] === 'x' || $body[1] === 'X'
+					|| $body[1] === 'b' || $body[1] === 'B'
+					|| $body[1] === 'o' || $body[1] === 'O');
+			$isFloatPrefix = !$isPrefixed && isset($s[$end])
+				&& ($s[$end] === '.' || $s[$end] === 'e' || $s[$end] === 'E');
+			if (!$isFloatPrefix) {
+				$look = $end;
+				while (isset($s[$look]) && ($s[$look] === ' ' || $s[$look] === "\t"
+					|| $s[$look] === "\n" || $s[$look] === "\r"
+					|| $s[$look] === "\f" || $s[$look] === "\v")
+				) {
+					$look++;
+				}
+				if (isset($s[$look]) && $s[$look] === '=' && isset($s[$look + 1])
+					&& $s[$look + 1] === '>'
+				) {
+					$pos = $end;
+					return self::_intFromLiteral($m[0]);
+				}
+			}
+		}
+		if ($strict) {
+			return null;
+		}
+		$bare = self::_consumeBareWord($s, $pos);
+		return $bare !== '' ? $bare : null;
+	}
+
+	/**
+	 * Has consumed a scalar at `$pos` in priority order: quoted string, float,
+	 * int, reserved keyword (`null`/`true`/`false`), and — under loose grammar
+	 * only — bare-word string.  Each numeric or keyword candidate has had to
+	 * reach an element-end (top-level `,`, `=>`, `)`, `]`, or end of input)
+	 * to commit; otherwise the span has fallen through to the bare-word
+	 * fallback so that mistyped or suffixed tokens (`1abc`, `truely`, `0xZZ`)
+	 * have become strings rather than being silently truncated.  Under strict
+	 * grammar the bare-word fallback has been disabled — the strict validator
+	 * has already rejected any input that would have reached it.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @param bool $strict whether to skip the bare-word fallback.
+	 * @return null|bool|float|int|string the parsed scalar.
+	 * @since 4.4.0
+	 */
+	private static function _consumeScalar(string $s, int &$pos, bool $strict = false): null|bool|float|int|string
+	{
+		if ($s[$pos] === '"' || $s[$pos] === "'") {
+			$str = self::_tryConsumeString($s, $pos);
+			if ($str !== null) {
+				return $str;
+			}
+		}
+		if (preg_match(self::FLOAT_LITERAL_PATTERN, $s, $m, 0, $pos)) {
+			$end = $pos + strlen($m[0]);
+			if (self::_atElementEnd($s, $end)) {
+				$pos = $end;
+				return self::_floatFromLiteral($m[0]);
+			}
+		}
+		if (preg_match(self::INT_LITERAL_PATTERN, $s, $m, 0, $pos)) {
+			$end = $pos + strlen($m[0]);
+			if (self::_atElementEnd($s, $end)) {
+				$pos = $end;
+				return self::_intFromLiteral($m[0]);
+			}
+		}
+		if (preg_match('/\Gnull\b/iA', $s, $m, 0, $pos) && self::_atElementEnd($s, $pos + 4)) {
+			$pos += 4;
+			return null;
+		}
+		if (preg_match('/\Gtrue\b/iA', $s, $m, 0, $pos) && self::_atElementEnd($s, $pos + 4)) {
+			$pos += 4;
+			return true;
+		}
+		if (preg_match('/\Gfalse\b/iA', $s, $m, 0, $pos) && self::_atElementEnd($s, $pos + 5)) {
+			$pos += 5;
+			return false;
+		}
+		if ($strict) {
+			return null;
+		}
+		return self::_consumeBareWord($s, $pos);
+	}
+
+	/**
+	 * Has converted a validated PHP-style integer-literal string to its PHP
+	 * `int` value, handling sign, underscored digit separators, and three
+	 * base prefixes: `0x`/`0X` (hex), `0b`/`0B` (binary), and `0o`/`0O`
+	 * (modern octal, PHP 8.1+).  PHP 7's leading-zero octal form has been
+	 * intentionally dropped — `017` resolves to decimal 17, not octal 15,
+	 * matching PHP 8.1's direction of forcing the explicit `0o` prefix for
+	 * octal intent and avoiding the long-standing leading-zero footgun.
+	 *
+	 * @param string $raw the validated literal — the regex has already
+	 *   guaranteed a well-formed form.
+	 * @return int the integer value.
+	 * @since 4.4.0
+	 */
+	private static function _intFromLiteral(string $raw): int
+	{
+		$sign = 1;
+		if ($raw[0] === '+') {
+			$raw = substr($raw, 1);
+		} elseif ($raw[0] === '-') {
+			$sign = -1;
+			$raw = substr($raw, 1);
+		}
+		$raw = str_replace('_', '', $raw);
+		if (strlen($raw) >= 2 && $raw[0] === '0') {
+			$p = $raw[1];
+			if ($p === 'x' || $p === 'X') {
+				return $sign * intval(substr($raw, 2), 16);
+			}
+			if ($p === 'b' || $p === 'B') {
+				return $sign * intval(substr($raw, 2), 2);
+			}
+			if ($p === 'o' || $p === 'O') {
+				return $sign * intval(substr($raw, 2), 8);
+			}
+		}
+		return $sign * (int) $raw;
+	}
+
+	/**
+	 * Has converted a validated PHP-style float-literal string to its PHP
+	 * `float` value.  Digit-separator underscores have been stripped before
+	 * casting so literals like `1_000.5_5` or `1.5e1_0` have resolved
+	 * correctly — PHP's `(float)` cast has not honored underscores in
+	 * numeric strings.
+	 *
+	 * @param string $raw the validated literal.
+	 * @return float the float value.
+	 * @since 4.4.0
+	 */
+	private static function _floatFromLiteral(string $raw): float
+	{
+		return (float) str_replace('_', '', $raw);
+	}
+
+	/**
+	 * Has tentatively consumed a single- or double-quoted string at `$pos`,
+	 * returning `null` and restoring `$pos` to its entry value when the input
+	 * has not provided a matching close quote.  An unterminated literal has
+	 * therefore yielded the bare-word fallback in the caller — the original
+	 * quote character has remained part of the resulting string.
+	 *
+	 * Escape sequences supported by each quote style:
+	 *
+	 * - single-quoted: `\\` → `\`, `\'` → `'`; any other `\X` has been
+	 *   preserved verbatim, matching PHP's `'...'` literal behavior.
+	 * - double-quoted: `\n`, `\r`, `\t`, `\v`, `\f`, `\e`, `\0`, `\\`, `\"`,
+	 *   and `\$` have resolved to the corresponding byte; any other `\X`
+	 *   has been preserved verbatim.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @return ?string the decoded string contents (without surrounding
+	 *   quotes), or `null` when the string has been unterminated.
+	 * @since 4.4.0
+	 */
+	private static function _tryConsumeString(string $s, int &$pos): ?string
+	{
+		static $dqEscapes = [
+			'n' => "\n", 'r' => "\r", 't' => "\t",
+			'v' => "\v", 'f' => "\f", 'e' => "\x1b",
+			'0' => "\0", '\\' => '\\', '"' => '"', '$' => '$',
+		];
+		$saved = $pos;
+		$quote = $s[$pos];
+		$pos++;
+		$len = strlen($s);
+		$result = '';
+		while ($pos < $len && $s[$pos] !== $quote) {
+			if ($s[$pos] === '\\' && $pos + 1 < $len) {
+				$next = $s[$pos + 1];
+				if ($quote === "'") {
+					if ($next === '\\' || $next === "'") {
+						$result .= $next;
+						$pos += 2;
+						continue;
+					}
+				} elseif (isset($dqEscapes[$next])) {
+					$result .= $dqEscapes[$next];
+					$pos += 2;
+					continue;
+				}
+			}
+			$result .= $s[$pos];
+			$pos++;
+		}
+		if ($pos >= $len) {
+			$pos = $saved;
+			return null;
+		}
+		$pos++;
+		return $result;
+	}
+
+	/**
+	 * Has consumed a bare-word string at `$pos` — every character up to (but
+	 * not including) the next top-level delimiter (`,`, `=>`, `)`, `]`, or
+	 * end of input), with the trailing whitespace trimmed.  When `$pos` has
+	 * already sat at a delimiter, no characters have been consumed and the
+	 * empty string has been returned so the caller can decide whether the
+	 * absence of a token has been an error.
+	 *
+	 * @param string $s the source string.
+	 * @param int &$pos the position cursor (in/out).
+	 * @return string the trimmed bare-word, possibly empty.
+	 * @since 4.4.0
+	 */
+	private static function _consumeBareWord(string $s, int &$pos): string
+	{
+		$len = strlen($s);
+		if ($pos >= $len) {
+			return '';
+		}
+		$c = $s[$pos];
+		if ($c === ',' || $c === ')' || $c === ']'
+			|| ($c === '=' && isset($s[$pos + 1]) && $s[$pos + 1] === '>')
+		) {
+			return '';
+		}
+		$start = $pos;
+		$pos++;
+		while ($pos < $len) {
+			$c = $s[$pos];
+			if ($c === ',' || $c === ')' || $c === ']') {
+				break;
+			}
+			if ($c === '=' && isset($s[$pos + 1]) && $s[$pos + 1] === '>') {
+				break;
+			}
+			$pos++;
+		}
+		return rtrim(substr($s, $start, $pos - $start));
+	}
+
+	/**
+	 * Has reported whether the next non-whitespace character at `$pos` ends
+	 * the current element — a top-level `,`, `=>`, `)`, `]`, or end of input.
+	 * Used by {@see _consumeScalar()} to decide when a number or reserved
+	 * keyword has committed cleanly versus fallen through to bare-word.
+	 *
+	 * @param string $s the source string.
+	 * @param int $pos the position to inspect (not advanced).
+	 * @return bool whether `$pos` has been at an element boundary.
+	 * @since 4.4.0
+	 */
+	private static function _atElementEnd(string $s, int $pos): bool
+	{
+		$len = strlen($s);
+		while ($pos < $len && ($s[$pos] === ' ' || $s[$pos] === "\t"
+			|| $s[$pos] === "\n" || $s[$pos] === "\r"
+			|| $s[$pos] === "\f" || $s[$pos] === "\v")
+		) {
+			$pos++;
+		}
+		if ($pos >= $len) {
+			return true;
+		}
+		$c = $s[$pos];
+		if ($c === ',' || $c === ')' || $c === ']') {
+			return true;
+		}
+		return $c === '=' && isset($s[$pos + 1]) && $s[$pos + 1] === '>';
+	}
+
+	// =========================================================================
+	// applyProperty() + Helpers
+	// =========================================================================
+
+	/**
+	 * Sets a named property on an object, coercing the value toward the setter's declared
+	 * parameter type before assignment. The value may be of any type — strings from XML
+	 * config, booleans from PHP config arrays, objects from template expressions, etc.
+	 * The final assignment always goes through the object's normal `__set()` chain so that
+	 * events, behaviors, and `js`-prefix wrapping are preserved.
+	 *
+	 * This is the recommended entry point for framework internals (configuration loaders,
+	 * template parsers, behavior injectors) that assign a property whose source type may
+	 * not match the setter's declared type.
+	 *
+	 * @param object $object the target object.
+	 * @param string $property the property name without the `set` prefix, e.g. `'Enabled'`.
+	 * @param mixed $value the value to set; coerced to the setter's declared type.
+	 * @since 4.4.0
+	 */
+	public static function applyProperty(object $object, string $property, mixed $value): void
+	{
+		$setter = 'set' . $property;
+		if (method_exists($object, $setter)
+			|| ($object instanceof TComponent && ($object->hasMethod($setter) || $object->getBehaviorsEnabled()))
+		) {
+			self::coerceForSetter($object, $setter, $value);
+		}
+		// Goes through __set() — preserves event/behavior/JS-prefix logic
+		$object->$property = $value;
+	}
+
+	/**
+	 * Coerces a value in-place to match a type hint declared on an object's setter.
+	 *
+	 * `$value` is taken by reference so that no copy is made at the call boundary
+	 * when the caller holds a large value. The value is only coerced when a concrete
+	 * type hint exists on the first parameter of `$method`; it is left unchanged
+	 * when no hint is found.
+	 *
+	 * Reflection and behavior-method lookup are delegated to
+	 * {@see TComponentReflection::getReflectionMethodByType()}, which maintains a
+	 * shared framework-wide cache and automatically searches active behaviors on
+	 * {@see TComponent} instances when the class itself does not declare the setter.
+	 *
+	 * @param object|string $classOrObject the class name, or an object instance (preferred
+	 *   when the object may carry active behaviors that expose the setter).
+	 * @param string $method the setter method name, e.g. `'setEnabled'`.
+	 * @param mixed &$value the value to coerce in-place.
+	 * @since 4.4.0
+	 */
+	public static function coerceForSetter(string|object $classOrObject, string $method, mixed &$value): void
+	{
+		$ref = TComponentReflection::getReflectionMethodByType($classOrObject, $method);
+		$type = $ref !== null ? ($ref->getParameters()[0] ?? null)?->getType() : null;
+		$value = self::coerceToType($value, $type);
+	}
+
+	/**
+	 * Coerces a value to the specified reflection type using the existing `ensure*`
+	 * helpers for scalar types and special handling for backed enums and union types.
+	 *
+	 * | Type hint             | Behavior                                           |
+	 * |-----------------------|----------------------------------------------------|
+	 * | `bool`                | {@see ensureBoolean} — 'true'/'false' aware        |
+	 * | `int`                 | {@see ensureInteger}                               |
+	 * | `float`               | {@see ensureFloat}                                 |
+	 * | `string`              | {@see ensureString} — bool→'true'/'false' aware    |
+	 * | `array` / `iterable`  | {@see ensureArray} — `(a,b,c)`/`[a,b,c]` supported |
+	 * | `object`              | {@see ensureObject}                                |
+	 * | `mixed` / `null`      | pass-through / `null`                              |
+	 * | Backed enum class     | `tryFrom()` exact backing value, then case-insensitive case-name scan |
+	 * | {@see IEnumerable}    | case-insensitive `valueOfConstant()` name→value; unknown → pass-through |
+	 * | Union type            | heuristic chain — see {@see _coerceUnionType}      |
+	 * | Nullable (`?T`)       | empty string / `null` input → `null`               |
+	 *
+	 * @param mixed $value the value to coerce.
+	 * @param null|\ReflectionType $type the reflection type to coerce toward, or `null`
+	 *   to return `$value` unchanged.
+	 * @return mixed the coerced value.
+	 * @since 4.4.0
+	 */
+	public static function coerceToType(mixed $value, ?\ReflectionType $type): mixed
+	{
+		if ($type === null) {
+			return $value;
+		}
+		if ($type instanceof \ReflectionNamedType) {
+			// Actual null, or empty string when the type permits null
+			if ($value === null || ($type->allowsNull() && $value === '')) {
+				return null;
+			}
+			return match ($type->getName()) {
+				self::TYPE_BOOL => self::ensureBoolean($value),
+				self::TYPE_INT => self::ensureInteger($value),
+				self::TYPE_FLOAT => self::ensureFloat($value),
+				self::TYPE_STRING => self::ensureString($value),
+				self::TYPE_ARRAY, self::TYPE_ITERABLE => self::ensureArray($value),
+				self::TYPE_OBJECT => self::ensureObject($value),
+				self::TYPE_MIXED, self::TYPE_NULL => $value,
+				default => self::_coerceToClass($value, $type->getName()),
+			};
+		}
+		if ($type instanceof \ReflectionUnionType) {
+			return self::_coerceUnionType($value, $type);
+		}
+		// ReflectionIntersectionType and any future reflection types: pass through
+		return $value;
+	}
+
+	/**
+	 * Coerces a value toward a non-builtin class type that Prado recognises as an
+	 * enumerable domain.  All other class types are returned unchanged.
+	 *
+	 * - **PHP 8.1 backed enums** (`BackedEnum`): first tries `$className::tryFrom($value)`
+	 *   for an exact backing-value match (e.g. `'red'` → `Color::Red`).  On a miss, a
+	 *   case-insensitive name scan runs over `$className::cases()`, so the PHP case name
+	 *   may be supplied in any casing (`'Red'`, `'RED'`, `'rEd'` all resolve to
+	 *   `Color::Red`).  If neither lookup succeeds the original `$value` is returned so
+	 *   the TypeError surfaces at the setter boundary.
+	 *
+	 * - **{@see IEnumerable} implementors** (including {@see TEnumerable} subclasses):
+	 *   resolves a constant *name* to its *value* via `valueOfConstant($value, false)`
+	 *   (case-insensitive).  For the conventional case where name equals value
+	 *   (`const Left = 'Left'`), any casing of the name (`'left'`, `'LEFT'`) normalizes
+	 *   to the canonical value `'Left'`.  When name differs from value (`const Alpha = 'a'`),
+	 *   any casing of the name resolves to the value `'a'`.  If no constant name matches,
+	 *   `$value` is returned unchanged so the TypeError surfaces at the setter boundary.
+	 *
+	 * @param mixed $value the value to coerce.
+	 * @param string $className the target class or interface name.
+	 * @return mixed the coerced value, or `$value` unchanged if coercion is not possible.
+	 * @since 4.4.0
+	 */
+	private static function _coerceToClass(mixed $value, string $className): mixed
+	{
+		if (is_a($className, \BackedEnum::class, true) && (is_string($value) || is_int($value))) {
+			$case = $className::tryFrom($value);
+			if ($case !== null) {
+				return $case;
+			}
+			if (is_string($value)) {
+				foreach ($className::cases() as $case) {
+					if (strcasecmp($case->name, $value) === 0) {
+						return $case;
+					}
+				}
+			}
+			return $value;
+		}
+		if (is_a($className, IEnumerable::class, true) && is_string($value)) {
+			return $className::valueOfConstant($value, false) ?? $value;
+		}
+		return $value;
+	}
+
+	/**
+	 * Coerces a value toward one of the types in a PHP union type hint.
+	 *
+	 * When the union is unambiguous (one non-null member) the single type is used
+	 * directly. For genuinely ambiguous unions a priority-ordered heuristic chain
+	 * selects the most appropriate type:
+	 *
+	 * 1. `null` / empty string → `null` (when `null` is in the union)
+	 * 2. `array` / typed object value whose type appears in the union → use it
+	 *    (pre-empts step 3 to prevent `(string)$array = "Array"` and
+	 *    `(string)$object` TypeError when the value has a native match)
+	 * 3. `string` in union → pass through / `ensureString` if not already a string
+	 *    (scalar non-string values such as `int` and `bool` are coerced to their
+	 *    string representation here when `string` is present in the union)
+	 * 4. Non-string typed value whose PHP type directly matches a union member → use it
+	 *    (only reached when `string` is NOT in the union); then PHP-compatible
+	 *    widening: `bool` → `int`/`float`, `int` → `float`
+	 * 5. `(a,b,c)` / `[a,b,c]` / `array(a,b,c)` notation + `array`/`iterable` in union → {@see ensureArray}
+	 * 6. `'true'`/`'false'` literal + `bool` in union → {@see ensureBoolean}
+	 * 7. Numeric value + `int`/`float` in union → float when `.` or `e`/`E` (scientific notation)
+	 *    is present, int otherwise; matching PHP non-strict behavior
+	 * 8. Non-builtin class types (backed enums, {@see IEnumerable} implementors) → {@see _coerceToClass}
+	 * 9. Fallback: first non-`null` type sorted by {@see TYPE_COERCE_ORDER}
+	 *
+	 * @param mixed $value the value to coerce.
+	 * @param \ReflectionUnionType $type the union type.
+	 * @return mixed the coerced value.
+	 * @since 4.4.0
+	 */
+	private static function _coerceUnionType(mixed $value, \ReflectionUnionType $type): mixed
+	{
+		/** @var \ReflectionNamedType[] $named */
+		$named = array_values(array_filter(
+			$type->getTypes(),
+			fn ($t) => $t instanceof \ReflectionNamedType
+		));
+		$names = array_map(fn (\ReflectionNamedType $t) => $t->getName(), $named);
+		/** @var array<string,\ReflectionNamedType> $typeMap */
+		$typeMap = array_combine($names, $named);
+
+		// 1. Null handling
+		$allowsNull = in_array(self::TYPE_NULL, $names, true);
+		if ($value === null || ($allowsNull && $value === '')) {
+			return null;
+		}
+
+		// Optimization: single non-null type — delegate directly
+		$nonNull = array_values(array_filter($named, fn (\ReflectionNamedType $t) => $t->getName() !== self::TYPE_NULL));
+		if (count($nonNull) === 1) {
+			return self::coerceToType($value, $nonNull[0]);
+		}
+
+		// 2. Pre-string short-circuit for non-stringable native values.
+		// Arrays become the useless string "Array" via (string)$arr, and objects
+		// without __toString() throw a TypeError via (string)$obj, so these two
+		// forms are claimed before the string-member check in step 3.
+		if (!is_string($value)) {
+			if (is_array($value)) {
+				// Prefer array over iterable when both are present.
+				if (isset($typeMap[self::TYPE_ARRAY])) {
+					return self::coerceToType($value, $typeMap[self::TYPE_ARRAY]);
+				}
+				if (isset($typeMap[self::TYPE_ITERABLE])) {
+					return self::coerceToType($value, $typeMap[self::TYPE_ITERABLE]);
+				}
+			} elseif (is_object($value)) {
+				foreach ($nonNull as $t) {
+					$n = $t->getName();
+					if (!$t->isBuiltin() && $value instanceof $n) {
+						return self::coerceToType($value, $t);
+					}
+				}
+			}
+		}
+
+		// 3. string is a valid union member — value is already valid as a string;
+		// non-string scalar values (bool, int, float) are coerced to their string
+		// representation here. Arrays and typed objects have already been claimed
+		// by step 2 when a native-type match existed, so only ungrabbed values
+		// reach ensureString().
+		if (in_array(self::TYPE_STRING, $names, true)) {
+			return is_string($value) ? $value : self::ensureString($value);
+		}
+
+		// 4. Native-type short-circuit: only reached when string is NOT in the union.
+		// First try an exact match (Pass A), then apply PHP non-strict widening
+		// coercions: bool → int/float (true=1, false=0) and int → float (Pass B).
+		if (!is_string($value)) {
+			// Pass A — exact native-type match
+			foreach ($nonNull as $t) {
+				$n = $t->getName();
+				if (
+					(is_bool($value) && $n === self::TYPE_BOOL) ||
+					(is_int($value) && $n === self::TYPE_INT) ||
+					(is_float($value) && $n === self::TYPE_FLOAT) ||
+					(is_object($value) && !$t->isBuiltin() && $value instanceof $n)
+				) {
+					return self::coerceToType($value, $t);
+				}
+			}
+			// Pass B — PHP non-strict widening when the native type is absent from the union
+			if (is_bool($value)) {
+				// bool widens to int first, then float (PHP non-strict: true=1, false=0)
+				foreach ([self::TYPE_INT, self::TYPE_FLOAT] as $target) {
+					if (isset($typeMap[$target])) {
+						return self::coerceToType($value, $typeMap[$target]);
+					}
+				}
+			} elseif (is_int($value)) {
+				// int widens to float (lossless promotion)
+				if (isset($typeMap[self::TYPE_FLOAT])) {
+					return self::coerceToType($value, $typeMap[self::TYPE_FLOAT]);
+				}
+			}
+			// No match — convert to string and continue with shape heuristics
+		}
+
+		$strValue = is_string($value) ? $value : self::ensureString($value);
+		$hasArray = in_array(self::TYPE_ARRAY, $names, true) || in_array(self::TYPE_ITERABLE, $names, true);
+		$hasBool = in_array(self::TYPE_BOOL, $names, true);
+		$hasInt = in_array(self::TYPE_INT, $names, true);
+		$hasFloat = in_array(self::TYPE_FLOAT, $names, true);
+
+		// 5. Array notation — unambiguous regardless of other types present.
+		// Three delimiter forms are accepted: the Prado `(...)` convention,
+		// the PHP 8 short `[...]` form, and the PHP `array(...)` keyword form.
+		if ($hasArray) {
+			$trimmed = trim($strValue);
+			$tlen = strlen($trimmed);
+			if ($tlen >= 2
+				&& (($trimmed[0] === '(' && $trimmed[$tlen - 1] === ')')
+					|| ($trimmed[0] === '[' && $trimmed[$tlen - 1] === ']')
+					|| ($trimmed[$tlen - 1] === ')' && stripos($trimmed, 'array') === 0))
+			) {
+				return self::ensureArray($strValue);
+			}
+		}
+
+		// 6. Boolean literals — 'true'/'false' only, not generic truthy strings
+		if ($hasBool && in_array(strtolower($strValue), [self::BOOL_TRUE, self::BOOL_FALSE], true)) {
+			return self::ensureBoolean($strValue);
+		}
+
+		// 7. Numeric shape
+		if (is_numeric($strValue)) {
+			if ($hasInt && $hasFloat) {
+				// Treat as float when: (a) a decimal point or scientific-notation exponent is
+				// present ('1e5', '2.5e-1'), or (b) the value exceeds PHP_INT range — matching
+				// PHP's own non-strict coercion where out-of-range integer strings promote to
+				// float.  The lossless round-trip `(string)(int)$s === ltrim($s, '+')` detects
+				// overflow without platform-specific constants.
+				if (str_contains($strValue, '.') || stripos($strValue, 'e') !== false) {
+					return (float) $strValue;
+				}
+				$intVal = (int) $strValue;
+				return ((string) $intVal === ltrim($strValue, '+')) ? $intVal : (float) $strValue;
+			}
+			if ($hasInt) {
+				return (int) $strValue;
+			}
+			if ($hasFloat) {
+				return (float) $strValue;
+			}
+		}
+
+		// 8. Non-builtin class types (backed enums, value objects).
+		// `isBuiltin()` returns `true` for `null` so the test has already
+		// excluded the `null` member of the union.
+		// Try the original $value first so that a PHP int reaches an int-backed enum's
+		// tryFrom() before being stringified.  Only fall back to $strValue when the
+		// original attempt produced no change (e.g. string-backed enums from non-string input).
+		foreach ($named as $t) {
+			if (!$t->isBuiltin()) {
+				$n = $t->getName();
+				$coerced = self::_coerceToClass($value, $n);
+				if ($coerced !== $value) {
+					return $coerced;
+				}
+				if ($strValue !== $value) {
+					$coerced = self::_coerceToClass($strValue, $n);
+					if ($coerced !== $strValue) {
+						return $coerced;
+					}
+				}
+			}
+		}
+
+		// 9. Fallback: sort by TYPE_COERCE_ORDER and coerce to the highest-priority type.
+		// Non-builtin class names not in the list sort after all builtin types,
+		// preserving their original reflection order relative to each other.
+		// $nonNull always has ≥ 2 members here (single-non-null is handled above).
+		$fallback = $nonNull;
+		usort($fallback, static function (\ReflectionNamedType $a, \ReflectionNamedType $b): int {
+			$max = count(self::TYPE_COERCE_ORDER);
+			$ai = array_search($a->getName(), self::TYPE_COERCE_ORDER, true);
+			$bi = array_search($b->getName(), self::TYPE_COERCE_ORDER, true);
+			return ($ai === false ? $max : $ai) <=> ($bi === false ? $max : $bi);
+		});
+		return self::coerceToType($strValue, $fallback[0]);
 	}
 }

--- a/framework/TPropertyValue.php
+++ b/framework/TPropertyValue.php
@@ -156,7 +156,7 @@ class TPropertyValue
 	public const ARRAY_STRICT_ERRORS = (1 << 2);
 
 	/**
-	 * Step-9 fallback order for {@see _coerceUnionType}: non-null union members are tried in this
+	 * Step-10 fallback order for {@see _coerceUnionType}: non-null union members are tried in this
 	 * sequence — int → float → string → bool → aggregate/catch-all — so resolution is deterministic
 	 * regardless of reflection order.  `null` is absent; step 1 handles it before any fallback.
 	 * @var string[]
@@ -245,86 +245,6 @@ class TPropertyValue
 	}
 
 	/**
-	 * Converts a value to enum type.
-	 *
-	 * When `$enums` is a class name, three styles are supported:
-	 *
-	 * - **PHP native `\BackedEnum`** *(4.4.0+)*: accepts an existing instance of the class,
-	 *   an exact backing value (via `tryFrom()`), or a case name (case-insensitive scan over
-	 *   `cases()`).  Returns the matching `\BackedEnum` instance; throws
-	 *   {@see TInvalidDataValueException} if none match.
-	 * - **{@see IEnumerable}** (including {@see TEnumerable}): accepts a constant name
-	 *   (case-insensitive); returns the canonical constant *value* (not the input string).
-	 * - **Any other class**: accepts any constant name present on the class; returns the value.
-	 *
-	 * When `$enums` is an array (or extra variadic arguments), the value is checked for strict
-	 * membership in the list; the matching element is returned unchanged.
-	 * @param mixed $value the value to be converted.
-	 * @param mixed $enums class name of the enumerable type, or array of valid enumeration values. If this is not an array,
-	 * the method considers its parameters are of variable length, and the second till the last parameters are enumeration values.
-	 * @throws TInvalidDataValueException if the value does not match any valid enumeration entry.
-	 * @return \BackedEnum|string the valid enumeration value or instance.
-	 */
-	public static function ensureEnum($value, $enums): string|\BackedEnum
-	{
-		if (func_num_args() === 2 && is_string($enums)) {
-			if (is_a($enums, \BackedEnum::class, true)) {
-				if ($value instanceof $enums) {
-					return $value;
-				}
-				// Guard backing-type before tryFrom: float (and other non-scalar) would cause
-				// a native TypeError from tryFrom rather than a clean TInvalidDataValueException.
-				if (is_string($value) || is_int($value)) {
-					$case = $enums::tryFrom($value);
-					if ($case !== null) {
-						return $case;
-					}
-				}
-				if (is_string($value)) {
-					foreach ($enums::cases() as $case) {
-						if (strcasecmp($case->name, $value) === 0) {
-							return $case;
-						}
-					}
-				}
-				$labels = implode(' | ', array_map(fn (\BackedEnum $c) => $c->name . '=' . $c->value, $enums::cases()));
-				$errVal = is_scalar($value) || $value === null ? $value : get_debug_type($value);
-				throw new TInvalidDataValueException('propertyvalue_enumvalue_invalid', $errVal, $labels);
-			} elseif (is_a($enums, IEnumerable::class, true)) {
-				if (is_string($value)) {
-					$resolved = $enums::valueOfConstant($value, false);
-					if ($resolved !== null) {
-						return $resolved;
-					}
-				}
-				$constants = is_a($enums, TEnumerable::class, true)
-					? $enums::getReflectionClass()->getConstants()
-					: (TComponentReflection::getReflectionClassByType($enums)?->getConstants() ?? []);
-			} else {
-				$ref = TComponentReflection::getReflectionClassByType($enums);
-				if ($ref?->hasConstant($value)) {
-					return $value;
-				}
-				$constants = $ref?->getConstants() ?? [];
-			}
-			$errVal = is_scalar($value) || $value === null ? $value : get_debug_type($value);
-			throw new TInvalidDataValueException(
-				'propertyvalue_enumvalue_invalid',
-				$errVal,
-				implode(' | ', array_keys($constants))
-			);
-		} elseif (!is_array($enums)) {
-			$enums = func_get_args();
-			array_shift($enums);
-		}
-		if (in_array($value, $enums, true)) {
-			return $value;
-		} else {
-			throw new TInvalidDataValueException('propertyvalue_enumvalue_invalid', $value, implode(' | ', $enums));
-		}
-	}
-
-	/**
 	 * Converts the value to 'null' if the given value is empty
 	 * @param mixed $value value to be converted
 	 * @return mixed input or NULL if input is empty
@@ -394,50 +314,298 @@ class TPropertyValue
 	}
 
 	// =========================================================================
+	// ensureEnum() + ensureEnumValue() + Helpers
+	// =========================================================================
+
+	/**
+	 * Validates a value against a class's declared constants (case-insensitive)
+	 * or against a list of permitted values, returning the canonical constant
+	 * name on a class match or the matching extras element otherwise.  Companion
+	 * to {@see ensureEnumValue()} which performs the name → value translation
+	 * step instead.
+	 *
+	 * Three call shapes share the one method:
+	 *
+	 * - **Class** — `ensureEnum($v, MyEnum::class)`.  Any casing of a constant
+	 *   name resolves to the canonical name (`'alpha'` → `'Alpha'` for
+	 *   `const Alpha = 'a'`).  PHP enums flow through the same path since
+	 *   their cases are class constants; an enum instance passed as `$v` is
+	 *   unwrapped to its `->name`.
+	 * - **Class + extras** — `ensureEnum($v, MyEnum::class, 'Auto', null)`
+	 *   or `ensureEnum($v, MyEnum::class, ['Auto', null, 'Custom' => 'x'])`.
+	 *   Additional permitted values consulted after the class lookup misses;
+	 *   passed either variadically or as a single array.  Entry semantics
+	 *   match {@see ensureEnumValue()} (see {@see _matchEnumExtra()}): string
+	 *   keys are case-insensitive aliases that return the canonical key as
+	 *   the name; int-keyed strings are case-insensitive names that return
+	 *   themselves; int-keyed non-strings (`null`, `false`, `0`, …) are
+	 *   strict-equality sentinels.
+	 * - **Value list** (no class) — `ensureEnum($v, ['a', 'b'])` or
+	 *   `ensureEnum($v, 'a', 'b', 'c')`.  Triggered when `$enums` is an
+	 *   array, or a string that doesn't resolve to a reflectable class.
+	 *   Strict-equality membership check; matching element returned
+	 *   unchanged.
+	 *
+	 * `$enums` also accepts an instance whose class is used.  The reflection
+	 * cache is shared across calls.
+	 *
+	 * @param mixed $value the value to be validated.
+	 * @param mixed $enums class name, instance, array of values, or first
+	 *   element of a value list.
+	 * @param mixed ...$extras additional permitted values (class form only);
+	 *   variadic or a single array; shared semantics with `ensureEnumValue`.
+	 * @throws TInvalidDataValueException when no class constant, extra, or
+	 *   list element matches.
+	 * @return mixed canonical constant name (class form), or the matching
+	 *   extra / list element (other forms).
+	 */
+	public static function ensureEnum($value, $enums, mixed ...$extras): mixed
+	{
+		// Normalize extras: accept either variadic args or a single array.
+		if (count($extras) === 1 && is_array($extras[0])) {
+			$extras = $extras[0];
+		}
+		$className = null;
+		$ref = null;
+		if (is_object($enums)) {
+			$className = $enums::class;
+			$ref = TComponentReflection::getReflectionClassByType($className);
+		} elseif (is_string($enums)) {
+			$ref = TComponentReflection::getReflectionClassByType($enums);
+			if ($ref !== null) {
+				$className = $enums;
+			}
+		}
+
+		if ($className !== null) {
+			// Enum instance pass-through: unwrap to the case's canonical name.
+			if ($value instanceof \UnitEnum && $value instanceof $className) {
+				return $value->name;
+			}
+			if (is_string($value)) {
+				// Fast path — exact case match.
+				if ($ref->hasConstant($value)) {
+					return $value;
+				}
+				// Slow path — case-insensitive enumeration; returns the
+				// canonical name so any-casing input normalizes.
+				foreach ($ref->getConstants() as $name => $_) {
+					if (strcasecmp($name, $value) === 0) {
+						return $name;
+					}
+				}
+			}
+			// Extras — unified matcher; canonical name returned on match.
+			if ($extras !== []) {
+				[$ok, $result] = self::_matchEnumExtra($value, $extras, true);
+				if ($ok) {
+					return $result;
+				}
+			}
+			$labels = implode(' | ', array_keys($ref->getConstants()));
+			if ($extras !== []) {
+				$labels .= ($labels !== '' ? ' | ' : '') . self::_formatEnumExtrasLabel($extras);
+			}
+			$errVal = is_scalar($value) || $value === null ? $value : get_debug_type($value);
+			throw new TInvalidDataValueException('propertyvalue_enumvalue_invalid', $errVal, $labels);
+		}
+
+		// Array / variadic form
+		if (!is_array($enums)) {
+			$enums = func_get_args();
+			array_shift($enums);
+		}
+		if (in_array($value, $enums, true)) {
+			return $value;
+		}
+		throw new TInvalidDataValueException(
+			'propertyvalue_enumvalue_invalid',
+			$value,
+			implode(' | ', $enums)
+		);
+	}
+
+	/**
+	 * Resolves a constant name (case-insensitive) on a class to its constant
+	 * VALUE.  Companion to {@see ensureEnum()} which returns the canonical
+	 * name; this method performs the name → value translation step.  For
+	 * `const Alpha = 'a'`, any casing of `'Alpha'` resolves to `'a'`.
+	 *
+	 * A class constant whose value is a `BackedEnum` case is unwrapped to
+	 * that case's `->value`; a non-backed `UnitEnum` case is returned as
+	 * the case object (no backing value exists); other constant values are
+	 * returned as-is.  An enum instance passed as `$value` is unwrapped the
+	 * same way.
+	 *
+	 * `$extras` is an optional array consulted after the class lookup misses;
+	 * it shares the unified semantics described in {@see _matchEnumExtra()} and
+	 * accepts the same mixed shape as {@see ensureEnum()}'s extras:
+	 *
+	 * - **String key** (`'Auto' => 'auto'`) — case-insensitive alias map; the
+	 *   key matches a string `$value` and the mapped value is returned.
+	 * - **Int-keyed string** (`'Auto'`) — case-insensitive name; the string
+	 *   is its own value and is returned on match.
+	 * - **Int-keyed non-string** (`null`, `false`, …) — strict-equality
+	 *   sentinel; the value is returned on match.
+	 *
+	 * Unlike {@see ensureEnum()}'s extras (which accept either variadic or
+	 * array shapes), this parameter is always a single array.
+	 *
+	 * @param mixed $value constant name to look up (case-insensitive), an
+	 *   enum instance of `$enums` to unwrap, or a sentinel covered by an
+	 *   int-keyed extras entry.
+	 * @param object|string $enums class name or instance whose class
+	 *   provides the constant table.
+	 * @param array $extras mixed alias map / sentinel list of additional
+	 *   virtual constants (shared shape with {@see ensureEnum()}).
+	 * @throws TInvalidDataValueException when no class constant nor extras
+	 *   key matches.
+	 * @return mixed BackedEnum backing value, non-backed UnitEnum case, raw
+	 *   constant value, or the matching extras value.
+	 * @since 4.4.0
+	 */
+	public static function ensureEnumValue(mixed $value, string|object $enums, array $extras = []): mixed
+	{
+		$className = is_object($enums) ? $enums::class : $enums;
+		// Enum instance pass-through.
+		if ($value instanceof \UnitEnum && $value instanceof $className) {
+			return $value instanceof \BackedEnum ? $value->value : $value;
+		}
+		$ref = TComponentReflection::getReflectionClassByType($className);
+		if ($ref !== null && is_string($value)) {
+			// Fast path — exact case match via ReflectionClass.
+			if ($ref->hasConstant($value)) {
+				$c = $ref->getConstant($value);
+				return $c instanceof \BackedEnum ? $c->value : $c;
+			}
+			// Slow path — case-insensitive enumeration.
+			foreach ($ref->getConstants() as $name => $constValue) {
+				if (strcasecmp($name, $value) === 0) {
+					return $constValue instanceof \BackedEnum ? $constValue->value : $constValue;
+				}
+			}
+		}
+		// Extras — unified matcher; mapped value returned on match.
+		if ($extras !== []) {
+			[$ok, $result] = self::_matchEnumExtra($value, $extras, false);
+			if ($ok) {
+				return $result;
+			}
+		}
+		$labels = $ref !== null ? implode(' | ', array_keys($ref->getConstants())) : '';
+		if ($extras !== []) {
+			$labels .= ($labels !== '' ? ' | ' : '') . self::_formatEnumExtrasLabel($extras);
+		}
+		$errVal = is_scalar($value) || $value === null ? $value : get_debug_type($value);
+		throw new TInvalidDataValueException('propertyvalue_enumvalue_invalid', $errVal, $labels);
+	}
+
+	/**
+	 * Walks the unified `$extras` array on behalf of {@see ensureEnum()} and
+	 * {@see ensureEnumValue()}.  Both methods accept the same extras shape and
+	 * the same matching rules; only the return value differs:
+	 *
+	 * - **String key** (`'Alias' => 'mapped'`) — case-insensitive match on the
+	 *   KEY against a string `$value`.  Returns the key when `$returnKey` is
+	 *   true (canonical name for `ensureEnum`); returns the mapped value
+	 *   otherwise (for `ensureEnumValue`).
+	 * - **Int-keyed string** (`'Auto'`) — the string is both name and value;
+	 *   case-insensitive match returns the string itself for both methods.
+	 * - **Int-keyed non-string** (`null`, `false`, `0`, `-1`, …) — strict
+	 *   equality sentinel; the matched value is returned by both methods.
+	 *
+	 * @since 4.4.0
+	 * @param mixed $value
+	 * @param array $extras
+	 * @param bool $returnKey
+	 * @return array{0: bool, 1: mixed} `[matched, result]` — `matched` is
+	 *   false when nothing in `$extras` satisfies `$value`.
+	 */
+	private static function _matchEnumExtra(mixed $value, array $extras, bool $returnKey): array
+	{
+		foreach ($extras as $key => $extraValue) {
+			if (is_string($key)) {
+				if (is_string($value) && strcasecmp($key, $value) === 0) {
+					return [true, $returnKey ? $key : $extraValue];
+				}
+			} elseif (is_string($extraValue)) {
+				if (is_string($value) && strcasecmp($extraValue, $value) === 0) {
+					return [true, $extraValue];
+				}
+			} elseif ($extraValue === $value) {
+				return [true, $extraValue];
+			}
+		}
+		return [false, null];
+	}
+
+	/**
+	 * Formats `$extras` as a `|`-separated label list for error messages.
+	 * Mirrors {@see _matchEnumExtra()}'s entry semantics: string-keyed
+	 * entries surface as their key, int-keyed strings as the string itself,
+	 * and int-keyed non-strings as their `var_export` form.
+	 *
+	 * @since 4.4.0
+	 * @param array $extras
+	 */
+	private static function _formatEnumExtrasLabel(array $extras): string
+	{
+		$labels = [];
+		foreach ($extras as $key => $extraValue) {
+			if (is_string($key)) {
+				$labels[] = $key;
+			} elseif (is_string($extraValue)) {
+				$labels[] = $extraValue;
+			} else {
+				$labels[] = var_export($extraValue, true);
+			}
+		}
+		return implode(' | ', $labels);
+	}
+
+	// =========================================================================
 	// ensureArray() + Helpers
 	// =========================================================================
 
 	/**
-	 * Has converted a value to array type.
+	 * Converts a value to an array, parsing strings as PHP-style array literals.
 	 *
-	 * Non-string values have been cast via PHP's `(array)` coercion.  String
-	 * values have been parsed as PHP-style array literals.  The behavior has
-	 * been controlled by two flag bits:
+	 * Non-string values are cast via PHP's `(array)` coercion.  String values
+	 * are parsed as PHP array literals.  Two flag bits control the behavior:
 	 *
-	 * - {@see ARRAY_STRICT_GRAMMAR} — has restricted the parser to the
-	 *   PHP-literal grammar (`[...]` short syntax or `array(...)` keyword
-	 *   form, no bare `(...)` array, no bare-word strings, no legacy octal,
-	 *   no auto-wrap of unbracketed input).
-	 * - {@see ARRAY_STRICT_ERRORS} — has converted the silent
-	 *   single-element fallback into a thrown
-	 *   {@see TInvalidDataValueException}.  Composable with the grammar flag.
+	 * - {@see ARRAY_STRICT_GRAMMAR} — restricts the parser to the PHP-literal
+	 *   grammar (`[...]` short syntax or `array(...)` keyword form, no bare
+	 *   `(...)` array, no bare-word strings, no legacy octal, no auto-wrap
+	 *   of unbracketed input).
+	 * - {@see ARRAY_STRICT_ERRORS} — converts the silent single-element
+	 *   fallback into a thrown {@see TInvalidDataValueException}.  Composable
+	 *   with the grammar flag.
 	 *
-	 * With `$flags === 0` (the default) the loose grammar has applied:
-	 * a trimmed string that has begun with `(` or `[` has been parsed in
-	 * place; anything else has been re-parsed as if wrapped in `(...)`, so
-	 * bare element lists like `red, green, blue` have resolved to
-	 * `['red', 'green', 'blue']`.  Loose grammar has accepted PHP-style
-	 * integers (decimal, hex `0xFF`, binary `0b101`, modern octal `0o17`,
-	 * with optional underscored separators; PHP 7's leading-zero octal form
-	 * has been dropped so `017` has read as decimal 17), floats
-	 * (`1.5`, `.5`, `1e10`, `1_000.5_5`), single- or double-quoted strings
-	 * with the common backslash escapes, the keywords `true`/`false`/`null`
+	 * With `$flags === 0` (the default) the loose grammar applies: a trimmed
+	 * string that begins with `(` or `[` is parsed in place; anything else is
+	 * re-parsed as if wrapped in `(...)`, so bare element lists like
+	 * `red, green, blue` resolve to `['red', 'green', 'blue']`.  Loose grammar
+	 * accepts PHP-style integers (decimal, hex `0xFF`, binary `0b101`, modern
+	 * octal `0o17`, with optional underscore separators; PHP 7's leading-zero
+	 * octal form is dropped, so `017` reads as decimal 17), floats (`1.5`,
+	 * `.5`, `1e10`, `1_000.5_5`), single- or double-quoted strings with the
+	 * common backslash escapes, the keywords `true`/`false`/`null`
 	 * (case-insensitive), unquoted bare-word strings, and nested arrays in
-	 * `(...)`, `[...]`, or `array(...)` form freely mixed.  Each element has
-	 * supported an optional `key => ` prefix (int or string literal); a
-	 * trailing comma has been accepted.  The bare-word rule has supported
-	 * template-attribute conventions like
+	 * `(...)`, `[...]`, or `array(...)` form freely mixed.  Each element
+	 * supports an optional `key => ` prefix (int or string literal); a
+	 * trailing comma is accepted.  The bare-word rule supports template-
+	 * attribute conventions like
 	 * `<com:TControl colors="red, green, blue"/>`.
 	 *
-	 * The parser has been regex-driven — no `eval()` — and the empty string
-	 * has always returned the empty array.
+	 * The parser is regex-driven — no `eval()` — and the empty string always
+	 * returns the empty array.
 	 *
 	 * @param mixed $value the value to be converted.
 	 * @param int $flags zero or more of {@see ARRAY_STRICT_GRAMMAR},
 	 *   {@see ARRAY_STRICT_ERRORS} combined with `|`.  Defaults to `0`
 	 *   (loose grammar, silent fallback).
-	 * @throws TInvalidDataValueException when {@see ARRAY_STRICT_ERRORS} has
-	 *   been set and the input has not parsed.
+	 * @throws TInvalidDataValueException when {@see ARRAY_STRICT_ERRORS} is
+	 *   set and the input does not parse.
 	 * @return array
 	 */
 	public static function ensureArray($value, int $flags = 0): array
@@ -1106,7 +1274,7 @@ class TPropertyValue
 	}
 
 	// =========================================================================
-	// applyProperty() + Helpers
+	// applyProperty() + coerceForSetter() + coerceToType() + Helpers
 	// =========================================================================
 
 	/**
@@ -1216,49 +1384,103 @@ class TPropertyValue
 	}
 
 	/**
-	 * Coerces a value toward a non-builtin class type that Prado recognises as an
-	 * enumerable domain.  All other class types are returned unchanged.
+	 * Has coerced a value toward a non-builtin class type that Prado has
+	 * recognized as an enumerable domain.  All other class types have been
+	 * returned unchanged.
 	 *
-	 * - **PHP 8.1 backed enums** (`BackedEnum`): first tries `$className::tryFrom($value)`
-	 *   for an exact backing-value match (e.g. `'red'` → `Color::Red`).  On a miss, a
-	 *   case-insensitive name scan runs over `$className::cases()`, so the PHP case name
-	 *   may be supplied in any casing (`'Red'`, `'RED'`, `'rEd'` all resolve to
-	 *   `Color::Red`).  If neither lookup succeeds the original `$value` is returned so
-	 *   the TypeError surfaces at the setter boundary.
-	 *
-	 * - **{@see IEnumerable} implementors** (including {@see TEnumerable} subclasses):
-	 *   resolves a constant *name* to its *value* via `valueOfConstant($value, false)`
-	 *   (case-insensitive).  For the conventional case where name equals value
-	 *   (`const Left = 'Left'`), any casing of the name (`'left'`, `'LEFT'`) normalizes
-	 *   to the canonical value `'Left'`.  When name differs from value (`const Alpha = 'a'`),
-	 *   any casing of the name resolves to the value `'a'`.  If no constant name matches,
-	 *   `$value` is returned unchanged so the TypeError surfaces at the setter boundary.
+	 * String inputs delegate to {@see _tryMatchEnum()} for case-insensitive
+	 * name lookup (and, for BackedEnum, value-based `tryFrom` first).  An int
+	 * input against a BackedEnum has been resolved through `tryFrom` directly.
+	 * On any miss, `$value` has been returned unchanged so the TypeError has
+	 * surfaced at the setter boundary.
 	 *
 	 * @param mixed $value the value to coerce.
 	 * @param string $className the target class or interface name.
-	 * @return mixed the coerced value, or `$value` unchanged if coercion is not possible.
+	 * @return mixed the coerced value, or `$value` unchanged on miss.
 	 * @since 4.4.0
 	 */
 	private static function _coerceToClass(mixed $value, string $className): mixed
 	{
-		if (is_a($className, \BackedEnum::class, true) && (is_string($value) || is_int($value))) {
-			$case = $className::tryFrom($value);
-			if ($case !== null) {
-				return $case;
+		if (is_a($className, \BackedEnum::class, true) && is_int($value)) {
+			try {
+				return $className::tryFrom($value) ?? $value;
+			} catch (\TypeError) {
+				return $value;
 			}
-			if (is_string($value)) {
-				foreach ($className::cases() as $case) {
-					if (strcasecmp($case->name, $value) === 0) {
-						return $case;
-					}
-				}
-			}
-			return $value;
 		}
-		if (is_a($className, IEnumerable::class, true) && is_string($value)) {
-			return $className::valueOfConstant($value, false) ?? $value;
+		if (is_string($value)) {
+			$match = self::_tryMatchEnum($className, $value);
+			if ($match !== null) {
+				return $match;
+			}
 		}
 		return $value;
+	}
+
+	/**
+	 * Has validated a string against an enumerable class by *constant name*
+	 * (case-insensitively), returning the matched form on a hit and `null`
+	 * on a miss.  The enum has acted purely as a name-validator — name→value
+	 * translation has been left to the class itself (or to a separate
+	 * coercion pass).  Returned forms:
+	 *
+	 * - `UnitEnum` / `BackedEnum` — the matched case object; for
+	 *   `BackedEnum` a `tryFrom($value)` backing-value lookup has run first
+	 *   so a raw backing value also resolves to its case.
+	 * - {@see IEnumerable} — the canonical constant name with original
+	 *   casing preserved, so `'red'` has resolved to `'Red'` against a
+	 *   `const Red = '#FF0000'` declaration.  The constant's *value* has
+	 *   *not* been returned here — the typical property type pattern
+	 *   `TWebColor|string` accepts the validated name string and the
+	 *   class itself has translated `'Red'` → `'#FF0000'` when needed.
+	 *
+	 * Name lookup has been case-insensitive — `'red'`, `'Red'`, and `'RED'`
+	 * have all resolved to the constant named `Red`.  When `$className` has
+	 * not been an enumerable class, the function has returned `null` without
+	 * doing anything.
+	 *
+	 * The helper has been the shared resolver behind {@see _coerceToClass()}
+	 * for string inputs and behind the enumerable-validation step of
+	 * {@see _coerceUnionType()}.
+	 *
+	 * @param string $className the candidate enumerable class name.
+	 * @param string $value the candidate constant name (or backing value
+	 *   for BackedEnum).
+	 * @return mixed the matched case (UnitEnum / BackedEnum) or canonical
+	 *   constant name (IEnumerable), or `null` on miss / non-enum class.
+	 * @since 4.4.0
+	 */
+	private static function _tryMatchEnum(string $className, string $value): mixed
+	{
+		if (is_a($className, \UnitEnum::class, true)) {
+			if (is_a($className, \BackedEnum::class, true)) {
+				try {
+					$case = $className::tryFrom($value);
+					if ($case !== null) {
+						return $case;
+					}
+				} catch (\TypeError) {
+				}
+			}
+			foreach ($className::cases() as $case) {
+				if (strcasecmp($case->name, $value) === 0) {
+					return $case;
+				}
+			}
+			return null;
+		}
+		if (is_a($className, IEnumerable::class, true)) {
+			$ref = TComponentReflection::getReflectionClassByType($className);
+			if ($ref === null) {
+				return null;
+			}
+			foreach ($ref->getConstants() as $name => $_) {
+				if (strcasecmp($name, $value) === 0) {
+					return $name;
+				}
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -1269,21 +1491,27 @@ class TPropertyValue
 	 * selects the most appropriate type:
 	 *
 	 * 1. `null` / empty string → `null` (when `null` is in the union)
-	 * 2. `array` / typed object value whose type appears in the union → use it
-	 *    (pre-empts step 3 to prevent `(string)$array = "Array"` and
+	 * 2. Enumerable validation — for string `$value`, case-insensitive
+	 *    constant-name lookup via {@see _tryMatchEnum()} against each
+	 *    enum-like (UnitEnum / IEnumerable) union member; the first match
+	 *    wins.  Return shape per {@see _tryMatchEnum()}'s contract.
+	 * 3. `array` / typed object value whose type appears in the union → use it
+	 *    (pre-empts step 4 to prevent `(string)$array = "Array"` and
 	 *    `(string)$object` TypeError when the value has a native match)
-	 * 3. `string` in union → pass through / `ensureString` if not already a string
+	 * 4. `string` in union → pass through / `ensureString` if not already a string
 	 *    (scalar non-string values such as `int` and `bool` are coerced to their
 	 *    string representation here when `string` is present in the union)
-	 * 4. Non-string typed value whose PHP type directly matches a union member → use it
+	 * 5. Non-string typed value whose PHP type directly matches a union member → use it
 	 *    (only reached when `string` is NOT in the union); then PHP-compatible
 	 *    widening: `bool` → `int`/`float`, `int` → `float`
-	 * 5. `(a,b,c)` / `[a,b,c]` / `array(a,b,c)` notation + `array`/`iterable` in union → {@see ensureArray}
-	 * 6. `'true'`/`'false'` literal + `bool` in union → {@see ensureBoolean}
-	 * 7. Numeric value + `int`/`float` in union → float when `.` or `e`/`E` (scientific notation)
+	 * 6. `(a,b,c)` / `[a,b,c]` / `array(a,b,c)` notation + `array`/`iterable` in union → {@see ensureArray}
+	 * 7. `'true'`/`'false'` literal + `bool` in union → {@see ensureBoolean}
+	 * 8. Numeric value + `int`/`float` in union → float when `.` or `e`/`E` (scientific notation)
 	 *    is present, int otherwise; matching PHP non-strict behavior
-	 * 8. Non-builtin class types (backed enums, {@see IEnumerable} implementors) → {@see _coerceToClass}
-	 * 9. Fallback: first non-`null` type sorted by {@see TYPE_COERCE_ORDER}
+	 * 9. Non-builtin class types — value-based lookup via {@see _coerceToClass}
+	 *    catches inputs that match an enum's *backing value* (e.g. `100` for an
+	 *    int-backed enum) where step 2's *name* lookup did not apply
+	 * 10. Fallback: first non-`null` type sorted by {@see TYPE_COERCE_ORDER}
 	 *
 	 * @param mixed $value the value to coerce.
 	 * @param \ReflectionUnionType $type the union type.
@@ -1313,10 +1541,26 @@ class TPropertyValue
 			return self::coerceToType($value, $nonNull[0]);
 		}
 
-		// 2. Pre-string short-circuit for non-stringable native values.
-		// Arrays become the useless string "Array" via (string)$arr, and objects
-		// without __toString() throw a TypeError via (string)$obj, so these two
-		// forms are claimed before the string-member check in step 3.
+		// 2. Enum validation.  Case-insensitive constant-name lookup against
+		// any enum-like (UnitEnum / IEnumerable) union member via
+		// {@see _tryMatchEnum()}, which returns `null` for non-enum classes;
+		// the first match wins.
+		if (is_string($value)) {
+			foreach ($nonNull as $t) {
+				if ($t->isBuiltin()) {
+					continue;
+				}
+				$match = self::_tryMatchEnum($t->getName(), $value);
+				if ($match !== null) {
+					return $match;
+				}
+			}
+		}
+
+		// 3. Non-stringable native short-circuit.  Arrays and typed-object
+		// instances have claimed a native union match before step 4 —
+		// `(string)$arr` would be the useless `"Array"` and `(string)$obj`
+		// TypeErrors without `__toString()`.
 		if (!is_string($value)) {
 			if (is_array($value)) {
 				// Prefer array over iterable when both are present.
@@ -1336,16 +1580,15 @@ class TPropertyValue
 			}
 		}
 
-		// 3. string is a valid union member — value is already valid as a string;
-		// non-string scalar values (bool, int, float) are coerced to their string
-		// representation here. Arrays and typed objects have already been claimed
-		// by step 2 when a native-type match existed, so only ungrabbed values
-		// reach ensureString().
+		// 4. String member.  Strings have passed through; non-string scalars
+		// (bool, int, float) have been coerced via {@see ensureString()}.
+		// Step 3 has already claimed any array or typed object with a
+		// native union match.
 		if (in_array(self::TYPE_STRING, $names, true)) {
 			return is_string($value) ? $value : self::ensureString($value);
 		}
 
-		// 4. Native-type short-circuit: only reached when string is NOT in the union.
+		// 5. Native-type short-circuit: only reached when string is NOT in the union.
 		// First try an exact match (Pass A), then apply PHP non-strict widening
 		// coercions: bool → int/float (true=1, false=0) and int → float (Pass B).
 		if (!is_string($value)) {
@@ -1384,7 +1627,7 @@ class TPropertyValue
 		$hasInt = in_array(self::TYPE_INT, $names, true);
 		$hasFloat = in_array(self::TYPE_FLOAT, $names, true);
 
-		// 5. Array notation — unambiguous regardless of other types present.
+		// 6. Array notation — unambiguous regardless of other types present.
 		// Three delimiter forms are accepted: the Prado `(...)` convention,
 		// the PHP 8 short `[...]` form, and the PHP `array(...)` keyword form.
 		if ($hasArray) {
@@ -1399,12 +1642,12 @@ class TPropertyValue
 			}
 		}
 
-		// 6. Boolean literals — 'true'/'false' only, not generic truthy strings
+		// 7. Boolean literals — 'true'/'false' only, not generic truthy strings
 		if ($hasBool && in_array(strtolower($strValue), [self::BOOL_TRUE, self::BOOL_FALSE], true)) {
 			return self::ensureBoolean($strValue);
 		}
 
-		// 7. Numeric shape
+		// 8. Numeric shape
 		if (is_numeric($strValue)) {
 			if ($hasInt && $hasFloat) {
 				// Treat as float when: (a) a decimal point or scientific-notation exponent is
@@ -1426,12 +1669,11 @@ class TPropertyValue
 			}
 		}
 
-		// 8. Non-builtin class types (backed enums, value objects).
-		// `isBuiltin()` returns `true` for `null` so the test has already
-		// excluded the `null` member of the union.
-		// Try the original $value first so that a PHP int reaches an int-backed enum's
-		// tryFrom() before being stringified.  Only fall back to $strValue when the
-		// original attempt produced no change (e.g. string-backed enums from non-string input).
+		// 9. Non-builtin class value-based lookup.  Tries the original $value
+		// first so a PHP int reaches an int-backed enum's tryFrom() before
+		// stringification; retries with $strValue only when the original
+		// attempt produced no change.  `isBuiltin()` excludes the `null`
+		// member of the union (which it reports as builtin).
 		foreach ($named as $t) {
 			if (!$t->isBuiltin()) {
 				$n = $t->getName();
@@ -1448,10 +1690,11 @@ class TPropertyValue
 			}
 		}
 
-		// 9. Fallback: sort by TYPE_COERCE_ORDER and coerce to the highest-priority type.
-		// Non-builtin class names not in the list sort after all builtin types,
-		// preserving their original reflection order relative to each other.
-		// $nonNull always has ≥ 2 members here (single-non-null is handled above).
+		// 10. Fallback.  Sorts non-null members by {@see TYPE_COERCE_ORDER}
+		// (non-builtin class names sort after every builtin, preserving
+		// reflection order among themselves) and coerces $strValue toward
+		// the winner.  $nonNull has ≥ 2 members here — single-non-null
+		// short-circuited above.
 		$fallback = $nonNull;
 		usort($fallback, static function (\ReflectionNamedType $a, \ReflectionNamedType $b): int {
 			$max = count(self::TYPE_COERCE_ORDER);

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -251,6 +251,7 @@ return [
 'Translation' => 'Prado\I18N\Translation',
 'TTranslate' => 'Prado\I18N\TTranslate',
 'TTranslateParameter' => 'Prado\I18N\TTranslateParameter',
+'ICoercible' => 'Prado\ICoercible',
 'IDataRenderer' => 'Prado\IDataRenderer',
 'IEnumerable' => 'Prado\IEnumerable',
 'IEventCycleParameter' => 'Prado\IEventCycleParameter',

--- a/tests/unit/Harness/TTestApplicationConfiguration.php
+++ b/tests/unit/Harness/TTestApplicationConfiguration.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * TTestApplicationConfiguration class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\TApplicationConfiguration;
+
+/**
+ * TTestApplicationConfiguration
+ *
+ * A testable subclass of {@see TApplicationConfiguration} that allows integration
+ * tests to inject pre-built module and service configurations without parsing XML
+ * or PHP files.
+ *
+ * Each module and service configuration entry uses the same three-element tuple
+ * format used internally by `TApplicationConfiguration`:
+ * ```
+ * [0] => class name (string)
+ * [1] => property array (string name => mixed value)
+ * [2] => raw config element (TXmlElement, array, or null)
+ * ```
+ *
+ * This class is auto-loaded by {@see PradoUnitRequires} — any test that includes
+ * `PradoUnitRequires.php` has access to it without an explicit `require_once`.
+ *
+ * Typical usage in a test:
+ * ```php
+ * $config = new TTestApplicationConfiguration();
+ * $config->addModuleConfig('mymod', TMyModule::class, [
+ *     'BoolProp' => 'true',
+ *     'IntProp'  => '42',
+ * ]);
+ *
+ * foreach ($config->getModules() as $id => [$type, $props]) {
+ *     $module = Prado::createComponent($type);
+ *     foreach ($props as $name => $value) {
+ *         $module->setSubProperty($name, $value);
+ *     }
+ * }
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestApplicationConfiguration extends TApplicationConfiguration
+{
+	/**
+	 * Has registered a module configuration entry under the given ID.
+	 *
+	 * The tuple format matches the internal representation consumed by
+	 * {@see TApplicationConfiguration::getModules()} and by
+	 * `TApplication::internalLoadModule()`.
+	 *
+	 * @param string $id the module ID used as the configuration key.
+	 * @param string $type the fully-qualified class name of the module.
+	 * @param array $properties property name → value pairs to apply via
+	 *   `setSubProperty()` during initialization.  Use string values when
+	 *   simulating XML configuration; PHP-typed values are accepted when
+	 *   simulating PHP array configuration.
+	 * @param mixed $element the raw configuration element passed to `init()`;
+	 *   use `null` when the module has no sub-configuration.
+	 */
+	public function addModuleConfig(string $id, string $type, array $properties = [], mixed $element = null): void
+	{
+		$this->_modules[$id] = [$type, $properties, $element];
+	}
+
+	/**
+	 * Has registered a service configuration entry under the given ID.
+	 *
+	 * The tuple format matches the internal representation consumed by
+	 * {@see TApplicationConfiguration::getServices()} and by
+	 * `TApplication::startService()`.
+	 *
+	 * @param string $id the service ID.
+	 * @param string $type the fully-qualified class name of the service.
+	 * @param array $properties property name → value pairs applied via
+	 *   `setSubProperty()` during service startup.
+	 * @param mixed $element the raw configuration element passed to `init()`;
+	 *   use `null` when the service has no sub-configuration.
+	 */
+	public function addServiceConfig(string $id, string $type, array $properties = [], mixed $element = null): void
+	{
+		$this->_services[$id] = [$type, $properties, $element];
+	}
+
+	/**
+	 * Has replaced the entire module configuration map.
+	 *
+	 * Each entry must follow the three-element tuple format:
+	 * `[$className, $propertyArray, $element]`.
+	 *
+	 * @param array $modules keyed by module ID.
+	 */
+	public function setModuleConfigs(array $modules): void
+	{
+		$this->_modules = $modules;
+	}
+
+	/**
+	 * Has replaced the entire service configuration map.
+	 *
+	 * Each entry must follow the three-element tuple format:
+	 * `[$className, $propertyArray, $element]`.
+	 *
+	 * @param array $services keyed by service ID.
+	 */
+	public function setServiceConfigs(array $services): void
+	{
+		$this->_services = $services;
+	}
+}

--- a/tests/unit/Harness/TTestApplicationConfiguration.php
+++ b/tests/unit/Harness/TTestApplicationConfiguration.php
@@ -67,7 +67,9 @@ class TTestApplicationConfiguration extends TApplicationConfiguration
 	 */
 	public function addModuleConfig(string $id, string $type, array $properties = [], mixed $element = null): void
 	{
-		$this->_modules[$id] = [$type, $properties, $element];
+		$modules = PradoUnit::getProp($this, '_modules');
+		$modules[$id] = [$type, $properties, $element];
+		PradoUnit::setProp($this, '_modules', $modules);
 	}
 
 	/**
@@ -86,7 +88,9 @@ class TTestApplicationConfiguration extends TApplicationConfiguration
 	 */
 	public function addServiceConfig(string $id, string $type, array $properties = [], mixed $element = null): void
 	{
-		$this->_services[$id] = [$type, $properties, $element];
+		$services = PradoUnit::getProp($this, '_services');
+		$services[$id] = [$type, $properties, $element];
+		PradoUnit::setProp($this, '_services', $services);
 	}
 
 	/**
@@ -99,7 +103,7 @@ class TTestApplicationConfiguration extends TApplicationConfiguration
 	 */
 	public function setModuleConfigs(array $modules): void
 	{
-		$this->_modules = $modules;
+		PradoUnit::setProp($this, '_modules', $modules);
 	}
 
 	/**
@@ -112,6 +116,6 @@ class TTestApplicationConfiguration extends TApplicationConfiguration
 	 */
 	public function setServiceConfigs(array $services): void
 	{
-		$this->_services = $services;
+		PradoUnit::setProp($this, '_services', $services);
 	}
 }

--- a/tests/unit/TComponentCoercionIntegrationTest.php
+++ b/tests/unit/TComponentCoercionIntegrationTest.php
@@ -1,0 +1,1519 @@
+<?php
+
+use Prado\TComponent;
+use Prado\TModule;
+use Prado\TService;
+use Prado\TPropertyValue;
+use Prado\Web\UI\TControl;
+
+/**
+ * String-backed enum for TComponent coercion integration tests.
+ */
+enum TCoercionTestColor: string
+{
+	case Red   = 'red';
+	case Green = 'green';
+	case Blue  = 'blue';
+}
+
+/**
+ * Sub-component for nested dot-notation sub-property coercion tests.
+ *
+ * All setters carry declared types so that {@see TPropertyValue::applyProperty}
+ * has a concrete type to coerce toward at each level of a dot-notation path.
+ */
+class TCoercionTestSubComponent extends TComponent
+{
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+
+	public function getBoolProp(): bool
+	{
+		return $this->_boolProp;
+	}
+
+	public function setBoolProp(bool $v): void
+	{
+		$this->_boolProp = $v;
+	}
+
+	public function getIntProp(): int
+	{
+		return $this->_intProp;
+	}
+
+	public function setIntProp(int $v): void
+	{
+		$this->_intProp = $v;
+	}
+
+	public function getFloatProp(): float
+	{
+		return $this->_floatProp;
+	}
+
+	public function setFloatProp(float $v): void
+	{
+		$this->_floatProp = $v;
+	}
+
+	public function getStringProp(): string
+	{
+		return $this->_stringProp;
+	}
+
+	public function setStringProp(string $v): void
+	{
+		$this->_stringProp = $v;
+	}
+
+	public function getArrayProp(): array
+	{
+		return $this->_arrayProp;
+	}
+
+	public function setArrayProp(array $v): void
+	{
+		$this->_arrayProp = $v;
+	}
+}
+
+/**
+ * Deeper sub-component for three-level dot-notation path tests (Sub.Deep.IntProp).
+ */
+class TCoercionTestDeepComponent extends TComponent
+{
+	private int $_intProp = 0;
+	private string $_stringProp = '';
+
+	public function getIntProp(): int
+	{
+		return $this->_intProp;
+	}
+
+	public function setIntProp(int $v): void
+	{
+		$this->_intProp = $v;
+	}
+
+	public function getStringProp(): string
+	{
+		return $this->_stringProp;
+	}
+
+	public function setStringProp(string $v): void
+	{
+		$this->_stringProp = $v;
+	}
+}
+
+/**
+ * Sub-component extended with a nested deep component for three-level path tests.
+ */
+class TCoercionTestSubComponentWithDeep extends TCoercionTestSubComponent
+{
+	private TCoercionTestDeepComponent $_deep;
+
+	public function __construct()
+	{
+		parent::__construct();
+		$this->_deep = new TCoercionTestDeepComponent();
+	}
+
+	public function getDeep(): TCoercionTestDeepComponent
+	{
+		return $this->_deep;
+	}
+
+	public function setDeep(TCoercionTestDeepComponent $v): void
+	{
+		$this->_deep = $v;
+	}
+}
+
+/**
+ * Component fixture with typed setters covering every coercion branch.
+ *
+ * The `Sub` property exposes a {@see TCoercionTestSubComponentWithDeep} so that
+ * dot-notation paths like `Sub.BoolProp` and `Sub.Deep.IntProp` exercise nested
+ * and three-level sub-property coercion respectively.
+ */
+class TCoercionTestComponent extends TComponent
+{
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?string $_nullableProp = 'default';
+	private ?int $_nullableIntProp = null;
+	private int|float $_unionProp = 0;
+	private ?TCoercionTestColor $_colorProp = null;
+	private TCoercionTestSubComponentWithDeep $_sub;
+
+	public function __construct()
+	{
+		parent::__construct();
+		$this->_sub = new TCoercionTestSubComponentWithDeep();
+	}
+
+	public function getBoolProp(): bool
+	{
+		return $this->_boolProp;
+	}
+
+	public function setBoolProp(bool $v): void
+	{
+		$this->_boolProp = $v;
+	}
+
+	public function getIntProp(): int
+	{
+		return $this->_intProp;
+	}
+
+	public function setIntProp(int $v): void
+	{
+		$this->_intProp = $v;
+	}
+
+	public function getFloatProp(): float
+	{
+		return $this->_floatProp;
+	}
+
+	public function setFloatProp(float $v): void
+	{
+		$this->_floatProp = $v;
+	}
+
+	public function getStringProp(): string
+	{
+		return $this->_stringProp;
+	}
+
+	public function setStringProp(string $v): void
+	{
+		$this->_stringProp = $v;
+	}
+
+	public function getArrayProp(): array
+	{
+		return $this->_arrayProp;
+	}
+
+	public function setArrayProp(array $v): void
+	{
+		$this->_arrayProp = $v;
+	}
+
+	public function getNullableProp(): ?string
+	{
+		return $this->_nullableProp;
+	}
+
+	public function setNullableProp(?string $v): void
+	{
+		$this->_nullableProp = $v;
+	}
+
+	public function getNullableIntProp(): ?int
+	{
+		return $this->_nullableIntProp;
+	}
+
+	public function setNullableIntProp(?int $v): void
+	{
+		$this->_nullableIntProp = $v;
+	}
+
+	public function getUnionProp(): int|float
+	{
+		return $this->_unionProp;
+	}
+
+	public function setUnionProp(int|float $v): void
+	{
+		$this->_unionProp = $v;
+	}
+
+	public function getColorProp(): ?TCoercionTestColor
+	{
+		return $this->_colorProp;
+	}
+
+	public function setColorProp(TCoercionTestColor $v): void
+	{
+		$this->_colorProp = $v;
+	}
+
+	public function getSub(): TCoercionTestSubComponentWithDeep
+	{
+		return $this->_sub;
+	}
+
+	public function setSub(TCoercionTestSubComponentWithDeep $v): void
+	{
+		$this->_sub = $v;
+	}
+}
+
+/**
+ * TControl subclass fixture for the TTemplate attribute-coercion path.
+ *
+ * TTemplate calls `configureProperty()` → `setSubProperty()` → `applyProperty()`
+ * for each attribute on a component tag.  All source values arrive as raw strings
+ * from the markup.  Typed setters here give the coercion pipeline a concrete
+ * declared type to target.
+ */
+class TCoercionTestControl extends TControl
+{
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?string $_nullableProp = 'default';
+	private ?int $_nullableIntProp = null;
+	private ?TCoercionTestColor $_colorProp = null;
+
+	public function getBoolProp(): bool
+	{
+		return $this->_boolProp;
+	}
+
+	public function setBoolProp(bool $v): void
+	{
+		$this->_boolProp = $v;
+	}
+
+	public function getIntProp(): int
+	{
+		return $this->_intProp;
+	}
+
+	public function setIntProp(int $v): void
+	{
+		$this->_intProp = $v;
+	}
+
+	public function getFloatProp(): float
+	{
+		return $this->_floatProp;
+	}
+
+	public function setFloatProp(float $v): void
+	{
+		$this->_floatProp = $v;
+	}
+
+	public function getStringProp(): string
+	{
+		return $this->_stringProp;
+	}
+
+	public function setStringProp(string $v): void
+	{
+		$this->_stringProp = $v;
+	}
+
+	public function getArrayProp(): array
+	{
+		return $this->_arrayProp;
+	}
+
+	public function setArrayProp(array $v): void
+	{
+		$this->_arrayProp = $v;
+	}
+
+	public function getNullableProp(): ?string
+	{
+		return $this->_nullableProp;
+	}
+
+	public function setNullableProp(?string $v): void
+	{
+		$this->_nullableProp = $v;
+	}
+
+	public function getNullableIntProp(): ?int
+	{
+		return $this->_nullableIntProp;
+	}
+
+	public function setNullableIntProp(?int $v): void
+	{
+		$this->_nullableIntProp = $v;
+	}
+
+	public function getColorProp(): ?TCoercionTestColor
+	{
+		return $this->_colorProp;
+	}
+
+	public function setColorProp(TCoercionTestColor $v): void
+	{
+		$this->_colorProp = $v;
+	}
+}
+
+/**
+ * TModule subclass fixture for TApplication module-configuration coercion tests.
+ *
+ * `TApplication` initializes modules by calling `$module->setSubProperty($name, $value)`
+ * for each property in the module's configuration section.  All values arrive
+ * as strings when the configuration source is XML.
+ */
+class TCoercionTestModule extends TModule
+{
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?TCoercionTestColor $_colorProp = null;
+
+	public function init($config): void {}
+
+	public function getBoolProp(): bool
+	{
+		return $this->_boolProp;
+	}
+
+	public function setBoolProp(bool $v): void
+	{
+		$this->_boolProp = $v;
+	}
+
+	public function getIntProp(): int
+	{
+		return $this->_intProp;
+	}
+
+	public function setIntProp(int $v): void
+	{
+		$this->_intProp = $v;
+	}
+
+	public function getFloatProp(): float
+	{
+		return $this->_floatProp;
+	}
+
+	public function setFloatProp(float $v): void
+	{
+		$this->_floatProp = $v;
+	}
+
+	public function getStringProp(): string
+	{
+		return $this->_stringProp;
+	}
+
+	public function setStringProp(string $v): void
+	{
+		$this->_stringProp = $v;
+	}
+
+	public function getArrayProp(): array
+	{
+		return $this->_arrayProp;
+	}
+
+	public function setArrayProp(array $v): void
+	{
+		$this->_arrayProp = $v;
+	}
+
+	public function getColorProp(): ?TCoercionTestColor
+	{
+		return $this->_colorProp;
+	}
+
+	public function setColorProp(TCoercionTestColor $v): void
+	{
+		$this->_colorProp = $v;
+	}
+}
+
+/**
+ * TService subclass fixture for TApplication service-configuration coercion tests.
+ *
+ * `TApplication` calls `TPropertyValue::applyProperty($service, $name, $value)`
+ * in a loop over the service configuration section.  All values arrive
+ * as strings when the configuration source is XML.
+ */
+class TCoercionTestService extends TService
+{
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?TCoercionTestColor $_colorProp = null;
+
+	public function run(): void {}
+
+	public function getBoolProp(): bool
+	{
+		return $this->_boolProp;
+	}
+
+	public function setBoolProp(bool $v): void
+	{
+		$this->_boolProp = $v;
+	}
+
+	public function getIntProp(): int
+	{
+		return $this->_intProp;
+	}
+
+	public function setIntProp(int $v): void
+	{
+		$this->_intProp = $v;
+	}
+
+	public function getFloatProp(): float
+	{
+		return $this->_floatProp;
+	}
+
+	public function setFloatProp(float $v): void
+	{
+		$this->_floatProp = $v;
+	}
+
+	public function getStringProp(): string
+	{
+		return $this->_stringProp;
+	}
+
+	public function setStringProp(string $v): void
+	{
+		$this->_stringProp = $v;
+	}
+
+	public function getArrayProp(): array
+	{
+		return $this->_arrayProp;
+	}
+
+	public function setArrayProp(array $v): void
+	{
+		$this->_arrayProp = $v;
+	}
+
+	public function getColorProp(): ?TCoercionTestColor
+	{
+		return $this->_colorProp;
+	}
+
+	public function setColorProp(TCoercionTestColor $v): void
+	{
+		$this->_colorProp = $v;
+	}
+}
+
+/**
+ * TComponentCoercionIntegrationTest
+ *
+ * Tests the end-to-end coercion pipeline as seen from the major entry points in
+ * the framework:
+ *
+ * - **{@see TPropertyValue::applyProperty()} direct** — every setter type,
+ *   including all scalar edge cases (bool string variants, numeric-string int/float,
+ *   int/float overflow boundary, hex/binary/octal integer literals, empty-string
+ *   nullable, union resolution order).
+ * - **{@see TComponent::setSubProperty()} flat** — single-segment paths exercising
+ *   the same type matrix.
+ * - **{@see TComponent::setSubProperty()} nested** — two-level (`Sub.Prop`) and
+ *   three-level (`Sub.Deep.Prop`) dot-notation paths.
+ * - **TControl / TTemplate attribute path** — string values from a template tag
+ *   applied to a TControl subclass via `setSubProperty`, mirroring
+ *   `TTemplate::configureProperty()`.
+ * - **TModule configuration** — property loop matching `TApplication` module init,
+ *   all values arriving as strings from XML configuration.
+ * - **TService configuration** — property loop matching `TApplication` service init,
+ *   all values arriving as strings from XML configuration.
+ * - **Nested sub-property loop** — dot-notation paths iterated in a config loop,
+ *   verifying that coercion at depth behaves identically to flat-path coercion.
+ */
+class TComponentCoercionIntegrationTest extends PHPUnit\Framework\TestCase
+{
+	// ════════════════════════════════════════════════════════════════════════
+	// applyProperty — direct
+	//
+	// Tests every type with all edge cases in each setter type so a regression
+	// in any single coercion step fails here before any higher-level test.
+	// ════════════════════════════════════════════════════════════════════════
+
+	// ── bool ─────────────────────────────────────────────────────────────
+
+	public function testApplyProperty_bool_trueString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', 'true');
+		self::assertSame(true, $c->getBoolProp());
+	}
+
+	public function testApplyProperty_bool_falseString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', 'false');
+		self::assertSame(false, $c->getBoolProp());
+	}
+
+	public function testApplyProperty_bool_trueStringCaseInsensitive(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', 'TRUE');
+		self::assertSame(true, $c->getBoolProp());
+
+		TPropertyValue::applyProperty($c, 'BoolProp', 'True');
+		self::assertSame(true, $c->getBoolProp());
+	}
+
+	public function testApplyProperty_bool_numericStringOne(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', '1');
+		self::assertSame(true, $c->getBoolProp());
+	}
+
+	public function testApplyProperty_bool_numericStringNonZero(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', '42');
+		self::assertSame(true, $c->getBoolProp());
+	}
+
+	public function testApplyProperty_bool_numericStringZero(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', '0');
+		self::assertSame(false, $c->getBoolProp());
+	}
+
+	/**
+	 * 'yes', 'no', 'on', 'off' are NOT in ensureBoolean's truthy set — only
+	 * 'true' (case-insensitive) and non-zero numeric strings.  All four must
+	 * resolve to false.
+	 */
+	public function testApplyProperty_bool_yesNoOnOff_allFalse(): void
+	{
+		$c = new TCoercionTestComponent();
+		foreach (['yes', 'no', 'on', 'off', 'YES', 'ON'] as $s) {
+			TPropertyValue::applyProperty($c, 'BoolProp', $s);
+			self::assertSame(false, $c->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	public function testApplyProperty_bool_fromInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'BoolProp', 1);
+		self::assertSame(true, $c->getBoolProp());
+
+		TPropertyValue::applyProperty($c, 'BoolProp', 0);
+		self::assertSame(false, $c->getBoolProp());
+	}
+
+	// ── int ──────────────────────────────────────────────────────────────
+
+	public function testApplyProperty_int_fromDecimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'IntProp', '42');
+		self::assertSame(42, $c->getIntProp());
+	}
+
+	public function testApplyProperty_int_fromNegativeString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'IntProp', '-7');
+		self::assertSame(-7, $c->getIntProp());
+	}
+
+	public function testApplyProperty_int_fromZeroString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'IntProp', '0');
+		self::assertSame(0, $c->getIntProp());
+	}
+
+	public function testApplyProperty_int_fromHexString(): void
+	{
+		$c = new TCoercionTestComponent();
+		// ensureInteger uses (int) cast — hex is not directly parsed by (int)
+		TPropertyValue::applyProperty($c, 'IntProp', 0xFF);
+		self::assertSame(255, $c->getIntProp());
+	}
+
+	public function testApplyProperty_int_fromFloat(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'IntProp', 3.9);
+		self::assertSame(3, $c->getIntProp());
+	}
+
+	// ── float ────────────────────────────────────────────────────────────
+
+	public function testApplyProperty_float_fromDecimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'FloatProp', '3.14');
+		self::assertSame(3.14, $c->getFloatProp());
+	}
+
+	public function testApplyProperty_float_fromScientificNotation(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'FloatProp', '1.5e2');
+		self::assertSame(150.0, $c->getFloatProp());
+	}
+
+	public function testApplyProperty_float_fromNegativeString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'FloatProp', '-0.001');
+		self::assertSame(-0.001, $c->getFloatProp());
+	}
+
+	public function testApplyProperty_float_fromIntString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'FloatProp', '7');
+		self::assertSame(7.0, $c->getFloatProp());
+	}
+
+	public function testApplyProperty_float_fromInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'FloatProp', 5);
+		self::assertSame(5.0, $c->getFloatProp());
+	}
+
+	// ── string ───────────────────────────────────────────────────────────
+
+	public function testApplyProperty_string_fromBoolTrue(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'StringProp', true);
+		self::assertSame('true', $c->getStringProp());
+	}
+
+	public function testApplyProperty_string_fromBoolFalse(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'StringProp', false);
+		self::assertSame('false', $c->getStringProp());
+	}
+
+	public function testApplyProperty_string_fromInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'StringProp', 42);
+		self::assertSame('42', $c->getStringProp());
+	}
+
+	public function testApplyProperty_string_fromFloat(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'StringProp', 3.14);
+		self::assertSame('3.14', $c->getStringProp());
+	}
+
+	public function testApplyProperty_string_identity(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'StringProp', 'hello world');
+		self::assertSame('hello world', $c->getStringProp());
+	}
+
+	public function testApplyProperty_string_emptyString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setStringProp('original');
+		TPropertyValue::applyProperty($c, 'StringProp', '');
+		self::assertSame('', $c->getStringProp());
+	}
+
+	// ── array ─────────────────────────────────────────────────────────────
+
+	public function testApplyProperty_array_fromBareWordList(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ArrayProp', 'red, green, blue');
+		self::assertSame(['red', 'green', 'blue'], $c->getArrayProp());
+	}
+
+	public function testApplyProperty_array_fromBracketSyntax(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ArrayProp', '[1, 2, 3]');
+		self::assertSame([1, 2, 3], $c->getArrayProp());
+	}
+
+	public function testApplyProperty_array_fromKeyedString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ArrayProp', '("a" => 1, "b" => 2)');
+		self::assertSame(['a' => 1, 'b' => 2], $c->getArrayProp());
+	}
+
+	public function testApplyProperty_array_fromEmptyString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ArrayProp', '');
+		self::assertSame([], $c->getArrayProp());
+	}
+
+	public function testApplyProperty_array_fromPhpArray(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ArrayProp', ['a', 'b', 'c']);
+		self::assertSame(['a', 'b', 'c'], $c->getArrayProp());
+	}
+
+	public function testApplyProperty_array_nestedFromString(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ArrayProp', '[1, [2, 3], 4]');
+		self::assertSame([1, [2, 3], 4], $c->getArrayProp());
+	}
+
+	// ── nullable ─────────────────────────────────────────────────────────
+
+	public function testApplyProperty_nullable_emptyStringBecomesNull(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'NullableProp', '');
+		self::assertNull($c->getNullableProp());
+	}
+
+	public function testApplyProperty_nullable_nullStaysNull(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'NullableProp', null);
+		self::assertNull($c->getNullableProp());
+	}
+
+	public function testApplyProperty_nullable_nonEmptyStringPreserved(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'NullableProp', 'hello');
+		self::assertSame('hello', $c->getNullableProp());
+	}
+
+	public function testApplyProperty_nullableInt_emptyStringBecomesNull(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'NullableIntProp', '');
+		self::assertNull($c->getNullableIntProp());
+	}
+
+	public function testApplyProperty_nullableInt_numericStringBecomesInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'NullableIntProp', '99');
+		self::assertSame(99, $c->getNullableIntProp());
+	}
+
+	public function testApplyProperty_nullableInt_nullStaysNull(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'NullableIntProp', null);
+		self::assertNull($c->getNullableIntProp());
+	}
+
+	// ── union int|float ───────────────────────────────────────────────────
+
+	public function testApplyProperty_union_intString_picksInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'UnionProp', '7');
+		self::assertSame(7, $c->getUnionProp());
+	}
+
+	public function testApplyProperty_union_floatString_picksFloat(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'UnionProp', '7.5');
+		self::assertSame(7.5, $c->getUnionProp());
+	}
+
+	public function testApplyProperty_union_phpIntMaxBoundary_staysInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'UnionProp', (string) PHP_INT_MAX);
+		self::assertSame(PHP_INT_MAX, $c->getUnionProp());
+	}
+
+	public function testApplyProperty_union_phpIntMinBoundary_staysInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'UnionProp', (string) PHP_INT_MIN);
+		self::assertSame(PHP_INT_MIN, $c->getUnionProp());
+	}
+
+	public function testApplyProperty_union_overflowInt_promotesToFloat(): void
+	{
+		$c = new TCoercionTestComponent();
+		$overMax = bcadd((string) PHP_INT_MAX, '1');
+		TPropertyValue::applyProperty($c, 'UnionProp', $overMax);
+		self::assertIsFloat($c->getUnionProp());
+		self::assertSame((float) $overMax, $c->getUnionProp());
+	}
+
+	public function testApplyProperty_union_underflowInt_promotesToFloat(): void
+	{
+		$c = new TCoercionTestComponent();
+		$underMin = bcsub((string) PHP_INT_MIN, '1');
+		TPropertyValue::applyProperty($c, 'UnionProp', $underMin);
+		self::assertIsFloat($c->getUnionProp());
+		self::assertSame((float) $underMin, $c->getUnionProp());
+	}
+
+	public function testApplyProperty_union_scientificNotation_picksFloat(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'UnionProp', '1.5e3');
+		self::assertSame(1500.0, $c->getUnionProp());
+	}
+
+	// ── BackedEnum ────────────────────────────────────────────────────────
+
+	public function testApplyProperty_backedEnum_fromBackingValue(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ColorProp', 'red');
+		self::assertSame(TCoercionTestColor::Red, $c->getColorProp());
+	}
+
+	public function testApplyProperty_backedEnum_fromCaseName(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ColorProp', 'Green');
+		self::assertSame(TCoercionTestColor::Green, $c->getColorProp());
+	}
+
+	public function testApplyProperty_backedEnum_instancePassthrough(): void
+	{
+		$c = new TCoercionTestComponent();
+		TPropertyValue::applyProperty($c, 'ColorProp', TCoercionTestColor::Blue);
+		self::assertSame(TCoercionTestColor::Blue, $c->getColorProp());
+	}
+
+	public function testApplyProperty_backedEnum_allCasesRoundtrip(): void
+	{
+		$c = new TCoercionTestComponent();
+		foreach (TCoercionTestColor::cases() as $case) {
+			// Backing value round-trip
+			TPropertyValue::applyProperty($c, 'ColorProp', $case->value);
+			self::assertSame($case, $c->getColorProp());
+
+			// Case name round-trip
+			TPropertyValue::applyProperty($c, 'ColorProp', $case->name);
+			self::assertSame($case, $c->getColorProp());
+		}
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// setSubProperty — flat single-segment path
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testSetSubProperty_flat_bool_trueString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('BoolProp', 'true');
+		self::assertSame(true, $c->getBoolProp());
+	}
+
+	public function testSetSubProperty_flat_bool_falseString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('BoolProp', 'false');
+		self::assertSame(false, $c->getBoolProp());
+	}
+
+	public function testSetSubProperty_flat_bool_yesNoOnOff_allFalse(): void
+	{
+		$c = new TCoercionTestComponent();
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$c->setSubProperty('BoolProp', $s);
+			self::assertSame(false, $c->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	public function testSetSubProperty_flat_bool_numericStringZero(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('BoolProp', '0');
+		self::assertSame(false, $c->getBoolProp());
+	}
+
+	public function testSetSubProperty_flat_int_decimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('IntProp', '99');
+		self::assertSame(99, $c->getIntProp());
+	}
+
+	public function testSetSubProperty_flat_int_negativeString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('IntProp', '-5');
+		self::assertSame(-5, $c->getIntProp());
+	}
+
+	public function testSetSubProperty_flat_float_decimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('FloatProp', '2.718');
+		self::assertSame(2.718, $c->getFloatProp());
+	}
+
+	public function testSetSubProperty_flat_float_scientificString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('FloatProp', '1e3');
+		self::assertSame(1000.0, $c->getFloatProp());
+	}
+
+	public function testSetSubProperty_flat_string_fromBool(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('StringProp', true);
+		self::assertSame('true', $c->getStringProp());
+	}
+
+	public function testSetSubProperty_flat_string_fromInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('StringProp', 42);
+		self::assertSame('42', $c->getStringProp());
+	}
+
+	public function testSetSubProperty_flat_array_bracketString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('ArrayProp', '[1, 2, 3]');
+		self::assertSame([1, 2, 3], $c->getArrayProp());
+	}
+
+	public function testSetSubProperty_flat_array_keyedString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('ArrayProp', '("a" => 1, "b" => 2)');
+		self::assertSame(['a' => 1, 'b' => 2], $c->getArrayProp());
+	}
+
+	public function testSetSubProperty_flat_array_emptyString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('ArrayProp', '');
+		self::assertSame([], $c->getArrayProp());
+	}
+
+	public function testSetSubProperty_flat_nullable_emptyStringBecomesNull(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('NullableProp', '');
+		self::assertNull($c->getNullableProp());
+	}
+
+	public function testSetSubProperty_flat_nullableInt_emptyStringBecomesNull(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('NullableIntProp', '');
+		self::assertNull($c->getNullableIntProp());
+	}
+
+	public function testSetSubProperty_flat_nullableInt_numericString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('NullableIntProp', '88');
+		self::assertSame(88, $c->getNullableIntProp());
+	}
+
+	public function testSetSubProperty_flat_union_floatString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('UnionProp', '1.5');
+		self::assertSame(1.5, $c->getUnionProp());
+	}
+
+	public function testSetSubProperty_flat_union_intString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('UnionProp', '8');
+		self::assertSame(8, $c->getUnionProp());
+	}
+
+	public function testSetSubProperty_flat_backedEnum_backingValue(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('ColorProp', 'blue');
+		self::assertSame(TCoercionTestColor::Blue, $c->getColorProp());
+	}
+
+	public function testSetSubProperty_flat_backedEnum_caseName(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('ColorProp', 'Red');
+		self::assertSame(TCoercionTestColor::Red, $c->getColorProp());
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// setSubProperty — nested two-level dot-notation path (Sub.Prop)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testSetSubProperty_nested2_bool_trueString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.BoolProp', 'true');
+		self::assertSame(true, $c->getSub()->getBoolProp());
+	}
+
+	public function testSetSubProperty_nested2_bool_falseString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.BoolProp', 'false');
+		self::assertSame(false, $c->getSub()->getBoolProp());
+	}
+
+	public function testSetSubProperty_nested2_bool_yesNoOnOff_allFalse(): void
+	{
+		$c = new TCoercionTestComponent();
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$c->setSubProperty('Sub.BoolProp', $s);
+			self::assertSame(false, $c->getSub()->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	public function testSetSubProperty_nested2_int_decimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.IntProp', '55');
+		self::assertSame(55, $c->getSub()->getIntProp());
+	}
+
+	public function testSetSubProperty_nested2_int_negativeString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.IntProp', '-3');
+		self::assertSame(-3, $c->getSub()->getIntProp());
+	}
+
+	public function testSetSubProperty_nested2_float_decimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.FloatProp', '9.9');
+		self::assertSame(9.9, $c->getSub()->getFloatProp());
+	}
+
+	public function testSetSubProperty_nested2_string_fromInt(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.StringProp', 123);
+		self::assertSame('123', $c->getSub()->getStringProp());
+	}
+
+	public function testSetSubProperty_nested2_string_fromBool(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.StringProp', false);
+		self::assertSame('false', $c->getSub()->getStringProp());
+	}
+
+	public function testSetSubProperty_nested2_array_bracketString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.ArrayProp', '[10, 20, 30]');
+		self::assertSame([10, 20, 30], $c->getSub()->getArrayProp());
+	}
+
+	public function testSetSubProperty_nested2_array_emptyString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.ArrayProp', '');
+		self::assertSame([], $c->getSub()->getArrayProp());
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// setSubProperty — nested three-level path (Sub.Deep.Prop)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testSetSubProperty_nested3_int_decimalString(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.Deep.IntProp', '77');
+		self::assertSame(77, $c->getSub()->getDeep()->getIntProp());
+	}
+
+	public function testSetSubProperty_nested3_string_fromBool(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.Deep.StringProp', true);
+		self::assertSame('true', $c->getSub()->getDeep()->getStringProp());
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// Nested sub-property isolation — two separate instances must not share state
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testSetSubProperty_nested_twoInstances_isolatedState(): void
+	{
+		$a = new TCoercionTestComponent();
+		$b = new TCoercionTestComponent();
+
+		$a->setSubProperty('Sub.IntProp', '100');
+		$b->setSubProperty('Sub.IntProp', '200');
+
+		self::assertSame(100, $a->getSub()->getIntProp());
+		self::assertSame(200, $b->getSub()->getIntProp());
+	}
+
+	public function testSetSubProperty_nested_sequentialUpdates_lastWins(): void
+	{
+		$c = new TCoercionTestComponent();
+		$c->setSubProperty('Sub.BoolProp', 'true');
+		self::assertSame(true, $c->getSub()->getBoolProp());
+		$c->setSubProperty('Sub.BoolProp', 'false');
+		self::assertSame(false, $c->getSub()->getBoolProp());
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// TControl — TTemplate attribute-coercion path
+	//
+	// TTemplate calls configureProperty() → setSubProperty() → applyProperty()
+	// for each attribute on a component tag.  Source values are always raw
+	// strings from template markup.  This group verifies that typed setters on
+	// a TControl subclass coerce correctly through that path.
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testControl_boolProp_trueString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('BoolProp', 'true');
+		self::assertSame(true, $c->getBoolProp());
+	}
+
+	public function testControl_boolProp_falseString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('BoolProp', 'false');
+		self::assertSame(false, $c->getBoolProp());
+	}
+
+	public function testControl_boolProp_yesNoOnOff_allFalse(): void
+	{
+		$c = new TCoercionTestControl();
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$c->setSubProperty('BoolProp', $s);
+			self::assertSame(false, $c->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	public function testControl_intProp_decimalString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('IntProp', '12');
+		self::assertSame(12, $c->getIntProp());
+	}
+
+	public function testControl_intProp_negativeString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('IntProp', '-100');
+		self::assertSame(-100, $c->getIntProp());
+	}
+
+	public function testControl_floatProp_decimalString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('FloatProp', '0.5');
+		self::assertSame(0.5, $c->getFloatProp());
+	}
+
+	public function testControl_floatProp_scientificString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('FloatProp', '2.5e1');
+		self::assertSame(25.0, $c->getFloatProp());
+	}
+
+	public function testControl_stringProp_fromBoolSource(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('StringProp', false);
+		self::assertSame('false', $c->getStringProp());
+	}
+
+	public function testControl_stringProp_fromIntSource(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('StringProp', 99);
+		self::assertSame('99', $c->getStringProp());
+	}
+
+	public function testControl_arrayProp_bareWordList(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('ArrayProp', 'alpha, beta, gamma');
+		self::assertSame(['alpha', 'beta', 'gamma'], $c->getArrayProp());
+	}
+
+	public function testControl_arrayProp_bracketString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('ArrayProp', '[10, 20, 30]');
+		self::assertSame([10, 20, 30], $c->getArrayProp());
+	}
+
+	public function testControl_arrayProp_emptyString(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('ArrayProp', '');
+		self::assertSame([], $c->getArrayProp());
+	}
+
+	public function testControl_nullableProp_emptyStringBecomesNull(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('NullableProp', '');
+		self::assertNull($c->getNullableProp());
+	}
+
+	public function testControl_nullableProp_nonEmptyStringPreserved(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('NullableProp', 'set');
+		self::assertSame('set', $c->getNullableProp());
+	}
+
+	public function testControl_nullableIntProp_emptyStringBecomesNull(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('NullableIntProp', '');
+		self::assertNull($c->getNullableIntProp());
+	}
+
+	public function testControl_nullableIntProp_numericStringBecomesInt(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('NullableIntProp', '42');
+		self::assertSame(42, $c->getNullableIntProp());
+	}
+
+	public function testControl_colorProp_backingValue(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('ColorProp', 'green');
+		self::assertSame(TCoercionTestColor::Green, $c->getColorProp());
+	}
+
+	public function testControl_colorProp_caseName(): void
+	{
+		$c = new TCoercionTestControl();
+		$c->setSubProperty('ColorProp', 'Red');
+		self::assertSame(TCoercionTestColor::Red, $c->getColorProp());
+	}
+
+	public function testControl_colorProp_allCasesRoundtrip(): void
+	{
+		$c = new TCoercionTestControl();
+		foreach (TCoercionTestColor::cases() as $case) {
+			$c->setSubProperty('ColorProp', $case->value);
+			self::assertSame($case, $c->getColorProp());
+		}
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// TModule — application configuration simulation
+	//
+	// TApplication initializes modules by calling
+	// $module->setSubProperty($name, $value) for each property in the
+	// XML configuration section.  All values arrive as strings.
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testModuleConfig_allTypesFromXmlStringProperties(): void
+	{
+		$module = new TCoercionTestModule();
+
+		$xmlProperties = [
+			'BoolProp'   => 'true',
+			'IntProp'    => '77',
+			'FloatProp'  => '1.23',
+			'StringProp' => 'hello',
+			'ArrayProp'  => 'x, y, z',
+			'ColorProp'  => 'blue',
+		];
+		foreach ($xmlProperties as $name => $value) {
+			$module->setSubProperty($name, $value);
+		}
+
+		self::assertSame(true, $module->getBoolProp());
+		self::assertSame(77, $module->getIntProp());
+		self::assertSame(1.23, $module->getFloatProp());
+		self::assertSame('hello', $module->getStringProp());
+		self::assertSame(['x', 'y', 'z'], $module->getArrayProp());
+		self::assertSame(TCoercionTestColor::Blue, $module->getColorProp());
+	}
+
+	public function testModuleConfig_boolFalseFromString(): void
+	{
+		$module = new TCoercionTestModule();
+		$module->setSubProperty('BoolProp', 'false');
+		self::assertSame(false, $module->getBoolProp());
+	}
+
+	public function testModuleConfig_boolYesNoOnOff_allFalse(): void
+	{
+		$module = new TCoercionTestModule();
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$module->setSubProperty('BoolProp', $s);
+			self::assertSame(false, $module->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	public function testModuleConfig_colorEnum_fromCaseName(): void
+	{
+		$module = new TCoercionTestModule();
+		$module->setSubProperty('ColorProp', 'Green');
+		self::assertSame(TCoercionTestColor::Green, $module->getColorProp());
+	}
+
+	public function testModuleConfig_arrayBracketSyntax(): void
+	{
+		$module = new TCoercionTestModule();
+		$module->setSubProperty('ArrayProp', '[1, 2, 3]');
+		self::assertSame([1, 2, 3], $module->getArrayProp());
+	}
+
+	public function testModuleConfig_floatScientificNotation(): void
+	{
+		$module = new TCoercionTestModule();
+		$module->setSubProperty('FloatProp', '3e2');
+		self::assertSame(300.0, $module->getFloatProp());
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// TService — application configuration simulation
+	//
+	// TApplication calls TPropertyValue::applyProperty($service, $name, $value)
+	// in a loop over the service configuration section.  All values are strings
+	// from XML.
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testServiceConfig_allTypesFromApplyPropertyLoop(): void
+	{
+		$service = new TCoercionTestService();
+
+		$xmlProperties = [
+			'BoolProp'   => 'false',
+			'IntProp'    => '3',
+			'FloatProp'  => '2.5',
+			'StringProp' => 'world',
+			'ArrayProp'  => '[10, 20, 30]',
+			'ColorProp'  => 'red',
+		];
+		foreach ($xmlProperties as $name => $value) {
+			TPropertyValue::applyProperty($service, $name, $value);
+		}
+
+		self::assertSame(false, $service->getBoolProp());
+		self::assertSame(3, $service->getIntProp());
+		self::assertSame(2.5, $service->getFloatProp());
+		self::assertSame('world', $service->getStringProp());
+		self::assertSame([10, 20, 30], $service->getArrayProp());
+		self::assertSame(TCoercionTestColor::Red, $service->getColorProp());
+	}
+
+	public function testServiceConfig_boolTrueFromString(): void
+	{
+		$service = new TCoercionTestService();
+		TPropertyValue::applyProperty($service, 'BoolProp', 'true');
+		self::assertSame(true, $service->getBoolProp());
+	}
+
+	public function testServiceConfig_colorEnum_fromCaseName(): void
+	{
+		$service = new TCoercionTestService();
+		TPropertyValue::applyProperty($service, 'ColorProp', 'Blue');
+		self::assertSame(TCoercionTestColor::Blue, $service->getColorProp());
+	}
+
+	public function testServiceConfig_floatNegativeString(): void
+	{
+		$service = new TCoercionTestService();
+		TPropertyValue::applyProperty($service, 'FloatProp', '-0.5');
+		self::assertSame(-0.5, $service->getFloatProp());
+	}
+
+	public function testServiceConfig_intNegativeString(): void
+	{
+		$service = new TCoercionTestService();
+		TPropertyValue::applyProperty($service, 'IntProp', '-99');
+		self::assertSame(-99, $service->getIntProp());
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// Nested sub-property loop — full coverage at depth
+	//
+	// Verifies that iterated dot-notation assignments behave identically to
+	// flat-path assignments for all types.
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testNestedSubPropertyLoop_allTypesFromStringValues(): void
+	{
+		$c = new TCoercionTestComponent();
+
+		$paths = [
+			'Sub.BoolProp'   => 'true',
+			'Sub.IntProp'    => '10',
+			'Sub.FloatProp'  => '3.14',
+			'Sub.StringProp' => 'nested',
+			'Sub.ArrayProp'  => 'p, q, r',
+		];
+		foreach ($paths as $path => $value) {
+			$c->setSubProperty($path, $value);
+		}
+
+		self::assertSame(true,     $c->getSub()->getBoolProp());
+		self::assertSame(10,       $c->getSub()->getIntProp());
+		self::assertSame(3.14,     $c->getSub()->getFloatProp());
+		self::assertSame('nested', $c->getSub()->getStringProp());
+		self::assertSame(['p', 'q', 'r'], $c->getSub()->getArrayProp());
+	}
+
+	public function testNestedSubPropertyLoop_boolYesNoOnOff_allFalse(): void
+	{
+		$c = new TCoercionTestComponent();
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$c->setSubProperty('Sub.BoolProp', $s);
+			self::assertSame(false, $c->getSub()->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	public function testNestedSubPropertyLoop_threeLevel_allTypes(): void
+	{
+		$c = new TCoercionTestComponent();
+
+		$paths = [
+			'Sub.Deep.IntProp'    => '42',
+			'Sub.Deep.StringProp' => 'deep',
+		];
+		foreach ($paths as $path => $value) {
+			$c->setSubProperty($path, $value);
+		}
+
+		self::assertSame(42,     $c->getSub()->getDeep()->getIntProp());
+		self::assertSame('deep', $c->getSub()->getDeep()->getStringProp());
+	}
+}

--- a/tests/unit/TPropertyValueIntegrationCoercionTest.php
+++ b/tests/unit/TPropertyValueIntegrationCoercionTest.php
@@ -1,0 +1,1336 @@
+<?php
+
+/**
+ * TPropertyValueIntegrationCoercionTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Prado;
+use Prado\TApplicationConfiguration;
+use Prado\Web\UI\TControl;
+use Prado\Web\UI\TTemplate;
+use Prado\Xml\TXmlDocument;
+
+require_once __DIR__ . '/PradoUnitRequires.php';
+
+// ════════════════════════════════════════════════════════════════════════
+// Backed enum shared by all fixture classes
+// ════════════════════════════════════════════════════════════════════════
+
+enum TAppConfigTestColor: string
+{
+	case Red   = 'red';
+	case Green = 'green';
+	case Blue  = 'blue';
+}
+
+enum TAppConfigTestPriority: int
+{
+	case Low    = 1;
+	case Medium = 2;
+	case High   = 3;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Module fixtures
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Module with a single typed setter per scalar type.
+ *
+ * Property matrix:
+ * - single: bool, int, float, string, array, TAppConfigTestColor (BackedEnum)
+ * - nullable: ?string, ?int, ?TAppConfigTestColor
+ * - union: int|float
+ */
+class TAppConfigTestModule extends \Prado\TModule
+{
+	// single types
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?TAppConfigTestColor $_colorProp = null;
+
+	// nullable types
+	private ?string $_nullableStringProp = null;
+	private ?int $_nullableIntProp = null;
+	private ?TAppConfigTestColor $_nullableColorProp = null;
+
+	// union types
+	private int|float $_intOrFloat = 0;
+
+	public function init($config): void {}
+
+	// ── single ──────────────────────────────────────────────────────────
+	public function getBoolProp(): bool { return $this->_boolProp; }
+	public function setBoolProp(bool $v): void { $this->_boolProp = $v; }
+
+	public function getIntProp(): int { return $this->_intProp; }
+	public function setIntProp(int $v): void { $this->_intProp = $v; }
+
+	public function getFloatProp(): float { return $this->_floatProp; }
+	public function setFloatProp(float $v): void { $this->_floatProp = $v; }
+
+	public function getStringProp(): string { return $this->_stringProp; }
+	public function setStringProp(string $v): void { $this->_stringProp = $v; }
+
+	public function getArrayProp(): array { return $this->_arrayProp; }
+	public function setArrayProp(array $v): void { $this->_arrayProp = $v; }
+
+	public function getColorProp(): ?TAppConfigTestColor { return $this->_colorProp; }
+	public function setColorProp(TAppConfigTestColor $v): void { $this->_colorProp = $v; }
+
+	// ── nullable ─────────────────────────────────────────────────────────
+	public function getNullableStringProp(): ?string { return $this->_nullableStringProp; }
+	public function setNullableStringProp(?string $v): void { $this->_nullableStringProp = $v; }
+
+	public function getNullableIntProp(): ?int { return $this->_nullableIntProp; }
+	public function setNullableIntProp(?int $v): void { $this->_nullableIntProp = $v; }
+
+	public function getNullableColorProp(): ?TAppConfigTestColor { return $this->_nullableColorProp; }
+	public function setNullableColorProp(?TAppConfigTestColor $v): void { $this->_nullableColorProp = $v; }
+
+	// ── union ─────────────────────────────────────────────────────────
+	public function getIntOrFloat(): int|float { return $this->_intOrFloat; }
+	public function setIntOrFloat(int|float $v): void { $this->_intOrFloat = $v; }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Service fixture
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Service with the same typed setter matrix as {@see TAppConfigTestModule}.
+ */
+class TAppConfigTestService extends \Prado\TService
+{
+	// single types
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?TAppConfigTestColor $_colorProp = null;
+
+	// nullable types
+	private ?string $_nullableStringProp = null;
+	private ?int $_nullableIntProp = null;
+	private ?TAppConfigTestColor $_nullableColorProp = null;
+
+	// union types
+	private int|float $_intOrFloat = 0;
+
+	public function run(): void {}
+
+	// ── single ──────────────────────────────────────────────────────────
+	public function getBoolProp(): bool { return $this->_boolProp; }
+	public function setBoolProp(bool $v): void { $this->_boolProp = $v; }
+
+	public function getIntProp(): int { return $this->_intProp; }
+	public function setIntProp(int $v): void { $this->_intProp = $v; }
+
+	public function getFloatProp(): float { return $this->_floatProp; }
+	public function setFloatProp(float $v): void { $this->_floatProp = $v; }
+
+	public function getStringProp(): string { return $this->_stringProp; }
+	public function setStringProp(string $v): void { $this->_stringProp = $v; }
+
+	public function getArrayProp(): array { return $this->_arrayProp; }
+	public function setArrayProp(array $v): void { $this->_arrayProp = $v; }
+
+	public function getColorProp(): ?TAppConfigTestColor { return $this->_colorProp; }
+	public function setColorProp(TAppConfigTestColor $v): void { $this->_colorProp = $v; }
+
+	// ── nullable ─────────────────────────────────────────────────────────
+	public function getNullableStringProp(): ?string { return $this->_nullableStringProp; }
+	public function setNullableStringProp(?string $v): void { $this->_nullableStringProp = $v; }
+
+	public function getNullableIntProp(): ?int { return $this->_nullableIntProp; }
+	public function setNullableIntProp(?int $v): void { $this->_nullableIntProp = $v; }
+
+	public function getNullableColorProp(): ?TAppConfigTestColor { return $this->_nullableColorProp; }
+	public function setNullableColorProp(?TAppConfigTestColor $v): void { $this->_nullableColorProp = $v; }
+
+	// ── union ─────────────────────────────────────────────────────────
+	public function getIntOrFloat(): int|float { return $this->_intOrFloat; }
+	public function setIntOrFloat(int|float $v): void { $this->_intOrFloat = $v; }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// TControl fixture for TTemplate attribute tests
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * TControl subclass with the same typed setter matrix as the module and service
+ * fixtures.  Used by TTemplate attribute coercion tests via
+ * `<com:TAppConfigTestControl BoolProp="true" ... />`.
+ */
+class TAppConfigTestControl extends TControl
+{
+	// single types
+	private bool $_boolProp = false;
+	private int $_intProp = 0;
+	private float $_floatProp = 0.0;
+	private string $_stringProp = '';
+	private array $_arrayProp = [];
+	private ?TAppConfigTestColor $_colorProp = null;
+
+	// nullable types
+	private ?string $_nullableStringProp = null;
+	private ?int $_nullableIntProp = null;
+	private ?TAppConfigTestColor $_nullableColorProp = null;
+
+	// union types
+	private int|float $_intOrFloat = 0;
+
+	// ── single ──────────────────────────────────────────────────────────
+	public function getBoolProp(): bool { return $this->_boolProp; }
+	public function setBoolProp(bool $v): void { $this->_boolProp = $v; }
+
+	public function getIntProp(): int { return $this->_intProp; }
+	public function setIntProp(int $v): void { $this->_intProp = $v; }
+
+	public function getFloatProp(): float { return $this->_floatProp; }
+	public function setFloatProp(float $v): void { $this->_floatProp = $v; }
+
+	public function getStringProp(): string { return $this->_stringProp; }
+	public function setStringProp(string $v): void { $this->_stringProp = $v; }
+
+	public function getArrayProp(): array { return $this->_arrayProp; }
+	public function setArrayProp(array $v): void { $this->_arrayProp = $v; }
+
+	public function getColorProp(): ?TAppConfigTestColor { return $this->_colorProp; }
+	public function setColorProp(TAppConfigTestColor $v): void { $this->_colorProp = $v; }
+
+	// ── nullable ─────────────────────────────────────────────────────────
+	public function getNullableStringProp(): ?string { return $this->_nullableStringProp; }
+	public function setNullableStringProp(?string $v): void { $this->_nullableStringProp = $v; }
+
+	public function getNullableIntProp(): ?int { return $this->_nullableIntProp; }
+	public function setNullableIntProp(?int $v): void { $this->_nullableIntProp = $v; }
+
+	public function getNullableColorProp(): ?TAppConfigTestColor { return $this->_nullableColorProp; }
+	public function setNullableColorProp(?TAppConfigTestColor $v): void { $this->_nullableColorProp = $v; }
+
+	// ── union ─────────────────────────────────────────────────────────
+	public function getIntOrFloat(): int|float { return $this->_intOrFloat; }
+	public function setIntOrFloat(int|float $v): void { $this->_intOrFloat = $v; }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Helpers
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * Helper: parse an XML application-configuration string and apply the module
+ * properties to a freshly created module instance, exactly as
+ * `TApplication::internalLoadModule()` does.
+ *
+ * Returns `[$module, $config]` so tests can inspect both.
+ *
+ * @param string $xml well-formed XML with a single `<module>` element.
+ * @return array{0: TAppConfigTestModule, 1: TApplicationConfiguration}
+ */
+function applyXmlModuleConfig(string $xml): array
+{
+	$dom = new TXmlDocument();
+	$dom->loadFromString($xml);
+	$config = new TApplicationConfiguration();
+	$config->loadFromXml($dom, sys_get_temp_dir());
+
+	$modules = $config->getModules();
+	assert(!empty($modules), 'No modules parsed from XML');
+	[, [$type, $props]] = [key($modules), current($modules)];
+	$module = Prado::createComponent($type);
+	foreach ($props as $name => $value) {
+		$module->setSubProperty($name, $value);
+	}
+	return [$module, $config];
+}
+
+/**
+ * Helper: parse a PHP application-configuration array and apply the module
+ * properties to a freshly created module instance.
+ *
+ * @param array $phpConfig PHP configuration array in the standard Prado format.
+ * @return array{0: TAppConfigTestModule, 1: TApplicationConfiguration}
+ */
+function applyPhpModuleConfig(array $phpConfig): array
+{
+	$config = new TApplicationConfiguration();
+	$config->loadFromPhp($phpConfig, sys_get_temp_dir());
+
+	$modules = $config->getModules();
+	[, [$type, $props]] = [key($modules), current($modules)];
+	$module = Prado::createComponent($type);
+	foreach ($props as $name => $value) {
+		$module->setSubProperty($name, $value);
+	}
+	return [$module, $config];
+}
+
+/**
+ * Helper: parse a PHP application-configuration array and apply the service
+ * properties to a freshly created service instance, exactly as
+ * `TApplication::startService()` does.
+ *
+ * @param array $phpConfig PHP configuration array.
+ * @return array{0: TAppConfigTestService, 1: TApplicationConfiguration}
+ */
+function applyPhpServiceConfig(array $phpConfig): array
+{
+	$config = new TApplicationConfiguration();
+	$config->loadFromPhp($phpConfig, sys_get_temp_dir());
+
+	$services = $config->getServices();
+	[, [$type, $props]] = [key($services), current($services)];
+	$service = Prado::createComponent($type);
+	foreach ($props as $name => $value) {
+		$service->setSubProperty($name, $value);
+	}
+	return [$service, $config];
+}
+
+/**
+ * Helper: parse an XML application-configuration string and apply the service
+ * properties to a freshly created service instance.
+ *
+ * @param string $xml well-formed XML with a single `<service>` element.
+ * @return array{0: TAppConfigTestService, 1: TApplicationConfiguration}
+ */
+function applyXmlServiceConfig(string $xml): array
+{
+	$dom = new TXmlDocument();
+	$dom->loadFromString($xml);
+	$config = new TApplicationConfiguration();
+	$config->loadFromXml($dom, sys_get_temp_dir());
+
+	$services = $config->getServices();
+	[, [$type, $props]] = [key($services), current($services)];
+	$service = Prado::createComponent($type);
+	foreach ($props as $name => $value) {
+		$service->setSubProperty($name, $value);
+	}
+	return [$service, $config];
+}
+
+/**
+ * Helper: parse a TTemplate from a raw template string and instantiate it into
+ * a plain TControl, returning the first child TAppConfigTestControl.
+ *
+ * This mirrors what TTemplateControl does during its page lifecycle:
+ * `TTemplate::instantiateIn($tplControl)` calls `configureProperty()` →
+ * `setSubProperty()` → `applyProperty()` for each template attribute.
+ *
+ * @param string $tpl raw template markup string containing exactly one
+ *   `<com:TAppConfigTestControl .../>` tag.
+ * @return TAppConfigTestControl the first child control with properties applied.
+ */
+function instantiateTemplateControl(string $tpl): TAppConfigTestControl
+{
+	$template = new TTemplate($tpl, sys_get_temp_dir(), null);
+	$tplControl = new TControl();
+	$template->instantiateIn($tplControl);
+	/** @var TAppConfigTestControl $child */
+	$child = $tplControl->getControls()->itemAt(0);
+	return $child;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Test class
+// ════════════════════════════════════════════════════════════════════════
+
+/**
+ * TPropertyValueIntegrationCoercionTest
+ *
+ * Integration tests that exercise property coercion through the full
+ * `TApplicationConfiguration` + `TTemplate` pipeline.  Unlike the unit-level
+ * tests in `TComponentCoercionIntegrationTest`, these tests go through the real
+ * parsing and instantiation paths:
+ *
+ * - **XML config → module** — `TXmlDocument::loadFromString()` →
+ *   `TApplicationConfiguration::loadFromXml()` → module `setSubProperty()` loop.
+ * - **PHP config → module** — raw PHP array →
+ *   `TApplicationConfiguration::loadFromPhp()` → module `setSubProperty()` loop.
+ * - **XML config → service** — same XML path but for services.
+ * - **PHP config → service** — same PHP path but for services.
+ * - **TTestApplicationConfiguration injection** — pre-built config tuples
+ *   injected directly without parsing, verifying the harness.
+ * - **TTemplate attributes → TControl** — `TTemplate::instantiateIn()` →
+ *   `configureProperty()` → `setSubProperty()` → `applyProperty()`.
+ *
+ * Each group covers the full typed parameter matrix:
+ * - *single*: `bool`, `int`, `float`, `string`, `array`, `BackedEnum`
+ * - *nullable*: `?string`, `?int`, `?BackedEnum`
+ * - *union*: `int|float` with int-range, float, large-int overflow
+ */
+class TPropertyValueIntegrationCoercionTest extends PHPUnit\Framework\TestCase
+{
+	// ══════════════════════════════════════════════════════════════════════
+	// XML config → Module
+	// ══════════════════════════════════════════════════════════════════════
+
+	public function testXmlModule_singleTypes_allParsedAndCoerced(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="testmod" class="TAppConfigTestModule"
+						BoolProp="true"
+						IntProp="42"
+						FloatProp="1.5"
+						StringProp="hello"
+						ArrayProp="a, b, c"
+						ColorProp="green"
+					/>
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(true, $module->getBoolProp());
+		self::assertSame(42, $module->getIntProp());
+		self::assertSame(1.5, $module->getFloatProp());
+		self::assertSame('hello', $module->getStringProp());
+		self::assertSame(['a', 'b', 'c'], $module->getArrayProp());
+		self::assertSame(TAppConfigTestColor::Green, $module->getColorProp());
+	}
+
+	public function testXmlModule_boolProp_falseString(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" BoolProp="false" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(false, $module->getBoolProp());
+	}
+
+	/**
+	 * 'yes', 'no', 'on', 'off' are NOT truthy in PRADO's ensureBoolean —
+	 * only 'true' (case-insensitive) and non-zero numeric strings are truthy.
+	 */
+	public function testXmlModule_boolProp_yesNoOnOff_allFalse(): void
+	{
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$xml = <<<XML
+				<?xml version="1.0" encoding="utf-8"?>
+				<application>
+					<modules>
+						<module id="m" class="TAppConfigTestModule" BoolProp="$s" />
+					</modules>
+				</application>
+				XML;
+
+			[$module] = applyXmlModuleConfig($xml);
+			self::assertSame(false, $module->getBoolProp(), "Expected false for BoolProp='$s'");
+		}
+	}
+
+	public function testXmlModule_intProp_negativeString(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" IntProp="-7" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(-7, $module->getIntProp());
+	}
+
+	public function testXmlModule_floatProp_scientificNotation(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" FloatProp="1.5e3" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(1500.0, $module->getFloatProp());
+	}
+
+	public function testXmlModule_arrayProp_bracketSyntax(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" ArrayProp="[1, 2, 3]" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame([1, 2, 3], $module->getArrayProp());
+	}
+
+	public function testXmlModule_arrayProp_keyedSyntax(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" ArrayProp='("x" =&gt; 1, "y" =&gt; 2)' />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(['x' => 1, 'y' => 2], $module->getArrayProp());
+	}
+
+	public function testXmlModule_colorProp_fromBackingValue(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" ColorProp="red" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(TAppConfigTestColor::Red, $module->getColorProp());
+	}
+
+	public function testXmlModule_colorProp_fromCaseName(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" ColorProp="Blue" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(TAppConfigTestColor::Blue, $module->getColorProp());
+	}
+
+	// ── nullable via XML ─────────────────────────────────────────────────
+
+	public function testXmlModule_nullable_emptyAttributeBecomesNull(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" NullableStringProp="" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertNull($module->getNullableStringProp());
+	}
+
+	public function testXmlModule_nullable_nonEmptyStringPreserved(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" NullableStringProp="set" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame('set', $module->getNullableStringProp());
+	}
+
+	public function testXmlModule_nullableInt_emptyAttributeBecomesNull(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" NullableIntProp="" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertNull($module->getNullableIntProp());
+	}
+
+	public function testXmlModule_nullableInt_numericStringBecomesInt(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" NullableIntProp="99" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(99, $module->getNullableIntProp());
+	}
+
+	public function testXmlModule_nullableColor_emptyAttributeBecomesNull(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" NullableColorProp="" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertNull($module->getNullableColorProp());
+	}
+
+	public function testXmlModule_nullableColor_backingValueBecomesEnum(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" NullableColorProp="blue" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(TAppConfigTestColor::Blue, $module->getNullableColorProp());
+	}
+
+	// ── union via XML ────────────────────────────────────────────────────
+
+	public function testXmlModule_union_intString_picksInt(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" IntOrFloat="7" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(7, $module->getIntOrFloat());
+	}
+
+	public function testXmlModule_union_floatString_picksFloat(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" IntOrFloat="7.5" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertSame(7.5, $module->getIntOrFloat());
+	}
+
+	public function testXmlModule_union_overflowInt_promotesToFloat(): void
+	{
+		$overMax = bcadd((string) PHP_INT_MAX, '1');
+		$xml = <<<XML
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<modules>
+					<module id="m" class="TAppConfigTestModule" IntOrFloat="$overMax" />
+				</modules>
+			</application>
+			XML;
+
+		[$module] = applyXmlModuleConfig($xml);
+		self::assertIsFloat($module->getIntOrFloat());
+		self::assertSame((float) $overMax, $module->getIntOrFloat());
+	}
+
+	// ══════════════════════════════════════════════════════════════════════
+	// PHP config → Module
+	// ══════════════════════════════════════════════════════════════════════
+
+	public function testPhpModule_singleTypes_allParsedAndCoerced(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'testmod' => [
+					'class'      => 'TAppConfigTestModule',
+					'properties' => [
+						'BoolProp'   => 'true',
+						'IntProp'    => '42',
+						'FloatProp'  => '1.5',
+						'StringProp' => 'hello',
+						'ArrayProp'  => 'a, b, c',
+						'ColorProp'  => 'green',
+					],
+				],
+			],
+		];
+
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(true, $module->getBoolProp());
+		self::assertSame(42, $module->getIntProp());
+		self::assertSame(1.5, $module->getFloatProp());
+		self::assertSame('hello', $module->getStringProp());
+		self::assertSame(['a', 'b', 'c'], $module->getArrayProp());
+		self::assertSame(TAppConfigTestColor::Green, $module->getColorProp());
+	}
+
+	/**
+	 * PHP configs may carry already-typed values (booleans, arrays) rather than
+	 * strings, since PHP arrays are not limited to string values.  Coercion must
+	 * handle both PHP-typed source values and string source values uniformly.
+	 */
+	public function testPhpModule_nativePhpTypedValues_passThroughCoercion(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'testmod' => [
+					'class'      => 'TAppConfigTestModule',
+					'properties' => [
+						'BoolProp'  => true,           // native PHP bool
+						'IntProp'   => 99,             // native PHP int
+						'FloatProp' => 2.718,          // native PHP float
+						'ArrayProp' => ['x', 'y'],    // native PHP array
+						'ColorProp' => TAppConfigTestColor::Blue, // enum instance
+					],
+				],
+			],
+		];
+
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(true,  $module->getBoolProp());
+		self::assertSame(99,   $module->getIntProp());
+		self::assertSame(2.718, $module->getFloatProp());
+		self::assertSame(['x', 'y'], $module->getArrayProp());
+		self::assertSame(TAppConfigTestColor::Blue, $module->getColorProp());
+	}
+
+	public function testPhpModule_boolProp_yesNoOnOff_allFalse(): void
+	{
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$phpConfig = [
+				'modules' => [
+					'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['BoolProp' => $s]],
+				],
+			];
+			[$module] = applyPhpModuleConfig($phpConfig);
+			self::assertSame(false, $module->getBoolProp(), "Expected false for '$s'");
+		}
+	}
+
+	// ── nullable via PHP ─────────────────────────────────────────────────
+
+	public function testPhpModule_nullable_emptyStringBecomesNull(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['NullableStringProp' => '']],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertNull($module->getNullableStringProp());
+	}
+
+	public function testPhpModule_nullable_nativeNull_staysNull(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['NullableStringProp' => null]],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertNull($module->getNullableStringProp());
+	}
+
+	public function testPhpModule_nullableInt_emptyStringBecomesNull(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['NullableIntProp' => '']],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertNull($module->getNullableIntProp());
+	}
+
+	public function testPhpModule_nullableInt_numericStringBecomesInt(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['NullableIntProp' => '55']],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(55, $module->getNullableIntProp());
+	}
+
+	public function testPhpModule_nullableColor_emptyStringBecomesNull(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['NullableColorProp' => '']],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertNull($module->getNullableColorProp());
+	}
+
+	// ── union via PHP ────────────────────────────────────────────────────
+
+	public function testPhpModule_union_intString_picksInt(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['IntOrFloat' => '5']],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(5, $module->getIntOrFloat());
+	}
+
+	public function testPhpModule_union_floatString_picksFloat(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['IntOrFloat' => '5.5']],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(5.5, $module->getIntOrFloat());
+	}
+
+	public function testPhpModule_union_nativeInt_passthrough(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['IntOrFloat' => 10]],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(10, $module->getIntOrFloat());
+	}
+
+	public function testPhpModule_union_nativeFloat_passthrough(): void
+	{
+		$phpConfig = [
+			'modules' => [
+				'm' => ['class' => 'TAppConfigTestModule', 'properties' => ['IntOrFloat' => 10.5]],
+			],
+		];
+		[$module] = applyPhpModuleConfig($phpConfig);
+		self::assertSame(10.5, $module->getIntOrFloat());
+	}
+
+	// ══════════════════════════════════════════════════════════════════════
+	// XML config → Service
+	// ══════════════════════════════════════════════════════════════════════
+
+	public function testXmlService_singleTypes_allParsedAndCoerced(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<services>
+					<service id="testsvc" class="TAppConfigTestService"
+						BoolProp="true"
+						IntProp="10"
+						FloatProp="3.14"
+						StringProp="world"
+						ArrayProp="x, y, z"
+						ColorProp="red"
+					/>
+				</services>
+			</application>
+			XML;
+
+		[$service] = applyXmlServiceConfig($xml);
+		self::assertSame(true, $service->getBoolProp());
+		self::assertSame(10, $service->getIntProp());
+		self::assertSame(3.14, $service->getFloatProp());
+		self::assertSame('world', $service->getStringProp());
+		self::assertSame(['x', 'y', 'z'], $service->getArrayProp());
+		self::assertSame(TAppConfigTestColor::Red, $service->getColorProp());
+	}
+
+	public function testXmlService_boolProp_yesNoOnOff_allFalse(): void
+	{
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$xml = <<<XML
+				<?xml version="1.0" encoding="utf-8"?>
+				<application>
+					<services>
+						<service id="s" class="TAppConfigTestService" BoolProp="$s" />
+					</services>
+				</application>
+				XML;
+
+			[$service] = applyXmlServiceConfig($xml);
+			self::assertSame(false, $service->getBoolProp(), "Expected false for BoolProp='$s'");
+		}
+	}
+
+	public function testXmlService_nullable_emptyAttributeBecomesNull(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<services>
+					<service id="s" class="TAppConfigTestService" NullableStringProp="" />
+				</services>
+			</application>
+			XML;
+
+		[$service] = applyXmlServiceConfig($xml);
+		self::assertNull($service->getNullableStringProp());
+	}
+
+	public function testXmlService_nullableInt_numericStringBecomesInt(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<services>
+					<service id="s" class="TAppConfigTestService" NullableIntProp="77" />
+				</services>
+			</application>
+			XML;
+
+		[$service] = applyXmlServiceConfig($xml);
+		self::assertSame(77, $service->getNullableIntProp());
+	}
+
+	public function testXmlService_union_intString_picksInt(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<services>
+					<service id="s" class="TAppConfigTestService" IntOrFloat="4" />
+				</services>
+			</application>
+			XML;
+
+		[$service] = applyXmlServiceConfig($xml);
+		self::assertSame(4, $service->getIntOrFloat());
+	}
+
+	public function testXmlService_union_floatString_picksFloat(): void
+	{
+		$xml = <<<'XML'
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<services>
+					<service id="s" class="TAppConfigTestService" IntOrFloat="4.5" />
+				</services>
+			</application>
+			XML;
+
+		[$service] = applyXmlServiceConfig($xml);
+		self::assertSame(4.5, $service->getIntOrFloat());
+	}
+
+	public function testXmlService_union_overflowInt_promotesToFloat(): void
+	{
+		$overMax = bcadd((string) PHP_INT_MAX, '1');
+		$xml = <<<XML
+			<?xml version="1.0" encoding="utf-8"?>
+			<application>
+				<services>
+					<service id="s" class="TAppConfigTestService" IntOrFloat="$overMax" />
+				</services>
+			</application>
+			XML;
+
+		[$service] = applyXmlServiceConfig($xml);
+		self::assertIsFloat($service->getIntOrFloat());
+	}
+
+	// ══════════════════════════════════════════════════════════════════════
+	// PHP config → Service
+	// ══════════════════════════════════════════════════════════════════════
+
+	public function testPhpService_singleTypes_allParsedAndCoerced(): void
+	{
+		$phpConfig = [
+			'services' => [
+				'testsvc' => [
+					'class'      => 'TAppConfigTestService',
+					'properties' => [
+						'BoolProp'   => 'false',
+						'IntProp'    => '3',
+						'FloatProp'  => '2.5',
+						'StringProp' => 'test',
+						'ArrayProp'  => '[10, 20, 30]',
+						'ColorProp'  => 'blue',
+					],
+				],
+			],
+		];
+
+		[$service] = applyPhpServiceConfig($phpConfig);
+		self::assertSame(false, $service->getBoolProp());
+		self::assertSame(3, $service->getIntProp());
+		self::assertSame(2.5, $service->getFloatProp());
+		self::assertSame('test', $service->getStringProp());
+		self::assertSame([10, 20, 30], $service->getArrayProp());
+		self::assertSame(TAppConfigTestColor::Blue, $service->getColorProp());
+	}
+
+	public function testPhpService_nativePhpTypedValues(): void
+	{
+		$phpConfig = [
+			'services' => [
+				'testsvc' => [
+					'class'      => 'TAppConfigTestService',
+					'properties' => [
+						'BoolProp'  => false,
+						'IntProp'   => 3,
+						'FloatProp' => 2.5,
+						'ArrayProp' => [10, 20, 30],
+					],
+				],
+			],
+		];
+
+		[$service] = applyPhpServiceConfig($phpConfig);
+		self::assertSame(false, $service->getBoolProp());
+		self::assertSame(3,    $service->getIntProp());
+		self::assertSame(2.5,  $service->getFloatProp());
+		self::assertSame([10, 20, 30], $service->getArrayProp());
+	}
+
+	public function testPhpService_nullable_emptyStringBecomesNull(): void
+	{
+		$phpConfig = [
+			'services' => [
+				's' => ['class' => 'TAppConfigTestService', 'properties' => ['NullableStringProp' => '']],
+			],
+		];
+		[$service] = applyPhpServiceConfig($phpConfig);
+		self::assertNull($service->getNullableStringProp());
+	}
+
+	public function testPhpService_nullableInt_numericString(): void
+	{
+		$phpConfig = [
+			'services' => [
+				's' => ['class' => 'TAppConfigTestService', 'properties' => ['NullableIntProp' => '11']],
+			],
+		];
+		[$service] = applyPhpServiceConfig($phpConfig);
+		self::assertSame(11, $service->getNullableIntProp());
+	}
+
+	public function testPhpService_union_intString_picksInt(): void
+	{
+		$phpConfig = [
+			'services' => [
+				's' => ['class' => 'TAppConfigTestService', 'properties' => ['IntOrFloat' => '9']],
+			],
+		];
+		[$service] = applyPhpServiceConfig($phpConfig);
+		self::assertSame(9, $service->getIntOrFloat());
+	}
+
+	public function testPhpService_union_floatString_picksFloat(): void
+	{
+		$phpConfig = [
+			'services' => [
+				's' => ['class' => 'TAppConfigTestService', 'properties' => ['IntOrFloat' => '9.9']],
+			],
+		];
+		[$service] = applyPhpServiceConfig($phpConfig);
+		self::assertSame(9.9, $service->getIntOrFloat());
+	}
+
+	// ══════════════════════════════════════════════════════════════════════
+	// TTestApplicationConfiguration — injection harness
+	// ══════════════════════════════════════════════════════════════════════
+
+	public function testHarness_addModuleConfig_appliesViaNormalLoop(): void
+	{
+		$config = new TTestApplicationConfiguration();
+		$config->addModuleConfig('m', 'TAppConfigTestModule', [
+			'BoolProp'   => 'true',
+			'IntProp'    => '20',
+			'FloatProp'  => '0.5',
+			'StringProp' => 'injected',
+			'ColorProp'  => 'green',
+		]);
+
+		$modules = $config->getModules();
+		self::assertArrayHasKey('m', $modules);
+		[$type, $props] = $modules['m'];
+		$module = Prado::createComponent($type);
+		foreach ($props as $name => $value) {
+			$module->setSubProperty($name, $value);
+		}
+
+		self::assertSame(true,       $module->getBoolProp());
+		self::assertSame(20,         $module->getIntProp());
+		self::assertSame(0.5,        $module->getFloatProp());
+		self::assertSame('injected', $module->getStringProp());
+		self::assertSame(TAppConfigTestColor::Green, $module->getColorProp());
+	}
+
+	public function testHarness_addServiceConfig_appliesViaNormalLoop(): void
+	{
+		$config = new TTestApplicationConfiguration();
+		$config->addServiceConfig('svc', 'TAppConfigTestService', [
+			'BoolProp'  => 'false',
+			'IntProp'   => '7',
+			'ColorProp' => 'red',
+		]);
+
+		$services = $config->getServices();
+		self::assertArrayHasKey('svc', $services);
+		[$type, $props] = $services['svc'];
+		$service = Prado::createComponent($type);
+		foreach ($props as $name => $value) {
+			$service->setSubProperty($name, $value);
+		}
+
+		self::assertSame(false, $service->getBoolProp());
+		self::assertSame(7,     $service->getIntProp());
+		self::assertSame(TAppConfigTestColor::Red, $service->getColorProp());
+	}
+
+	public function testHarness_setModuleConfigs_replacesEntireMap(): void
+	{
+		$config = new TTestApplicationConfiguration();
+		$config->addModuleConfig('old', 'TAppConfigTestModule', ['IntProp' => '1']);
+		$config->setModuleConfigs([
+			'new' => ['TAppConfigTestModule', ['IntProp' => '99'], null],
+		]);
+
+		$modules = $config->getModules();
+		self::assertArrayNotHasKey('old', $modules);
+		self::assertArrayHasKey('new', $modules);
+	}
+
+	public function testHarness_nullable_injectedNull_staysNull(): void
+	{
+		$config = new TTestApplicationConfiguration();
+		$config->addModuleConfig('m', 'TAppConfigTestModule', [
+			'NullableStringProp' => null,
+			'NullableIntProp'    => null,
+		]);
+
+		[$type, $props] = $config->getModules()['m'];
+		$module = Prado::createComponent($type);
+		foreach ($props as $name => $value) {
+			$module->setSubProperty($name, $value);
+		}
+
+		self::assertNull($module->getNullableStringProp());
+		self::assertNull($module->getNullableIntProp());
+	}
+
+	// ══════════════════════════════════════════════════════════════════════
+	// TTemplate attributes → TControl
+	//
+	// TTemplate::instantiateIn() → configureProperty() → setSubProperty() →
+	// applyProperty().  All attribute values are raw strings from the markup.
+	// ══════════════════════════════════════════════════════════════════════
+
+	public function testTemplate_control_singleTypes_allAttributesCoerced(): void
+	{
+		$tpl = '<com:TAppConfigTestControl'
+			. ' BoolProp="true"'
+			. ' IntProp="42"'
+			. ' FloatProp="1.5"'
+			. ' StringProp="template"'
+			. ' ArrayProp="p, q, r"'
+			. ' ColorProp="green"'
+			. ' />';
+
+		$child = instantiateTemplateControl($tpl);
+		self::assertInstanceOf(TAppConfigTestControl::class, $child);
+		self::assertSame(true,       $child->getBoolProp());
+		self::assertSame(42,         $child->getIntProp());
+		self::assertSame(1.5,        $child->getFloatProp());
+		self::assertSame('template', $child->getStringProp());
+		self::assertSame(['p', 'q', 'r'], $child->getArrayProp());
+		self::assertSame(TAppConfigTestColor::Green, $child->getColorProp());
+	}
+
+	public function testTemplate_control_boolProp_falseString(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl BoolProp="false" />');
+		self::assertSame(false, $child->getBoolProp());
+	}
+
+	public function testTemplate_control_boolProp_yesNoOnOff_allFalse(): void
+	{
+		foreach (['yes', 'no', 'on', 'off'] as $s) {
+			$child = instantiateTemplateControl('<com:TAppConfigTestControl BoolProp="' . $s . '" />');
+			self::assertSame(false, $child->getBoolProp(), "Expected false for BoolProp='$s'");
+		}
+	}
+
+	public function testTemplate_control_intProp_negativeString(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl IntProp="-5" />');
+		self::assertSame(-5, $child->getIntProp());
+	}
+
+	public function testTemplate_control_floatProp_scientificNotation(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl FloatProp="2e3" />');
+		self::assertSame(2000.0, $child->getFloatProp());
+	}
+
+	public function testTemplate_control_arrayProp_bracketSyntax(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl ArrayProp="[10, 20, 30]" />');
+		self::assertSame([10, 20, 30], $child->getArrayProp());
+	}
+
+	public function testTemplate_control_arrayProp_bareWordList(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl ArrayProp="a, b, c" />');
+		self::assertSame(['a', 'b', 'c'], $child->getArrayProp());
+	}
+
+	public function testTemplate_control_colorProp_fromBackingValue(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl ColorProp="blue" />');
+		self::assertSame(TAppConfigTestColor::Blue, $child->getColorProp());
+	}
+
+	public function testTemplate_control_colorProp_fromCaseName(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl ColorProp="Red" />');
+		self::assertSame(TAppConfigTestColor::Red, $child->getColorProp());
+	}
+
+	public function testTemplate_control_colorProp_allCasesRoundtrip(): void
+	{
+		foreach (TAppConfigTestColor::cases() as $case) {
+			// Via backing value
+			$child = instantiateTemplateControl('<com:TAppConfigTestControl ColorProp="' . $case->value . '" />');
+			self::assertSame($case, $child->getColorProp());
+
+			// Via case name
+			$child = instantiateTemplateControl('<com:TAppConfigTestControl ColorProp="' . $case->name . '" />');
+			self::assertSame($case, $child->getColorProp());
+		}
+	}
+
+	// ── nullable via template ────────────────────────────────────────────
+
+	public function testTemplate_control_nullable_emptyAttributeBecomesNull(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl NullableStringProp="" />');
+		self::assertNull($child->getNullableStringProp());
+	}
+
+	public function testTemplate_control_nullable_nonEmptyPreserved(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl NullableStringProp="set" />');
+		self::assertSame('set', $child->getNullableStringProp());
+	}
+
+	public function testTemplate_control_nullableInt_emptyAttributeBecomesNull(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl NullableIntProp="" />');
+		self::assertNull($child->getNullableIntProp());
+	}
+
+	public function testTemplate_control_nullableInt_numericStringBecomesInt(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl NullableIntProp="33" />');
+		self::assertSame(33, $child->getNullableIntProp());
+	}
+
+	public function testTemplate_control_nullableColor_emptyAttributeBecomesNull(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl NullableColorProp="" />');
+		self::assertNull($child->getNullableColorProp());
+	}
+
+	public function testTemplate_control_nullableColor_backingValue(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl NullableColorProp="red" />');
+		self::assertSame(TAppConfigTestColor::Red, $child->getNullableColorProp());
+	}
+
+	// ── union via template ────────────────────────────────────────────────
+
+	public function testTemplate_control_union_intString_picksInt(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl IntOrFloat="6" />');
+		self::assertSame(6, $child->getIntOrFloat());
+	}
+
+	public function testTemplate_control_union_floatString_picksFloat(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl IntOrFloat="6.5" />');
+		self::assertSame(6.5, $child->getIntOrFloat());
+	}
+
+	public function testTemplate_control_union_scientificNotation_picksFloat(): void
+	{
+		$child = instantiateTemplateControl('<com:TAppConfigTestControl IntOrFloat="1.5e2" />');
+		self::assertSame(150.0, $child->getIntOrFloat());
+	}
+
+	public function testTemplate_control_union_overflowInt_promotesToFloat(): void
+	{
+		$overMax = bcadd((string) PHP_INT_MAX, '1');
+		$child   = instantiateTemplateControl('<com:TAppConfigTestControl IntOrFloat="' . $overMax . '" />');
+		self::assertIsFloat($child->getIntOrFloat());
+		self::assertSame((float) $overMax, $child->getIntOrFloat());
+	}
+
+	// ── multiple attributes in one template tag ───────────────────────────
+
+	public function testTemplate_control_multipleAttributes_allCoercedTogether(): void
+	{
+		$tpl = '<com:TAppConfigTestControl'
+			. ' BoolProp="false"'
+			. ' IntProp="-3"'
+			. ' FloatProp="0.001"'
+			. ' StringProp="multi"'
+			. ' ColorProp="red"'
+			. ' NullableStringProp=""'
+			. ' NullableIntProp="7"'
+			. ' IntOrFloat="2.5"'
+			. ' />';
+
+		$child = instantiateTemplateControl($tpl);
+		self::assertSame(false,   $child->getBoolProp());
+		self::assertSame(-3,      $child->getIntProp());
+		self::assertSame(0.001,   $child->getFloatProp());
+		self::assertSame('multi', $child->getStringProp());
+		self::assertSame(TAppConfigTestColor::Red, $child->getColorProp());
+		self::assertNull($child->getNullableStringProp());
+		self::assertSame(7,   $child->getNullableIntProp());
+		self::assertSame(2.5, $child->getIntOrFloat());
+	}
+}

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -84,7 +84,7 @@ enum TPropertyValueTestColor: string
 	case Blue  = 'blue';
 }
 
-/** Int-backed enum used to test F-10 (ensureEnum type guard) and F-16 (step-8 int path). */
+/** Int-backed enum used to test F-10 (ensureEnum type guard) and the step-9 int path. */
 enum TPropertyValueTestPriority: int
 {
 	case Low  = 1;
@@ -92,9 +92,26 @@ enum TPropertyValueTestPriority: int
 }
 
 /**
+ * Non-backed UnitEnum fixture, used to verify that the step-2 enum-validation
+ * path handles pure UnitEnums (no `tryFrom`, name lookup only).
+ */
+enum TPropertyValueTestStatus
+{
+	case Active;
+	case Pending;
+	case Closed;
+}
+
+/**
  * IEnumerable fixture where constant NAME differs from constant VALUE.
- * Used to verify that _coerceToClass (step 8 in _coerceUnionType) actually
- * transforms 'Alpha' → 'a' and that the change is detected by the `!==` guard.
+ * Used to verify the validate-name-not-value semantic shared by both
+ * {@see TPropertyValue::ensureEnum()} and the coercion path
+ * ({@see TPropertyValue::coerceToType()} / `_coerceUnionType()`): an
+ * any-casing input that matches a constant resolves to the canonical
+ * NAME (`'Alpha'`), not the constant's value (`'a'`).  Name→value
+ * translation lives inside the enum class via the trait's
+ * `valueOfConstant()` helper, called separately by callers that need
+ * the value.
  */
 class TPropertyValueTestCodeEnum implements IEnumerable
 {
@@ -108,16 +125,6 @@ class TPropertyValueTestCodeEnum implements IEnumerable
  */
 class TPropertyValueTest extends PHPUnit\Framework\TestCase
 {
-	protected function setUp(): void
-	{
-	}
-
-
-	protected function tearDown(): void
-	{
-	}
-
-
 	// ════════════════════════════════════════════════════════════════════════
 	// Constants
 	// ════════════════════════════════════════════════════════════════════════
@@ -413,8 +420,10 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame((float) PHP_INT_MAX, TPropertyValue::ensureFloat(PHP_INT_MAX));
 	}
 	
-	public function testEnsureArray()
+	public function testEnsureArraySmoke(): void
 	{
+		// At-a-glance baseline for the most common shapes; the more specific
+		// tests below exercise each branch in detail.
 		self::assertSame([], TPropertyValue::ensureArray(null));
 		self::assertSame([], TPropertyValue::ensureArray(''));
 		self::assertSame([], TPropertyValue::ensureArray([]));
@@ -426,77 +435,77 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
 	}
 
-	// ── ensureArray: eval branch — string starting and ending with parentheses ──
+	// ── ensureArray: parsed-literal branch — string wrapped in `(...)`/`[...]` ──
 
-	public function testEnsureArrayEvalEmptyParens()
+	public function testEnsureArrayParseEmptyParens()
 	{
-		// '()' → eval('return array();') → []
+		// '()' → empty array literal → []
 		self::assertSame([], TPropertyValue::ensureArray('()'));
 	}
 
-	public function testEnsureArrayEvalParensWithWhitespace()
+	public function testEnsureArrayParseParensWithWhitespace()
 	{
-		// '( )' → eval('return array( );') → []
+		// '( )' → empty array literal with internal whitespace → []
 		self::assertSame([], TPropertyValue::ensureArray('( )'));
 
 		// '(   )' → same
 		self::assertSame([], TPropertyValue::ensureArray('(   )'));
 	}
 
-	public function testEnsureArrayEvalOuterWhitespaceTrimmed()
+	public function testEnsureArrayParseOuterWhitespaceTrimmed()
 	{
 		// Leading/trailing whitespace on the whole string is trimmed before the
-		// paren check, so '  ("a", "b")  ' hits the eval branch.
+		// paren check, so '  ("a", "b")  ' enters the parsed-literal branch.
 		self::assertSame(['a', 'b'], TPropertyValue::ensureArray('  ("a", "b")  '));
 	}
 
-	public function testEnsureArrayEvalDoubleQuotedStrings()
+	public function testEnsureArrayParseDoubleQuotedStrings()
 	{
 		// Double-quoted string elements
 		self::assertSame(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
 		self::assertSame(['a', 'b', 'c'], TPropertyValue::ensureArray('("a", "b", "c")'));
 	}
 
-	public function testEnsureArrayEvalSingleQuotedStrings()
+	public function testEnsureArrayParseSingleQuotedStrings()
 	{
 		// Single-quoted string elements
 		self::assertSame(['my', 'prop'], TPropertyValue::ensureArray("('my', 'prop')"));
 		self::assertSame(['hello', 'world'], TPropertyValue::ensureArray("('hello', 'world')"));
 	}
 
-	public function testEnsureArrayEvalIntegerElements()
+	public function testEnsureArrayParseIntegerElements()
 	{
-		// Integer elements — eval parses them as PHP integers
+		// Integer elements
 		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('(1, 2, 3)'));
 		self::assertSame([0, 100, -5], TPropertyValue::ensureArray('(0, 100, -5)'));
 	}
 
-	public function testEnsureArrayEvalFloatElements()
+	public function testEnsureArrayParseFloatElements()
 	{
 		// Float elements
 		self::assertSame([1.5, 2.5], TPropertyValue::ensureArray('(1.5, 2.5)'));
 		self::assertSame([-0.5, 3.14], TPropertyValue::ensureArray('(-0.5, 3.14)'));
 	}
 
-	public function testEnsureArrayEvalMixedTypes()
+	public function testEnsureArrayParseMixedTypes()
 	{
 		// Mixed PHP types in one expression
 		self::assertSame([1, 'two', 3.0], TPropertyValue::ensureArray('(1, "two", 3.0)'));
 	}
 
-	public function testEnsureArrayEvalBooleanAndNull()
+	public function testEnsureArrayParseBooleanAndNull()
 	{
-		// PHP keywords true, false, null parsed by eval
+		// PHP keyword tokens true / false / null (case-insensitive)
 		self::assertSame([true, false, null], TPropertyValue::ensureArray('(true, false, null)'));
 	}
 
-	public function testEnsureArrayEvalAssociativeStringKeys()
+	public function testEnsureArrayParseAssociativeStringKeys()
 	{
 		// Associative array with string keys
 		self::assertSame(['x' => 1, 'y' => 2], TPropertyValue::ensureArray('("x" => 1, "y" => 2)'));
 	}
 
-	public function testEnsureArrayEvalAssociativeIntegerKeys()
+	public function testEnsureArrayParseAssociativeIntegerKeys()
 	{
 		// Explicit integer keys
 		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray('(5 => "a", 10 => "b")'));
@@ -515,14 +524,14 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray("(5\f=> \"a\", 10\v=> \"b\")"));
 	}
 
-	public function testEnsureArrayEvalSingleElement()
+	public function testEnsureArrayParseSingleElement()
 	{
 		// Single element
 		self::assertSame(['only'], TPropertyValue::ensureArray('("only")'));
 		self::assertSame([42], TPropertyValue::ensureArray('(42)'));
 	}
 
-	public function testEnsureArrayEvalNestedArrays()
+	public function testEnsureArrayParseNestedArrays()
 	{
 		// Nested arrays — use the PHP 8 short `[]` form at the inner level.
 		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('([1, 2], [3, 4])'));
@@ -532,13 +541,13 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[(1, 2), [3, 4]]'));
 	}
 
-	public function testEnsureArrayEvalEmptyStringElement()
+	public function testEnsureArrayParseEmptyStringElement()
 	{
 		// A single empty string element
 		self::assertSame([''], TPropertyValue::ensureArray('("")'));
 	}
 
-	public function testEnsureArrayEvalComplexExpression()
+	public function testEnsureArrayParseComplexExpression()
 	{
 		// A realistic config-style expression with integers, strings, and nested array
 		self::assertSame(
@@ -630,6 +639,11 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		// specifically to disambiguate.  Leading-zero literals have been
 		// read as decimal here.
 		self::assertSame([17, 123], TPropertyValue::ensureArray('[017, 0123]'));
+		// The auto-wrap path has also dropped legacy octal — `'017'` without
+		// brackets goes through the same int regex once wrapped in `(...)`.
+		self::assertSame([17],  TPropertyValue::ensureArray('017'));
+		self::assertSame([123], TPropertyValue::ensureArray('0123'));
+		self::assertSame([17, 123], TPropertyValue::ensureArray('017, 0123'));
 	}
 
 	public function testEnsureArrayUnderscoredIntegers()
@@ -736,6 +750,13 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		// preserved verbatim (no exception, matching PHP literal behavior).
 		self::assertSame(["a\nb"], TPropertyValue::ensureArray('["a\nb"]'));
 		self::assertSame(["tab\there"], TPropertyValue::ensureArray('["tab\there"]'));
+		// Less common control escapes — \r carriage return, \v vertical tab,
+		// \f form feed, \e escape (ESC, \x1b).  All decode to the same byte
+		// PHP's double-quoted string literal produces.
+		self::assertSame(["cr\rlf"],     TPropertyValue::ensureArray('["cr\rlf"]'));
+		self::assertSame(["v\vtab"],     TPropertyValue::ensureArray('["v\vtab"]'));
+		self::assertSame(["f\ffeed"],    TPropertyValue::ensureArray('["f\ffeed"]'));
+		self::assertSame(["esc\x1bend"], TPropertyValue::ensureArray('["esc\eend"]'));
 		self::assertSame(["back\\slash"], TPropertyValue::ensureArray('["back\\\\slash"]'));
 		self::assertSame(['quote"in'], TPropertyValue::ensureArray('["quote\"in"]'));
 		self::assertSame(['$x'], TPropertyValue::ensureArray('["\$x"]'));
@@ -771,6 +792,17 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame([[[[[[[[[[1]]]]]]]]]], TPropertyValue::ensureArray('[[[[[[[[[[1]]]]]]]]]]'));
 		// Mixed `(...)` / `[...]` / `array(...)` at each level.
 		self::assertSame([[[[1]]]], TPropertyValue::ensureArray('[(array([1]))]'));
+	}
+
+	public function testEnsureArrayDeepNestingUnderStrictGrammar()
+	{
+		// Strict grammar has accepted the same deep nesting through `[...]`
+		// and `array(...)` only (no bare `(...)`).
+		$strict = TPropertyValue::ARRAY_STRICT_GRAMMAR;
+		self::assertSame([[[[[[[[[[1]]]]]]]]]], TPropertyValue::ensureArray('[[[[[[[[[[1]]]]]]]]]]', $strict));
+		self::assertSame([[[1]]], TPropertyValue::ensureArray('[array([1])]', $strict));
+		// Strict rejects nested bare `(...)` and falls back to single-element.
+		self::assertSame(['[(array([1]))]'], TPropertyValue::ensureArray('[(array([1]))]', $strict));
 	}
 
 	public function testEnsureArrayUnicodeAndMultibyte()
@@ -900,6 +932,14 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame([1, 2], TPropertyValue::ensureArray('array (1, 2)'));
 		self::assertSame([[1], [2]], TPropertyValue::ensureArray('[array(1), [2]]'));
 		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[(1, 2), array(3, 4)]'));
+		// Surrounding whitespace at the top level exercises _skipArrayKeyword
+		// when the parser entry sees `(?&ws)` before the `array` token.
+		self::assertSame([1, 2], TPropertyValue::ensureArray('   array  (1, 2)   '));
+		self::assertSame([1, 2], TPropertyValue::ensureArray("\tarray\t(1, 2)\t"));
+		// Nested `array(array(...))` — recursive use of the keyword form.
+		self::assertSame([[1, 2]], TPropertyValue::ensureArray('array(array(1, 2))'));
+		// Three-deep mixed: array → [ → array → scalar.
+		self::assertSame([[[1, 2]]], TPropertyValue::ensureArray('array([array(1, 2)])'));
 	}
 
 	// ── ensureArray: strict grammar ──────────────────────────────────────────
@@ -1067,6 +1107,16 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		} catch (TInvalidDataValueException $e) {
 			self::assertInstanceOf(TInvalidDataValueException::class, $e);
 		}
+		// Auto-wrap can't save an unbalanced opener inside a `[...]` input —
+		// `'[1, 2'` wrapped becomes `'([1, 2)'`, still unbalanced, still
+		// rejected by both grammars.  ARRAY_STRICT_ERRORS converts the
+		// silent fallback into a thrown exception.
+		try {
+			TPropertyValue::ensureArray('[1, 2', TPropertyValue::ARRAY_STRICT_ERRORS);
+			self::fail('Expected TInvalidDataValueException for unparseable bracketed input under loose grammar');
+		} catch (TInvalidDataValueException $e) {
+			self::assertInstanceOf(TInvalidDataValueException::class, $e);
+		}
 	}
 
 	public function testEnsureArrayStrictBothThrowsOnNonPhpLiteral()
@@ -1085,7 +1135,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		}
 	}
 
-	// ── ensureArray: non-eval string branch — plain strings ──────────────────
+	// ── ensureArray: fallback / passthrough branch — plain strings ──────────
 
 	public function testEnsureArrayStringNotParens()
 	{
@@ -1096,7 +1146,8 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testEnsureArrayStringWithLeadingParenOnly()
 	{
-		// Starts with '(' but does NOT end with ')' → plain string, not eval
+		// Starts with '(' but does NOT end with ')' → not a balanced literal;
+		// auto-wrap can't save it either, so falls back to single-element string.
 		self::assertSame(['(partial'], TPropertyValue::ensureArray('(partial'));
 	}
 
@@ -1114,7 +1165,8 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testEnsureArraySingleCharParens()
 	{
-		// Single-char strings: '(' or ')' have len=1 < 2, so do NOT trigger eval
+		// Single-char strings: '(' or ')' aren't a balanced literal and the
+		// wrap-then-parse retry also fails — single-element fallback wins.
 		self::assertSame(['('], TPropertyValue::ensureArray('('));
 		self::assertSame([')'], TPropertyValue::ensureArray(')'));
 	}
@@ -1304,8 +1356,8 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 		// ── Variadic form (func_num_args > 2 or non-string second arg) ───────
 
-		// Single-element array form: value is in the array
-		self::assertEquals('only', TPropertyValue::ensureEnum('only', ['only']));
+		// Single-value variadic form: $value matches the trailing varargs.
+		self::assertEquals('only', TPropertyValue::ensureEnum('only', 'only'));
 
 		// Variadic form with many values
 		self::assertEquals('z', TPropertyValue::ensureEnum('z', 'a', 'b', 'c', 'z'));
@@ -1317,9 +1369,10 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		} catch (TInvalidDataValueException $e) {
 		}
 
-		// ── Class-constant form — case-insensitive, returns canonical constant value ─────
+		// ── Class-constant form — case-insensitive, returns canonical constant NAME ──
 
-		// Case-insensitive: 'debug' (lowercase) resolves to 'Debug' (the constant value)
+		// Case-insensitive: 'debug' (lowercase) resolves to 'Debug' (the canonical name).
+		// TApplicationMode has name == value, so the same string doubles as the value.
 		self::assertEquals('Debug', TPropertyValue::ensureEnum('debug', \Prado\TApplicationMode::class));
 
 		// Exception message names valid constants
@@ -1337,132 +1390,519 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals('Debug', TPropertyValue::ensureEnum('Debug', \Prado\TApplicationMode::class));
 	}
 	
-	// ── BackedEnum form ──────────────────────────────────────────────────────
-
-	public function testEnsureEnum_backedEnum_byBackingValue(): void
-	{
-		// A string backing value resolves via tryFrom().
-		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('red',   TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::ensureEnum('green', TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('blue',  TPropertyValueTestColor::class));
-	}
-
-	public function testEnsureEnum_backedEnum_byCaseName(): void
-	{
-		// Case name (not backing value) resolves via name scan.
-		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('Red',   TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::ensureEnum('Green', TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('Blue',  TPropertyValueTestColor::class));
-	}
-
-	public function testEnsureEnum_backedEnum_caseInsensitiveCaseName(): void
-	{
-		// The case-name scan is case-insensitive: any casing of the PHP case name resolves
-		// to the correct enum case, even when it does not match the backing value.
-		// TPropertyValueTestColor has Red='red', Green='green', Blue='blue'.
-		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('RED',   TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::ensureEnum('GREEN', TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('BLUE',  TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('rEd',   TPropertyValueTestColor::class));
-		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('bLuE',  TPropertyValueTestColor::class));
-		// Unresolvable value still throws
-		$this->expectException(TInvalidDataValueException::class);
-		TPropertyValue::ensureEnum('purple', TPropertyValueTestColor::class);
-	}
-
-	public function testEnsureEnum_backedEnum_existingInstance_passedThrough(): void
-	{
-		// An already-correct instance is returned unchanged (identity, not just equality).
-		$case = TPropertyValueTestColor::Green;
-		self::assertSame($case, TPropertyValue::ensureEnum($case, TPropertyValueTestColor::class));
-	}
-
-	public function testEnsureEnum_backedEnum_invalidValue_throws(): void
-	{
-		// A value that matches neither a backing value nor a case name throws.
-		try {
-			TPropertyValue::ensureEnum('purple', TPropertyValueTestColor::class);
-			self::fail('Expected TInvalidDataValueException for unknown backing value');
-		} catch (TInvalidDataValueException $e) {
-			self::assertStringContainsString('purple', $e->getMessage());
-		}
-	}
-
-	public function testEnsureEnum_backedEnum_errorMessageListsCases(): void
-	{
-		// The exception message includes name=value pairs for every case.
-		try {
-			TPropertyValue::ensureEnum('invalid', TPropertyValueTestColor::class);
-			self::fail('Expected TInvalidDataValueException');
-		} catch (TInvalidDataValueException $e) {
-			self::assertStringContainsString('Red=red',   $e->getMessage());
-			self::assertStringContainsString('Green=green', $e->getMessage());
-			self::assertStringContainsString('Blue=blue',  $e->getMessage());
-		}
-	}
-
-	public function testEnsureEnum_backedEnum_nonScalarValue_throwsCleanly(): void
-	{
-		// F-10: before the fix, tryFrom($value) was called without a type guard, so passing
-		// a float, array, or bool to an ensureEnum backed-enum call caused a native TypeError
-		// from tryFrom() rather than a clean TInvalidDataValueException.
-		$cases = [3.14, [], true, new \stdClass()];
-		$threw = 0;
-		foreach ($cases as $bad) {
-			try {
-				TPropertyValue::ensureEnum($bad, TPropertyValueTestColor::class);
-				self::fail('Expected TInvalidDataValueException for ' . get_debug_type($bad));
-			} catch (TInvalidDataValueException $e) {
-				$threw++;
-			}
-		}
-		self::assertSame(count($cases), $threw);
-	}
-
-	public function testEnsureEnum_backedEnum_intValue_resolvesByBackingValue(): void
-	{
-		// F-10 (positive path): an int value on an int-backed enum reaches tryFrom correctly.
-		self::assertSame(TPropertyValueTestPriority::Low,  TPropertyValue::ensureEnum(1, TPropertyValueTestPriority::class));
-		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::ensureEnum(2, TPropertyValueTestPriority::class));
-	}
-
-	public function testEnsureEnum_iEnumerable_nonStringValue_throwsCleanly(): void
-	{
-		// F-03: before the fix, hasConstant($value) was called without an is_string guard,
-		// so passing a non-string caused a native TypeError inside hasConstant().
-		$cases = [42, 3.14, true, [], null];
-		$threw = 0;
-		foreach ($cases as $bad) {
-			try {
-				TPropertyValue::ensureEnum($bad, TPropertyValueTestDirection::class);
-				self::fail('Expected TInvalidDataValueException for ' . get_debug_type($bad));
-			} catch (TInvalidDataValueException $e) {
-				$threw++;
-			}
-		}
-		self::assertSame(count($cases), $threw);
-	}
+	// ── ensureEnum — class form with case-insensitive constant-name lookup ──
 
 	public function testEnsureEnum_iEnumerable_caseInsensitiveName(): void
 	{
-		// valueOfConstant($value, false) accepts any casing of the constant name.
-		// TPropertyValueTestDirection has North='North', South='South', etc.
+		// Case-sensitive fast path matches; case-insensitive slow path
+		// matches too.  TPropertyValueTestDirection has North='North', etc.
+		// (name == value), so the canonical name returned doubles as the
+		// constant value here.
+		self::assertSame('North', TPropertyValue::ensureEnum('North', TPropertyValueTestDirection::class));
 		self::assertSame('North', TPropertyValue::ensureEnum('north', TPropertyValueTestDirection::class));
 		self::assertSame('South', TPropertyValue::ensureEnum('SOUTH', TPropertyValueTestDirection::class));
 		self::assertSame('East',  TPropertyValue::ensureEnum('east',  TPropertyValueTestDirection::class));
 		self::assertSame('West',  TPropertyValue::ensureEnum('wEsT',  TPropertyValueTestDirection::class));
 	}
 
-	public function testEnsureEnum_iEnumerable_returnsCanonicalValue(): void
+	public function testEnsureEnum_returnsCanonicalNameNotValue(): void
 	{
-		// ensureEnum must return the constant VALUE, not the input string.
-		// TPropertyValueTestCodeEnum has Alpha='a', Beta='b' (name ≠ value).
-		// Any casing of the name resolves to the canonical lowercase value.
-		self::assertSame('a', TPropertyValue::ensureEnum('Alpha', TPropertyValueTestCodeEnum::class));
-		self::assertSame('a', TPropertyValue::ensureEnum('alpha', TPropertyValueTestCodeEnum::class));
-		self::assertSame('a', TPropertyValue::ensureEnum('ALPHA', TPropertyValueTestCodeEnum::class));
-		self::assertSame('b', TPropertyValue::ensureEnum('Beta',  TPropertyValueTestCodeEnum::class));
-		self::assertSame('b', TPropertyValue::ensureEnum('BETA',  TPropertyValueTestCodeEnum::class));
+		// When constant name differs from value (TCodeEnum has `const Alpha = 'a'`),
+		// ensureEnum returns the canonical NAME (with original casing preserved),
+		// NOT the value.  Pair with {@see TPropertyValue::ensureEnumValue()} for
+		// the value-translation step.
+		self::assertSame('Alpha', TPropertyValue::ensureEnum('Alpha', TPropertyValueTestCodeEnum::class));
+		self::assertSame('Alpha', TPropertyValue::ensureEnum('alpha', TPropertyValueTestCodeEnum::class));
+		self::assertSame('Alpha', TPropertyValue::ensureEnum('ALPHA', TPropertyValueTestCodeEnum::class));
+		self::assertSame('Beta',  TPropertyValue::ensureEnum('Beta',  TPropertyValueTestCodeEnum::class));
+		self::assertSame('Beta',  TPropertyValue::ensureEnum('BETA',  TPropertyValueTestCodeEnum::class));
+	}
+
+	public function testEnsureEnum_invalidName_throwsWithConstantListing(): void
+	{
+		// The error message lists every constant of the class so the caller
+		// can see the valid set.
+		try {
+			TPropertyValue::ensureEnum('NotAMode', \Prado\TApplicationMode::class);
+			self::fail('Expected TInvalidDataValueException for invalid constant');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('NotAMode', $e->getMessage());
+			self::assertStringContainsString('Debug',    $e->getMessage());
+			self::assertStringContainsString('Normal',   $e->getMessage());
+		}
+	}
+
+	// ── ensureEnumValue — case-insensitive name → constant VALUE ────────────
+
+	public function testEnsureEnumValue_iEnumerable_returnsConstantValue(): void
+	{
+		// ensureEnumValue resolves the input name (case-insensitively) to the
+		// constant's VALUE.  For `const Alpha = 'a'`, any casing of `'Alpha'`
+		// resolves to `'a'`.  Companion to {@see ensureEnum()} which returns
+		// the canonical name.
+		self::assertSame('a', TPropertyValue::ensureEnumValue('Alpha', TPropertyValueTestCodeEnum::class));
+		self::assertSame('a', TPropertyValue::ensureEnumValue('alpha', TPropertyValueTestCodeEnum::class));
+		self::assertSame('a', TPropertyValue::ensureEnumValue('ALPHA', TPropertyValueTestCodeEnum::class));
+		self::assertSame('b', TPropertyValue::ensureEnumValue('Beta',  TPropertyValueTestCodeEnum::class));
+		self::assertSame('b', TPropertyValue::ensureEnumValue('BETA',  TPropertyValueTestCodeEnum::class));
+	}
+
+	public function testEnsureEnumValue_iEnumerable_nameEqualsValueNoOpDistinction(): void
+	{
+		// When name == value, ensureEnumValue and ensureEnum return the same
+		// string — the distinction only matters for fixtures where name ≠ value.
+		self::assertSame('North', TPropertyValue::ensureEnumValue('north', TPropertyValueTestDirection::class));
+		self::assertSame('South', TPropertyValue::ensureEnumValue('SOUTH', TPropertyValueTestDirection::class));
+		self::assertSame('East',  TPropertyValue::ensureEnumValue('EAST',  TPropertyValueTestDirection::class));
+	}
+
+	public function testEnsureEnumValue_invalidName_throws(): void
+	{
+		try {
+			TPropertyValue::ensureEnumValue('not-a-constant', TPropertyValueTestCodeEnum::class);
+			self::fail('Expected TInvalidDataValueException for invalid IEnumerable name');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('not-a-constant', $e->getMessage());
+			self::assertStringContainsString('Alpha', $e->getMessage());
+			self::assertStringContainsString('Beta',  $e->getMessage());
+		}
+	}
+
+	// ── ensureEnum — BackedEnum / UnitEnum support ──────────────────────────
+
+	public function testEnsureEnum_backedEnum_returnsCaseName(): void
+	{
+		// PHP enum cases are class constants — they flow through the same
+		// reflection-based path.  Returns the case name as a string (not
+		// the case instance).
+		self::assertSame('Red',   TPropertyValue::ensureEnum('Red',   TPropertyValueTestColor::class));
+		self::assertSame('Red',   TPropertyValue::ensureEnum('red',   TPropertyValueTestColor::class));
+		self::assertSame('Red',   TPropertyValue::ensureEnum('RED',   TPropertyValueTestColor::class));
+		self::assertSame('Green', TPropertyValue::ensureEnum('green', TPropertyValueTestColor::class));
+		self::assertSame('Blue',  TPropertyValue::ensureEnum('blue',  TPropertyValueTestColor::class));
+		// Int-backed enum — name lookup works the same way.
+		self::assertSame('Low',  TPropertyValue::ensureEnum('low',  TPropertyValueTestPriority::class));
+		self::assertSame('High', TPropertyValue::ensureEnum('HIGH', TPropertyValueTestPriority::class));
+	}
+
+	public function testEnsureEnum_unitEnum_returnsCaseName(): void
+	{
+		// Non-backed UnitEnum cases are also class constants.
+		self::assertSame('Active',  TPropertyValue::ensureEnum('active',  TPropertyValueTestStatus::class));
+		self::assertSame('Pending', TPropertyValue::ensureEnum('PENDING', TPropertyValueTestStatus::class));
+		self::assertSame('Closed',  TPropertyValue::ensureEnum('Closed',  TPropertyValueTestStatus::class));
+	}
+
+	public function testEnsureEnum_enumInstance_unwrappedToName(): void
+	{
+		// An already-typed enum instance passes through as its ->name.
+		self::assertSame('Red',    TPropertyValue::ensureEnum(TPropertyValueTestColor::Red,    TPropertyValueTestColor::class));
+		self::assertSame('High',   TPropertyValue::ensureEnum(TPropertyValueTestPriority::High, TPropertyValueTestPriority::class));
+		self::assertSame('Active', TPropertyValue::ensureEnum(TPropertyValueTestStatus::Active, TPropertyValueTestStatus::class));
+	}
+
+	// ── ensureEnum — object as $enums ───────────────────────────────────────
+
+	public function testEnsureEnum_objectAsEnums(): void
+	{
+		// When $enums is an object, its class is used for resolution.
+		$instance = new TPropertyValueTestDirection();
+		self::assertSame('East', TPropertyValue::ensureEnum('east', $instance));
+		// Invalid value still throws.
+		$this->expectException(TInvalidDataValueException::class);
+		TPropertyValue::ensureEnum('InvalidDirection', $instance);
+	}
+
+	// ── ensureEnum — extras (list of permitted values) ──────────────────────
+
+	public function testEnsureEnum_withExtras_classResolvesFirst(): void
+	{
+		// A valid class constant is resolved before extras are consulted.
+		self::assertSame(
+			'North',
+			TPropertyValue::ensureEnum('North', TPropertyValueTestDirection::class, null, false, 'Auto')
+		);
+	}
+
+	public function testEnsureEnum_withExtras_classFailsFallsToExtras(): void
+	{
+		// 'Auto' is not a constant in TApplicationMode but matches the extra.
+		self::assertSame(
+			'Auto',
+			TPropertyValue::ensureEnum('Auto', \Prado\TApplicationMode::class, 'Auto')
+		);
+		self::assertFalse(
+			TPropertyValue::ensureEnum(false, TPropertyValueTestDirection::class, null, false)
+		);
+		self::assertSame(
+			0,
+			TPropertyValue::ensureEnum(0, TPropertyValueTestDirection::class, null, false, 0, -1)
+		);
+	}
+
+	public function testEnsureEnum_withExtras_nullExtra(): void
+	{
+		self::assertNull(TPropertyValue::ensureEnum(null, TPropertyValueTestDirection::class, null));
+		// null is permitted, but false is not → throws.
+		try {
+			TPropertyValue::ensureEnum(false, TPropertyValueTestDirection::class, null);
+			self::fail('Expected TInvalidDataValueException for unmatched value with null extra');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('NULL', $e->getMessage());
+		}
+	}
+
+	public function testEnsureEnum_withExtras_arrayShape(): void
+	{
+		// Extras may be passed as a single array or variadically — the two
+		// shapes produce identical results.
+		$cls = TPropertyValueTestDirection::class;
+		self::assertSame('Auto',  TPropertyValue::ensureEnum('Auto', $cls, ['Auto', null, 0]));
+		self::assertSame('Auto',  TPropertyValue::ensureEnum('Auto', $cls, 'Auto', null, 0));
+		self::assertNull(TPropertyValue::ensureEnum(null, $cls, [null, false]));
+		self::assertNull(TPropertyValue::ensureEnum(null, $cls, null, false));
+		self::assertSame(-1, TPropertyValue::ensureEnum(-1, $cls, [-1, 0, 'Auto']));
+		// A valid class constant still resolves first regardless of extras shape.
+		self::assertSame('North', TPropertyValue::ensureEnum('North', $cls, ['Auto']));
+		self::assertSame('North', TPropertyValue::ensureEnum('North', $cls, 'Auto'));
+	}
+
+	public function testEnsureEnum_withExtras_allFail_errorIncludesExtras(): void
+	{
+		try {
+			TPropertyValue::ensureEnum(
+				'NoSuchValue',
+				TPropertyValueTestDirection::class,
+				null,
+				false,
+				0,
+				-1,
+				'Auto'
+			);
+			self::fail('Expected throw when neither class nor extras match');
+		} catch (TInvalidDataValueException $e) {
+			$msg = $e->getMessage();
+			self::assertStringContainsString('North',  $msg);
+			self::assertStringContainsString('South',  $msg);
+			self::assertStringContainsString('NULL',   $msg);
+			self::assertStringContainsString('false',  $msg);
+			// Int-keyed string extras surface as the bare name (no var_export quoting).
+			self::assertStringContainsString('Auto',   $msg);
+		}
+	}
+
+	// ── ensureEnumValue — BackedEnum / UnitEnum support ─────────────────────
+
+	public function testEnsureEnumValue_backedEnum_returnsBackingValue(): void
+	{
+		// BackedEnum case constants are unwrapped to their ->value.
+		self::assertSame('red',   TPropertyValue::ensureEnumValue('Red',   TPropertyValueTestColor::class));
+		self::assertSame('red',   TPropertyValue::ensureEnumValue('red',   TPropertyValueTestColor::class));
+		self::assertSame('green', TPropertyValue::ensureEnumValue('Green', TPropertyValueTestColor::class));
+		self::assertSame('blue',  TPropertyValue::ensureEnumValue('BLUE',  TPropertyValueTestColor::class));
+		// Int-backed enum.
+		self::assertSame(1, TPropertyValue::ensureEnumValue('Low',  TPropertyValueTestPriority::class));
+		self::assertSame(2, TPropertyValue::ensureEnumValue('high', TPropertyValueTestPriority::class));
+	}
+
+	public function testEnsureEnumValue_unitEnum_returnsCaseObject(): void
+	{
+		// Non-backed UnitEnum has no underlying value — the case object
+		// (which IS the constant slot's content) is returned as-is.
+		self::assertSame(TPropertyValueTestStatus::Active,  TPropertyValue::ensureEnumValue('active',  TPropertyValueTestStatus::class));
+		self::assertSame(TPropertyValueTestStatus::Pending, TPropertyValue::ensureEnumValue('PENDING', TPropertyValueTestStatus::class));
+	}
+
+	public function testEnsureEnumValue_enumInstance_unwrapped(): void
+	{
+		// Instance pass-through: BackedEnum → ->value, UnitEnum → the case.
+		self::assertSame('red', TPropertyValue::ensureEnumValue(TPropertyValueTestColor::Red,    TPropertyValueTestColor::class));
+		self::assertSame(2,     TPropertyValue::ensureEnumValue(TPropertyValueTestPriority::High, TPropertyValueTestPriority::class));
+		self::assertSame(TPropertyValueTestStatus::Active, TPropertyValue::ensureEnumValue(TPropertyValueTestStatus::Active, TPropertyValueTestStatus::class));
+	}
+
+	// ── ensureEnumValue — object as $enums ──────────────────────────────────
+
+	public function testEnsureEnumValue_objectAsEnums(): void
+	{
+		$instance = new TPropertyValueTestDirection();
+		self::assertSame('East', TPropertyValue::ensureEnumValue('east', $instance));
+	}
+
+	// ── ensureEnumValue — $extras key/value map ─────────────────────────────
+
+	public function testEnsureEnumValue_extras_mapKeyToValue(): void
+	{
+		// $extras is a case-insensitive key→value map; matched keys resolve
+		// to their mapped values.  Distinct from ensureEnum()'s extras
+		// (list of permitted values).
+		$extras = ['Auto' => 'auto', 'System' => 0, 'Default' => null];
+		self::assertSame('auto', TPropertyValue::ensureEnumValue('Auto',    TPropertyValueTestDirection::class, $extras));
+		self::assertSame('auto', TPropertyValue::ensureEnumValue('auto',    TPropertyValueTestDirection::class, $extras));
+		self::assertSame('auto', TPropertyValue::ensureEnumValue('AUTO',    TPropertyValueTestDirection::class, $extras));
+		self::assertSame(0,      TPropertyValue::ensureEnumValue('system',  TPropertyValueTestDirection::class, $extras));
+		self::assertNull(TPropertyValue::ensureEnumValue('default', TPropertyValueTestDirection::class, $extras));
+	}
+
+	public function testEnsureEnumValue_extras_classResolvesFirst(): void
+	{
+		// A valid constant name is resolved before the extras map is consulted.
+		$extras = ['North' => 'overridden', 'Auto' => 'auto'];
+		self::assertSame('North', TPropertyValue::ensureEnumValue('North', TPropertyValueTestDirection::class, $extras));
+		self::assertSame('auto',  TPropertyValue::ensureEnumValue('Auto',  TPropertyValueTestDirection::class, $extras));
+	}
+
+	public function testEnsureEnumValue_extras_allFail_errorIncludesExtraKeys(): void
+	{
+		try {
+			TPropertyValue::ensureEnumValue(
+				'NoSuchKey',
+				TPropertyValueTestDirection::class,
+				['Auto' => 'auto', 'Custom' => 99]
+			);
+			self::fail('Expected throw when neither class nor extras match');
+		} catch (TInvalidDataValueException $e) {
+			$msg = $e->getMessage();
+			self::assertStringContainsString('NoSuchKey', $msg);
+			self::assertStringContainsString('North',  $msg);
+			self::assertStringContainsString('Auto',   $msg);
+			self::assertStringContainsString('Custom', $msg);
+		}
+	}
+
+	// ── ensureEnum / ensureEnumValue — unified extras semantics ─────────────
+
+	/**
+	 * Both methods accept the same extras shape and share matching rules; only
+	 * the return value differs.  String-keyed entries are case-insensitive
+	 * aliases on the KEY: ensureEnum returns the key (canonical name),
+	 * ensureEnumValue returns the mapped value.
+	 */
+	public function testEnsureEnum_extras_stringKeyed_returnsCanonicalKey(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		// Same extras drive both methods to symmetric but distinct results.
+		$extras = ['Auto' => 'auto', 'System' => 0, 'Default' => null];
+		self::assertSame('Auto',   TPropertyValue::ensureEnum('auto',    $cls, $extras));
+		self::assertSame('Auto',   TPropertyValue::ensureEnum('AUTO',    $cls, $extras));
+		self::assertSame('System', TPropertyValue::ensureEnum('system',  $cls, $extras));
+		self::assertSame('Default',TPropertyValue::ensureEnum('default', $cls, $extras));
+		// And ensureEnumValue on the same extras returns the mapped values.
+		self::assertSame('auto',   TPropertyValue::ensureEnumValue('auto',    $cls, $extras));
+		self::assertSame(0,        TPropertyValue::ensureEnumValue('system',  $cls, $extras));
+		self::assertNull(TPropertyValue::ensureEnumValue('default', $cls, $extras));
+	}
+
+	/**
+	 * Int-keyed string extras are case-insensitive names whose string is its
+	 * own value — both methods return the string itself on match.  This is
+	 * the unified extension that lets `ensureEnum($v, $cls, 'Auto')` accept
+	 * any casing of `'Auto'`.
+	 */
+	public function testEnsureEnum_extras_intKeyedString_caseInsensitive(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		// Variadic form.
+		self::assertSame('Auto', TPropertyValue::ensureEnum('AUTO', $cls, 'Auto'));
+		self::assertSame('Auto', TPropertyValue::ensureEnum('auto', $cls, 'Auto'));
+		// Array form.
+		self::assertSame('Auto', TPropertyValue::ensureEnum('AUTO', $cls, ['Auto']));
+		// Mixed with sentinels — string match wins over sentinels for string $value.
+		self::assertSame('Auto', TPropertyValue::ensureEnum('aUtO', $cls, [null, false, 'Auto']));
+		// ensureEnumValue does the same thing for int-keyed strings.
+		self::assertSame('Auto', TPropertyValue::ensureEnumValue('auto', $cls, ['Auto']));
+		self::assertSame('Auto', TPropertyValue::ensureEnumValue('AUTO', $cls, ['Auto', null, false]));
+	}
+
+	/**
+	 * Non-string $value never satisfies a string-form extra (int-keyed string
+	 * OR string-keyed alias) — case-insensitive matching is string-only by
+	 * design, so sentinels and aliases stay cleanly separated.
+	 */
+	public function testEnsureEnum_extras_nonStringValue_doesNotMatchStringForms(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		foreach ([null, false, true, 0, 1, -1] as $nonString) {
+			// int-keyed string 'Auto' cannot satisfy a non-string $value.
+			try {
+				TPropertyValue::ensureEnum($nonString, $cls, ['Auto']);
+				self::fail('Non-string value should not match int-keyed string extra: ' . var_export($nonString, true));
+			} catch (TInvalidDataValueException $e) {
+				self::assertInstanceOf(TInvalidDataValueException::class, $e);
+			}
+			// String-keyed alias 'Auto' => 'auto' cannot either.
+			try {
+				TPropertyValue::ensureEnum($nonString, $cls, ['Auto' => 'auto']);
+				self::fail('Non-string value should not match string-keyed alias extra: ' . var_export($nonString, true));
+			} catch (TInvalidDataValueException $e) {
+				self::assertInstanceOf(TInvalidDataValueException::class, $e);
+			}
+		}
+	}
+
+	// ── ensureEnum — scalar sentinels in extras (TWebColor|false pattern) ───
+
+	/**
+	 * Properties typed as `TWebColor|false`, `TWebColor|null`, `TWebColor|int`,
+	 * etc., rely on extras to admit scalar sentinels alongside the enum's
+	 * constants without a separate branch.  This covers each of the six common
+	 * scalar sentinels (null, false, true, -1, 0, 1) as an extras member that
+	 * matches its corresponding $value input.
+	 */
+	public function testEnsureEnum_extras_scalarSentinels_eachMatchesItself(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		self::assertNull(TPropertyValue::ensureEnum(null,  $cls, null));
+		self::assertFalse(TPropertyValue::ensureEnum(false, $cls, false));
+		self::assertTrue(TPropertyValue::ensureEnum(true,  $cls, true));
+		self::assertSame(-1, TPropertyValue::ensureEnum(-1, $cls, -1));
+		self::assertSame(0,  TPropertyValue::ensureEnum(0,  $cls, 0));
+		self::assertSame(1,  TPropertyValue::ensureEnum(1,  $cls, 1));
+		// Same matrix in array-shape extras.
+		self::assertNull(TPropertyValue::ensureEnum(null,  $cls, [null]));
+		self::assertFalse(TPropertyValue::ensureEnum(false, $cls, [false]));
+		self::assertTrue(TPropertyValue::ensureEnum(true,  $cls, [true]));
+		self::assertSame(-1, TPropertyValue::ensureEnum(-1, $cls, [-1]));
+		self::assertSame(0,  TPropertyValue::ensureEnum(0,  $cls, [0]));
+		self::assertSame(1,  TPropertyValue::ensureEnum(1,  $cls, [1]));
+		// All six sentinels coexist in a single extras list.
+		$all = [null, false, true, -1, 0, 1];
+		self::assertNull(TPropertyValue::ensureEnum(null,  $cls, $all));
+		self::assertFalse(TPropertyValue::ensureEnum(false, $cls, $all));
+		self::assertTrue(TPropertyValue::ensureEnum(true,  $cls, $all));
+		self::assertSame(-1, TPropertyValue::ensureEnum(-1, $cls, $all));
+		self::assertSame(0,  TPropertyValue::ensureEnum(0,  $cls, $all));
+		self::assertSame(1,  TPropertyValue::ensureEnum(1,  $cls, $all));
+		// Class constants still resolve ahead of the extras list.
+		self::assertSame('North', TPropertyValue::ensureEnum('North', $cls, $all));
+	}
+
+	/**
+	 * Strict equality guarantee: extras use `in_array(..., true)` so look-alike
+	 * scalars do not cross-match.  `TWebColor|false` must reject `0`; an int-
+	 * extras `1` must reject `true`; etc.  Locked in to prevent regression to
+	 * loose comparison.
+	 */
+	public function testEnsureEnum_extras_scalarSentinels_strictNoCrossMatch(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		// Each pair: (extras-member, list of look-alike inputs that MUST be rejected).
+		$matrix = [
+			['extra' => false, 'bogus' => [0, '0', '', null]],
+			['extra' => true,  'bogus' => [1, '1', 'true']],
+			['extra' => null,  'bogus' => [false, 0, '']],
+			['extra' => 0,     'bogus' => [false, null, '0']],
+			['extra' => 1,     'bogus' => [true, '1']],
+			['extra' => -1,    'bogus' => ['-1', true]],
+		];
+		foreach ($matrix as $row) {
+			foreach ($row['bogus'] as $bogus) {
+				try {
+					TPropertyValue::ensureEnum($bogus, $cls, $row['extra']);
+					self::fail(
+						var_export($row['extra'], true) . ' extra must not cross-match '
+						. var_export($bogus, true)
+					);
+				} catch (TInvalidDataValueException $e) {
+					self::assertInstanceOf(TInvalidDataValueException::class, $e);
+				}
+			}
+		}
+	}
+
+	// ── ensureEnumValue — non-existent class ────────────────────────────────
+
+	/**
+	 * Symmetric to ensureEnum's non-existent-class test: an unreflectable class
+	 * name leaves the reflection cache holding null and triggers the extras-only
+	 * fall-through, which throws when extras is also empty.
+	 */
+	public function testEnsureEnumValue_nonExistentClass_throwsInvalidDataValueException(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		TPropertyValue::ensureEnumValue('Foo', 'TPropertyValueNonExistentClass99999XYZ');
+	}
+
+	// ── ensureEnumValue — mixed-shape extras (alias map + sentinel list) ────
+
+	/**
+	 * String-keyed extras act as a case-insensitive alias map (key compared to
+	 * $value, mapped value returned); int-keyed extras act as a strict-equality
+	 * permitted list (value compared to $value, returned on match).  The two
+	 * shapes may be mixed freely in one array — covering sentinels like null,
+	 * false, 0 without requiring synthetic keys.
+	 */
+	public function testEnsureEnumValue_mixedExtras_aliasMapAndSentinelList(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		// String-keyed alias still resolves a string $value.
+		self::assertSame('auto', TPropertyValue::ensureEnumValue('Auto', $cls, ['Auto' => 'auto']));
+		// Int-keyed sentinels are matched against $value with ===.
+		self::assertNull(TPropertyValue::ensureEnumValue(null,   $cls, [null]));
+		self::assertFalse(TPropertyValue::ensureEnumValue(false, $cls, [false]));
+		self::assertTrue(TPropertyValue::ensureEnumValue(true,   $cls, [true]));
+		self::assertSame(-1, TPropertyValue::ensureEnumValue(-1,  $cls, [-1]));
+		self::assertSame(0,  TPropertyValue::ensureEnumValue(0,   $cls, [0]));
+		self::assertSame(1,  TPropertyValue::ensureEnumValue(1,   $cls, [1]));
+		// Mixed: alias map + sentinel list in one array.
+		$mixed = ['Auto' => 'auto', null, false, -1];
+		self::assertSame('auto', TPropertyValue::ensureEnumValue('Auto',  $cls, $mixed));
+		self::assertSame('auto', TPropertyValue::ensureEnumValue('AUTO',  $cls, $mixed));
+		self::assertNull(TPropertyValue::ensureEnumValue(null,  $cls, $mixed));
+		self::assertFalse(TPropertyValue::ensureEnumValue(false, $cls, $mixed));
+		self::assertSame(-1, TPropertyValue::ensureEnumValue(-1,  $cls, $mixed));
+		// Class constants still resolve ahead of the extras list.
+		self::assertSame('North', TPropertyValue::ensureEnumValue('north', $cls, $mixed));
+	}
+
+	/**
+	 * Strict-equality guarantee for int-keyed extras: a `false` sentinel must
+	 * not satisfy `0`, a `null` sentinel must not satisfy `false`, etc.
+	 * Symmetric to the same matrix on ensureEnum.
+	 */
+	public function testEnsureEnumValue_intKeyedExtras_strictNoCrossMatch(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		$matrix = [
+			['extra' => false, 'bogus' => [0, '0', '']],
+			['extra' => true,  'bogus' => [1, '1']],
+			['extra' => null,  'bogus' => [false, 0, '']],
+			['extra' => 0,     'bogus' => [false, '0']],
+			['extra' => 1,     'bogus' => [true, '1']],
+		];
+		foreach ($matrix as $row) {
+			foreach ($row['bogus'] as $bogus) {
+				try {
+					TPropertyValue::ensureEnumValue($bogus, $cls, [$row['extra']]);
+					self::fail(
+						var_export($row['extra'], true) . ' int-keyed extra must not cross-match '
+						. var_export($bogus, true)
+					);
+				} catch (TInvalidDataValueException $e) {
+					self::assertInstanceOf(TInvalidDataValueException::class, $e);
+				}
+			}
+		}
+	}
+
+	// ── ensureEnum — mixed-shape extras only normalize single-array form ────
+
+	/**
+	 * The single-array normalization fires only when extras is exactly one
+	 * array argument.  Mixing a leading scalar with a trailing array leaves
+	 * the array as a literal extras member (and matches nothing in strict
+	 * equality unless $value is also an array).
+	 */
+	public function testEnsureEnum_mixedShapeExtras_doNotNormalize(): void
+	{
+		$cls = TPropertyValueTestDirection::class;
+		// Two-arg form: ['North', ['extra1','extra2']] — the inner array is literal.
+		// 'North' resolves on the class lookup before extras are considered.
+		self::assertSame('North', TPropertyValue::ensureEnum('North', $cls, 'leading', ['trailing']));
+		// The literal array IS findable when $value is the same array (strict ==).
+		self::assertSame(['trailing'], TPropertyValue::ensureEnum(['trailing'], $cls, 'leading', ['trailing']));
+		// And the leading scalar is still findable.
+		self::assertSame('leading', TPropertyValue::ensureEnum('leading', $cls, 'leading', ['trailing']));
 	}
 
 	public function testEnsureNullIfEmpty()
@@ -1888,13 +2328,18 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeCodeEnumCaseInsensitiveName(): void
 	{
-		// When constant name ≠ constant value (const Alpha = 'a'), a case-insensitive
-		// name match still resolves to the canonical constant value.
+		// When the constant name differs from the constant value (`const Alpha = 'a'`),
+		// the coercion has validated the input string against the constant *name*
+		// and returned the canonical name (case-corrected) — *not* the constant
+		// value.  Any name→value translation has stayed inside the enum class
+		// itself (e.g. via `TPropertyValueTestCodeEnum::valueOfConstant()`).
+		// Compare {@see testEnsureEnum_iEnumerable_returnsCanonicalValue} which
+		// is a different entry point and intentionally returns the value.
 		$t = $this->typeOf(fn(TPropertyValueTestCodeEnum $x) => $x);
-		self::assertSame('a', TPropertyValue::coerceToType('alpha', $t));
-		self::assertSame('a', TPropertyValue::coerceToType('ALPHA', $t));
-		self::assertSame('b', TPropertyValue::coerceToType('beta',  $t));
-		self::assertSame('b', TPropertyValue::coerceToType('BETA',  $t));
+		self::assertSame('Alpha', TPropertyValue::coerceToType('alpha', $t));
+		self::assertSame('Alpha', TPropertyValue::coerceToType('ALPHA', $t));
+		self::assertSame('Beta',  TPropertyValue::coerceToType('beta',  $t));
+		self::assertSame('Beta',  TPropertyValue::coerceToType('BETA',  $t));
 	}
 
 	public function testCoerceToTypeCustomIEnumerableInvalidPassesThrough(): void
@@ -2172,8 +2617,9 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeUnionArrayKeywordNotationWins(): void
 	{
-		// Bug CU1: step 4 only detected `(...)` and `[...]` as array notation but
-		// missed the PHP `array(...)` keyword form.  All three must be recognized.
+		// Bug CU1: step 6 (array notation) used to detect only `(...)` and
+		// `[...]`, missing the PHP `array(...)` keyword form.  All three
+		// must be recognized.
 		$t = $this->typeOf(fn(int|array $x) => $x);
 		self::assertSame([1, 2, 3], TPropertyValue::coerceToType('array(1, 2, 3)', $t));
 		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('Array("a", "b")', $t));
@@ -2212,9 +2658,9 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeUnionFallbackUsesTypeCoerceOrder(): void
 	{
-		// 'not-numeric' matches no heuristic → fallback (step 9).
+		// 'not-numeric' matches no heuristic → fallback (step 10).
 		// TYPE_COERCE_ORDER places int before array, so ensureInteger('not-numeric') = 0,
-		// matching PHP non-strict behaviour (implicit string→int yields 0 with a notice).
+		// matching PHP non-strict behavior (implicit string→int yields 0 with a notice).
 		$t = $this->typeOf(fn(int|array $x) => $x);
 		self::assertSame(0, TPropertyValue::coerceToType('not-numeric', $t));
 		// array-only union: no int → array is first in order → single-element array.
@@ -2234,7 +2680,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	{
 		// Empty string with no `null` member: the null short-circuit does not fire.
 		// Neither array notation, bool literal, nor numeric apply to '', so the fallback
-		// (step 9) sorts by TYPE_COERCE_ORDER.  int (position 0) comes before bool
+		// (step 10) sorts by TYPE_COERCE_ORDER.  int (position 0) comes before bool
 		// (position 3); ensureInteger('') = 0.
 		$t = $this->typeOf(fn(bool|int $x) => $x);
 		self::assertSame(0, TPropertyValue::coerceToType('', $t));
@@ -2242,7 +2688,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeUnionStringMemberCoercesNonStringViaEnsureString(): void
 	{
-		// Step 2: when `string` is a union member and the value is NOT already a string,
+		// Step 4: when `string` is a union member and the value is NOT already a string,
 		// ensureString() is called (bool→'true'/'false', int→string, etc.).
 		$t = $this->typeOf(fn(string|int $x) => $x);
 		self::assertSame('true',  TPropertyValue::coerceToType(true,  $t));
@@ -2252,9 +2698,9 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeUnionIterableInUnion(): void
 	{
-		// `iterable` in a union sets $hasArray=true, so array-notation strings (step 4)
-		// are still parsed correctly.  Step 5 only fires for '(...)' / '[...]' / 'array(...)'
-		// notation, so 'true'/'false' fall through to step 6 (bool literals) and are coerced to bool.
+		// `iterable` in a union sets $hasArray=true, so array-notation strings (step 6)
+		// are still parsed correctly.  Step 6 only fires for '(...)' / '[...]' / 'array(...)'
+		// notation, so 'true'/'false' fall through to step 7 (bool literals) and are coerced to bool.
 		$t = $this->typeOf(fn(iterable|bool $x) => $x);
 		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('("a", "b")', $t));
 		self::assertSame(true,       TPropertyValue::coerceToType('true',       $t));
@@ -2263,17 +2709,17 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeUnionFloatOnlyNumeric(): void
 	{
-		// Step 7: when `float` is present but `int` is not, any numeric string → float.
-		// Bool literals win step 6 before the numeric check (step 7).
+		// Step 8: when `float` is present but `int` is not, any numeric string → float.
+		// Bool literals win step 7 before the numeric check (step 8).
 		$t = $this->typeOf(fn(float|bool $x) => $x);
 		self::assertSame(3.14, TPropertyValue::coerceToType('3.14', $t));
 		self::assertSame(42.0, TPropertyValue::coerceToType('42',   $t));
 		self::assertSame(true, TPropertyValue::coerceToType('true', $t));
 	}
 
-	public function testCoerceToTypeUnionStep7ScientificNotation(): void
+	public function testCoerceToTypeUnionScientificNotation(): void
 	{
-		// Step 7: scientific notation ('1e5', '1E+3') contains no '.' but still represents
+		// Step 8 (numeric shape): scientific notation ('1e5', '1E+3') contains no '.' but still represents
 		// a float.  Without the stripos('e') check the str_contains('.') branch returned
 		// (int)'1e5', whereas PHP non-strict mode promotes these strings to float.
 		$t = $this->typeOf(fn(int|float $x) => $x);
@@ -2289,12 +2735,12 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame(3.14,      TPropertyValue::coerceToType('3.14',   $t));
 	}
 
-	public function testCoerceToTypeUnionStep7LargeIntStringPromotesToFloat(): void
+	public function testCoerceToTypeUnionLargeIntStringPromotesToFloat(): void
 	{
 		// F-08: a numeric string that exceeds PHP_INT_MAX (or is below PHP_INT_MIN) must
-		// promote to float when both int and float are in the union, matching PHP's own
-		// non-strict coercion rules.  Before the fix, (int)$s saturated silently at
-		// PHP_INT_MAX/MIN instead of returning the float representation.
+		// promote to float when both int and float are in the union (step 8 — numeric
+		// shape), matching PHP's own non-strict coercion rules.  Before the fix, (int)$s
+		// saturated silently at PHP_INT_MAX/MIN instead of returning the float representation.
 		$t = $this->typeOf(fn(int|float $x) => $x);
 		// Values that fit in int — must stay int
 		self::assertSame(PHP_INT_MAX, TPropertyValue::coerceToType((string) PHP_INT_MAX, $t));
@@ -2308,61 +2754,65 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame((float) $underMin, TPropertyValue::coerceToType($underMin, $t));
 	}
 
-	public function testCoerceToTypeUnionStep8BackedEnumInMultiMemberUnion(): void
+	public function testCoerceToTypeUnionBackedEnumInMultiMemberUnion(): void
 	{
-		// Step 8 (non-builtin class) is only reached when multiple non-null members exist
-		// (otherwise the single-non-null optimisation delegates directly).
-		// A valid enum backing value is coerced; an invalid one passes through unchanged.
+		// Step 9 (non-builtin class lookup) is only reached when multiple non-null
+		// members exist (otherwise the single-non-null optimization delegates
+		// directly).  A valid enum backing value is coerced; an invalid one
+		// passes through unchanged.
 		$t = $this->typeOf(fn(TPropertyValueTestColor|int $x) => $x);
 		self::assertSame(TPropertyValueTestColor::Blue, TPropertyValue::coerceToType('blue', $t));
-		// '99' is numeric → step 7 (int), step 8 not reached.
+		// '99' is numeric → step 8 (numeric shape) → int, step 9 not reached.
 		self::assertSame(99, TPropertyValue::coerceToType('99', $t));
 	}
 
-	public function testCoerceToTypeUnionStep8IntBackedEnumFromPhpInt(): void
+	public function testCoerceToTypeUnionIntBackedEnumFromPhpInt(): void
 	{
-		// F-16: step 8 previously called _coerceToClass($strValue, …) exclusively, so a PHP
+		// F-16: step 9 previously called _coerceToClass($strValue, …) exclusively, so a PHP
 		// int value was stringified to e.g. '1' before reaching tryFrom().  For int-backed
 		// enums tryFrom('1') returns null (type mismatch), silently failing the coercion.
 		// The fix tries _coerceToClass($value, …) first so the original PHP int reaches
 		// tryFrom(1) and resolves correctly.
 		//
 		// Union uses bool (not string/int/float) so that:
-		//   - step 3 is skipped (string absent)
-		//   - step 4 Pass A/B are skipped (int/float absent, bool doesn't match an int)
-		//   - step 7 is skipped (no int/float in union)
-		// …forcing the PHP int to reach step 8 where _coerceToClass is called.
+		//   - step 4 is skipped (string absent)
+		//   - step 5 Pass A/B are skipped (int/float absent, bool doesn't match an int)
+		//   - step 8 is skipped (no int/float in union)
+		// …forcing the PHP int to reach step 9 where _coerceToClass is called.
 		$t = $this->typeOf(fn(TPropertyValueTestPriority|bool $x) => $x);
-		// PHP int → int-backed enum via original-value path in step 8
+		// PHP int → int-backed enum via original-value path in step 9
 		self::assertSame(TPropertyValueTestPriority::Low,  TPropertyValue::coerceToType(1, $t));
 		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType(2, $t));
-		// Unknown int → no enum case, no bool literal → step 9 picks bool (lower TYPE_COERCE_ORDER
+		// Unknown int → no enum case, no bool literal → step 10 picks bool (lower TYPE_COERCE_ORDER
 		// index than a non-builtin class); ensureBoolean(99) = true (non-zero numeric).
 		self::assertSame(true, TPropertyValue::coerceToType(99, $t));
 	}
 
-	public function testCoerceToTypeUnionStep8IEnumerableChangedValue(): void
+	public function testCoerceToTypeUnionEnumValidatesNameWithCaseCorrection(): void
 	{
-		// Step 8: when _coerceToClass returns a value DIFFERENT from $strValue, the
-		// coerced result is used.  TPropertyValueTestCodeEnum has const Alpha='a', so
-		// valueOfConstant('Alpha')='a' ≠ 'Alpha', triggering the !== guard.
+		// Step 2 has validated the input string against TCodeEnum's constant
+		// names case-insensitively and returned the *canonical name* — the
+		// constant's value (`'a'` for `const Alpha = 'a'`) has NOT been
+		// returned here; any name→value translation has stayed inside the
+		// enum class.
 		$t = $this->typeOf(fn(TPropertyValueTestCodeEnum|int $x) => $x);
-		self::assertSame('a', TPropertyValue::coerceToType('Alpha', $t));
-		self::assertSame('b', TPropertyValue::coerceToType('Beta',  $t));
-		// Unrecognised name: valueOfConstant returns null → falls back to $strValue →
-		// $coerced === $strValue → step 8 does NOT return → fallback (step 9).
-		// int|TPropertyValueTestCodeEnum canonical order: non-builtin last? or first?
-		// Either way step 9 runs ensureInteger or _coerceToClass on 'Unknown'.
-		// Assert only that the result is deterministic (no exception).
-		$result = TPropertyValue::coerceToType('Unknown', $t);
-		self::assertTrue(is_int($result) || is_string($result));
+		self::assertSame('Alpha', TPropertyValue::coerceToType('Alpha', $t));
+		self::assertSame('Alpha', TPropertyValue::coerceToType('alpha', $t));
+		self::assertSame('Alpha', TPropertyValue::coerceToType('ALPHA', $t));
+		self::assertSame('Beta',  TPropertyValue::coerceToType('Beta',  $t));
+		self::assertSame('Beta',  TPropertyValue::coerceToType('beta',  $t));
+		// Unrecognized name: step 2 misses, fallback chain runs through to
+		// step 10 (fallback) — int is first in TYPE_COERCE_ORDER, so
+		// ensureInteger('Unknown') = 0.
+		self::assertSame(0, TPropertyValue::coerceToType('Unknown', $t));
 	}
 
 	public function testCoerceToTypeUnionObjectInstancePreservedByNativeTypeShortCircuit(): void
 	{
-		// Step 3: when $value is a non-string object whose PHP type matches a non-builtin
-		// union member, it is returned without any conversion.
-		// Uses a plain stdClass (not an enum) to confirm the general object path.
+		// Step 3 (pre-string short-circuit): when $value is a non-string object
+		// whose PHP type matches a non-builtin union member, it is returned
+		// without any conversion.  Uses a plain stdClass (not an enum) to
+		// confirm the general object path.
 		$t = $this->typeOf(fn(\stdClass|int $x) => $x);
 		$obj = new \stdClass();
 		$obj->x = 'preserved';
@@ -2384,10 +2834,11 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testCoerceToTypeUnionArrayPreservedWhenStringAlsoInUnion(): void
 	{
-		// Bug CU2: when `string` is in the union, step 3 (the old step 2) fired
-		// ensureString() on array values, producing the useless string "Array"
-		// instead of preserving the array.  The pre-string short-circuit (step 2)
-		// must claim array values before the string coercion path fires.
+		// Bug CU2: when `string` is in the union, step 4 (string member) used
+		// to fire ensureString() on array values, producing the useless string
+		// "Array" instead of preserving the array.  The pre-string short-
+		// circuit (step 3) now claims array values before the string coercion
+		// path fires.
 		$t = $this->typeOf(fn(string|array $x) => $x);
 		self::assertSame([1, 2, 3],          TPropertyValue::coerceToType([1, 2, 3], $t));
 		self::assertSame([],                 TPropertyValue::coerceToType([],        $t));
@@ -2395,7 +2846,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		// A string value still passes through as-is.
 		self::assertSame('hello',            TPropertyValue::coerceToType('hello',   $t));
 		// Scalar non-string values (bool, int) still coerce to string when string
-		// is in the union — the step 2 short-circuit is limited to arrays/objects.
+		// is in the union — the step 3 short-circuit is limited to arrays/objects.
 		self::assertSame('true', TPropertyValue::coerceToType(true, $t));
 		self::assertSame('42',   TPropertyValue::coerceToType(42,   $t));
 	}
@@ -2427,46 +2878,184 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame(TPropertyValueTestColor::Red, TPropertyValue::coerceToType(TPropertyValueTestColor::Red, $t));
 	}
 
-	public function testCoerceToTypeUnionStep3BoolWidensToInt(): void
+	public function testCoerceToTypeUnionBoolWidensToInt(): void
 	{
-		// Step 3 pass B: when bool is absent from the union, a native bool is widened
-		// to int (true=1, false=0), matching PHP's non-strict coercion behaviour.
+		// Step 5 (native-type) pass B: when bool is absent from the union, a
+		// native bool widens to int (true=1, false=0), matching PHP's non-
+		// strict coercion behavior.
 		$t = $this->typeOf(fn(int|array $x) => $x);
 		self::assertSame(1, TPropertyValue::coerceToType(true,  $t));
 		self::assertSame(0, TPropertyValue::coerceToType(false, $t));
 	}
 
-	public function testCoerceToTypeUnionStep3BoolWidensToFloatWhenNoInt(): void
+	public function testCoerceToTypeUnionBoolWidensToFloatWhenNoInt(): void
 	{
-		// When int is absent but float is present, bool widens to float.
+		// When int is absent but float is present, bool widens to float (step 5 pass B).
 		$t = $this->typeOf(fn(float|array $x) => $x);
 		self::assertSame(1.0, TPropertyValue::coerceToType(true,  $t));
 		self::assertSame(0.0, TPropertyValue::coerceToType(false, $t));
 	}
 
-	public function testCoerceToTypeUnionStep3BoolPreservedWhenBoolInUnion(): void
+	public function testCoerceToTypeUnionBoolPreservedWhenBoolInUnion(): void
 	{
-		// When bool IS in the union, pass A exact-match fires and the value stays bool.
+		// When bool IS in the union, step 5 pass A exact-match fires and the
+		// value stays bool.
 		$t = $this->typeOf(fn(bool|int $x) => $x);
 		self::assertSame(true,  TPropertyValue::coerceToType(true,  $t));
 		self::assertSame(false, TPropertyValue::coerceToType(false, $t));
 	}
 
-	public function testCoerceToTypeUnionStep3IntWidensToFloat(): void
+	public function testCoerceToTypeUnionIntWidensToFloat(): void
 	{
-		// Step 3 pass B: when int is absent but float is present, a native int widens
-		// to float (lossless promotion), matching PHP non-strict behaviour.
+		// Step 5 (native-type) pass B: when int is absent but float is
+		// present, a native int widens to float (lossless promotion),
+		// matching PHP non-strict behavior.
 		$t = $this->typeOf(fn(float|array $x) => $x);
 		self::assertSame(42.0, TPropertyValue::coerceToType(42, $t));
 		self::assertSame(-1.0, TPropertyValue::coerceToType(-1, $t));
 	}
 
-	public function testCoerceToTypeUnionStep3IntPreservedWhenIntInUnion(): void
+	public function testCoerceToTypeUnionIntPreservedWhenIntInUnion(): void
 	{
-		// When int IS in the union, pass A exact-match fires and the value stays int.
+		// When int IS in the union, step 5 pass A exact-match fires and the
+		// value stays int.
 		$t = $this->typeOf(fn(int|float $x) => $x);
 		self::assertSame(7,  TPropertyValue::coerceToType(7,  $t));
 		self::assertSame(-3, TPropertyValue::coerceToType(-3, $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// Step 2 — enumerable transition (name lookup precedes string member)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeUnionStep2IEnumerableNameWinsOverString(): void
+	{
+		// `TWebColor|string|null` with 'Red' has validated against TWebColor's
+		// constant names and returned the canonical name `'Red'` (any-casing
+		// input is corrected).  The enum has been used as a *validator*, not
+		// a transition table — name→value translation has stayed inside the
+		// class itself (e.g. via {@see TPropertyValue::ensureHexColor()}).
+		// Pre-step-2 the `string` union member silently dominated and the
+		// untouched input passed through.
+		$t = $this->typeOf(fn(\Prado\Web\UI\TWebColor|string|null $x) => $x);
+		self::assertSame('Red',  TPropertyValue::coerceToType('Red',  $t));
+		self::assertSame('Red',  TPropertyValue::coerceToType('red',  $t));
+		self::assertSame('Red',  TPropertyValue::coerceToType('RED',  $t));
+		self::assertSame('Blue', TPropertyValue::coerceToType('Blue', $t));
+		self::assertSame('Blue', TPropertyValue::coerceToType('BLUE', $t));
+		// Unknown name has fallen through to step 4 (string in union) → pass through.
+		self::assertSame('not-a-color', TPropertyValue::coerceToType('not-a-color', $t));
+		// Empty string with nullable union → null (step 1 still fires first).
+		self::assertNull(TPropertyValue::coerceToType('', $t));
+	}
+
+	public function testCoerceToTypeUnionStep2BackedEnumNameWinsOverString(): void
+	{
+		// `TPropertyValueTestColor|string|null` with a case name resolves to the case;
+		// the backing value also resolves (BackedEnum::tryFrom path inside _tryMatchEnum).
+		$t = $this->typeOf(fn(TPropertyValueTestColor|string|null $x) => $x);
+		// Case name (any casing).
+		self::assertSame(TPropertyValueTestColor::Red,  TPropertyValue::coerceToType('Red',  $t));
+		self::assertSame(TPropertyValueTestColor::Red,  TPropertyValue::coerceToType('RED',  $t));
+		self::assertSame(TPropertyValueTestColor::Blue, TPropertyValue::coerceToType('Blue', $t));
+		// Backing value.
+		self::assertSame(TPropertyValueTestColor::Blue, TPropertyValue::coerceToType('blue', $t));
+		// Unknown → fall through to step 4 string member.
+		self::assertSame('not-a-color', TPropertyValue::coerceToType('not-a-color', $t));
+	}
+
+	public function testCoerceToTypeBackedEnumGuardsAgainstBackingTypeMismatch(): void
+	{
+		// PHP 8.1+ `BackedEnum::tryFrom()` is strict on the backing type — a
+		// string against an int-backed enum (or an int against a string-backed
+		// enum) raises TypeError.  Both _tryMatchEnum() (string side) and
+		// _coerceToClass() (int side) have wrapped the call so the lookup
+		// falls through to the name scan / single-element pass-through.
+
+		// String input against int-backed enum — should fall through to name
+		// lookup and resolve via `cases()` iteration.
+		$intBacked = $this->typeOf(fn(TPropertyValueTestPriority $x) => $x);
+		self::assertSame(TPropertyValueTestPriority::Low,  TPropertyValue::coerceToType('Low',  $intBacked));
+		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType('High', $intBacked));
+		// String backing value DOES work because the input is a string and the
+		// backing-string check (gettype) matches — but for int-backed there's
+		// no string backing, so the name path is the only one that resolves.
+		self::assertSame(TPropertyValueTestPriority::Low, TPropertyValue::coerceToType('low', $intBacked));
+
+		// Int input against string-backed enum — should pass through unchanged
+		// (no name lookup for non-string inputs in _coerceToClass).
+		$stringBacked = $this->typeOf(fn(TPropertyValueTestColor $x) => $x);
+		self::assertSame(99, TPropertyValue::coerceToType(99, $stringBacked));
+
+		// Mixed-enum union (string-backed + int-backed): a string name that
+		// matches the int-backed enum has resolved via the second iteration
+		// after the first enum's tryFrom raised the wrapped TypeError.
+		$mixed = $this->typeOf(fn(TPropertyValueTestColor|TPropertyValueTestPriority $x) => $x);
+		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType('High', $mixed));
+	}
+
+	public function testCoerceToTypeUnionStep2MultipleEnumsFirstMatchWins(): void
+	{
+		// Union with two enumerable members.  Iteration order is the union's
+		// declared order; the first matching enum wins.  TPropertyValueTestColor
+		// has cases Red/Blue, TPropertyValueTestPriority has Low/High — disjoint
+		// names, so each input resolves unambiguously.
+		$t = $this->typeOf(fn(TPropertyValueTestColor|TPropertyValueTestPriority|null $x) => $x);
+		self::assertSame(TPropertyValueTestColor::Red,    TPropertyValue::coerceToType('Red',  $t));
+		self::assertSame(TPropertyValueTestPriority::Low, TPropertyValue::coerceToType('Low',  $t));
+		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType('High', $t));
+	}
+
+	public function testCoerceToTypeUnionStep2NonStringValueSkipsEnumTranslation(): void
+	{
+		// Step 2 only fires for string $value.  Non-string inputs go through
+		// the existing chain — int 1 against a BackedEnum|bool union still
+		// reaches step 9 (_coerceToClass) for backing-value lookup.
+		$t = $this->typeOf(fn(TPropertyValueTestPriority|bool $x) => $x);
+		self::assertSame(TPropertyValueTestPriority::Low,  TPropertyValue::coerceToType(1, $t));
+		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType(2, $t));
+	}
+
+	public function testCoerceToTypeUnionStep2EnumMissContinuesChain(): void
+	{
+		// An enum-name miss has let the rest of the coercion chain run.
+		// `TWebColor|int|null` with the numeric string '42' — TWebColor has no
+		// constant named '42', so step 2 finds nothing; step 8 (numeric shape)
+		// converts '42' to int 42.
+		$t = $this->typeOf(fn(\Prado\Web\UI\TWebColor|int|null $x) => $x);
+		self::assertSame(42, TPropertyValue::coerceToType('42', $t));
+		self::assertNull(TPropertyValue::coerceToType('', $t));
+	}
+
+	public function testCoerceToTypeUnionStep2PlainUnitEnumInUnion(): void
+	{
+		// A non-backed UnitEnum has no backing value — the step-2 path has had
+		// to fall straight through to the cases() name scan.  Returns the case
+		// object, not a string.
+		$t = $this->typeOf(fn(TPropertyValueTestStatus|string $x) => $x);
+		self::assertSame(TPropertyValueTestStatus::Active,  TPropertyValue::coerceToType('Active',  $t));
+		self::assertSame(TPropertyValueTestStatus::Active,  TPropertyValue::coerceToType('active',  $t));
+		self::assertSame(TPropertyValueTestStatus::Pending, TPropertyValue::coerceToType('PENDING', $t));
+		// Name miss → step 4 string member.
+		self::assertSame('archived', TPropertyValue::coerceToType('archived', $t));
+	}
+
+	public function testTryMatchEnumReturnsDistinctFormsByEnumKind(): void
+	{
+		// Locks in the return-shape invariant of {@see _tryMatchEnum()} that
+		// the rest of the coercion layer depends on:
+		//   - non-backed UnitEnum → case object
+		//   - BackedEnum          → case object
+		//   - IEnumerable         → canonical NAME (string, case-corrected)
+		// All three are exercised via coerceToType on a single non-null union
+		// with the same input string so each test asserts only its own kind.
+		$status   = $this->typeOf(fn(TPropertyValueTestStatus|null $x) => $x);
+		$color    = $this->typeOf(fn(TPropertyValueTestColor|null $x) => $x);
+		$codeEnum = $this->typeOf(fn(TPropertyValueTestCodeEnum|null $x) => $x);
+		self::assertSame(TPropertyValueTestStatus::Active, TPropertyValue::coerceToType('Active', $status));
+		self::assertSame(TPropertyValueTestColor::Red,     TPropertyValue::coerceToType('Red',    $color));
+		// IEnumerable returns the canonical NAME, not the value 'a'.
+		self::assertSame('Alpha', TPropertyValue::coerceToType('Alpha', $codeEnum));
 	}
 
 	// ════════════════════════════════════════════════════════════════════════
@@ -2850,10 +3439,15 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals('#BBEEDD', TPropertyValue::ensureHexColor('#BED'));
 		self::assertEquals('#CCDDEE', TPropertyValue::ensureHexColor('#cde'));
 		
-		// Web Colors 
+		// Web Colors
 		self::assertEquals('#FFFFFF', TPropertyValue::ensureHexColor('White'));
 		self::assertEquals('#C0C0C0', TPropertyValue::ensureHexColor('silver')); //lower case
 		self::assertEquals('#808080', TPropertyValue::ensureHexColor('GRAY'));	//uppers case
+		// Genuinely mixed case — verifies TWebColor::valueOfConstant($v, false)
+		// drives the lookup case-insensitively (the implementation that
+		// replaced the old `new ReflectionClass + array_change_key_case`).
+		self::assertEquals('#00BFFF', TPropertyValue::ensureHexColor('dEePsKyBlUe'));
+		self::assertEquals('#FFB6C1', TPropertyValue::ensureHexColor('LiGhTpInK'));
 		self::assertEquals('#000000', TPropertyValue::ensureHexColor('Black'));
 		self::assertEquals('#FF0000', TPropertyValue::ensureHexColor('Red'));
 		self::assertEquals('#800000', TPropertyValue::ensureHexColor('Maroon'));
@@ -3224,14 +3818,14 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	}
 
 	// ════════════════════════════════════════════════════════════════════════
-	// ensureArray — trailing comma in eval branch
+	// ensureArray — trailing comma in array literal
 	// ════════════════════════════════════════════════════════════════════════
 
 	/**
-	 * PHP allows a trailing comma inside array() since PHP 5.0.  The eval branch
-	 * must accept expressions like '(1, 2, 3,)' without error.
+	 * PHP allows a trailing comma inside an array literal since PHP 5.0.  The
+	 * parser must accept expressions like '(1, 2, 3,)' without error.
 	 */
-	public function testEnsureArray_evalBranch_trailingCommaAccepted(): void
+	public function testEnsureArray_parseBranch_trailingCommaAccepted(): void
 	{
 		self::assertSame([1, 2, 3],       TPropertyValue::ensureArray('(1, 2, 3,)'));
 		self::assertSame(['a', 'b'],       TPropertyValue::ensureArray('("a", "b",)'));

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -1,8 +1,108 @@
 <?php
 
 use Prado\Exceptions\TInvalidDataValueException;
+use Prado\IEnumerable;
+use Prado\TComponent;
 use Prado\TPropertyValue;
 use Prado\Web\Javascripts\TJavaScript;
+
+/**
+ * A custom IEnumerable implementation that does NOT extend TEnumerable.
+ * Uses TConstantReflectionTrait only (no Iterator). Verifies that
+ * _coerceToClass checks IEnumerable, not TEnumerable.
+ */
+class TPropertyValueTestDirection implements IEnumerable
+{
+	use \Prado\Util\Traits\TConstantReflectionTrait;
+
+	const North = 'North';
+	const South = 'South';
+	const East  = 'East';
+	const West  = 'West';
+}
+
+/**
+ * A custom IEnumerable + Iterator implementation using TConstantReflectionTrait
+ * and TArrayCopyIteratorTrait directly, without extending TEnumerable.
+ * Verifies that TConstantReflectionTrait::getIteratorArrayCopy() satisfies the
+ * abstract contract in TArrayCopyIteratorTrait and provides constants as the
+ * iterator backing store.
+ */
+class TPropertyValueTestSeason implements IEnumerable, \Iterator
+{
+	use \Prado\Util\Traits\TConstantReflectionTrait,
+		\Prado\Util\Traits\TArrayCopyIteratorTrait {
+		getIteratorArrayDirect as public;
+		setIteratorArrayDirect as public;
+	}
+
+	const Spring = 'Spring';
+	const Summer = 'Summer';
+	const Autumn = 'Autumn';
+	const Winter = 'Winter';
+}
+
+/**
+ * Fixture: backing array that contains a `false` value, used to verify that
+ * TArrayIteratorTrait::valid() does not prematurely terminate iteration.
+ */
+class TPropertyValueTestFlags implements \Iterator
+{
+	use \Prado\Util\Traits\TArrayCopyIteratorTrait;
+
+	protected function getIteratorArrayCopy(): array
+	{
+		return ['Enabled' => true, 'Disabled' => false, 'Unknown' => null];
+	}
+}
+
+/**
+ * Fixture: uses both TConstantReflectionTrait and TArrayCopyIteratorTrait but
+ * overrides getIteratorArrayCopy() to return a custom array, verifying that the
+ * class-level definition takes precedence over TConstantReflectionTrait's
+ * constant-backed implementation.
+ */
+class TPropertyValueTestCustomIterator implements IEnumerable, \Iterator
+{
+	use \Prado\Util\Traits\TConstantReflectionTrait;
+	use \Prado\Util\Traits\TArrayCopyIteratorTrait;
+
+	const A = 'A';
+	const B = 'B';
+
+	protected function getIteratorArrayCopy(): array
+	{
+		return ['X' => 'x', 'Y' => 'y'];
+	}
+}
+
+/** Backed enum used by coerceToType / applyProperty tests. */
+enum TPropertyValueTestColor: string
+{
+	case Red   = 'red';
+	case Green = 'green';
+	case Blue  = 'blue';
+}
+
+/** Int-backed enum used to test F-10 (ensureEnum type guard) and F-16 (step-8 int path). */
+enum TPropertyValueTestPriority: int
+{
+	case Low  = 1;
+	case High = 2;
+}
+
+/**
+ * IEnumerable fixture where constant NAME differs from constant VALUE.
+ * Used to verify that _coerceToClass (step 8 in _coerceUnionType) actually
+ * transforms 'Alpha' → 'a' and that the change is detected by the `!==` guard.
+ */
+class TPropertyValueTestCodeEnum implements IEnumerable
+{
+	use \Prado\Util\Traits\TConstantReflectionTrait;
+
+	const Alpha = 'a';
+	const Beta  = 'b';
+}
 
 /**
  */
@@ -15,6 +115,49 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	protected function tearDown(): void
 	{
+	}
+
+
+	// ════════════════════════════════════════════════════════════════════════
+	// Constants
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * TYPE_* string constants represent the canonical PHP type names used by
+	 * coerceToType() and ensureEnum().
+	 */
+	public function testTypeConstants(): void
+	{
+		self::assertSame('bool',     TPropertyValue::TYPE_BOOL);
+		self::assertSame('int',      TPropertyValue::TYPE_INT);
+		self::assertSame('float',    TPropertyValue::TYPE_FLOAT);
+		self::assertSame('string',   TPropertyValue::TYPE_STRING);
+		self::assertSame('array',    TPropertyValue::TYPE_ARRAY);
+		self::assertSame('iterable', TPropertyValue::TYPE_ITERABLE);
+		self::assertSame('object',   TPropertyValue::TYPE_OBJECT);
+		self::assertSame('mixed',    TPropertyValue::TYPE_MIXED);
+		self::assertSame('null',     TPropertyValue::TYPE_NULL);
+	}
+
+	/**
+	 * BOOL_TRUE and BOOL_FALSE must equal the canonical string representations
+	 * that ensureString() produces for bool values.
+	 */
+	public function testBoolStringConstants(): void
+	{
+		self::assertSame('true',  TPropertyValue::BOOL_TRUE);
+		self::assertSame('false', TPropertyValue::BOOL_FALSE);
+	}
+
+	/**
+	 * COLOR_RED, COLOR_GREEN, and COLOR_BLUE must equal the string keys that
+	 * ensureHexColor() expects in named-key color arrays.
+	 */
+	public function testColorConstants(): void
+	{
+		self::assertSame('red',   TPropertyValue::COLOR_RED);
+		self::assertSame('green', TPropertyValue::COLOR_GREEN);
+		self::assertSame('blue',  TPropertyValue::COLOR_BLUE);
 	}
 
 
@@ -83,8 +226,19 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		// and != 0 → true
 		self::assertTrue(TPropertyValue::ensureBoolean('  1  '));
 	}
-	
-	
+
+	/**
+	 * BOOL_TRUE / BOOL_FALSE must round-trip through ensureBoolean().
+	 * The upper-case variant of BOOL_TRUE must also be accepted.
+	 */
+	public function testBoolStringConstants_ensureBooleanRoundTrip(): void
+	{
+		self::assertTrue( TPropertyValue::ensureBoolean(TPropertyValue::BOOL_TRUE));
+		self::assertFalse(TPropertyValue::ensureBoolean(TPropertyValue::BOOL_FALSE));
+		self::assertTrue(TPropertyValue::ensureBoolean(strtoupper(TPropertyValue::BOOL_TRUE)));
+	}
+
+
 	public function testEnsureString()
 	{
 		$value = 'myLiteral';
@@ -136,7 +290,28 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		};
 		self::assertSame('stringified', TPropertyValue::ensureString($obj));
 	}
-	
+
+	/**
+	 * ensureString(bool) must produce the canonical BOOL_TRUE / BOOL_FALSE constants,
+	 * not PHP's raw (string) cast ('1' / '').
+	 */
+	public function testBoolStringConstants_ensureStringProducesConstants(): void
+	{
+		self::assertSame(TPropertyValue::BOOL_TRUE,  TPropertyValue::ensureString(true));
+		self::assertSame(TPropertyValue::BOOL_FALSE, TPropertyValue::ensureString(false));
+	}
+
+	public function testEnsureString_jsLiteral_passedThroughUnchanged(): void
+	{
+		// F-01: ensureString must return a TJavaScriptLiteral as-is (identity, not string cast)
+		// so that downstream JS renderers receive the opaque literal object rather than a
+		// double-encoded string.  Before the fix the return type was declared `string` but
+		// the object was returned anyway; the widened `string|\Stringable` return type now
+		// accurately reflects this path.
+		$lit = new \Prado\Web\Javascripts\TJavaScriptLiteral('alert(1)');
+		self::assertSame($lit, TPropertyValue::ensureString($lit));
+	}
+
 	public function testEnsureInteger()
 	{
 		self::assertEquals(0, TPropertyValue::ensureInteger(null));
@@ -240,15 +415,15 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	
 	public function testEnsureArray()
 	{
-		self::assertEquals([], TPropertyValue::ensureArray(null));
-		self::assertEquals([], TPropertyValue::ensureArray(''));
-		self::assertEquals([], TPropertyValue::ensureArray([]));
-		self::assertEquals([0 => 0], TPropertyValue::ensureArray(0));
-		self::assertEquals([0 => 1], TPropertyValue::ensureArray(1));
-		self::assertEquals(['value'], TPropertyValue::ensureArray('value'));
-		self::assertEquals(['value'], TPropertyValue::ensureArray(' value '));
-		self::assertEquals([], TPropertyValue::ensureArray('()'));
-		self::assertEquals(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
+		self::assertSame([], TPropertyValue::ensureArray(null));
+		self::assertSame([], TPropertyValue::ensureArray(''));
+		self::assertSame([], TPropertyValue::ensureArray([]));
+		self::assertSame([0 => 0], TPropertyValue::ensureArray(0));
+		self::assertSame([0 => 1], TPropertyValue::ensureArray(1));
+		self::assertSame(['value'], TPropertyValue::ensureArray('value'));
+		self::assertSame(['value'], TPropertyValue::ensureArray(' value '));
+		self::assertSame([], TPropertyValue::ensureArray('()'));
+		self::assertSame(['my', 'prop'], TPropertyValue::ensureArray('("my", "prop")'));
 	}
 
 	// ── ensureArray: eval branch — string starting and ending with parentheses ──
@@ -327,6 +502,19 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray('(5 => "a", 10 => "b")'));
 	}
 
+	public function testEnsureArrayIntegerKey_formFeedAndVerticalTabBeforeArrow(): void
+	{
+		// F-05: _consumeKey's whitespace scan between an integer key literal and the `=>`
+		// arrow previously only checked space/tab/\n/\r, omitting \f (form-feed) and
+		// \v (vertical-tab).  The regex validator accepts them (PCRE \s matches all six ASCII
+		// whitespace chars), so the validator/parser pair was inconsistent: the validator
+		// accepted the input but the extractor failed to skip \f/\v and could not locate `=>`,
+		// causing the key to be lost.
+		self::assertSame([5 => 'a'], TPropertyValue::ensureArray("(5\f=> \"a\")"));
+		self::assertSame([5 => 'a'], TPropertyValue::ensureArray("(5\v=> \"a\")"));
+		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray("(5\f=> \"a\", 10\v=> \"b\")"));
+	}
+
 	public function testEnsureArrayEvalSingleElement()
 	{
 		// Single element
@@ -336,9 +524,12 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 
 	public function testEnsureArrayEvalNestedArrays()
 	{
-		// Nested arrays using the array() constructor inside the expression
-		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('(array(1, 2), array(3, 4))'));
-		self::assertSame([['a', 'b'], ['c']], TPropertyValue::ensureArray('(array("a", "b"), array("c"))'));
+		// Nested arrays — use the PHP 8 short `[]` form at the inner level.
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('([1, 2], [3, 4])'));
+		self::assertSame([['a', 'b'], ['c']], TPropertyValue::ensureArray('(["a", "b"], ["c"])'));
+		// Parser also accepts `(...)` nested inside `(...)` and vice versa.
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('((1, 2), (3, 4))'));
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[(1, 2), [3, 4]]'));
 	}
 
 	public function testEnsureArrayEvalEmptyStringElement()
@@ -352,8 +543,547 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		// A realistic config-style expression with integers, strings, and nested array
 		self::assertSame(
 			[11, 'abc', 'xyz', [12, 'bcd', 'wxy', '']],
-			TPropertyValue::ensureArray('(11, "abc", "xyz", array(12, "bcd", "wxy", ""))')
+			TPropertyValue::ensureArray('(11, "abc", "xyz", [12, "bcd", "wxy", ""])')
 		);
+	}
+
+	// ── ensureArray: bracket `[...]` syntax (PHP 8 short form) ───────────────
+
+	public function testEnsureArrayBracketEmpty()
+	{
+		self::assertSame([], TPropertyValue::ensureArray('[]'));
+		self::assertSame([], TPropertyValue::ensureArray('[ ]'));
+		self::assertSame([], TPropertyValue::ensureArray('  [   ]  '));
+	}
+
+	public function testEnsureArrayBracketScalars()
+	{
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('[1, 2, 3]'));
+		self::assertSame(['a', 'b'], TPropertyValue::ensureArray('["a", "b"]'));
+		self::assertSame([1.5, -0.5], TPropertyValue::ensureArray('[1.5, -0.5]'));
+		self::assertSame([true, false, null], TPropertyValue::ensureArray('[true, false, null]'));
+	}
+
+	public function testEnsureArrayBracketAssociative()
+	{
+		self::assertSame(['x' => 1, 'y' => 2], TPropertyValue::ensureArray('["x" => 1, "y" => 2]'));
+		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray('[5 => "a", 10 => "b"]'));
+	}
+
+	public function testEnsureArrayBracketNested()
+	{
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[[1, 2], [3, 4]]'));
+		self::assertSame([[[1]]], TPropertyValue::ensureArray('[[[1]]]'));
+	}
+
+	public function testEnsureArrayTrailingComma()
+	{
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('(1, 2, 3,)'));
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('[1, 2, 3,]'));
+	}
+
+	public function testEnsureArrayScientificFloat()
+	{
+		self::assertSame([1.0e5, 2.5e-3], TPropertyValue::ensureArray('[1e5, 2.5e-3]'));
+	}
+
+	public function testEnsureArrayCaseInsensitiveKeywords()
+	{
+		// PHP itself treats true/false/null as case-insensitive keywords.
+		self::assertSame([true, false, null], TPropertyValue::ensureArray('[TRUE, False, NULL]'));
+	}
+
+	// ── ensureArray: malformed bracketed input falls back to single element ──
+
+	public function testEnsureArrayMalformedFallsBackToSingleElement()
+	{
+		// Stray comma — neither PHP nor our parser accepts an empty element.
+		self::assertSame(['(1, ,2)'], TPropertyValue::ensureArray('(1, ,2)'));
+		// Mismatched delimiters (open `(`, close `]`) — first/last chars don't
+		// pair, and the auto-wrap `((1, 2])` still fails to balance.
+		self::assertSame(['(1, 2]'], TPropertyValue::ensureArray('(1, 2]'));
+		// Note: `("abc)` and `(foo)` are no longer fallbacks under bare-word.
+		// `(foo)` resolves to `['foo']` and `("abc)` to `['"abc']` (the
+		// literal `"` has stayed as part of the bare-word string).
+	}
+
+	// ── ensureArray: extended numeric literal forms ──────────────────────────
+
+	public function testEnsureArrayHexIntegers()
+	{
+		self::assertSame([255, 16, 0xFF], TPropertyValue::ensureArray('[0xFF, 0X10, 0xff]'));
+		self::assertSame([-255, 0xCAFE], TPropertyValue::ensureArray('[-0xFF, 0xCAFE]'));
+	}
+
+	public function testEnsureArrayBinaryIntegers()
+	{
+		self::assertSame([5, 0b1010_0011], TPropertyValue::ensureArray('[0b101, 0B10100011]'));
+	}
+
+	public function testEnsureArrayOctalIntegers()
+	{
+		// Modern explicit-prefix form.
+		self::assertSame([15, 15], TPropertyValue::ensureArray('[0o17, 0O17]'));
+		// PHP 7's leading-zero octal form has been intentionally dropped
+		// because the silent meaning-shift (`017` reading as 15, not 17)
+		// has been a long-standing footgun — PHP 8.1 has introduced `0o`
+		// specifically to disambiguate.  Leading-zero literals have been
+		// read as decimal here.
+		self::assertSame([17, 123], TPropertyValue::ensureArray('[017, 0123]'));
+	}
+
+	public function testEnsureArrayUnderscoredIntegers()
+	{
+		self::assertSame([1000, 1_000_000], TPropertyValue::ensureArray('[1_000, 1_000_000]'));
+		self::assertSame([0xFFFF, 0b1010_0011], TPropertyValue::ensureArray('[0xFF_FF, 0b1010_0011]'));
+	}
+
+	public function testEnsureArrayUnderscoredFloats()
+	{
+		self::assertSame([1000.5, 1.5e10], TPropertyValue::ensureArray('[1_000.5, 1.5e1_0]'));
+		self::assertSame([1000.55], TPropertyValue::ensureArray('[1_000.5_5]'));
+	}
+
+	public function testEnsureArrayPrefixedAsKey()
+	{
+		// Prefixed integer literals are valid array keys.
+		self::assertSame([255 => 'a', 5 => 'b'], TPropertyValue::ensureArray('[0xFF => "a", 0b101 => "b"]'));
+	}
+
+	public function testEnsureArrayMalformedUnderscoreBecomesBareWord()
+	{
+		// Underscores adjacent to a base prefix or another underscore are
+		// rejected by PHP's numeric grammar — under bare-word, the malformed
+		// token has resolved to a string element instead of falling back.
+		self::assertSame(['0x_FF'], TPropertyValue::ensureArray('[0x_FF]'));
+		self::assertSame(['1__0'], TPropertyValue::ensureArray('[1__0]'));
+		self::assertSame(['1_'], TPropertyValue::ensureArray('[1_]'));
+	}
+
+	// ── ensureArray: auto-wrap of unbracketed element lists ──────────────────
+	//
+	// An unbracketed string is treated as if it were already wrapped in `(...)`
+	// before parsing — the function's job is to put the value into an array,
+	// the parser is just the processing pass after that wrapping.
+
+	public function testEnsureArrayAutoWrapSingleScalar()
+	{
+		self::assertSame([1], TPropertyValue::ensureArray('1'));
+		self::assertSame([1.5], TPropertyValue::ensureArray('1.5'));
+		self::assertSame([true], TPropertyValue::ensureArray('true'));
+		self::assertSame([false], TPropertyValue::ensureArray('false'));
+		self::assertSame([null], TPropertyValue::ensureArray('null'));
+		self::assertSame(['hello'], TPropertyValue::ensureArray('"hello"'));
+		self::assertSame(['hello'], TPropertyValue::ensureArray("'hello'"));
+	}
+
+	public function testEnsureArrayAutoWrapBareList()
+	{
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('1, 2, 3'));
+		self::assertSame(['a', 'b'], TPropertyValue::ensureArray('"a", "b"'));
+		self::assertSame([1, 'two', 3.0], TPropertyValue::ensureArray('1, "two", 3.0'));
+		self::assertSame([true, false, null], TPropertyValue::ensureArray('true, false, null'));
+	}
+
+	public function testEnsureArrayAutoWrapAssociative()
+	{
+		self::assertSame(['x' => 1, 'y' => 2], TPropertyValue::ensureArray('"x" => 1, "y" => 2'));
+		self::assertSame([5 => 'a', 10 => 'b'], TPropertyValue::ensureArray('5 => "a", 10 => "b"'));
+	}
+
+	public function testEnsureArrayAutoWrapExtendedNumerics()
+	{
+		self::assertSame([255, 5, 15], TPropertyValue::ensureArray('0xFF, 0b101, 0o17'));
+		self::assertSame([1000, 0xFFFF], TPropertyValue::ensureArray('1_000, 0xFF_FF'));
+	}
+
+	public function testEnsureArrayAutoWrapWithNestedBrackets()
+	{
+		// Bare top-level list with bracketed elements (mix of (...) and [...])
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[1, 2], [3, 4]'));
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('(1, 2), [3, 4]'));
+	}
+
+	public function testEnsureArrayMalformedStructureFallsBack()
+	{
+		// Structural problems — unbalanced brackets, stray inner parens —
+		// fall back to a single-element wrapping of the original input.
+		self::assertSame(['(unbalanced'], TPropertyValue::ensureArray('(unbalanced'));
+		self::assertSame(['unbalanced)'], TPropertyValue::ensureArray('unbalanced)'));
+		self::assertSame(['[1, 2'], TPropertyValue::ensureArray('[1, 2'));
+		self::assertSame(['a(b)c'], TPropertyValue::ensureArray('a(b)c'));
+	}
+
+	// ── ensureArray: quoted strings preserve internal commas ─────────────────
+
+	public function testEnsureArrayQuotedStringPreservesInternalCommas()
+	{
+		// Single-quoted string containing a comma — one element, comma kept.
+		self::assertSame(['hello, world'], TPropertyValue::ensureArray("'hello, world'"));
+		// Double-quoted, same behavior.
+		self::assertSame(['hello, world'], TPropertyValue::ensureArray('"hello, world"'));
+		// Two adjacent quoted strings, each holding a comma, separated by a
+		// top-level comma — two elements, internal commas kept.
+		self::assertSame(['a, b', 'c, d'], TPropertyValue::ensureArray("'a, b', 'c, d'"));
+		// Quoted key + quoted value, both holding commas.
+		self::assertSame(['x, y' => '1, 2'], TPropertyValue::ensureArray('"x, y" => "1, 2"'));
+	}
+
+	public function testEnsureArrayDoubleQuotedEscapeSequences()
+	{
+		// Double-quoted strings have decoded the PHP-equivalent escape set:
+		// \n, \r, \t, \v, \f, \e, \0, \\, \", \$ — anything else has been
+		// preserved verbatim (no exception, matching PHP literal behavior).
+		self::assertSame(["a\nb"], TPropertyValue::ensureArray('["a\nb"]'));
+		self::assertSame(["tab\there"], TPropertyValue::ensureArray('["tab\there"]'));
+		self::assertSame(["back\\slash"], TPropertyValue::ensureArray('["back\\\\slash"]'));
+		self::assertSame(['quote"in'], TPropertyValue::ensureArray('["quote\"in"]'));
+		self::assertSame(['$x'], TPropertyValue::ensureArray('["\$x"]'));
+		self::assertSame(["null\0byte"], TPropertyValue::ensureArray('["null\0byte"]'));
+		// Unknown escape preserved verbatim (backslash + char).
+		self::assertSame(['\q'], TPropertyValue::ensureArray('["\q"]'));
+	}
+
+	public function testEnsureArraySingleQuotedEscapeSequences()
+	{
+		// Single-quoted strings have decoded only \\ and \' — every other
+		// `\X` has been preserved as a literal backslash followed by the
+		// next character, matching PHP `'...'` semantics.
+		self::assertSame(["it's"], TPropertyValue::ensureArray("['it\\'s']"));
+		self::assertSame(['path\\to'], TPropertyValue::ensureArray("['path\\\\to']"));
+		// `\n` inside single quotes is two literal chars: backslash and n.
+		self::assertSame(['a\\nb'], TPropertyValue::ensureArray("['a\\nb']"));
+		// `\t` likewise stays as backslash-t.
+		self::assertSame(['x\\ty'], TPropertyValue::ensureArray("['x\\ty']"));
+	}
+
+	public function testEnsureArrayEscapeSequencesInKeys()
+	{
+		// Quoted strings work as keys too — escape decoding applies there.
+		self::assertSame(["a\nb" => 1], TPropertyValue::ensureArray('["a\nb" => 1]'));
+		self::assertSame(['it\'s' => 'fine'], TPropertyValue::ensureArray("['it\\'s' => 'fine']"));
+	}
+
+	public function testEnsureArrayDeepNesting()
+	{
+		// 10 levels deep — guards against catastrophic PCRE backtracking
+		// and against any per-call recursion overhead.
+		self::assertSame([[[[[[[[[[1]]]]]]]]]], TPropertyValue::ensureArray('[[[[[[[[[[1]]]]]]]]]]'));
+		// Mixed `(...)` / `[...]` / `array(...)` at each level.
+		self::assertSame([[[[1]]]], TPropertyValue::ensureArray('[(array([1]))]'));
+	}
+
+	public function testEnsureArrayUnicodeAndMultibyte()
+	{
+		// Multi-byte content inside quoted strings has been preserved
+		// byte-for-byte (the parser has been byte-oriented).
+		self::assertSame(['héllo', '日本'], TPropertyValue::ensureArray('["héllo", "日本"]'));
+		// Bare-word with multi-byte content.
+		self::assertSame(['café', 'naïve'], TPropertyValue::ensureArray('café, naïve'));
+	}
+
+	public function testEnsureArrayLargeNumericLiterals()
+	{
+		// Numbers that overflow PHP's int range have been parsed via the
+		// `(int)` cast, which saturates at PHP_INT_MAX/MIN on 64-bit.
+		self::assertSame([PHP_INT_MAX], TPropertyValue::ensureArray('[' . PHP_INT_MAX . ']'));
+		// Hex up to and beyond int width.
+		self::assertSame([0x7FFFFFFFFFFFFFFF], TPropertyValue::ensureArray('[0x7FFFFFFFFFFFFFFF]'));
+	}
+
+	public function testEnsureArrayDeeplyNestedUnclosedFallsBack()
+	{
+		// Validator catches the unbalanced opener at every depth and falls
+		// back to a single-element wrapping of the original input.
+		self::assertSame(['[[[1'], TPropertyValue::ensureArray('[[[1'));
+		self::assertSame(['((((1))'], TPropertyValue::ensureArray('((((1))'));
+		self::assertSame(['[array(1)'], TPropertyValue::ensureArray('[array(1)'));
+	}
+
+	// ── ensureArray: bare-word (unquoted string) elements ────────────────────
+	//
+	// Intentional divergence from PHP literal syntax: any token that doesn't
+	// parse as a quoted string, number, or reserved keyword has become a
+	// bare-word string.  This has supported XML/CSS-style attribute values
+	// such as `<com:TControl colors="red, green, blue"/>`.
+
+	public function testEnsureArrayBareWordList()
+	{
+		self::assertSame(['red', 'green', 'blue'], TPropertyValue::ensureArray('red, green, blue'));
+		self::assertSame(['a', 'b', 'c'], TPropertyValue::ensureArray('a, b, c'));
+		// Same content with explicit brackets.
+		self::assertSame(['red', 'green', 'blue'], TPropertyValue::ensureArray('[red, green, blue]'));
+		// Hyphenated identifiers (common in CSS-style values).
+		self::assertSame(['on-hover', 'on-click', 'on-focus'], TPropertyValue::ensureArray('on-hover, on-click, on-focus'));
+	}
+
+	public function testEnsureArrayBareWordPreservesInternalSpaces()
+	{
+		self::assertSame(['string a', 'string b', 'string c'], TPropertyValue::ensureArray('string a, string b, string c'));
+		self::assertSame(['hello world'], TPropertyValue::ensureArray('hello world'));
+		// Leading/trailing whitespace inside each element has been trimmed.
+		self::assertSame(['red', 'green', 'blue'], TPropertyValue::ensureArray('  red  ,  green  ,  blue  '));
+	}
+
+	public function testEnsureArrayBareWordMixedWithQuoted()
+	{
+		// Quoted strings have taken priority over bare-word for the spans
+		// they cover, and a final bare-word has been parsed normally.
+		self::assertSame(['string a', 'string b', 'string c'], TPropertyValue::ensureArray('["string a", \'string b\', string c]'));
+		self::assertSame(['a', 'b c', 'd'], TPropertyValue::ensureArray('"a", b c, \'d\''));
+	}
+
+	public function testEnsureArrayBareWordKeepsNumbersNumeric()
+	{
+		// Numbers have stayed numeric — only non-numeric tokens have become
+		// bare-word strings.
+		self::assertSame([1, 'two', 3.5, 'four'], TPropertyValue::ensureArray('1, two, 3.5, four'));
+	}
+
+	public function testEnsureArrayBareWordReservedKeywordPriority()
+	{
+		// `null` / `true` / `false` (case-insensitive) have outranked bare-
+		// word so a comma-separated list of keywords has produced PHP scalars.
+		self::assertSame([true, false, null, 'red'], TPropertyValue::ensureArray('true, false, null, red'));
+		self::assertSame([true, false, null], TPropertyValue::ensureArray('TRUE, False, NULL'));
+		// A full identifier that has merely *started* with a keyword has not
+		// matched the keyword (word-boundary check) and so has remained bare.
+		self::assertSame(['truely', 'nullable', 'falsely'], TPropertyValue::ensureArray('truely, nullable, falsely'));
+	}
+
+	public function testEnsureArrayBareWordMistypedNumberIsString()
+	{
+		// Mistyped numbers have intentionally fallen through to bare-word,
+		// matching the user's intuition that anything that isn't strictly
+		// numeric has been a string.
+		self::assertSame(['1abc'], TPropertyValue::ensureArray('1abc'));
+		self::assertSame(['1.5xyz'], TPropertyValue::ensureArray('1.5xyz'));
+		// CSS-style "value with unit".
+		self::assertSame(['width: 100auto'], TPropertyValue::ensureArray('width: 100auto'));
+		// Hex-looking but invalid: Z isn't a hex digit.
+		self::assertSame(['0xZZ'], TPropertyValue::ensureArray('0xZZ'));
+	}
+
+	public function testEnsureArrayBareWordAsKey()
+	{
+		self::assertSame(['foo' => 'bar'], TPropertyValue::ensureArray('foo => bar'));
+		self::assertSame(['name' => 'Alice', 'role' => 'admin'], TPropertyValue::ensureArray('name => Alice, role => admin'));
+		// Bare-word keys may carry internal spaces, same as bare-word values.
+		self::assertSame(['user name' => 'Alice Smith'], TPropertyValue::ensureArray('user name => Alice Smith'));
+	}
+
+	public function testEnsureArrayBareWordFromUnterminatedQuote()
+	{
+		// An unterminated quote has no longer been a fallback — bare-word
+		// has picked it up with the literal quote character kept in the
+		// resulting string.
+		self::assertSame(['"abc'], TPropertyValue::ensureArray('("abc)'));
+		self::assertSame(["'abc"], TPropertyValue::ensureArray("('abc)"));
+	}
+
+	public function testEnsureArrayBareWordSingleElement()
+	{
+		// Previously a fallback; now resolves cleanly via bare-word.
+		self::assertSame(['foo'], TPropertyValue::ensureArray('(foo)'));
+		self::assertSame(['hello world'], TPropertyValue::ensureArray('(hello world)'));
+	}
+
+	// ── ensureArray: array(...) keyword form (PHP literal) ───────────────────
+
+	public function testEnsureArrayAcceptsArrayKeyword()
+	{
+		// Loose grammar has accepted the PHP `array(...)` keyword form at any
+		// depth and freely mixed with `(...)` / `[...]`.  Case-insensitive.
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('array(1, 2, 3)'));
+		self::assertSame([1, 2], TPropertyValue::ensureArray('Array(1, 2)'));
+		self::assertSame([1, 2], TPropertyValue::ensureArray('ARRAY(1, 2)'));
+		self::assertSame([1, 2], TPropertyValue::ensureArray('array (1, 2)'));
+		self::assertSame([[1], [2]], TPropertyValue::ensureArray('[array(1), [2]]'));
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[(1, 2), array(3, 4)]'));
+	}
+
+	// ── ensureArray: strict grammar ──────────────────────────────────────────
+	//
+	// ARRAY_STRICT_GRAMMAR has restricted the parser to the PHP-literal
+	// grammar — `[...]` or `array(...)` only, no bare-word strings, no legacy
+	// octal, no auto-wrap of unbracketed input.
+
+	public function testEnsureArrayStrictGrammarAcceptsPhpLiterals()
+	{
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('[1, 2, 3]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('array(1, 2, 3)', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame([1, 2], TPropertyValue::ensureArray('Array(1, 2)', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame([[1], [2]], TPropertyValue::ensureArray('[array(1), [2]]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame([1 => 'a', 2 => 'b'], TPropertyValue::ensureArray('[1 => "a", 2 => "b"]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame([255, 5, 15], TPropertyValue::ensureArray('[0xFF, 0b101, 0o17]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		// Trailing commas allowed (PHP literal supports them).
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('[1, 2, 3,]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+	}
+
+	public function testEnsureArrayStrictGrammarRejectsBareParens()
+	{
+		// `(...)` alone is not a PHP array literal — strict has fallen back.
+		self::assertSame(['(1, 2, 3)'], TPropertyValue::ensureArray('(1, 2, 3)', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+	}
+
+	// ── ensureArray: ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN ───────────────────
+	//
+	// The ALLOW_BARE_PAREN flag (combined with ARRAY_STRICT_GRAMMAR) has
+	// extended the strict grammar to also accept `(...)` as a valid array
+	// delimiter at every depth, while still prohibiting bare-word strings,
+	// legacy octal, and auto-wrap of unbracketed input.
+
+	public function testEnsureArrayAllowBareParenAcceptsParenForm(): void
+	{
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR | TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN;
+		// Bare-paren `(...)` form that strict-only mode would reject.
+		self::assertSame([1, 2, 3],    TPropertyValue::ensureArray('(1, 2, 3)', $flags));
+		self::assertSame(['a', 'b'],   TPropertyValue::ensureArray('("a", "b")', $flags));
+		self::assertSame([],           TPropertyValue::ensureArray('()', $flags));
+		// Trailing comma.
+		self::assertSame([1, 2],       TPropertyValue::ensureArray('(1, 2,)', $flags));
+		// `[...]` and `array(...)` still work.
+		self::assertSame([1, 2, 3],    TPropertyValue::ensureArray('[1, 2, 3]', $flags));
+		self::assertSame([1, 2],       TPropertyValue::ensureArray('array(1, 2)', $flags));
+	}
+
+	public function testEnsureArrayAllowBareParenFreeMixing(): void
+	{
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR | TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN;
+		// `(...)`, `[...]`, and `array(...)` freely mixed at every depth.
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('([1, 2], [3, 4])', $flags));
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('[(1, 2), array(3, 4)]', $flags));
+		self::assertSame([[1, 2], [3, 4]], TPropertyValue::ensureArray('((1, 2), (3, 4))', $flags));
+	}
+
+	public function testEnsureArrayAllowBareParenStillRejectsBareWords(): void
+	{
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR | TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN;
+		// Bare-word strings are still rejected — the scalar subset remains strict.
+		self::assertSame(['(red, green)'], TPropertyValue::ensureArray('(red, green)', $flags));
+		self::assertSame(['[foo, bar]'],   TPropertyValue::ensureArray('[foo, bar]', $flags));
+	}
+
+	public function testEnsureArrayAllowBareParenStillRejectsLegacyOctal(): void
+	{
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR | TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN;
+		// Legacy octal (leading zero) is still rejected under strict scalar rules.
+		self::assertSame(['(017)'], TPropertyValue::ensureArray('(017)', $flags));
+		self::assertSame(['[017]'], TPropertyValue::ensureArray('[017]', $flags));
+		// Modern octal still accepted.
+		self::assertSame([15], TPropertyValue::ensureArray('(0o17)', $flags));
+	}
+
+	public function testEnsureArrayAllowBareParenStillRejectsAutoWrap(): void
+	{
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR | TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN;
+		// Unbracketed bare element lists are NOT auto-wrapped — same as plain STRICT.
+		self::assertSame(['1, 2, 3'],  TPropertyValue::ensureArray('1, 2, 3', $flags));
+		self::assertSame(['"a", "b"'], TPropertyValue::ensureArray('"a", "b"', $flags));
+	}
+
+	public function testEnsureArrayAllowBareParenWithoutStrictHasNoEffect(): void
+	{
+		// ALLOW_BARE_PAREN has no effect when ARRAY_STRICT_GRAMMAR is absent —
+		// the loose grammar already accepts `(...)`.
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN;
+		self::assertSame([1, 2, 3],  TPropertyValue::ensureArray('(1, 2, 3)', $flags));
+		self::assertSame(['a', 'b'], TPropertyValue::ensureArray('("a", "b")', $flags));
+		// Auto-wrap still fires in loose mode.
+		self::assertSame([1, 2, 3],  TPropertyValue::ensureArray('1, 2, 3', $flags));
+	}
+
+	public function testEnsureArrayAllowBareParenWithStrictErrors(): void
+	{
+		// When combined with ARRAY_STRICT_ERRORS, a rejected input still throws.
+		$flags = TPropertyValue::ARRAY_STRICT_GRAMMAR
+			| TPropertyValue::ARRAY_STRICT_GRAMMAR_ALLOW_BARE_PAREN
+			| TPropertyValue::ARRAY_STRICT_ERRORS;
+		// Valid forms — no throw.
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('(1, 2, 3)', $flags));
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('[1, 2, 3]', $flags));
+		// Bare word in paren — rejected (no bare words in strict scalar mode).
+		try {
+			TPropertyValue::ensureArray('(red, green)', $flags);
+			self::fail('Expected TInvalidDataValueException for bare word under strict+paren+errors');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('(red, green)', $e->getMessage());
+		}
+	}
+
+	public function testEnsureArrayStrictGrammarRejectsBareWord()
+	{
+		// Bare-word strings have been silently fallen back to single element.
+		self::assertSame(['[red, green]'], TPropertyValue::ensureArray('[red, green]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame(['red'], TPropertyValue::ensureArray('red', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame(['hello world'], TPropertyValue::ensureArray('hello world', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+	}
+
+	public function testEnsureArrayStrictGrammarRejectsAutoWrap()
+	{
+		// Bare element lists without brackets have not been auto-wrapped.
+		self::assertSame(['1, 2, 3'], TPropertyValue::ensureArray('1, 2, 3', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame(['"a", "b"'], TPropertyValue::ensureArray('"a", "b"', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+	}
+
+	public function testEnsureArrayStrictGrammarRejectsLegacyOctal()
+	{
+		// PHP's leading-zero octal form (`017` = 15) applied only to source-code integer
+		// literals, never to string coercion.  PHP 8.1 deprecated it in source and
+		// introduced `0o17` for disambiguation.  The strict parser rejects the leading-zero
+		// form as ambiguous legacy syntax regardless of PHP version.
+		self::assertSame(['[017]'], TPropertyValue::ensureArray('[017]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		self::assertSame(['[0123]'], TPropertyValue::ensureArray('[0123]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		// Decimal with leading zero — also rejected.
+		self::assertSame(['[019]'], TPropertyValue::ensureArray('[019]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		// Plain zero still works.
+		self::assertSame([0], TPropertyValue::ensureArray('[0]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+		// Modern octal still works.
+		self::assertSame([15], TPropertyValue::ensureArray('[0o17]', TPropertyValue::ARRAY_STRICT_GRAMMAR));
+	}
+
+	// ── ensureArray: strict errors ───────────────────────────────────────────
+	//
+	// ARRAY_STRICT_ERRORS has converted the silent fallback into a thrown
+	// TInvalidDataValueException.
+
+	public function testEnsureArrayStrictErrorsLooseGrammarStillParsesBareWord()
+	{
+		// Without strict grammar, bare-word still parses — no throw.
+		self::assertSame(['red', 'green'], TPropertyValue::ensureArray('red, green', TPropertyValue::ARRAY_STRICT_ERRORS));
+		self::assertSame(['hello world'], TPropertyValue::ensureArray('hello world', TPropertyValue::ARRAY_STRICT_ERRORS));
+	}
+
+	public function testEnsureArrayStrictErrorsThrowsOnStructuralFailure()
+	{
+		try {
+			TPropertyValue::ensureArray('(1, ,2)', TPropertyValue::ARRAY_STRICT_ERRORS);
+			self::fail('Expected TInvalidDataValueException for stray comma');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('(1, ,2)', $e->getMessage());
+		}
+		try {
+			TPropertyValue::ensureArray('(unbalanced', TPropertyValue::ARRAY_STRICT_ERRORS);
+			self::fail('Expected TInvalidDataValueException for unbalanced bracket');
+		} catch (TInvalidDataValueException $e) {
+		}
+	}
+
+	public function testEnsureArrayStrictBothThrowsOnNonPhpLiteral()
+	{
+		$strict = TPropertyValue::ARRAY_STRICT_GRAMMAR | TPropertyValue::ARRAY_STRICT_ERRORS;
+		// Valid PHP literals still parse.
+		self::assertSame([1, 2, 3], TPropertyValue::ensureArray('[1, 2, 3]', $strict));
+		self::assertSame([1, 2], TPropertyValue::ensureArray('array(1, 2)', $strict));
+		// Anything PHP itself would reject throws.
+		foreach (['[red]', '(1, 2)', '1, 2', '[017]'] as $bad) {
+			try {
+				TPropertyValue::ensureArray($bad, $strict);
+				self::fail("Expected throw for input: $bad");
+			} catch (TInvalidDataValueException $e) {
+				self::assertStringContainsString($bad, $e->getMessage());
+			}
+		}
 	}
 
 	// ── ensureArray: non-eval string branch — plain strings ──────────────────
@@ -467,7 +1197,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		$obj = new stdClass();
 		$obj->key = 'Prop';
 		self::assertEquals($obj, TPropertyValue::ensureObject(['key' => 'Prop']));
-		self::assertEquals($obj, TPropertyValue::ensureObject($obj));
+		self::assertSame($obj, TPropertyValue::ensureObject($obj));
 	}
 
 	public function testEnsureObjectEdgeCases()
@@ -588,14 +1318,10 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		} catch (TInvalidDataValueException $e) {
 		}
 
-		// ── Class-constant form — returns the value as-is when found ─────────
+		// ── Class-constant form — case-insensitive, returns canonical constant value ─────
 
-		// Case-sensitive: 'debug' (lowercase) is NOT a TApplicationMode constant
-		try {
-			TPropertyValue::ensureEnum('debug', \Prado\TApplicationMode::class);
-			self::fail('Expected TInvalidDataValueException for wrong case');
-		} catch (TInvalidDataValueException $e) {
-		}
+		// Case-insensitive: 'debug' (lowercase) resolves to 'Debug' (the constant value)
+		self::assertEquals('Debug', TPropertyValue::ensureEnum('debug', \Prado\TApplicationMode::class));
 
 		// Exception message names valid constants
 		try {
@@ -611,6 +1337,134 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals('Debug', TPropertyValue::ensureEnum('Debug', \Prado\TApplicationMode::class));
 	}
 	
+	// ── BackedEnum form ──────────────────────────────────────────────────────
+
+	public function testEnsureEnum_backedEnum_byBackingValue(): void
+	{
+		// A string backing value resolves via tryFrom().
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('red',   TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::ensureEnum('green', TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('blue',  TPropertyValueTestColor::class));
+	}
+
+	public function testEnsureEnum_backedEnum_byCaseName(): void
+	{
+		// Case name (not backing value) resolves via name scan.
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('Red',   TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::ensureEnum('Green', TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('Blue',  TPropertyValueTestColor::class));
+	}
+
+	public function testEnsureEnum_backedEnum_caseInsensitiveCaseName(): void
+	{
+		// The case-name scan is case-insensitive: any casing of the PHP case name resolves
+		// to the correct enum case, even when it does not match the backing value.
+		// TPropertyValueTestColor has Red='red', Green='green', Blue='blue'.
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('RED',   TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::ensureEnum('GREEN', TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('BLUE',  TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::ensureEnum('rEd',   TPropertyValueTestColor::class));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::ensureEnum('bLuE',  TPropertyValueTestColor::class));
+		// Unresolvable value still throws
+		$this->expectException(TInvalidDataValueException::class);
+		TPropertyValue::ensureEnum('purple', TPropertyValueTestColor::class);
+	}
+
+	public function testEnsureEnum_backedEnum_existingInstance_passedThrough(): void
+	{
+		// An already-correct instance is returned unchanged (identity, not just equality).
+		$case = TPropertyValueTestColor::Green;
+		self::assertSame($case, TPropertyValue::ensureEnum($case, TPropertyValueTestColor::class));
+	}
+
+	public function testEnsureEnum_backedEnum_invalidValue_throws(): void
+	{
+		// A value that matches neither a backing value nor a case name throws.
+		try {
+			TPropertyValue::ensureEnum('purple', TPropertyValueTestColor::class);
+			self::fail('Expected TInvalidDataValueException for unknown backing value');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('purple', $e->getMessage());
+		}
+	}
+
+	public function testEnsureEnum_backedEnum_errorMessageListsCases(): void
+	{
+		// The exception message includes name=value pairs for every case.
+		try {
+			TPropertyValue::ensureEnum('invalid', TPropertyValueTestColor::class);
+			self::fail('Expected TInvalidDataValueException');
+		} catch (TInvalidDataValueException $e) {
+			self::assertStringContainsString('Red=red',   $e->getMessage());
+			self::assertStringContainsString('Green=green', $e->getMessage());
+			self::assertStringContainsString('Blue=blue',  $e->getMessage());
+		}
+	}
+
+	public function testEnsureEnum_backedEnum_nonScalarValue_throwsCleanly(): void
+	{
+		// F-10: before the fix, tryFrom($value) was called without a type guard, so passing
+		// a float, array, or bool to an ensureEnum backed-enum call caused a native TypeError
+		// from tryFrom() rather than a clean TInvalidDataValueException.
+		$cases = [3.14, [], true, new \stdClass()];
+		$threw = 0;
+		foreach ($cases as $bad) {
+			try {
+				TPropertyValue::ensureEnum($bad, TPropertyValueTestColor::class);
+				self::fail('Expected TInvalidDataValueException for ' . get_debug_type($bad));
+			} catch (TInvalidDataValueException $e) {
+				$threw++;
+			}
+		}
+		self::assertSame(count($cases), $threw);
+	}
+
+	public function testEnsureEnum_backedEnum_intValue_resolvesByBackingValue(): void
+	{
+		// F-10 (positive path): an int value on an int-backed enum reaches tryFrom correctly.
+		self::assertSame(TPropertyValueTestPriority::Low,  TPropertyValue::ensureEnum(1, TPropertyValueTestPriority::class));
+		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::ensureEnum(2, TPropertyValueTestPriority::class));
+	}
+
+	public function testEnsureEnum_iEnumerable_nonStringValue_throwsCleanly(): void
+	{
+		// F-03: before the fix, hasConstant($value) was called without an is_string guard,
+		// so passing a non-string caused a native TypeError inside hasConstant().
+		$cases = [42, 3.14, true, [], null];
+		$threw = 0;
+		foreach ($cases as $bad) {
+			try {
+				TPropertyValue::ensureEnum($bad, TPropertyValueTestDirection::class);
+				self::fail('Expected TInvalidDataValueException for ' . get_debug_type($bad));
+			} catch (TInvalidDataValueException $e) {
+				$threw++;
+			}
+		}
+		self::assertSame(count($cases), $threw);
+	}
+
+	public function testEnsureEnum_iEnumerable_caseInsensitiveName(): void
+	{
+		// valueOfConstant($value, false) accepts any casing of the constant name.
+		// TPropertyValueTestDirection has North='North', South='South', etc.
+		self::assertSame('North', TPropertyValue::ensureEnum('north', TPropertyValueTestDirection::class));
+		self::assertSame('South', TPropertyValue::ensureEnum('SOUTH', TPropertyValueTestDirection::class));
+		self::assertSame('East',  TPropertyValue::ensureEnum('east',  TPropertyValueTestDirection::class));
+		self::assertSame('West',  TPropertyValue::ensureEnum('wEsT',  TPropertyValueTestDirection::class));
+	}
+
+	public function testEnsureEnum_iEnumerable_returnsCanonicalValue(): void
+	{
+		// ensureEnum must return the constant VALUE, not the input string.
+		// TPropertyValueTestCodeEnum has Alpha='a', Beta='b' (name ≠ value).
+		// Any casing of the name resolves to the canonical lowercase value.
+		self::assertSame('a', TPropertyValue::ensureEnum('Alpha', TPropertyValueTestCodeEnum::class));
+		self::assertSame('a', TPropertyValue::ensureEnum('alpha', TPropertyValueTestCodeEnum::class));
+		self::assertSame('a', TPropertyValue::ensureEnum('ALPHA', TPropertyValueTestCodeEnum::class));
+		self::assertSame('b', TPropertyValue::ensureEnum('Beta',  TPropertyValueTestCodeEnum::class));
+		self::assertSame('b', TPropertyValue::ensureEnum('BETA',  TPropertyValueTestCodeEnum::class));
+	}
+
 	public function testEnsureNullIfEmpty()
 	{
 		self::assertNull(TPropertyValue::ensureNullIfEmpty(''));
@@ -618,7 +1472,6 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertNull(TPropertyValue::ensureNullIfEmpty(null));
 		self::assertNull(TPropertyValue::ensureNullIfEmpty([]));
 		self::assertNull(TPropertyValue::ensureNullIfEmpty(false));
-		self::assertNull(TPropertyValue::ensureNullIfEmpty(null));
 		self::assertNull(TPropertyValue::ensureNullIfEmpty('0'));
 		self::assertNull(TPropertyValue::ensureNullIfEmpty(0));
 
@@ -677,6 +1530,1226 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	}
 	
 	
+	// ════════════════════════════════════════════════════════════════════════
+	// Helpers
+	// ════════════════════════════════════════════════════════════════════════
+
+	/** Returns the ReflectionType of a closure's first parameter. */
+	private function typeOf(\Closure $fn): \ReflectionType
+	{
+		return (new \ReflectionFunction($fn))->getParameters()[0]->getType();
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — null type passthrough
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeNullTypePassesThrough(): void
+	{
+		self::assertSame('hello', TPropertyValue::coerceToType('hello', null));
+		self::assertSame(42,      TPropertyValue::coerceToType(42,      null));
+		self::assertNull(         TPropertyValue::coerceToType(null,    null));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — named types (scalar)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeBool(): void
+	{
+		$t = $this->typeOf(fn(bool $x) => $x);
+		self::assertSame(true,  TPropertyValue::coerceToType('true',  $t));
+		self::assertSame(false, TPropertyValue::coerceToType('false', $t));
+		self::assertSame(true,  TPropertyValue::coerceToType('True',  $t));
+		self::assertSame(true,  TPropertyValue::coerceToType(true,    $t));
+		self::assertSame(false, TPropertyValue::coerceToType(false,   $t));
+		self::assertSame(true,  TPropertyValue::coerceToType(1,       $t));
+		self::assertSame(false, TPropertyValue::coerceToType(0,       $t));
+	}
+
+	public function testCoerceToTypeInt(): void
+	{
+		$t = $this->typeOf(fn(int $x) => $x);
+		self::assertSame(42,  TPropertyValue::coerceToType('42',  $t));
+		self::assertSame(0,   TPropertyValue::coerceToType('0',   $t));
+		self::assertSame(-5,  TPropertyValue::coerceToType('-5',  $t));
+		self::assertSame(7,   TPropertyValue::coerceToType(7,     $t));
+		self::assertSame(1,   TPropertyValue::coerceToType(1.9,   $t)); // truncation
+	}
+
+	public function testCoerceToTypeFloat(): void
+	{
+		$t = $this->typeOf(fn(float $x) => $x);
+		self::assertSame(3.14, TPropertyValue::coerceToType('3.14', $t));
+		self::assertSame(0.0,  TPropertyValue::coerceToType('0',    $t));
+		self::assertSame(-1.5, TPropertyValue::coerceToType(-1.5,   $t));
+		self::assertSame(42.0, TPropertyValue::coerceToType(42,     $t));
+	}
+
+	public function testCoerceToTypeString(): void
+	{
+		$t = $this->typeOf(fn(string $x) => $x);
+		self::assertSame('hello', TPropertyValue::coerceToType('hello', $t));
+		// ensureString — bool-aware, not just (string) cast
+		self::assertSame('true',  TPropertyValue::coerceToType(true,    $t));
+		self::assertSame('false', TPropertyValue::coerceToType(false,   $t));
+		self::assertSame('42',    TPropertyValue::coerceToType(42,      $t));
+		self::assertSame('',      TPropertyValue::coerceToType('',      $t));
+	}
+
+	public function testCoerceToTypeArray(): void
+	{
+		$t = $this->typeOf(fn(array $x) => $x);
+		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('("a", "b")', $t));
+		self::assertSame(['val'],    TPropertyValue::coerceToType('val',        $t));
+		self::assertSame([1, 2],     TPropertyValue::coerceToType([1, 2],       $t));
+		self::assertSame([],         TPropertyValue::coerceToType('',           $t));
+	}
+
+	public function testCoerceToTypeMixedPassesThrough(): void
+	{
+		$t = $this->typeOf(fn(mixed $x) => $x);
+		self::assertSame('hello', TPropertyValue::coerceToType('hello', $t));
+		self::assertSame(99,      TPropertyValue::coerceToType(99,      $t));
+		self::assertNull(         TPropertyValue::coerceToType(null,    $t));
+	}
+
+	public function testCoerceToTypeIterable(): void
+	{
+		// iterable shares the same match arm as array — ensureArray() is called.
+		$t = $this->typeOf(fn(iterable $x) => $x);
+		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('("a", "b")', $t));
+		self::assertSame(['val'],    TPropertyValue::coerceToType('val',        $t));
+		self::assertSame([1, 2],    TPropertyValue::coerceToType([1, 2],       $t));
+		self::assertSame([],        TPropertyValue::coerceToType('',           $t));
+		self::assertNull(           TPropertyValue::coerceToType(null,         $t));
+	}
+
+	public function testCoerceToTypeObject(): void
+	{
+		// ensureObject() casts the value with (object).
+		$t = $this->typeOf(fn(object $x) => $x);
+		$obj = new \stdClass();
+		// An existing object passes through as the same instance.
+		self::assertSame($obj, TPropertyValue::coerceToType($obj, $t));
+		// An array is cast to stdClass with matching properties.
+		$fromArray = TPropertyValue::coerceToType(['k' => 'v'], $t);
+		self::assertInstanceOf(\stdClass::class, $fromArray);
+		self::assertSame('v', $fromArray->k);
+		// null triggers the unconditional null branch before the match.
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+	}
+
+	public function testCoerceToTypeNullToNonNullableNamedTypeReturnsNull(): void
+	{
+		// The first branch in the named-type path is `if ($value === null ...)` with no
+		// allowsNull() guard — null is returned for any named type, nullable or not.
+		// Enforcement of the actual type constraint is left to the setter boundary.
+		self::assertNull(TPropertyValue::coerceToType(null, $this->typeOf(fn(bool   $x) => $x)));
+		self::assertNull(TPropertyValue::coerceToType(null, $this->typeOf(fn(int    $x) => $x)));
+		self::assertNull(TPropertyValue::coerceToType(null, $this->typeOf(fn(float  $x) => $x)));
+		self::assertNull(TPropertyValue::coerceToType(null, $this->typeOf(fn(string $x) => $x)));
+		self::assertNull(TPropertyValue::coerceToType(null, $this->typeOf(fn(array  $x) => $x)));
+		self::assertNull(TPropertyValue::coerceToType(null, $this->typeOf(fn(object $x) => $x)));
+	}
+
+	public function testCoerceToTypeEmptyStringToNonNullableTypes(): void
+	{
+		// Empty string does NOT trigger the null branch for non-nullable types (no allowsNull()),
+		// so it flows to the match arms and is coerced via the appropriate ensure* helper.
+		self::assertSame(false, TPropertyValue::coerceToType('', $this->typeOf(fn(bool  $x) => $x)));
+		self::assertSame(0,     TPropertyValue::coerceToType('', $this->typeOf(fn(int   $x) => $x)));
+		self::assertSame(0.0,   TPropertyValue::coerceToType('', $this->typeOf(fn(float $x) => $x)));
+		self::assertSame([],    TPropertyValue::coerceToType('', $this->typeOf(fn(array $x) => $x)));
+		// string '' → '' unchanged (still a valid string value).
+		self::assertSame('',    TPropertyValue::coerceToType('', $this->typeOf(fn(string $x) => $x)));
+	}
+
+	public function testCoerceToTypeNonEnumerableClassPassesThrough(): void
+	{
+		// _coerceToClass returns $value unchanged for classes that are neither
+		// BackedEnum nor IEnumerable.
+		$t = $this->typeOf(fn(\stdClass $x) => $x);
+		self::assertSame('whatever', TPropertyValue::coerceToType('whatever', $t));
+		$obj = new \stdClass();
+		self::assertSame($obj, TPropertyValue::coerceToType($obj, $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — nullable named types
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeNullableBool(): void
+	{
+		$t = $this->typeOf(fn(?bool $x) => $x);
+		self::assertNull(         TPropertyValue::coerceToType('',    $t)); // empty → null
+		self::assertNull(         TPropertyValue::coerceToType(null,  $t));
+		self::assertSame(true,    TPropertyValue::coerceToType('true', $t));
+		self::assertSame(false,   TPropertyValue::coerceToType('false', $t));
+	}
+
+	public function testCoerceToTypeNullableInt(): void
+	{
+		$t = $this->typeOf(fn(?int $x) => $x);
+		self::assertNull(     TPropertyValue::coerceToType('',   $t));
+		self::assertNull(     TPropertyValue::coerceToType(null, $t));
+		self::assertSame(5,   TPropertyValue::coerceToType('5',  $t));
+		self::assertSame(-3,  TPropertyValue::coerceToType('-3', $t));
+	}
+
+	public function testCoerceToTypeNullableString(): void
+	{
+		$t = $this->typeOf(fn(?string $x) => $x);
+		// empty string on a nullable string → null (config semantics: blank attr = absent)
+		self::assertNull(         TPropertyValue::coerceToType('',     $t));
+		self::assertNull(         TPropertyValue::coerceToType(null,   $t));
+		self::assertSame('hello', TPropertyValue::coerceToType('hello', $t));
+	}
+
+	public function testCoerceToTypeNullableFloat(): void
+	{
+		$t = $this->typeOf(fn(?float $x) => $x);
+		self::assertNull(      TPropertyValue::coerceToType('',    $t));
+		self::assertNull(      TPropertyValue::coerceToType(null,  $t));
+		self::assertSame(1.5,  TPropertyValue::coerceToType('1.5', $t));
+		self::assertSame(0.0,  TPropertyValue::coerceToType(0,     $t));
+		self::assertSame(-2.5, TPropertyValue::coerceToType(-2.5,  $t));
+	}
+
+	public function testCoerceToTypeNullableArray(): void
+	{
+		$t = $this->typeOf(fn(?array $x) => $x);
+		self::assertNull(            TPropertyValue::coerceToType('',          $t));
+		self::assertNull(            TPropertyValue::coerceToType(null,        $t));
+		self::assertSame(['x'],      TPropertyValue::coerceToType('x',         $t));
+		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('("a", "b")', $t));
+		self::assertSame([1, 2],     TPropertyValue::coerceToType([1, 2],      $t));
+	}
+
+	public function testCoerceToTypeNullableObject(): void
+	{
+		$t = $this->typeOf(fn(?object $x) => $x);
+		self::assertNull(TPropertyValue::coerceToType('',   $t));
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+		// An existing object is returned as the same instance.
+		$obj = new \stdClass();
+		self::assertSame($obj, TPropertyValue::coerceToType($obj, $t));
+	}
+
+	public function testCoerceToTypeIntersectionTypePassesThrough(): void
+	{
+		// ReflectionIntersectionType (A&B) reaches the final `return $value` in
+		// coerceToType — no conversion is attempted.
+		$t = $this->typeOf(fn(\Countable&\Iterator $x) => $x);
+		// Conforming instance passes through.
+		$obj = new \ArrayObject([1, 2, 3]);
+		self::assertSame($obj, TPropertyValue::coerceToType($obj, $t));
+		// Even a non-conforming value is returned unchanged (type enforcement at caller).
+		self::assertSame('hello', TPropertyValue::coerceToType('hello', $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — backed enum
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeBackedEnum(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestColor $x) => $x);
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::coerceToType('red',   $t));
+		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::coerceToType('green', $t));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::coerceToType('blue',  $t));
+		// Invalid value: tryFrom returns null → original string falls back
+		self::assertSame('purple', TPropertyValue::coerceToType('purple', $t));
+	}
+
+	public function testCoerceToTypeNullableBackedEnum(): void
+	{
+		$t = $this->typeOf(fn(?TPropertyValueTestColor $x) => $x);
+		self::assertNull(TPropertyValue::coerceToType('', $t));
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+		self::assertSame(TPropertyValueTestColor::Red, TPropertyValue::coerceToType('red', $t));
+	}
+
+	public function testCoerceToTypeBackedEnumCaseInsensitiveCaseName(): void
+	{
+		// The case-name scan is case-insensitive: any casing of the PHP case name
+		// resolves to the correct enum case even when the backing value differs.
+		// TPropertyValueTestColor has Red='red', Green='green', Blue='blue'.
+		$t = $this->typeOf(fn(TPropertyValueTestColor $x) => $x);
+		// Exact case name (original exact-match behavior preserved)
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::coerceToType('Red',   $t));
+		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::coerceToType('Green', $t));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::coerceToType('Blue',  $t));
+		// All-caps — not a backing value, resolved by case-insensitive case-name scan
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::coerceToType('RED',   $t));
+		self::assertSame(TPropertyValueTestColor::Green, TPropertyValue::coerceToType('GREEN', $t));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::coerceToType('BLUE',  $t));
+		// Mixed-case
+		self::assertSame(TPropertyValueTestColor::Red,   TPropertyValue::coerceToType('rEd',   $t));
+		self::assertSame(TPropertyValueTestColor::Blue,  TPropertyValue::coerceToType('bLuE',  $t));
+		// Unresolvable value still passes through
+		self::assertSame('purple', TPropertyValue::coerceToType('purple', $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — TEnumerable subclasses
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeTEnumerableValidConstantName(): void
+	{
+		// TApplicationMode follows the convention const Off = 'Off', so name === value.
+		// valueOfConstant('Off') returns 'Off'.
+		$t = $this->typeOf(fn(\Prado\TApplicationMode $x) => $x);
+		self::assertSame('Off',         TPropertyValue::coerceToType('Off',         $t));
+		self::assertSame('Debug',       TPropertyValue::coerceToType('Debug',       $t));
+		self::assertSame('Normal',      TPropertyValue::coerceToType('Normal',      $t));
+		self::assertSame('Performance', TPropertyValue::coerceToType('Performance', $t));
+	}
+
+	public function testCoerceToTypeTEnumerableCaseInsensitiveName(): void
+	{
+		// valueOfConstant($value, false) accepts any casing of the constant name.
+		// TApplicationMode has const Off = 'Off', so 'off' → 'Off', 'DEBUG' → 'Debug'.
+		$t = $this->typeOf(fn(\Prado\TApplicationMode $x) => $x);
+		self::assertSame('Off',         TPropertyValue::coerceToType('off',         $t));
+		self::assertSame('Debug',       TPropertyValue::coerceToType('debug',       $t));
+		self::assertSame('Normal',      TPropertyValue::coerceToType('NORMAL',      $t));
+		self::assertSame('Performance', TPropertyValue::coerceToType('performance', $t));
+	}
+
+	public function testCoerceToTypeTEnumerableInvalidValuePassesThrough(): void
+	{
+		// An unrecognised value is returned unchanged so the TypeError surfaces at
+		// the setter boundary rather than silently coercing to something unexpected.
+		$t = $this->typeOf(fn(\Prado\TApplicationMode $x) => $x);
+		self::assertSame('NotAMode', TPropertyValue::coerceToType('NotAMode', $t));
+	}
+
+	public function testCoerceToTypeNullableTEnumerableEmptyStringToNull(): void
+	{
+		$t = $this->typeOf(fn(?\Prado\TApplicationMode $x) => $x);
+		self::assertNull(TPropertyValue::coerceToType('',   $t));
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+		self::assertSame('Debug', TPropertyValue::coerceToType('Debug', $t));
+	}
+
+	public function testCoerceToTypeUnionTEnumerableInUnion(): void
+	{
+		// TApplicationMode|null — valid constant name passes through, invalid falls back.
+		$t = $this->typeOf(fn(\Prado\TApplicationMode|null $x) => $x);
+		self::assertSame('Normal', TPropertyValue::coerceToType('Normal', $t));
+		self::assertNull(TPropertyValue::coerceToType('', $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// IEnumerable — custom implementor (does not extend TEnumerable)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testIEnumerableIsInterface(): void
+	{
+		$ref = new \ReflectionClass(IEnumerable::class);
+		self::assertTrue($ref->isInterface());
+	}
+
+	public function testTEnumerableImplementsIEnumerable(): void
+	{
+		self::assertInstanceOf(IEnumerable::class, new \Prado\TApplicationMode());
+		self::assertTrue(is_a(\Prado\TApplicationMode::class, IEnumerable::class, true));
+	}
+
+	public function testCustomIEnumerableNotExtendingTEnumerable(): void
+	{
+		// TPropertyValueTestDirection implements IEnumerable but does NOT extend TEnumerable.
+		// _coerceToClass must still handle it via the IEnumerable check.
+		self::assertFalse(is_a(TPropertyValueTestDirection::class, \Prado\TEnumerable::class, true));
+		self::assertTrue(is_a(TPropertyValueTestDirection::class, IEnumerable::class, true));
+	}
+
+	public function testCoerceToTypeCustomIEnumerableValidName(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestDirection $x) => $x);
+		self::assertSame('North', TPropertyValue::coerceToType('North', $t));
+		self::assertSame('South', TPropertyValue::coerceToType('South', $t));
+		self::assertSame('East',  TPropertyValue::coerceToType('East',  $t));
+		self::assertSame('West',  TPropertyValue::coerceToType('West',  $t));
+	}
+
+	public function testCoerceToTypeCustomIEnumerableCaseInsensitiveName(): void
+	{
+		// valueOfConstant($value, false) is case-insensitive: any casing of the
+		// constant name is accepted and resolves to the canonical constant value.
+		// TPropertyValueTestDirection has North='North', South='South', etc.
+		$t = $this->typeOf(fn(TPropertyValueTestDirection $x) => $x);
+		self::assertSame('North', TPropertyValue::coerceToType('north', $t));
+		self::assertSame('South', TPropertyValue::coerceToType('SOUTH', $t));
+		self::assertSame('East',  TPropertyValue::coerceToType('east',  $t));
+		self::assertSame('West',  TPropertyValue::coerceToType('wEsT',  $t));
+	}
+
+	public function testCoerceToTypeCodeEnumCaseInsensitiveName(): void
+	{
+		// When constant name ≠ constant value (const Alpha = 'a'), a case-insensitive
+		// name match still resolves to the canonical constant value.
+		$t = $this->typeOf(fn(TPropertyValueTestCodeEnum $x) => $x);
+		self::assertSame('a', TPropertyValue::coerceToType('alpha', $t));
+		self::assertSame('a', TPropertyValue::coerceToType('ALPHA', $t));
+		self::assertSame('b', TPropertyValue::coerceToType('beta',  $t));
+		self::assertSame('b', TPropertyValue::coerceToType('BETA',  $t));
+	}
+
+	public function testCoerceToTypeCustomIEnumerableInvalidPassesThrough(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestDirection $x) => $x);
+		self::assertSame('NorthEast', TPropertyValue::coerceToType('NorthEast', $t));
+	}
+
+	public function testCoerceToTypeBackedEnumNonStringNonIntPassesThrough(): void
+	{
+		// _coerceToClass only calls tryFrom() when value is string or int.
+		// Any other PHP type passes through unchanged — the setter boundary enforces
+		// the type contract.
+		$t = $this->typeOf(fn(TPropertyValueTestColor $x) => $x);
+		self::assertSame(3.14,         TPropertyValue::coerceToType(3.14,         $t));
+		self::assertSame(true,         TPropertyValue::coerceToType(true,         $t));
+		self::assertSame(['not-enum'],  TPropertyValue::coerceToType(['not-enum'],  $t));
+	}
+
+	public function testCoerceToTypeIEnumerableNonStringPassesThrough(): void
+	{
+		// _coerceToClass only calls valueOfConstant() when value is string.
+		// Non-strings pass through so the setter boundary can enforce the type.
+		$t = $this->typeOf(fn(TPropertyValueTestDirection $x) => $x);
+		self::assertSame(42,   TPropertyValue::coerceToType(42,   $t));
+		self::assertSame(true, TPropertyValue::coerceToType(true, $t));
+		self::assertSame(3.14, TPropertyValue::coerceToType(3.14, $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// TArrayIteratorTrait / TArrayCopyIteratorTrait / TReflectionCacheTrait
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testTConstantReflectionTraitStaticMethods(): void
+	{
+		// Basic happy-path coverage for all four static reflection methods.
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('Spring'));
+		self::assertFalse(TPropertyValueTestSeason::hasConstant('Monsoon'));
+		self::assertSame('Summer', TPropertyValueTestSeason::valueOfConstant('Summer'));
+		self::assertNull(TPropertyValueTestSeason::valueOfConstant('Monsoon'));
+		self::assertSame('Winter', TPropertyValueTestSeason::constantOfValue('Winter'));
+		self::assertNull(TPropertyValueTestSeason::constantOfValue('Monsoon'));
+		self::assertTrue(TPropertyValueTestSeason::hasConstantValue('Autumn'));
+		self::assertFalse(TPropertyValueTestSeason::hasConstantValue('Monsoon'));
+	}
+
+	public function testTConstantReflectionTraitCaseInsensitive(): void
+	{
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('spring', false));
+		self::assertFalse(TPropertyValueTestSeason::hasConstant('spring', true));
+		self::assertTrue(TPropertyValueTestSeason::hasConstantValue('spring', false));
+		self::assertFalse(TPropertyValueTestSeason::hasConstantValue('spring', true));
+		self::assertSame('Spring', TPropertyValueTestSeason::valueOfConstant('spring', false));
+		self::assertNull(TPropertyValueTestSeason::valueOfConstant('spring', true));
+		self::assertSame('Spring', TPropertyValueTestSeason::constantOfValue('spring', false));
+		self::assertNull(TPropertyValueTestSeason::constantOfValue('spring', true));
+	}
+
+	public function testTConstantReflectionTraitPrefixAffix(): void
+	{
+		// Only constants whose name starts with 'S' should match.
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('Spring', 'S'));
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('Summer', 'S'));
+		self::assertFalse(TPropertyValueTestSeason::hasConstant('Autumn', 'S'));
+		self::assertSame('Spring', TPropertyValueTestSeason::valueOfConstant('Spring', 'S'));
+		self::assertNull(TPropertyValueTestSeason::valueOfConstant('Autumn', 'S'));
+		self::assertTrue(TPropertyValueTestSeason::hasConstantValue('Spring', 'S'));
+		self::assertFalse(TPropertyValueTestSeason::hasConstantValue('Autumn', 'S'));
+		self::assertSame('Spring', TPropertyValueTestSeason::constantOfValue('Spring', 'S'));
+		self::assertNull(TPropertyValueTestSeason::constantOfValue('Autumn', 'S'));
+	}
+
+	public function testTConstantReflectionTraitSuffixAffix(): void
+	{
+		// Only constants whose name ends with 'er' should match (Summer, Winter).
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('Summer', '*er'));
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('Winter', '*er'));
+		self::assertFalse(TPropertyValueTestSeason::hasConstant('Spring', '*er'));
+		self::assertFalse(TPropertyValueTestSeason::hasConstant('Autumn', '*er'));
+		self::assertSame('Summer', TPropertyValueTestSeason::constantOfValue('Summer', '*er'));
+		self::assertNull(TPropertyValueTestSeason::constantOfValue('Spring', '*er'));
+	}
+
+	public function testTConstantReflectionTraitEmptyAffixFallsBackToPlainMatch(): void
+	{
+		// An empty string as $caseOrAffix must not trigger an offset warning and
+		// must behave as a plain (no-affix) match.
+		self::assertTrue(TPropertyValueTestSeason::hasConstant('Spring', ''));
+		self::assertFalse(TPropertyValueTestSeason::hasConstant('Monsoon', ''));
+		self::assertSame('Spring', TPropertyValueTestSeason::valueOfConstant('Spring', ''));
+		self::assertNull(TPropertyValueTestSeason::valueOfConstant('Monsoon', ''));
+	}
+
+	public function testTArrayIteratorTraitLazyLoadsOnFirstAccess(): void
+	{
+		// No constructor on TPropertyValueTestSeason — store starts null.
+		// Accessing the iterator must trigger getIteratorArrayCopy().
+		$season = new TPropertyValueTestSeason();
+		self::assertNull($season->getIteratorArrayDirect());
+		$season->rewind(); // triggers loadIteratorArray()
+		self::assertNotNull($season->getIteratorArrayDirect());
+	}
+
+	public function testTArrayIteratorTraitIteratesConstants(): void
+	{
+		$season = new TPropertyValueTestSeason();
+		$collected = [];
+		foreach ($season as $name => $value) {
+			$collected[$name] = $value;
+		}
+		self::assertSame([
+			'Spring' => 'Spring',
+			'Summer' => 'Summer',
+			'Autumn' => 'Autumn',
+			'Winter' => 'Winter',
+		], $collected);
+	}
+
+	public function testTArrayIteratorTraitRewinds(): void
+	{
+		$season = new TPropertyValueTestSeason();
+		foreach ($season as $name => $value) {}
+		$first = null;
+		foreach ($season as $name => $value) {
+			$first = $name;
+			break;
+		}
+		self::assertSame('Spring', $first);
+	}
+
+	public function testSetIteratorArrayDirectOverridesLazyLoad(): void
+	{
+		$season = new TPropertyValueTestSeason();
+		$season->setIteratorArrayDirect(['Dry' => 'Dry', 'Wet' => 'Wet']);
+		$collected = [];
+		foreach ($season as $name => $value) {
+			$collected[$name] = $value;
+		}
+		self::assertSame(['Dry' => 'Dry', 'Wet' => 'Wet'], $collected);
+	}
+
+	public function testSetIteratorArrayDirectNullResetsLazyLoad(): void
+	{
+		$season = new TPropertyValueTestSeason();
+		foreach ($season as $_) {} // populates store
+		self::assertNotNull($season->getIteratorArrayDirect());
+		$season->setIteratorArrayDirect(null); // reset
+		self::assertNull($season->getIteratorArrayDirect());
+		// Next access re-populates from getIteratorArrayCopy()
+		$season->rewind();
+		self::assertNotNull($season->getIteratorArrayDirect());
+	}
+
+	public function testTEnumerableLazyLoadsOnFirstIteratorAccess(): void
+	{
+		// TEnumerable has no constructor — store starts null and is populated
+		// only on the first iterator access.
+		$mode = new \Prado\TApplicationMode();
+		$prop = new \ReflectionProperty(\Prado\TEnumerable::class, '_iterator_array');
+		$prop->setAccessible(true);
+		self::assertNull($prop->getValue($mode));
+		$mode->rewind(); // triggers lazy load
+		self::assertNotNull($prop->getValue($mode));
+	}
+
+	public function testTReflectionCacheTraitReturnsSameInstance(): void
+	{
+		// getReflectionClass() must return the identical cached object on every call
+		// and must reflect the calling class via late static binding.
+		$r1 = TPropertyValueTestSeason::getReflectionClass();
+		$r2 = TPropertyValueTestSeason::getReflectionClass();
+		self::assertSame($r1, $r2);
+		self::assertSame(TPropertyValueTestSeason::class, $r1->getName());
+		// A different class gets its own cached entry, not the same instance.
+		$r3 = TPropertyValueTestDirection::getReflectionClass();
+		self::assertNotSame($r1, $r3);
+		self::assertSame(TPropertyValueTestDirection::class, $r3->getName());
+	}
+
+	public function testGetIteratorArrayOverrideIsUsed(): void
+	{
+		// TPropertyValueTestCustomIterator overrides getIteratorArrayCopy() to return
+		// ['X' => 'x', 'Y' => 'y'] even though it has constants A and B.
+		$obj = new TPropertyValueTestCustomIterator();
+		$collected = [];
+		foreach ($obj as $k => $v) {
+			$collected[$k] = $v;
+		}
+		self::assertSame(['X' => 'x', 'Y' => 'y'], $collected);
+		// Static reflection still sees the declared constants, not the iterator array.
+		self::assertTrue(TPropertyValueTestCustomIterator::hasConstant('A'));
+		self::assertFalse(TPropertyValueTestCustomIterator::hasConstant('X'));
+	}
+
+	public function testValidHandlesFalseValueInArray(): void
+	{
+		// valid() must not terminate early when the current value is false.
+		$flags = new TPropertyValueTestFlags();
+		$collected = [];
+		foreach ($flags as $k => $v) {
+			$collected[$k] = $v;
+		}
+		self::assertCount(3, $collected);
+		self::assertArrayHasKey('Enabled', $collected);
+		self::assertArrayHasKey('Disabled', $collected);
+		self::assertArrayHasKey('Unknown', $collected);
+		self::assertFalse($collected['Disabled']);
+	}
+
+	public function testValidReturnsFalseAfterExhaustion(): void
+	{
+		$season = new TPropertyValueTestSeason();
+		foreach ($season as $_) {}
+		// Pointer is now past the end — valid() must return false.
+		self::assertFalse($season->valid());
+		// key() and current() return null / false at end-of-array.
+		self::assertNull($season->key());
+		self::assertFalse($season->current());
+	}
+
+	public function testLoadIteratorArrayIsIdempotent(): void
+	{
+		// A second iteration must not call getIteratorArrayCopy() again;
+		// the backing store populated on the first iteration is reused after rewind.
+		$season = new TPropertyValueTestSeason();
+		iterator_to_array($season);
+		$storeAfterFirst = $season->getIteratorArrayDirect();
+		$season->rewind();
+		self::assertSame($storeAfterFirst, $season->getIteratorArrayDirect());
+	}
+
+	public function testTEnumerableClassUsesTraitChain(): void
+	{
+		// TEnumerable must use both TConstantReflectionTrait and TArrayCopyIteratorTrait.
+		$traits = (new \ReflectionClass(\Prado\TEnumerable::class))->getTraitNames();
+		self::assertContains(\Prado\Util\Traits\TConstantReflectionTrait::class, $traits);
+		self::assertContains(\Prado\Util\Traits\TArrayCopyIteratorTrait::class, $traits);
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — union types (heuristic chain)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeUnionStringMemberPassesThrough(): void
+	{
+		// When string is in the union the value is already valid — no coercion
+		$t = $this->typeOf(fn(int|string $x) => $x);
+		self::assertSame('42',    TPropertyValue::coerceToType('42',    $t));
+		self::assertSame('hello', TPropertyValue::coerceToType('hello', $t));
+	}
+
+	public function testCoerceToTypeUnionNullableCollapsesToNull(): void
+	{
+		$t = $this->typeOf(fn(int|null $x) => $x);
+		self::assertNull(TPropertyValue::coerceToType('',   $t));
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+		self::assertSame(42, TPropertyValue::coerceToType('42', $t));
+	}
+
+	public function testCoerceToTypeUnionSingleNonNullDelegates(): void
+	{
+		// int|null with non-empty value → acts like plain int
+		$t = $this->typeOf(fn(int|null $x) => $x);
+		self::assertSame(7, TPropertyValue::coerceToType('7', $t));
+	}
+
+	public function testCoerceToTypeUnionArrayNotationWins(): void
+	{
+		// Array notation detected before numeric check
+		$t = $this->typeOf(fn(int|array $x) => $x);
+		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('("a", "b")', $t));
+		// Numeric: no array notation → int
+		self::assertSame(42, TPropertyValue::coerceToType('42', $t));
+	}
+
+	public function testCoerceToTypeUnionArrayKeywordNotationWins(): void
+	{
+		// Bug CU1: step 4 only detected `(...)` and `[...]` as array notation but
+		// missed the PHP `array(...)` keyword form.  All three must be recognized.
+		$t = $this->typeOf(fn(int|array $x) => $x);
+		self::assertSame([1, 2, 3], TPropertyValue::coerceToType('array(1, 2, 3)', $t));
+		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('Array("a", "b")', $t));
+		self::assertSame([1, 2], TPropertyValue::coerceToType('array (1, 2)', $t));
+		// `(...)` and `[...]` still work.
+		self::assertSame(['x', 'y'], TPropertyValue::coerceToType('("x", "y")', $t));
+		self::assertSame(['x', 'y'], TPropertyValue::coerceToType('["x", "y"]', $t));
+	}
+
+	public function testCoerceToTypeUnionBoolLiteralWins(): void
+	{
+		$t = $this->typeOf(fn(bool|int $x) => $x);
+		self::assertSame(true,  TPropertyValue::coerceToType('true',  $t));
+		self::assertSame(false, TPropertyValue::coerceToType('false', $t));
+		// Numeric: not a bool literal → int (first type after bool)
+		self::assertSame(42, TPropertyValue::coerceToType('42', $t));
+	}
+
+	public function testCoerceToTypeUnionIntFloat(): void
+	{
+		$t = $this->typeOf(fn(int|float $x) => $x);
+		// No decimal → int
+		self::assertSame(42,   TPropertyValue::coerceToType('42',   $t));
+		// Decimal present → float
+		self::assertSame(3.14, TPropertyValue::coerceToType('3.14', $t));
+	}
+
+	public function testCoerceToTypeUnionBackedEnum(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestColor|null $x) => $x);
+		self::assertSame(TPropertyValueTestColor::Blue, TPropertyValue::coerceToType('blue', $t));
+		self::assertNull(TPropertyValue::coerceToType('', $t));
+		// Invalid enum value: falls back to fallback type (null handled, enum fails) → original
+		self::assertSame('magenta', TPropertyValue::coerceToType('magenta', $t));
+	}
+
+	public function testCoerceToTypeUnionFallbackUsesTypeCoerceOrder(): void
+	{
+		// 'not-numeric' matches no heuristic → fallback (step 9).
+		// TYPE_COERCE_ORDER places int before array, so ensureInteger('not-numeric') = 0,
+		// matching PHP non-strict behaviour (implicit string→int yields 0 with a notice).
+		$t = $this->typeOf(fn(int|array $x) => $x);
+		self::assertSame(0, TPropertyValue::coerceToType('not-numeric', $t));
+		// array-only union: no int → array is first in order → single-element array.
+		$ta = $this->typeOf(fn(array|object $x) => $x);
+		self::assertSame(['not-numeric'], TPropertyValue::coerceToType('not-numeric', $ta));
+	}
+
+	public function testCoerceToTypeUnionNullWithoutNullMemberReturnsNull(): void
+	{
+		// The `$value === null` check in _coerceUnionType (step 1) is unconditional —
+		// null is returned even when `null` is not a member of the union.
+		$t = $this->typeOf(fn(bool|int $x) => $x);
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+	}
+
+	public function testCoerceToTypeUnionEmptyStringNoNullInUnion(): void
+	{
+		// Empty string with no `null` member: the null short-circuit does not fire.
+		// Neither array notation, bool literal, nor numeric apply to '', so the fallback
+		// (step 9) sorts by TYPE_COERCE_ORDER.  int (position 0) comes before bool
+		// (position 3); ensureInteger('') = 0.
+		$t = $this->typeOf(fn(bool|int $x) => $x);
+		self::assertSame(0, TPropertyValue::coerceToType('', $t));
+	}
+
+	public function testCoerceToTypeUnionStringMemberCoercesNonStringViaEnsureString(): void
+	{
+		// Step 2: when `string` is a union member and the value is NOT already a string,
+		// ensureString() is called (bool→'true'/'false', int→string, etc.).
+		$t = $this->typeOf(fn(string|int $x) => $x);
+		self::assertSame('true',  TPropertyValue::coerceToType(true,  $t));
+		self::assertSame('false', TPropertyValue::coerceToType(false, $t));
+		self::assertSame('42',    TPropertyValue::coerceToType(42,    $t));
+	}
+
+	public function testCoerceToTypeUnionIterableInUnion(): void
+	{
+		// `iterable` in a union sets $hasArray=true, so array-notation strings (step 4)
+		// are still parsed correctly.  Step 5 only fires for '(...)' / '[...]' / 'array(...)'
+		// notation, so 'true'/'false' fall through to step 6 (bool literals) and are coerced to bool.
+		$t = $this->typeOf(fn(iterable|bool $x) => $x);
+		self::assertSame(['a', 'b'], TPropertyValue::coerceToType('("a", "b")', $t));
+		self::assertSame(true,       TPropertyValue::coerceToType('true',       $t));
+		self::assertSame(false,      TPropertyValue::coerceToType('false',      $t));
+	}
+
+	public function testCoerceToTypeUnionFloatOnlyNumeric(): void
+	{
+		// Step 7: when `float` is present but `int` is not, any numeric string → float.
+		// Bool literals win step 6 before the numeric check (step 7).
+		$t = $this->typeOf(fn(float|bool $x) => $x);
+		self::assertSame(3.14, TPropertyValue::coerceToType('3.14', $t));
+		self::assertSame(42.0, TPropertyValue::coerceToType('42',   $t));
+		self::assertSame(true, TPropertyValue::coerceToType('true', $t));
+	}
+
+	public function testCoerceToTypeUnionStep7ScientificNotation(): void
+	{
+		// Step 7: scientific notation ('1e5', '1E+3') contains no '.' but still represents
+		// a float.  Without the stripos('e') check the str_contains('.') branch returned
+		// (int)'1e5', whereas PHP non-strict mode promotes these strings to float.
+		$t = $this->typeOf(fn(int|float $x) => $x);
+		self::assertSame(100000.0,  TPropertyValue::coerceToType('1e5',    $t));  // lowercase e
+		self::assertSame(100000.0,  TPropertyValue::coerceToType('1E5',    $t));  // uppercase E
+		self::assertSame(1500.0,    TPropertyValue::coerceToType('1.5e3',  $t));  // dot + e
+		self::assertSame(0.001,     TPropertyValue::coerceToType('1e-3',   $t));  // negative exponent
+		self::assertSame(3000.0,    TPropertyValue::coerceToType('3e+3',   $t));  // explicit + exponent
+		// Plain integers still resolve to int (no dot, no e)
+		self::assertSame(42,        TPropertyValue::coerceToType('42',     $t));
+		self::assertSame(-7,        TPropertyValue::coerceToType('-7',     $t));
+		// Plain float (dot, no e) still resolves to float
+		self::assertSame(3.14,      TPropertyValue::coerceToType('3.14',   $t));
+	}
+
+	public function testCoerceToTypeUnionStep7LargeIntStringPromotesToFloat(): void
+	{
+		// F-08: a numeric string that exceeds PHP_INT_MAX (or is below PHP_INT_MIN) must
+		// promote to float when both int and float are in the union, matching PHP's own
+		// non-strict coercion rules.  Before the fix, (int)$s saturated silently at
+		// PHP_INT_MAX/MIN instead of returning the float representation.
+		$t = $this->typeOf(fn(int|float $x) => $x);
+		// Values that fit in int — must stay int
+		self::assertSame(PHP_INT_MAX, TPropertyValue::coerceToType((string) PHP_INT_MAX, $t));
+		self::assertSame(PHP_INT_MIN, TPropertyValue::coerceToType((string) PHP_INT_MIN, $t));
+		// Values that overflow int — must promote to float
+		$overMax = bcadd((string) PHP_INT_MAX, '1');
+		$underMin = bcsub((string) PHP_INT_MIN, '1');
+		self::assertIsFloat(TPropertyValue::coerceToType($overMax,  $t));
+		self::assertIsFloat(TPropertyValue::coerceToType($underMin, $t));
+		self::assertSame((float) $overMax,  TPropertyValue::coerceToType($overMax,  $t));
+		self::assertSame((float) $underMin, TPropertyValue::coerceToType($underMin, $t));
+	}
+
+	public function testCoerceToTypeUnionStep8BackedEnumInMultiMemberUnion(): void
+	{
+		// Step 8 (non-builtin class) is only reached when multiple non-null members exist
+		// (otherwise the single-non-null optimisation delegates directly).
+		// A valid enum backing value is coerced; an invalid one passes through unchanged.
+		$t = $this->typeOf(fn(TPropertyValueTestColor|int $x) => $x);
+		self::assertSame(TPropertyValueTestColor::Blue, TPropertyValue::coerceToType('blue', $t));
+		// '99' is numeric → step 7 (int), step 8 not reached.
+		self::assertSame(99, TPropertyValue::coerceToType('99', $t));
+	}
+
+	public function testCoerceToTypeUnionStep8IntBackedEnumFromPhpInt(): void
+	{
+		// F-16: step 8 previously called _coerceToClass($strValue, …) exclusively, so a PHP
+		// int value was stringified to e.g. '1' before reaching tryFrom().  For int-backed
+		// enums tryFrom('1') returns null (type mismatch), silently failing the coercion.
+		// The fix tries _coerceToClass($value, …) first so the original PHP int reaches
+		// tryFrom(1) and resolves correctly.
+		//
+		// Union uses bool (not string/int/float) so that:
+		//   - step 3 is skipped (string absent)
+		//   - step 4 Pass A/B are skipped (int/float absent, bool doesn't match an int)
+		//   - step 7 is skipped (no int/float in union)
+		// …forcing the PHP int to reach step 8 where _coerceToClass is called.
+		$t = $this->typeOf(fn(TPropertyValueTestPriority|bool $x) => $x);
+		// PHP int → int-backed enum via original-value path in step 8
+		self::assertSame(TPropertyValueTestPriority::Low,  TPropertyValue::coerceToType(1, $t));
+		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType(2, $t));
+		// Unknown int → no enum case, no bool literal → step 9 picks bool (lower TYPE_COERCE_ORDER
+		// index than a non-builtin class); ensureBoolean(99) = true (non-zero numeric).
+		self::assertSame(true, TPropertyValue::coerceToType(99, $t));
+	}
+
+	public function testCoerceToTypeUnionStep8IEnumerableChangedValue(): void
+	{
+		// Step 8: when _coerceToClass returns a value DIFFERENT from $strValue, the
+		// coerced result is used.  TPropertyValueTestCodeEnum has const Alpha='a', so
+		// valueOfConstant('Alpha')='a' ≠ 'Alpha', triggering the !== guard.
+		$t = $this->typeOf(fn(TPropertyValueTestCodeEnum|int $x) => $x);
+		self::assertSame('a', TPropertyValue::coerceToType('Alpha', $t));
+		self::assertSame('b', TPropertyValue::coerceToType('Beta',  $t));
+		// Unrecognised name: valueOfConstant returns null → falls back to $strValue →
+		// $coerced === $strValue → step 8 does NOT return → fallback (step 9).
+		// int|TPropertyValueTestCodeEnum canonical order: non-builtin last? or first?
+		// Either way step 9 runs ensureInteger or _coerceToClass on 'Unknown'.
+		// Assert only that the result is deterministic (no exception).
+		$result = TPropertyValue::coerceToType('Unknown', $t);
+		self::assertTrue(is_int($result) || is_string($result));
+	}
+
+	public function testCoerceToTypeUnionObjectInstancePreservedByNativeTypeShortCircuit(): void
+	{
+		// Step 3: when $value is a non-string object whose PHP type matches a non-builtin
+		// union member, it is returned without any conversion.
+		// Uses a plain stdClass (not an enum) to confirm the general object path.
+		$t = $this->typeOf(fn(\stdClass|int $x) => $x);
+		$obj = new \stdClass();
+		$obj->x = 'preserved';
+		self::assertSame($obj, TPropertyValue::coerceToType($obj, $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceToType — union native-type short-circuit (non-string values)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceToTypeUnionNativeArrayPreserved(): void
+	{
+		// Without the native-type check an array value would be ensureString'd to "Array",
+		// match no heuristic, and fall back to (int)"Array" = 0.
+		$t = $this->typeOf(fn(int|array $x) => $x);
+		self::assertSame([1, 2], TPropertyValue::coerceToType([1, 2], $t));
+		self::assertSame([],     TPropertyValue::coerceToType([],     $t));
+	}
+
+	public function testCoerceToTypeUnionArrayPreservedWhenStringAlsoInUnion(): void
+	{
+		// Bug CU2: when `string` is in the union, step 3 (the old step 2) fired
+		// ensureString() on array values, producing the useless string "Array"
+		// instead of preserving the array.  The pre-string short-circuit (step 2)
+		// must claim array values before the string coercion path fires.
+		$t = $this->typeOf(fn(string|array $x) => $x);
+		self::assertSame([1, 2, 3],          TPropertyValue::coerceToType([1, 2, 3], $t));
+		self::assertSame([],                 TPropertyValue::coerceToType([],        $t));
+		self::assertSame(['key' => 'value'], TPropertyValue::coerceToType(['key' => 'value'], $t));
+		// A string value still passes through as-is.
+		self::assertSame('hello',            TPropertyValue::coerceToType('hello',   $t));
+		// Scalar non-string values (bool, int) still coerce to string when string
+		// is in the union — the step 2 short-circuit is limited to arrays/objects.
+		self::assertSame('true', TPropertyValue::coerceToType(true, $t));
+		self::assertSame('42',   TPropertyValue::coerceToType(42,   $t));
+	}
+
+	public function testCoerceToTypeUnionNativeBoolPreserved(): void
+	{
+		$t = $this->typeOf(fn(bool|array $x) => $x);
+		self::assertSame(true,  TPropertyValue::coerceToType(true,  $t));
+		self::assertSame(false, TPropertyValue::coerceToType(false, $t));
+	}
+
+	public function testCoerceToTypeUnionNativeIntPreserved(): void
+	{
+		$t = $this->typeOf(fn(int|array $x) => $x);
+		self::assertSame(42, TPropertyValue::coerceToType(42, $t));
+		self::assertSame(-5, TPropertyValue::coerceToType(-5, $t));
+	}
+
+	public function testCoerceToTypeUnionNativeFloatPreserved(): void
+	{
+		$t = $this->typeOf(fn(float|array $x) => $x);
+		self::assertSame(3.14, TPropertyValue::coerceToType(3.14, $t));
+	}
+
+	public function testCoerceToTypeUnionNativeEnumPreserved(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestColor|int $x) => $x);
+		// Already the right enum type — should come back unchanged
+		self::assertSame(TPropertyValueTestColor::Red, TPropertyValue::coerceToType(TPropertyValueTestColor::Red, $t));
+	}
+
+	public function testCoerceToTypeUnionStep3BoolWidensToInt(): void
+	{
+		// Step 3 pass B: when bool is absent from the union, a native bool is widened
+		// to int (true=1, false=0), matching PHP's non-strict coercion behaviour.
+		$t = $this->typeOf(fn(int|array $x) => $x);
+		self::assertSame(1, TPropertyValue::coerceToType(true,  $t));
+		self::assertSame(0, TPropertyValue::coerceToType(false, $t));
+	}
+
+	public function testCoerceToTypeUnionStep3BoolWidensToFloatWhenNoInt(): void
+	{
+		// When int is absent but float is present, bool widens to float.
+		$t = $this->typeOf(fn(float|array $x) => $x);
+		self::assertSame(1.0, TPropertyValue::coerceToType(true,  $t));
+		self::assertSame(0.0, TPropertyValue::coerceToType(false, $t));
+	}
+
+	public function testCoerceToTypeUnionStep3BoolPreservedWhenBoolInUnion(): void
+	{
+		// When bool IS in the union, pass A exact-match fires and the value stays bool.
+		$t = $this->typeOf(fn(bool|int $x) => $x);
+		self::assertSame(true,  TPropertyValue::coerceToType(true,  $t));
+		self::assertSame(false, TPropertyValue::coerceToType(false, $t));
+	}
+
+	public function testCoerceToTypeUnionStep3IntWidensToFloat(): void
+	{
+		// Step 3 pass B: when int is absent but float is present, a native int widens
+		// to float (lossless promotion), matching PHP non-strict behaviour.
+		$t = $this->typeOf(fn(float|array $x) => $x);
+		self::assertSame(42.0, TPropertyValue::coerceToType(42, $t));
+		self::assertSame(-1.0, TPropertyValue::coerceToType(-1, $t));
+	}
+
+	public function testCoerceToTypeUnionStep3IntPreservedWhenIntInUnion(): void
+	{
+		// When int IS in the union, pass A exact-match fires and the value stays int.
+		$t = $this->typeOf(fn(int|float $x) => $x);
+		self::assertSame(7,  TPropertyValue::coerceToType(7,  $t));
+		self::assertSame(-3, TPropertyValue::coerceToType(-3, $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceForSetter — reflection cache, typed and untyped setters
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceForSetterScalarTypes(): void
+	{
+		$obj = new class {
+			public function setBool(bool $v): void {}
+			public function setInt(int $v): void {}
+			public function setFloat(float $v): void {}
+			public function setStr(string $v): void {}
+			public function setArr(array $v): void {}
+		};
+		$class = get_class($obj);
+
+		$v = 'true';  TPropertyValue::coerceForSetter($class, 'setBool',  $v);  self::assertSame(true,    $v);
+		$v = 'false'; TPropertyValue::coerceForSetter($class, 'setBool',  $v);  self::assertSame(false,   $v);
+		$v = '42';    TPropertyValue::coerceForSetter($class, 'setInt',   $v);  self::assertSame(42,      $v);
+		$v = '3.14';  TPropertyValue::coerceForSetter($class, 'setFloat', $v);  self::assertSame(3.14,    $v);
+		$v = 'hello'; TPropertyValue::coerceForSetter($class, 'setStr',   $v);  self::assertSame('hello', $v);
+		$v = 'a';     TPropertyValue::coerceForSetter($class, 'setArr',   $v);  self::assertSame(['a'],   $v);
+	}
+
+	public function testCoerceForSetterNoTypeHintLeavesValueUnchanged(): void
+	{
+		$obj = new class {
+			public function setValue($v): void {}
+		};
+		$class = get_class($obj);
+		$v = 'raw';
+		TPropertyValue::coerceForSetter($class, 'setValue', $v);
+		self::assertSame('raw', $v);
+	}
+
+	public function testCoerceForSetterNonExistentMethodLeavesValueUnchanged(): void
+	{
+		$v = 'hello';
+		TPropertyValue::coerceForSetter(TComponent::class, 'setNonExistentXyz', $v);
+		self::assertSame('hello', $v);
+	}
+
+	public function testCoerceForSetterCacheIsStable(): void
+	{
+		// Two calls for the same method must produce identical results (cache hit path)
+		$obj = new class {
+			public function setCount(int $v): void {}
+		};
+		$class = get_class($obj);
+		$a = '7';
+		$b = '7';
+		TPropertyValue::coerceForSetter($class, 'setCount', $a);
+		TPropertyValue::coerceForSetter($class, 'setCount', $b);
+		self::assertSame($a, $b);
+		self::assertSame(7, $a);
+	}
+
+	public function testCoerceForSetterCaseInsensitiveMethodName(): void
+	{
+		// PHP method calls are case-insensitive; the cache must not create separate
+		// entries for different casings of the same setter name.
+		$obj = new class {
+			public function setFlag(bool $v): void {}
+		};
+		$class = get_class($obj);
+
+		$a = 'true';
+		$b = 'false';
+		$c = 'true';
+		TPropertyValue::coerceForSetter($class, 'setFlag',   $a); // populates cache
+		TPropertyValue::coerceForSetter($class, 'SETFLAG',   $b); // must hit same entry
+		TPropertyValue::coerceForSetter($class, 'SetFlag',   $c); // must hit same entry
+		self::assertSame(true,  $a);
+		self::assertSame(false, $b);
+		self::assertSame(true,  $c);
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// applyProperty
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testApplyPropertyCoercesStringViaTypedSetter(): void
+	{
+		$obj = new class extends TComponent {
+			private bool $_enabled = false;
+			private int  $_count   = 0;
+			public function getEnabled(): bool { return $this->_enabled; }
+			public function setEnabled(bool $v): void { $this->_enabled = $v; }
+			public function getCount(): int { return $this->_count; }
+			public function setCount(int $v): void { $this->_count = $v; }
+		};
+
+		TPropertyValue::applyProperty($obj, 'Enabled', 'true');
+		self::assertSame(true, $obj->getEnabled());
+
+		TPropertyValue::applyProperty($obj, 'Enabled', 'false');
+		self::assertSame(false, $obj->getEnabled());
+
+		TPropertyValue::applyProperty($obj, 'Count', '99');
+		self::assertSame(99, $obj->getCount());
+	}
+
+	public function testApplyPropertyCoercesNonStringValues(): void
+	{
+		// Non-string values are coerced too, not passed through raw.
+		// bool → bool setter: ensureBoolean is idempotent, result is unchanged
+		$obj = new class extends TComponent {
+			private bool   $_flag  = false;
+			private string $_label = '';
+			public function getFlag(): bool    { return $this->_flag; }
+			public function setFlag(bool $v): void   { $this->_flag = $v; }
+			public function getLabel(): string { return $this->_label; }
+			public function setLabel(string $v): void { $this->_label = $v; }
+		};
+
+		TPropertyValue::applyProperty($obj, 'Flag', true);
+		self::assertSame(true, $obj->getFlag());
+
+		TPropertyValue::applyProperty($obj, 'Flag', false);
+		self::assertSame(false, $obj->getFlag());
+
+		// bool → string setter: ensureString(true) = "true", NOT the raw PHP cast "1"
+		TPropertyValue::applyProperty($obj, 'Label', true);
+		self::assertSame('true', $obj->getLabel());
+
+		TPropertyValue::applyProperty($obj, 'Label', false);
+		self::assertSame('false', $obj->getLabel());
+	}
+
+	public function testApplyPropertyGoesthroughSetterPipeline(): void
+	{
+		// A getter-only property triggers TInvalidOperationException via __set().
+		// If applyProperty bypassed __set() and called the setter directly it would
+		// silently succeed (or get a different error), so this confirms the route.
+		$obj = new class extends TComponent {
+			public function getReadOnly(): string { return 'r'; }
+		};
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		TPropertyValue::applyProperty($obj, 'ReadOnly', 'value');
+	}
+
+	public function testApplyPropertyWithSubPath(): void
+	{
+		// Ensure setSubProperty (which now calls applyProperty) coerces correctly
+		$inner = new class extends TComponent {
+			private int $_size = 0;
+			public function getSize(): int { return $this->_size; }
+			public function setSize(int $v): void { $this->_size = $v; }
+		};
+		$outer = new class($inner) extends TComponent {
+			public function __construct(private object $_inner) { parent::__construct(); }
+			public function getInner(): object { return $this->_inner; }
+		};
+
+		$outer->setSubProperty('Inner.Size', '7');
+		self::assertSame(7, $inner->getSize());
+	}
+
+	public function testCoerceForSetterTEnumerableTypedSetter(): void
+	{
+		$obj = new class extends TComponent {
+			public function setMode(\Prado\TApplicationMode $v): void {}
+		};
+		$class = get_class($obj);
+
+		$v = 'Debug';
+		TPropertyValue::coerceForSetter($class, 'setMode', $v);
+		self::assertSame('Debug', $v);
+
+		// Invalid value is passed through unchanged.
+		$v = 'Unknown';
+		TPropertyValue::coerceForSetter($class, 'setMode', $v);
+		self::assertSame('Unknown', $v);
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// coerceForSetter — behavior-aware (object form)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testCoerceForSetterAcceptsObjectInsteadOfClassName(): void
+	{
+		// Passing an object works the same as passing get_class($object).
+		$obj = new class extends TComponent {
+			public function setScore(int $v): void {}
+		};
+		$v = '10';
+		TPropertyValue::coerceForSetter($obj, 'setScore', $v);
+		self::assertSame(10, $v);
+	}
+
+	public function testCoerceForSetterNoMatchingBehaviorLeavesValueUnchanged(): void
+	{
+		// TComponent with behaviors enabled but no behavior that exposes the setter.
+		$obj = new class extends TComponent {
+			// no setFoo on the class itself
+		};
+		$behavior = new class extends \Prado\Util\TBehavior {
+			// also no setFoo
+		};
+		$obj->attachBehavior('b', $behavior);
+
+		$v = 'raw';
+		TPropertyValue::coerceForSetter($obj, 'setFoo', $v);
+		self::assertSame('raw', $v);
+	}
+
+	public function testCoerceForSetterBehaviorTypedSetterIsUsed(): void
+	{
+		// When the class has no setter but an active behavior does, its type hint wins.
+		$obj = new class extends TComponent {
+			// no setFlag on this class
+		};
+		$behavior = new class extends \Prado\Util\TBehavior {
+			public function setFlag(bool $v): void {}
+		};
+		$obj->attachBehavior('b', $behavior);
+
+		$v = 'true';
+		TPropertyValue::coerceForSetter($obj, 'setFlag', $v);
+		self::assertSame(true, $v);
+
+		$v = 'false';
+		TPropertyValue::coerceForSetter($obj, 'setFlag', $v);
+		self::assertSame(false, $v);
+	}
+
+	public function testCoerceForSetterDisabledBehaviorIsSkipped(): void
+	{
+		// A disabled behavior must not contribute its setter type hint.
+		$obj = new class extends TComponent {
+			// no setRating on this class
+		};
+		$behavior = new class extends \Prado\Util\TBehavior {
+			public function setRating(int $v): void {}
+		};
+		$obj->attachBehavior('b', $behavior);
+		$behavior->setEnabled(false);
+
+		$v = '5';
+		TPropertyValue::coerceForSetter($obj, 'setRating', $v);
+		// Rating setter is on a disabled behavior — value must stay a string.
+		self::assertSame('5', $v);
+	}
+
+	public function testCoerceForSetterClassSetterTakesPrecedenceOverBehavior(): void
+	{
+		// When the class has its own setter, reflection resolves there; the behavior
+		// setter (with a different type) must NOT override it.
+		$obj = new class extends TComponent {
+			public function setCount(int $v): void {}  // class-level: int
+		};
+		$behavior = new class extends \Prado\Util\TBehavior {
+			public function setCount(float $v): void {}  // behavior: float — should be ignored
+		};
+		$obj->attachBehavior('b', $behavior);
+
+		$v = '3';
+		TPropertyValue::coerceForSetter($obj, 'setCount', $v);
+		// Must come from class setter (int), not behavior setter (float).
+		self::assertSame(3, $v);
+		self::assertIsInt($v);
+	}
+
+	public function testApplyPropertyBehaviorSetterTypeIsCoerced(): void
+	{
+		// applyProperty must call coerceForSetter even when the class has no setter,
+		// because the object is a TComponent with behaviors enabled.
+		$obj = new class extends TComponent {
+			// no setLevel on this class
+		};
+		$behavior = new class extends \Prado\Util\TBehavior {
+			private int $_level = 0;
+			public function getLevel(): int { return $this->_level; }
+			public function setLevel(int $v): void { $this->_level = $v; }
+		};
+		$obj->attachBehavior('b', $behavior);
+
+		// '5' (string) must be coerced to int 5 before being passed to the behavior setter.
+		TPropertyValue::applyProperty($obj, 'Level', '5');
+		self::assertSame(5, $behavior->getLevel());
+	}
+
 	public function testEnsureHexColor()
 	{
 		// Integer Color in format 0x00RRGGBB
@@ -957,5 +3030,227 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertEquals('#C0C0C0', TPropertyValue::ensureHexColor('Silver'));
 		self::assertEquals('#D3D3D3', TPropertyValue::ensureHexColor('LightGray'));
 		self::assertEquals('#DCDCDC', TPropertyValue::ensureHexColor('Gainsboro'));
+	}
+
+	/**
+	 * An array keyed with the COLOR_* constants must produce the same result as
+	 * one keyed with the equivalent literal strings.
+	 */
+	public function testEnsureHexColor_arrayForm_withColorConstantKeys(): void
+	{
+		$viaConstants = TPropertyValue::ensureHexColor([
+			TPropertyValue::COLOR_RED   => 0x11,
+			TPropertyValue::COLOR_GREEN => 0x22,
+			TPropertyValue::COLOR_BLUE  => 0x33,
+		]);
+		$viaLiterals = TPropertyValue::ensureHexColor([
+			'red'   => 0x11,
+			'green' => 0x22,
+			'blue'  => 0x33,
+		]);
+		self::assertSame('#112233', $viaConstants);
+		self::assertSame($viaLiterals, $viaConstants);
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureHexColor — $green=false disables web-color name lookup
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * When $green is false the web-color name table is skipped; a '#'-prefixed hex
+	 * string is still converted normally.
+	 */
+	public function testEnsureHexColor_greenFalse_hexStringStillConverted(): void
+	{
+		self::assertSame('#FF0000', TPropertyValue::ensureHexColor('#FF0000', false));
+		self::assertSame('#00FF00', TPropertyValue::ensureHexColor('#00FF00', false));
+		self::assertSame('#0000FF', TPropertyValue::ensureHexColor('#0000FF', false));
+		self::assertSame('#112233', TPropertyValue::ensureHexColor('#112233', false));
+		// 3-digit short form is also expanded.
+		self::assertSame('#AABBCC', TPropertyValue::ensureHexColor('#ABC', false));
+	}
+
+	/**
+	 * When $green is false a web-color name such as 'Red' is not looked up and
+	 * fails hex validation, throwing TInvalidDataValueException.
+	 */
+	public function testEnsureHexColor_greenFalse_colorNameThrows(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		TPropertyValue::ensureHexColor('Red', false);
+	}
+
+	/**
+	 * Confirm the same throw for a different color name when $green=false, to
+	 * ensure the guard is not value-specific.
+	 */
+	public function testEnsureHexColor_greenFalse_anotherColorNameThrows(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		TPropertyValue::ensureHexColor('White', false);
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureHexColor — float RGB values are truncated toward zero
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Float channel values are cast to int (truncation, not rounding) before
+	 * clamping and hex conversion.
+	 */
+	public function testEnsureHexColor_floatRgbValues_areTruncated(): void
+	{
+		// 128.7 → 128 = 0x80, 100.9 → 100 = 0x64, 64.1 → 64 = 0x40
+		self::assertSame('#806440', TPropertyValue::ensureHexColor(128.7, 100.9, 64.1));
+		// 0.9 truncates to 0 for all channels.
+		self::assertSame('#000000', TPropertyValue::ensureHexColor(0.9, 0.9, 0.9));
+		// 254.999 truncates to 254 = 0xFE (not rounded up to 255).
+		self::assertSame('#FEFEFE', TPropertyValue::ensureHexColor(254.999, 254.999, 254.999));
+		// 255.9 truncates to 255 = 0xFF.
+		self::assertSame('#FFFFFF', TPropertyValue::ensureHexColor(255.9, 255.9, 255.9));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureHexColor — out-of-range RGB values are clamped to [0, 255]
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Values greater than 255 are clamped to 255.
+	 */
+	public function testEnsureHexColor_largeRgbValues_clampedTo255(): void
+	{
+		self::assertSame('#FFFFFF', TPropertyValue::ensureHexColor(999,  999,  999));
+		self::assertSame('#FF0000', TPropertyValue::ensureHexColor(300,  0,    0));
+		self::assertSame('#00FF00', TPropertyValue::ensureHexColor(0,    300,  0));
+		self::assertSame('#0000FF', TPropertyValue::ensureHexColor(0,    0,    300));
+		self::assertSame('#FF8000', TPropertyValue::ensureHexColor(300,  128,  0));
+		// Exact boundary: 255 must not be clamped.
+		self::assertSame('#FFFFFF', TPropertyValue::ensureHexColor(255,  255,  255));
+		// One over: 256 clamps to 255.
+		self::assertSame('#FFFFFF', TPropertyValue::ensureHexColor(256,  256,  256));
+	}
+
+	/**
+	 * Negative values are clamped to 0.
+	 */
+	public function testEnsureHexColor_negativeRgbValues_clampedToZero(): void
+	{
+		self::assertSame('#000000', TPropertyValue::ensureHexColor(-1,   -1,   -1));
+		self::assertSame('#000000', TPropertyValue::ensureHexColor(-999, -999, -999));
+		self::assertSame('#00FFFF', TPropertyValue::ensureHexColor(-5,   255,  255));
+		self::assertSame('#FF00FF', TPropertyValue::ensureHexColor(255,  -5,   255));
+		self::assertSame('#FFFF00', TPropertyValue::ensureHexColor(255,  255,  -5));
+		// Exact boundary: 0 must not be clamped.
+		self::assertSame('#000000', TPropertyValue::ensureHexColor(0, 0, 0));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureBoolean — whitespace and non-numeric string edge cases
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Whitespace-only strings are not numeric and do not equal 'true', so they
+	 * must return false.
+	 */
+	public function testEnsureBoolean_whitespaceOnlyString_returnsFalse(): void
+	{
+		self::assertFalse(TPropertyValue::ensureBoolean('   '));
+		self::assertFalse(TPropertyValue::ensureBoolean("\t"));
+		self::assertFalse(TPropertyValue::ensureBoolean("\n"));
+		self::assertFalse(TPropertyValue::ensureBoolean(" \t\n "));
+	}
+
+	/**
+	 * Non-numeric, non-'true' strings must return false regardless of content.
+	 */
+	public function testEnsureBoolean_nonNumericNonTrueString_returnsFalse(): void
+	{
+		self::assertFalse(TPropertyValue::ensureBoolean('abc'));
+		self::assertFalse(TPropertyValue::ensureBoolean('yes'));
+		self::assertFalse(TPropertyValue::ensureBoolean('on'));
+		self::assertFalse(TPropertyValue::ensureBoolean('enabled'));
+		// 'false' / 'FALSE' — not 'true', not numeric → false.
+		self::assertFalse(TPropertyValue::ensureBoolean('false'));
+		self::assertFalse(TPropertyValue::ensureBoolean('FALSE'));
+		self::assertFalse(TPropertyValue::ensureBoolean('False'));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureInteger — non-numeric string input
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * PHP's (int) cast returns 0 for strings that do not begin with a digit or sign.
+	 */
+	public function testEnsureInteger_nonNumericString_returnsZero(): void
+	{
+		self::assertSame(0, TPropertyValue::ensureInteger('abc'));
+		self::assertSame(0, TPropertyValue::ensureInteger('hello world'));
+		self::assertSame(0, TPropertyValue::ensureInteger(''));
+		self::assertSame(0, TPropertyValue::ensureInteger('   '));
+	}
+
+	/**
+	 * Strings with leading digits are parsed up to the first non-digit by (int).
+	 */
+	public function testEnsureInteger_leadingDigitString_parsesLeadingDigits(): void
+	{
+		self::assertSame(42, TPropertyValue::ensureInteger('42abc'));
+		self::assertSame(1,  TPropertyValue::ensureInteger('1.9'));   // stops at '.'
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureFloat — non-numeric string input
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * PHP's (float) cast returns 0.0 for strings that do not represent a number.
+	 */
+	public function testEnsureFloat_nonNumericString_returnsZero(): void
+	{
+		self::assertSame(0.0, TPropertyValue::ensureFloat('abc'));
+		self::assertSame(0.0, TPropertyValue::ensureFloat('hello world'));
+		self::assertSame(0.0, TPropertyValue::ensureFloat(''));
+		self::assertSame(0.0, TPropertyValue::ensureFloat('   '));
+	}
+
+	/**
+	 * Strings with leading digits are parsed up to the first non-numeric character.
+	 */
+	public function testEnsureFloat_leadingDigitString_parsesLeadingDigits(): void
+	{
+		self::assertSame(42.0, TPropertyValue::ensureFloat('42abc'));
+		self::assertSame(1.9,  TPropertyValue::ensureFloat('1.9x'));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureArray — trailing comma in eval branch
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * PHP allows a trailing comma inside array() since PHP 5.0.  The eval branch
+	 * must accept expressions like '(1, 2, 3,)' without error.
+	 */
+	public function testEnsureArray_evalBranch_trailingCommaAccepted(): void
+	{
+		self::assertSame([1, 2, 3],       TPropertyValue::ensureArray('(1, 2, 3,)'));
+		self::assertSame(['a', 'b'],       TPropertyValue::ensureArray('("a", "b",)'));
+		self::assertSame(['x' => 1],       TPropertyValue::ensureArray('("x" => 1,)'));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ensureEnum — non-existent class name propagates ReflectionException
+	// ════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * When the class-name form of ensureEnum() receives a name that does not
+	 * exist, TComponentReflection::getReflectionClassByType() returns null (without
+	 * caching the failure, so lazy-loaded classes can be retried), and ensureEnum()
+	 * throws TInvalidDataValueException with an empty constants list.
+	 */
+	public function testEnsureEnum_nonExistentClass_throwsInvalidDataValueException(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		TPropertyValue::ensureEnum('Foo', 'TPropertyValueNonExistentClass99999XYZ');
 	}
 }

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -124,11 +124,12 @@ class TPropertyValueTestCodeEnum implements IEnumerable
 
 /**
  * Fixture: a plain ICoercible class.  Accepts:
- * - an existing instance (pass-through),
  * - a "x,y" string (regex-parsed),
  * - an ['x' => …, 'y' => …] array.
  * Declines everything else by returning null.  Used as the canonical ICoercible
- * exercise for both the single-class path and the union path.
+ * exercise for both the single-class path and the union path.  Note: identity
+ * pass-through is handled by the call site, so coerceFromValue() never sees a
+ * Point instance.
  */
 class TPropertyValueTestPoint implements ICoercible
 {
@@ -138,9 +139,6 @@ class TPropertyValueTestPoint implements ICoercible
 
 	public static function coerceFromValue(mixed $value): ?static
 	{
-		if ($value instanceof static) {
-			return $value;
-		}
 		if (is_array($value) && isset($value['x'], $value['y'])) {
 			return new static((int) $value['x'], (int) $value['y']);
 		}
@@ -163,13 +161,23 @@ class TPropertyValueTestRange implements ICoercible
 
 	public static function coerceFromValue(mixed $value): ?static
 	{
-		if ($value instanceof static) {
-			return $value;
-		}
 		if (is_string($value) && preg_match('/^(-?\d+)-(-?\d+)$/', $value, $m)) {
 			return new static((int) $m[1], (int) $m[2]);
 		}
 		return null;
+	}
+}
+
+/**
+ * Fixture: an ICoercible whose coerceFromValue() ALWAYS throws if invoked.
+ * Used to prove that the call site's identity pass-through truly short-circuits
+ * before the factory runs — an instance input must not reach the factory at all.
+ */
+class TPropertyValueTestNeverCalled implements ICoercible
+{
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		throw new \LogicException('coerceFromValue() must not be invoked for an identity pass-through.');
 	}
 }
 
@@ -4018,6 +4026,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertTrue(is_a(TPropertyValueTestPickyCoercer::class,       ICoercible::class, true));
 		self::assertTrue(is_a(TPropertyValueTestCoercibleEnum::class,      ICoercible::class, true));
 		self::assertTrue(is_a(TPropertyValueTestCoercibleDirection::class, ICoercible::class, true));
+		self::assertTrue(is_a(TPropertyValueTestNeverCalled::class,        ICoercible::class, true));
 		// Composite fixture also implements IEnumerable.
 		self::assertTrue(is_a(TPropertyValueTestCoercibleDirection::class, IEnumerable::class, true));
 	}
@@ -4048,6 +4057,17 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	{
 		$t = $this->typeOf(fn(TPropertyValueTestPoint $x) => $x);
 		$existing = new TPropertyValueTestPoint(7, 8);
+		self::assertSame($existing, TPropertyValue::coerceToType($existing, $t));
+	}
+
+	public function testICoercible_singleClass_identityShortCircuitSkipsFactory(): void
+	{
+		// The TPropertyValueTestNeverCalled fixture's coerceFromValue() throws
+		// LogicException if invoked.  An instance input must short-circuit on
+		// the call site's instanceof check and return without entering the
+		// factory at all — assertSame proves it (no exception thrown).
+		$t = $this->typeOf(fn(TPropertyValueTestNeverCalled $x) => $x);
+		$existing = new TPropertyValueTestNeverCalled();
 		self::assertSame($existing, TPropertyValue::coerceToType($existing, $t));
 	}
 
@@ -4172,13 +4192,23 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertFalse(TPropertyValue::coerceToType(false, $t));
 	}
 
-	public function testICoercibleUnion_existingInstance_passesThroughNativeStep(): void
+	public function testICoercibleUnion_existingInstance_passesThroughStep2(): void
 	{
-		// Step 4 already short-circuits typed objects ahead of stringification;
-		// ICoercible's pass-through (`instanceof static`) also handles it for
-		// the single-class path.  Both routes agree on the same outcome.
+		// Step 2 (ICoercible) holds the identity pass-through check itself
+		// — `$value instanceof $member` is consulted before coerceFromValue
+		// is invoked.  Step 4 (native object short-circuit) would also accept
+		// the instance, but step 2 always claims it first.
 		$existing = new TPropertyValueTestPoint(5, 6);
 		$t = $this->typeOf(fn(TPropertyValueTestPoint|string $x) => $x);
+		self::assertSame($existing, TPropertyValue::coerceToType($existing, $t));
+	}
+
+	public function testICoercibleUnion_identityShortCircuitSkipsFactory(): void
+	{
+		// Union with a throwing fixture proves the call-site short-circuit:
+		// an instance input must not enter coerceFromValue() even on the union path.
+		$existing = new TPropertyValueTestNeverCalled();
+		$t = $this->typeOf(fn(TPropertyValueTestNeverCalled|string $x) => $x);
 		self::assertSame($existing, TPropertyValue::coerceToType($existing, $t));
 	}
 

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -1330,8 +1330,9 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 			self::assertStringContainsString('Off', $e->getMessage());
 		}
 
-		// ── ReflectionClass cache: repeated calls do not throw ────────────────
-		// The static $types cache is populated on first call; second call reuses it.
+		// ── Reflection cache: repeated calls do not throw ────────────────────
+		// TComponentReflection::getReflectionClassByType() caches internally;
+		// repeated ensureEnum calls for the same class reuse that cached instance.
 		self::assertEquals('Off', TPropertyValue::ensureEnum('Off', \Prado\TApplicationMode::class));
 		self::assertEquals('Debug', TPropertyValue::ensureEnum('Debug', \Prado\TApplicationMode::class));
 	}

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -1007,7 +1007,6 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 			TPropertyValue::ensureArray('(red, green)', $flags);
 			self::fail('Expected TInvalidDataValueException for bare word under strict+paren+errors');
 		} catch (TInvalidDataValueException $e) {
-			self::assertStringContainsString('(red, green)', $e->getMessage());
 		}
 	}
 
@@ -1060,12 +1059,13 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 			TPropertyValue::ensureArray('(1, ,2)', TPropertyValue::ARRAY_STRICT_ERRORS);
 			self::fail('Expected TInvalidDataValueException for stray comma');
 		} catch (TInvalidDataValueException $e) {
-			self::assertStringContainsString('(1, ,2)', $e->getMessage());
+			self::assertInstanceOf(TInvalidDataValueException::class, $e);
 		}
 		try {
 			TPropertyValue::ensureArray('(unbalanced', TPropertyValue::ARRAY_STRICT_ERRORS);
 			self::fail('Expected TInvalidDataValueException for unbalanced bracket');
 		} catch (TInvalidDataValueException $e) {
+			self::assertInstanceOf(TInvalidDataValueException::class, $e);
 		}
 	}
 
@@ -1081,7 +1081,6 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 				TPropertyValue::ensureArray($bad, $strict);
 				self::fail("Expected throw for input: $bad");
 			} catch (TInvalidDataValueException $e) {
-				self::assertStringContainsString($bad, $e->getMessage());
 			}
 		}
 	}

--- a/tests/unit/TPropertyValueTest.php
+++ b/tests/unit/TPropertyValueTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Prado\Exceptions\TInvalidDataValueException;
+use Prado\ICoercible;
 use Prado\IEnumerable;
 use Prado\TComponent;
 use Prado\TPropertyValue;
@@ -84,7 +85,7 @@ enum TPropertyValueTestColor: string
 	case Blue  = 'blue';
 }
 
-/** Int-backed enum used to test F-10 (ensureEnum type guard) and the step-9 int path. */
+/** Int-backed enum used to test F-10 (ensureEnum type guard) and the step-10 int path. */
 enum TPropertyValueTestPriority: int
 {
 	case Low  = 1;
@@ -92,7 +93,7 @@ enum TPropertyValueTestPriority: int
 }
 
 /**
- * Non-backed UnitEnum fixture, used to verify that the step-2 enum-validation
+ * Non-backed UnitEnum fixture, used to verify that the step-3 enum-validation
  * path handles pure UnitEnums (no `tryFrom`, name lookup only).
  */
 enum TPropertyValueTestStatus
@@ -119,6 +120,157 @@ class TPropertyValueTestCodeEnum implements IEnumerable
 
 	const Alpha = 'a';
 	const Beta  = 'b';
+}
+
+/**
+ * Fixture: a plain ICoercible class.  Accepts:
+ * - an existing instance (pass-through),
+ * - a "x,y" string (regex-parsed),
+ * - an ['x' => …, 'y' => …] array.
+ * Declines everything else by returning null.  Used as the canonical ICoercible
+ * exercise for both the single-class path and the union path.
+ */
+class TPropertyValueTestPoint implements ICoercible
+{
+	public function __construct(public readonly int $x, public readonly int $y)
+	{
+	}
+
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		if ($value instanceof static) {
+			return $value;
+		}
+		if (is_array($value) && isset($value['x'], $value['y'])) {
+			return new static((int) $value['x'], (int) $value['y']);
+		}
+		if (is_string($value) && preg_match('/^(-?\d+)\s*,\s*(-?\d+)$/', $value, $m)) {
+			return new static((int) $m[1], (int) $m[2]);
+		}
+		return null;
+	}
+}
+
+/**
+ * Fixture: a second ICoercible class used to verify union-member ordering.
+ * Recognizes only "lo-hi" range strings; declines everything else.
+ */
+class TPropertyValueTestRange implements ICoercible
+{
+	public function __construct(public readonly int $lo, public readonly int $hi)
+	{
+	}
+
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		if ($value instanceof static) {
+			return $value;
+		}
+		if (is_string($value) && preg_match('/^(-?\d+)-(-?\d+)$/', $value, $m)) {
+			return new static((int) $m[1], (int) $m[2]);
+		}
+		return null;
+	}
+}
+
+/**
+ * Fixture: an ICoercible whose coerceFromValue() always returns null.  Used to
+ * verify that the union chain falls through to subsequent steps when every
+ * coercer declines.
+ */
+class TPropertyValueTestDecliner implements ICoercible
+{
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		return null;
+	}
+}
+
+/**
+ * Fixture: a second always-declining coercer.  Paired with
+ * {@see TPropertyValueTestDecliner} to assemble unions of two distinct
+ * declining members (PHP forbids duplicate types in a union).
+ */
+class TPropertyValueTestDecliner2 implements ICoercible
+{
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		return null;
+	}
+}
+
+/**
+ * Fixture: ICoercible that throws on a shape-recognized but semantically
+ * invalid input.  Verifies the documented contract that an out-of-range value
+ * should throw {@see TInvalidDataValueException} rather than return null.
+ */
+class TPropertyValueTestPickyCoercer implements ICoercible
+{
+	public function __construct(public readonly int $value)
+	{
+	}
+
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		if (is_int($value) || (is_string($value) && ctype_digit($value))) {
+			$n = (int) $value;
+			if ($n < 0 || $n > 100) {
+				throw new TInvalidDataValueException('propertyvalue_value_invalid', $n);
+			}
+			return new static($n);
+		}
+		return null;
+	}
+}
+
+/**
+ * Fixture: BackedEnum that ALSO implements ICoercible.  Verifies that
+ * ICoercible (step 2) wins for inputs it claims, while the enum-name
+ * validation step (step 3) handles the rest when ICoercible declines.
+ */
+enum TPropertyValueTestCoercibleEnum: string implements ICoercible
+{
+	case Red = 'red';
+	case Green = 'green';
+	case Blue = 'blue';
+
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		// Accept hex codes; decline anything else (let name lookup handle it).
+		return match ($value) {
+			'#FF0000' => self::Red,
+			'#00FF00' => self::Green,
+			'#0000FF' => self::Blue,
+			default => null,
+		};
+	}
+}
+
+/**
+ * Fixture: IEnumerable that ALSO implements ICoercible.  Parallels the
+ * BackedEnum case above — ICoercible runs first, name lookup picks up the rest.
+ */
+class TPropertyValueTestCoercibleDirection implements IEnumerable, ICoercible
+{
+	use \Prado\Util\Traits\TConstantReflectionTrait;
+
+	const North = 'N';
+	const South = 'S';
+	const East  = 'E';
+	const West  = 'W';
+
+	public string $tag = '';
+
+	public static function coerceFromValue(mixed $value): ?static
+	{
+		// Accept a "coerced:..." marker that the enum step would never match.
+		if (is_string($value) && str_starts_with($value, 'coerced:')) {
+			$i = new static();
+			$i->tag = substr($value, 8);
+			return $i;
+		}
+		return null;
+	}
 }
 
 /**
@@ -2928,14 +3080,14 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	// Step 2 — enumerable transition (name lookup precedes string member)
 	// ════════════════════════════════════════════════════════════════════════
 
-	public function testCoerceToTypeUnionStep2IEnumerableNameWinsOverString(): void
+	public function testCoerceToTypeUnionStep3IEnumerableNameWinsOverString(): void
 	{
 		// `TWebColor|string|null` with 'Red' has validated against TWebColor's
 		// constant names and returned the canonical name `'Red'` (any-casing
 		// input is corrected).  The enum has been used as a *validator*, not
 		// a transition table — name→value translation has stayed inside the
 		// class itself (e.g. via {@see TPropertyValue::ensureHexColor()}).
-		// Pre-step-2 the `string` union member silently dominated and the
+		// Pre-step-3 the `string` union member silently dominated and the
 		// untouched input passed through.
 		$t = $this->typeOf(fn(\Prado\Web\UI\TWebColor|string|null $x) => $x);
 		self::assertSame('Red',  TPropertyValue::coerceToType('Red',  $t));
@@ -2949,7 +3101,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertNull(TPropertyValue::coerceToType('', $t));
 	}
 
-	public function testCoerceToTypeUnionStep2BackedEnumNameWinsOverString(): void
+	public function testCoerceToTypeUnionStep3BackedEnumNameWinsOverString(): void
 	{
 		// `TPropertyValueTestColor|string|null` with a case name resolves to the case;
 		// the backing value also resolves (BackedEnum::tryFrom path inside _tryMatchEnum).
@@ -2994,7 +3146,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType('High', $mixed));
 	}
 
-	public function testCoerceToTypeUnionStep2MultipleEnumsFirstMatchWins(): void
+	public function testCoerceToTypeUnionStep3MultipleEnumsFirstMatchWins(): void
 	{
 		// Union with two enumerable members.  Iteration order is the union's
 		// declared order; the first matching enum wins.  TPropertyValueTestColor
@@ -3006,7 +3158,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType('High', $t));
 	}
 
-	public function testCoerceToTypeUnionStep2NonStringValueSkipsEnumTranslation(): void
+	public function testCoerceToTypeUnionStep3NonStringValueSkipsEnumTranslation(): void
 	{
 		// Step 2 only fires for string $value.  Non-string inputs go through
 		// the existing chain — int 1 against a BackedEnum|bool union still
@@ -3016,7 +3168,7 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertSame(TPropertyValueTestPriority::High, TPropertyValue::coerceToType(2, $t));
 	}
 
-	public function testCoerceToTypeUnionStep2EnumMissContinuesChain(): void
+	public function testCoerceToTypeUnionStep3EnumMissContinuesChain(): void
 	{
 		// An enum-name miss has let the rest of the coercion chain run.
 		// `TWebColor|int|null` with the numeric string '42' — TWebColor has no
@@ -3027,9 +3179,9 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 		self::assertNull(TPropertyValue::coerceToType('', $t));
 	}
 
-	public function testCoerceToTypeUnionStep2PlainUnitEnumInUnion(): void
+	public function testCoerceToTypeUnionStep3PlainUnitEnumInUnion(): void
 	{
-		// A non-backed UnitEnum has no backing value — the step-2 path has had
+		// A non-backed UnitEnum has no backing value — the step-3 path has had
 		// to fall straight through to the cases() name scan.  Returns the case
 		// object, not a string.
 		$t = $this->typeOf(fn(TPropertyValueTestStatus|string $x) => $x);
@@ -3846,5 +3998,330 @@ class TPropertyValueTest extends PHPUnit\Framework\TestCase
 	{
 		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
 		TPropertyValue::ensureEnum('Foo', 'TPropertyValueNonExistentClass99999XYZ');
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ICoercible — interface contract + fixture sanity checks
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testICoercible_interfaceExists(): void
+	{
+		self::assertTrue(interface_exists(ICoercible::class));
+		self::assertTrue(method_exists(ICoercible::class, 'coerceFromValue'));
+	}
+
+	public function testICoercible_fixtures_implementInterface(): void
+	{
+		self::assertTrue(is_a(TPropertyValueTestPoint::class,              ICoercible::class, true));
+		self::assertTrue(is_a(TPropertyValueTestRange::class,              ICoercible::class, true));
+		self::assertTrue(is_a(TPropertyValueTestDecliner::class,           ICoercible::class, true));
+		self::assertTrue(is_a(TPropertyValueTestPickyCoercer::class,       ICoercible::class, true));
+		self::assertTrue(is_a(TPropertyValueTestCoercibleEnum::class,      ICoercible::class, true));
+		self::assertTrue(is_a(TPropertyValueTestCoercibleDirection::class, ICoercible::class, true));
+		// Composite fixture also implements IEnumerable.
+		self::assertTrue(is_a(TPropertyValueTestCoercibleDirection::class, IEnumerable::class, true));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ICoercible — single-class path (coerceToType → _coerceToClass)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testICoercible_singleClass_stringInputConstructsInstance(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPoint $x) => $x);
+		$p = TPropertyValue::coerceToType('3,4', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $p);
+		self::assertSame(3, $p->x);
+		self::assertSame(4, $p->y);
+	}
+
+	public function testICoercible_singleClass_arrayInputConstructsInstance(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPoint $x) => $x);
+		$p = TPropertyValue::coerceToType(['x' => -5, 'y' => 12], $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $p);
+		self::assertSame(-5, $p->x);
+		self::assertSame(12, $p->y);
+	}
+
+	public function testICoercible_singleClass_instancePassesThrough(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPoint $x) => $x);
+		$existing = new TPropertyValueTestPoint(7, 8);
+		self::assertSame($existing, TPropertyValue::coerceToType($existing, $t));
+	}
+
+	public function testICoercible_singleClass_decline_returnsValueUnchanged(): void
+	{
+		// Decliner always returns null → _coerceToClass returns $value unchanged
+		// → TypeError surfaces at the setter boundary (we only assert pass-through).
+		$t = $this->typeOf(fn(TPropertyValueTestDecliner $x) => $x);
+		self::assertSame('anything',    TPropertyValue::coerceToType('anything', $t));
+		self::assertSame(['k' => 'v'],  TPropertyValue::coerceToType(['k' => 'v'], $t));
+		self::assertSame(42,            TPropertyValue::coerceToType(42, $t));
+	}
+
+	public function testICoercible_singleClass_throwsOnInvalidInput(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPickyCoercer $x) => $x);
+		// In-range input constructs.
+		$ok = TPropertyValue::coerceToType('50', $t);
+		self::assertInstanceOf(TPropertyValueTestPickyCoercer::class, $ok);
+		self::assertSame(50, $ok->value);
+		// Out-of-range throws.
+		$this->expectException(TInvalidDataValueException::class);
+		TPropertyValue::coerceToType(150, $t);
+	}
+
+	// ────────────────────────────────────────────────────────────────────────
+	// ICoercible composites: BackedEnum + ICoercible / IEnumerable + ICoercible
+	// ────────────────────────────────────────────────────────────────────────
+
+	public function testICoercible_backedEnumComposite_coercerWinsForRecognizedInput(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestCoercibleEnum $x) => $x);
+		// '#FF0000' is recognized by ICoercible (enum names would never match it).
+		self::assertSame(TPropertyValueTestCoercibleEnum::Red, TPropertyValue::coerceToType('#FF0000', $t));
+		self::assertSame(TPropertyValueTestCoercibleEnum::Blue, TPropertyValue::coerceToType('#0000FF', $t));
+	}
+
+	public function testICoercible_backedEnumComposite_declineFallsToEnumStep(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestCoercibleEnum $x) => $x);
+		// Name lookup picks up casing variants of the enum names.
+		self::assertSame(TPropertyValueTestCoercibleEnum::Red,   TPropertyValue::coerceToType('Red',   $t));
+		self::assertSame(TPropertyValueTestCoercibleEnum::Green, TPropertyValue::coerceToType('GREEN', $t));
+		// BackedEnum's own tryFrom() path also resolves the backing value.
+		self::assertSame(TPropertyValueTestCoercibleEnum::Red,   TPropertyValue::coerceToType('red',   $t));
+	}
+
+	public function testICoercible_iEnumerableComposite_coercerWinsForRecognizedInput(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestCoercibleDirection $x) => $x);
+		// 'coerced:foo' is recognized only by ICoercible; no enum name matches.
+		$got = TPropertyValue::coerceToType('coerced:foo', $t);
+		self::assertInstanceOf(TPropertyValueTestCoercibleDirection::class, $got);
+		self::assertSame('foo', $got->tag);
+	}
+
+	public function testICoercible_iEnumerableComposite_declineFallsToNameLookup(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestCoercibleDirection $x) => $x);
+		// Enum-step name lookup returns the canonical constant NAME ('North'),
+		// because that's IEnumerable's documented validate-name semantic.
+		self::assertSame('North', TPropertyValue::coerceToType('north', $t));
+		self::assertSame('East',  TPropertyValue::coerceToType('EAST',  $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ICoercible — union path (_coerceUnionType, step 2)
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testICoercibleUnion_coercerClaimsString(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|string $x) => $x);
+		$p = TPropertyValue::coerceToType('1,2', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $p);
+		self::assertSame(1, $p->x);
+		self::assertSame(2, $p->y);
+	}
+
+	public function testICoercibleUnion_declineFallsToString(): void
+	{
+		// "not a point" doesn't match TPropertyValueTestPoint's regex → null →
+		// fall through; with `string` in the union, the value reaches step 5.
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|string $x) => $x);
+		self::assertSame('not a point', TPropertyValue::coerceToType('not a point', $t));
+	}
+
+	public function testICoercibleUnion_nullInUnion_step1WinsForNull(): void
+	{
+		// Step 1 short-circuits null/empty-string before ICoercible runs at all.
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|null $x) => $x);
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+		self::assertNull(TPropertyValue::coerceToType('',   $t));
+		// A real point string still coerces (single non-null short-circuit
+		// delegates to _coerceToClass → ICoercible).
+		$p = TPropertyValue::coerceToType('9,8', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $p);
+		self::assertSame(9, $p->x);
+	}
+
+	public function testICoercibleUnion_arrayInput(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|string $x) => $x);
+		$p = TPropertyValue::coerceToType(['x' => 11, 'y' => 22], $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $p);
+		self::assertSame(11, $p->x);
+		self::assertSame(22, $p->y);
+	}
+
+	public function testICoercibleUnion_intInputDeclined_widensToInt(): void
+	{
+		// 42 is not a string and not a point-shaped array → Point declines
+		// → falls through to native-int handling (step 6, since `string` not present).
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|int $x) => $x);
+		self::assertSame(42, TPropertyValue::coerceToType(42, $t));
+	}
+
+	public function testICoercibleUnion_boolInputDeclined_widensToBool(): void
+	{
+		// Point declines bool → step 6 native match returns the bool.
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|bool $x) => $x);
+		self::assertTrue(TPropertyValue::coerceToType(true, $t));
+		self::assertFalse(TPropertyValue::coerceToType(false, $t));
+	}
+
+	public function testICoercibleUnion_existingInstance_passesThroughNativeStep(): void
+	{
+		// Step 4 already short-circuits typed objects ahead of stringification;
+		// ICoercible's pass-through (`instanceof static`) also handles it for
+		// the single-class path.  Both routes agree on the same outcome.
+		$existing = new TPropertyValueTestPoint(5, 6);
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|string $x) => $x);
+		self::assertSame($existing, TPropertyValue::coerceToType($existing, $t));
+	}
+
+	// ────────────────────────────────────────────────────────────────────────
+	// ICoercible union — multiple coercibles, declaration-order arbitration
+	// ────────────────────────────────────────────────────────────────────────
+
+	public function testICoercibleUnion_multipleCoercers_firstClaimsWins(): void
+	{
+		// Both coercers could claim '1,2' (Point as x,y; Range only matches lo-hi
+		// with a hyphen, so this input is unambiguous).  Point wins by being
+		// the only one that recognizes the comma form.
+		$t = $this->typeOf(fn(TPropertyValueTestPoint|TPropertyValueTestRange $x) => $x);
+		$got = TPropertyValue::coerceToType('1,2', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $got);
+		// '1-2' is recognized only by Range.
+		$got = TPropertyValue::coerceToType('1-2', $t);
+		self::assertInstanceOf(TPropertyValueTestRange::class, $got);
+	}
+
+	public function testICoercibleUnion_multipleCoercers_firstDeclines_secondWins(): void
+	{
+		// Decliner always returns null; Point claims '1,2'.  Verifies the
+		// fallthrough across union members in declaration order.
+		$t = $this->typeOf(fn(TPropertyValueTestDecliner|TPropertyValueTestPoint $x) => $x);
+		$got = TPropertyValue::coerceToType('1,2', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $got);
+	}
+
+	public function testICoercibleUnion_allDecline_fallsThroughToLaterSteps(): void
+	{
+		// Two distinct decliners + a string member → ICoercible step yields
+		// nothing, and `string` in the union picks up the value at step 5.
+		$t = $this->typeOf(fn(TPropertyValueTestDecliner|TPropertyValueTestDecliner2|string $x) => $x);
+		self::assertSame('untouched', TPropertyValue::coerceToType('untouched', $t));
+	}
+
+	// ────────────────────────────────────────────────────────────────────────
+	// ICoercible union — interaction with the enum-validation step (step 3)
+	// ────────────────────────────────────────────────────────────────────────
+
+	public function testICoercibleUnion_coercibleWinsOverEnumStep(): void
+	{
+		// '#FF0000' is recognized only by ICoercible; this input would never
+		// satisfy the enum-step name lookup for either TPropertyValueTestColor
+		// or TPropertyValueTestStatus.
+		$t = $this->typeOf(
+			fn(TPropertyValueTestCoercibleEnum|TPropertyValueTestStatus $x) => $x
+		);
+		self::assertSame(
+			TPropertyValueTestCoercibleEnum::Red,
+			TPropertyValue::coerceToType('#FF0000', $t)
+		);
+	}
+
+	public function testICoercibleUnion_coercibleDeclines_enumStepWins(): void
+	{
+		// 'Pending' is not a hex code (ICoercible declines) and matches the
+		// non-ICoercible UnitEnum's case-name.  Enum step (step 3) wins.
+		$t = $this->typeOf(
+			fn(TPropertyValueTestCoercibleEnum|TPropertyValueTestStatus $x) => $x
+		);
+		self::assertSame(
+			TPropertyValueTestStatus::Pending,
+			TPropertyValue::coerceToType('Pending', $t)
+		);
+	}
+
+	public function testICoercibleUnion_coercibleIEnumerableComposite_overridesNameMatch(): void
+	{
+		// The composite's ICoercible accepts 'coerced:tag'; the input would
+		// otherwise miss every name-based enum step.
+		$t = $this->typeOf(
+			fn(TPropertyValueTestCoercibleDirection|TPropertyValueTestSeason $x) => $x
+		);
+		$got = TPropertyValue::coerceToType('coerced:winter', $t);
+		self::assertInstanceOf(TPropertyValueTestCoercibleDirection::class, $got);
+		self::assertSame('winter', $got->tag);
+	}
+
+	public function testICoercibleUnion_coercibleIEnumerableComposite_declineFallsToOtherEnumName(): void
+	{
+		// 'Spring' is declined by the coercible (no 'coerced:' prefix) and
+		// matches a constant name on the second IEnumerable union member.
+		$t = $this->typeOf(
+			fn(TPropertyValueTestCoercibleDirection|TPropertyValueTestSeason $x) => $x
+		);
+		self::assertSame('Spring', TPropertyValue::coerceToType('Spring', $t));
+	}
+
+	// ────────────────────────────────────────────────────────────────────────
+	// ICoercible union — throw policy
+	// ────────────────────────────────────────────────────────────────────────
+
+	public function testICoercibleUnion_throwsPropagateThroughChain(): void
+	{
+		// A shape-recognized but out-of-range value throws and does NOT
+		// fall through to subsequent union members.  This is the documented
+		// contract: decline ≠ broken; broken is a thrown exception.
+		$t = $this->typeOf(fn(TPropertyValueTestPickyCoercer|string $x) => $x);
+		$this->expectException(TInvalidDataValueException::class);
+		TPropertyValue::coerceToType(999, $t);
+	}
+
+	public function testICoercibleUnion_inRangeValueCoercesNormally(): void
+	{
+		$t = $this->typeOf(fn(TPropertyValueTestPickyCoercer|string $x) => $x);
+		$got = TPropertyValue::coerceToType(50, $t);
+		self::assertInstanceOf(TPropertyValueTestPickyCoercer::class, $got);
+		self::assertSame(50, $got->value);
+	}
+
+	public function testICoercibleUnion_pickyDeclinesNonInt_fallsToString(): void
+	{
+		// 'abc' isn't int-shaped → picky declines → string step takes it.
+		$t = $this->typeOf(fn(TPropertyValueTestPickyCoercer|string $x) => $x);
+		self::assertSame('abc', TPropertyValue::coerceToType('abc', $t));
+	}
+
+	// ════════════════════════════════════════════════════════════════════════
+	// ICoercible — order verification with no other typed members
+	// ════════════════════════════════════════════════════════════════════════
+
+	public function testICoercibleUnion_twoCoerciblesPlusNull_orderingPreserved(): void
+	{
+		// Decliner|Point|null: Decliner declines → Point claims → instance
+		// constructed.  Verifies that the null-handling step doesn't interfere
+		// with reflection-order iteration through ICoercible members.
+		$t = $this->typeOf(fn(TPropertyValueTestDecliner|TPropertyValueTestPoint|null $x) => $x);
+		$got = TPropertyValue::coerceToType('3,3', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $got);
+		self::assertSame(3, $got->x);
+		self::assertNull(TPropertyValue::coerceToType(null, $t));
+		self::assertNull(TPropertyValue::coerceToType('',   $t));
+	}
+
+	public function testICoercibleUnion_unionWithNonCoercibleClass_coercibleStepSkipsNonImplementers(): void
+	{
+		// Plain stdClass (not ICoercible) appears alongside Point in the union.
+		// The ICoercible step iterates non-builtin members and SKIPS those that
+		// don't implement the interface, then Point claims.
+		$t = $this->typeOf(fn(\stdClass|TPropertyValueTestPoint $x) => $x);
+		$got = TPropertyValue::coerceToType('7,7', $t);
+		self::assertInstanceOf(TPropertyValueTestPoint::class, $got);
 	}
 }


### PR DESCRIPTION
Fixed #836. - coercion
Fixed #852. - ensureArray

Modules and Templates supports typed setters from configuration (xml and php) and templates.

The reason why `eval` was not removed from ensureArray was because of the complexity of parsing.  We can see that complexity now with regex parsing.

and the reason why property coercion was not completed until now was because of its respective complexity, as we can see.

at this point, there is no reason NOT to type everything in Prado.

I'd also like the setters to `return $this` for setter chaining common in other frameworks.

PS. This is basically the same logic PHP does internally for every method and every parameter.