### PR TITLE
Prado JS Conversion from ES5 to ES6

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,7 @@ Upgrading from v4.3.3
 ---------------------
 - TPropertyValue::ensureEnum normalizes the case of the enum constant name.
 - TReCaptcha2::getResponse changed to TReCaptcha2::getCaptchaResponse - no longer overrides TApplicationComponent::getResponse (#1132)
+- Prado JS dispatches `prado:ajaxComplete` event with jQuery.onAjaxComplete for non-dependence on jQuery. Use this event instead of the jQuery event.
 
 Upgrading from v4.3.2
 ---------------------

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,8 +7,9 @@ export default [
 		files: ['framework/Web/Javascripts/source/**/*.js'],
 
 		languageOptions: {
-			// Current source targets ES5+ with some ES6 idioms.
-			ecmaVersion: 2015,
+			// Source targets ES2022. Browsers: Chrome 94+, Firefox 93+, Safari 15+
+			// (the same baseline jQuery 3.7 supports).
+			ecmaVersion: 2022,
 
 			// Scripts are concatenated / loaded as <script> tags — not modules.
 			// When ESM conversion happens, change this to 'module'.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,11 +26,28 @@ export default [
 				// Logger is declared/initialised by prado.js — must be writable.
 				Logger:      'writable',
 				tinyMCE:     'readonly', // optional TinyMCE editor
+				tinyMCE_GZ:  'readonly', // optional TinyMCE gzip-compressor (htmlarea.js)
 				grecaptcha:  'readonly', // optional reCAPTCHA
 				// Rico is defined by colorpicker.js (bundled copy of ricoColor.js).
 				Rico:        'writable',
 				// CustomEvent is polyfilled by prado.js for older browsers.
 				CustomEvent: 'writable',
+
+				// Third-party libraries Prado integrates with via PHP-emitted scripts.
+				hljs:        'readonly', // highlight.js — TTextHighlighter
+				ClipboardJS: 'readonly', // clipboard.js — TTextHighlighter copy-code
+
+				// reCAPTCHA v2 loader callback. Defined in validation3.js, called
+				// asynchronously by Google's loader script.
+				TReCaptcha2_onloadCallback: 'writable',
+
+				// logger.js public exports — defined in logger.js, used by
+				// PHP-emitted client scripts and dev consoles.
+				LogEntry:    'writable',
+				LogConsole:  'writable',
+				puts:        'writable',
+				print_r:     'writable',
+				var_dump:    'writable',
 			},
 		},
 
@@ -45,8 +62,14 @@ export default [
 			// Warn so we can track and eliminate instances over time.
 			'no-eval': 'warn',
 
-			// Some variables are declared but used only conditionally.
-			'no-unused-vars': 'warn',
+			// Some variables are declared but used only conditionally. Allow
+			// `_`-prefixed args/locals to be intentionally unused (e.g. event
+			// handlers that ignore the event object).
+			'no-unused-vars': ['warn', {
+				argsIgnorePattern: '^_',
+				varsIgnorePattern: '^_',
+				caughtErrorsIgnorePattern: '^_',
+			}],
 
 			// Loose equality is used intentionally in several places (value == false, etc.).
 			'eqeqeq': 'off',
@@ -57,7 +80,11 @@ export default [
 			'no-undef': 'warn',
 
 			// var-in-switch-case redeclarations are common in the legacy code; warn only.
-			'no-redeclare': 'warn',
+			// `builtinGlobals: false` lets the file that DEFINES a global
+			// (e.g. logger.js defining puts/var_dump/print_r, prado.js
+			// defining Prado) keep its `var foo = …` declaration without
+			// being flagged as a redeclaration of the globals listed above.
+			'no-redeclare': ['warn', { builtinGlobals: false }],
 
 			// debugger statements remaining in legacy code; warn so they appear in
 			// the lint report but do not block CI.

--- a/framework/Web/Javascripts/source/prado/activecontrols/activecontrols3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/activecontrols3.js
@@ -129,9 +129,9 @@ Prado.WebUI.TJuiAutoComplete = Prado.Class(Prado.WebUI.TActiveTextBox,
 	getUpdatedChoices(request, callback) {
         const lastTerm = this.extractLastTerm(request.term);
 		const params = new Array(lastTerm, "__TJuiAutoComplete_onSuggest__");
-		const options = Object.assign(this.options, {
-			'autocompleteCallback' : callback
-		});
+		// Stash the autocomplete-widget callback on this.options so onComplete
+		// can invoke it after the server round-trip resolves.
+		Object.assign(this.options, { autocompleteCallback: callback });
 		Prado.Callback(this.options.EventTarget, params, this.onComplete.bind(this), this.options);
 	},
 

--- a/framework/Web/Javascripts/source/prado/activecontrols/activecontrols3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/activecontrols3.js
@@ -3,7 +3,7 @@
 /**
  * Generic postback control.
  */
-Prado.WebUI.CallbackControl = jQuery.klass(Prado.WebUI.PostBackControl,
+Prado.WebUI.CallbackControl = Prado.Class(Prado.WebUI.PostBackControl,
 {
 	onPostBack(options, event) {
 		const request = new Prado.CallbackRequest(options.EventTarget, options);
@@ -15,13 +15,13 @@ Prado.WebUI.CallbackControl = jQuery.klass(Prado.WebUI.PostBackControl,
 /**
  * TActiveButton control.
  */
-Prado.WebUI.TActiveButton = jQuery.klass(Prado.WebUI.CallbackControl);
+Prado.WebUI.TActiveButton = Prado.Class(Prado.WebUI.CallbackControl);
 /**
  * TActiveLinkButton control.
  */
-Prado.WebUI.TActiveLinkButton = jQuery.klass(Prado.WebUI.CallbackControl);
+Prado.WebUI.TActiveLinkButton = Prado.Class(Prado.WebUI.CallbackControl);
 
-Prado.WebUI.TActiveImageButton = jQuery.klass(Prado.WebUI.TImageButton,
+Prado.WebUI.TActiveImageButton = Prado.Class(Prado.WebUI.TImageButton,
 {
 	onPostBack(options, event) {
 		this.addXYInput(options, event);
@@ -34,7 +34,7 @@ Prado.WebUI.TActiveImageButton = jQuery.klass(Prado.WebUI.TImageButton,
 /**
  * Active check box.
  */
-Prado.WebUI.TActiveCheckBox = jQuery.klass(Prado.WebUI.CallbackControl,
+Prado.WebUI.TActiveCheckBox = Prado.Class(Prado.WebUI.CallbackControl,
 {
 	onPostBack(options, event) {
 		const request = new Prado.CallbackRequest(options.EventTarget, options);
@@ -46,19 +46,19 @@ Prado.WebUI.TActiveCheckBox = jQuery.klass(Prado.WebUI.CallbackControl,
 /**
  * TActiveRadioButton control.
  */
-Prado.WebUI.TActiveRadioButton = jQuery.klass(Prado.WebUI.TActiveCheckBox);
+Prado.WebUI.TActiveRadioButton = Prado.Class(Prado.WebUI.TActiveCheckBox);
 
 
-Prado.WebUI.TActiveCheckBoxList = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TActiveCheckBoxList = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		for(let i = 0; i<options.ItemCount; i++)
 		{
-			const checkBoxOptions = jQuery.extend({}, options,
-			{
+			const checkBoxOptions = {
+				...options,
 				ID : `${options.ID}_c${i}`,
 				EventTarget : `${options.ListName}$c${i}`
-			});
+			};
 			new Prado.WebUI.TActiveCheckBox(checkBoxOptions);
 		}
 	}
@@ -69,14 +69,14 @@ Prado.WebUI.TActiveRadioButtonList = Prado.WebUI.TActiveCheckBoxList;
 /**
  * TActiveTextBox control, handles onchange event.
  */
-Prado.WebUI.TActiveTextBox = jQuery.klass(Prado.WebUI.TTextBox,
+Prado.WebUI.TActiveTextBox = Prado.Class(Prado.WebUI.TTextBox,
 {
 	onInit(options) {
 		this.options=options;
 		if(options['TextMode'] != 'MultiLine')
 			this.observe(this.element, "keydown", this.handleReturnKey.bind(this));
 		if(this.options['AutoPostBack']==true)
-			this.observe(this.element, "change", jQuery.proxy(this.doCallback,this,options));
+			this.observe(this.element, "change", this.doCallback.bind(this, options));
 	},
 
 	doCallback(options, event) {
@@ -90,13 +90,13 @@ Prado.WebUI.TActiveTextBox = jQuery.klass(Prado.WebUI.TTextBox,
  * TJuiAutoComplete control.
  */
 
-Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
+Prado.WebUI.TJuiAutoComplete = Prado.Class(Prado.WebUI.TActiveTextBox,
 {
 	initialize(options) {
 		this.options = options;
 		this.observers = new Array();
 		this.hasResults = false;
-		jQuery.extend(this.options, {
+		Object.assign(this.options, {
 			source: this.getUpdatedChoices.bind(this),
 			select: this.selectEntry.bind(this),
 			focus() {
@@ -129,7 +129,7 @@ Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
 	getUpdatedChoices(request, callback) {
         const lastTerm = this.extractLastTerm(request.term);
 		const params = new Array(lastTerm, "__TJuiAutoComplete_onSuggest__");
-		const options = jQuery.extend(this.options, {
+		const options = Object.assign(this.options, {
 			'autocompleteCallback' : callback
 		});
 		Prado.Callback(this.options.EventTarget, params, this.onComplete.bind(this), this.options);
@@ -159,17 +159,25 @@ Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
 
 
 	onComplete(request, result) {
-  		const that = this;
-  		if(that.options.textCssClass===undefined)
-  		{
-			jQuery.each(result, (idx, item) => {
-				result[idx]['value']=jQuery.trim(jQuery('<div/>').html(item['label']).text());
-			});
-  		} else {
-			jQuery.each(result, (idx, item) => {
-				result[idx]['value']=jQuery.trim(jQuery('<div/>').html(item['label']).find(`.${that.options.textCssClass}`).text());
-			});
-  		}
+		// Decode the HTML in `label` to plain text for the underlying value.
+		// Uses a detached <div> as the HTML parser; matches the old
+		// jQuery('<div/>').html(label).text() pattern.
+		const decode = (html) => {
+			const div = document.createElement('div');
+			div.innerHTML = html;
+			return div;
+		};
+		if(this.options.textCssClass === undefined) {
+			for (const item of result) {
+				item.value = decode(item.label).textContent.trim();
+			}
+		} else {
+			const sel = `.${this.options.textCssClass}`;
+			for (const item of result) {
+				const node = decode(item.label).querySelector(sel);
+				item.value = (node ? node.textContent : '').trim();
+			}
+		}
 
 		request.options.autocompleteCallback(result);
 	}
@@ -178,10 +186,10 @@ Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
 /**
  * Time Triggered Callback class.
  */
-Prado.WebUI.TTimeTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TTimeTriggeredCallback = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
-		this.options = jQuery.extend({ Interval : 1	}, options || {});
+		this.options = { Interval : 1, ...(options || {}) };
 		Prado.WebUI.TTimeTriggeredCallback.registerTimer(this);
 	},
 
@@ -224,7 +232,7 @@ Prado.WebUI.TTimeTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 	}
 });
 
-jQuery.extend(Prado.WebUI.TTimeTriggeredCallback,
+Object.assign(Prado.WebUI.TTimeTriggeredCallback,
 {
 
 	//class methods
@@ -251,7 +259,7 @@ jQuery.extend(Prado.WebUI.TTimeTriggeredCallback,
 	}
 });
 
-Prado.WebUI.ActiveListControl = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.ActiveListControl = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		if(this.element)
@@ -268,17 +276,17 @@ Prado.WebUI.ActiveListControl = jQuery.klass(Prado.WebUI.Control,
 	}
 });
 
-Prado.WebUI.TActiveDropDownList = jQuery.klass(Prado.WebUI.ActiveListControl);
-Prado.WebUI.TActiveListBox = jQuery.klass(Prado.WebUI.ActiveListControl);
+Prado.WebUI.TActiveDropDownList = Prado.Class(Prado.WebUI.ActiveListControl);
+Prado.WebUI.TActiveListBox = Prado.Class(Prado.WebUI.ActiveListControl);
 
 /**
  * Observe event of a particular control to trigger a callback request.
  */
-Prado.WebUI.TEventTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TEventTriggeredCallback = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		this.options = options || {} ;
-		const element = jQuery(`#${options['ControlID']}`).get(0);
+		const element = document.getElementById(options['ControlID']);
 		if(element)
 			this.observe(element, this.getEventName(element), this.doCallback.bind(this));
 	},
@@ -311,7 +319,7 @@ Prado.WebUI.TEventTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 /**
  * Observe changes to a property of a particular control to trigger a callback.
  */
-Prado.WebUI.TValueTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TValueTriggeredCallback = Prado.Class(Prado.WebUI.Control,
 {
 	count : 1,
 
@@ -320,7 +328,7 @@ Prado.WebUI.TValueTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 	onInit(options) {
 		this.options = options || {} ;
 		this.options.PropertyName = this.options.PropertyName || 'value';
-		const element = jQuery(`#${options['ControlID']}`).get(0);
+		const element = document.getElementById(options['ControlID']);
 		this.value = element ? element[this.options.PropertyName] : undefined;
 		Prado.WebUI.TValueTriggeredCallback.register(this);
 		this.startObserving();
@@ -336,7 +344,7 @@ Prado.WebUI.TValueTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 	},
 
 	checkChanges() {
-		const element = jQuery(`#${this.options.ControlID}`).get(0);
+		const element = document.getElementById(this.options.ControlID);
 		if(element)
 		{
 			const value = element[this.options.PropertyName];
@@ -367,7 +375,7 @@ Prado.WebUI.TValueTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 	}
 });
 
-jQuery.extend(Prado.WebUI.TValueTriggeredCallback,
+Object.assign(Prado.WebUI.TValueTriggeredCallback,
 {
 	//class methods
 
@@ -382,5 +390,5 @@ jQuery.extend(Prado.WebUI.TValueTriggeredCallback,
 	}
 });
 
-Prado.WebUI.TActiveTableCell = jQuery.klass(Prado.WebUI.CallbackControl);
-Prado.WebUI.TActiveTableRow = jQuery.klass(Prado.WebUI.CallbackControl);
+Prado.WebUI.TActiveTableCell = Prado.Class(Prado.WebUI.CallbackControl);
+Prado.WebUI.TActiveTableRow = Prado.Class(Prado.WebUI.CallbackControl);

--- a/framework/Web/Javascripts/source/prado/activecontrols/activecontrols3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/activecontrols3.js
@@ -5,9 +5,8 @@
  */
 Prado.WebUI.CallbackControl = jQuery.klass(Prado.WebUI.PostBackControl,
 {
-	onPostBack : function(options, event)
-	{
-		var request = new Prado.CallbackRequest(options.EventTarget, options);
+	onPostBack(options, event) {
+		const request = new Prado.CallbackRequest(options.EventTarget, options);
 		request.dispatch();
 		event.preventDefault();
 	}
@@ -24,10 +23,9 @@ Prado.WebUI.TActiveLinkButton = jQuery.klass(Prado.WebUI.CallbackControl);
 
 Prado.WebUI.TActiveImageButton = jQuery.klass(Prado.WebUI.TImageButton,
 {
-	onPostBack : function(options, event)
-	{
+	onPostBack(options, event) {
 		this.addXYInput(options, event);
-		var request = new Prado.CallbackRequest(options.EventTarget, options);
+		const request = new Prado.CallbackRequest(options.EventTarget, options);
 		request.dispatch();
 		event.preventDefault();
 		this.removeXYInput(options, event);
@@ -38,9 +36,8 @@ Prado.WebUI.TActiveImageButton = jQuery.klass(Prado.WebUI.TImageButton,
  */
 Prado.WebUI.TActiveCheckBox = jQuery.klass(Prado.WebUI.CallbackControl,
 {
-	onPostBack : function(options, event)
-	{
-		var request = new Prado.CallbackRequest(options.EventTarget, options);
+	onPostBack(options, event) {
+		const request = new Prado.CallbackRequest(options.EventTarget, options);
 		if(request.dispatch()==false)
 			event.preventDefault();
 	}
@@ -54,14 +51,13 @@ Prado.WebUI.TActiveRadioButton = jQuery.klass(Prado.WebUI.TActiveCheckBox);
 
 Prado.WebUI.TActiveCheckBoxList = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
-		for(var i = 0; i<options.ItemCount; i++)
+	onInit(options) {
+		for(let i = 0; i<options.ItemCount; i++)
 		{
-			var checkBoxOptions = jQuery.extend({}, options,
+			const checkBoxOptions = jQuery.extend({}, options,
 			{
-				ID : options.ID+"_c"+i,
-				EventTarget : options.ListName+"$c"+i
+				ID : `${options.ID}_c${i}`,
+				EventTarget : `${options.ListName}$c${i}`
 			});
 			new Prado.WebUI.TActiveCheckBox(checkBoxOptions);
 		}
@@ -75,8 +71,7 @@ Prado.WebUI.TActiveRadioButtonList = Prado.WebUI.TActiveCheckBoxList;
  */
 Prado.WebUI.TActiveTextBox = jQuery.klass(Prado.WebUI.TTextBox,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options=options;
 		if(options['TextMode'] != 'MultiLine')
 			this.observe(this.element, "keydown", this.handleReturnKey.bind(this));
@@ -84,9 +79,8 @@ Prado.WebUI.TActiveTextBox = jQuery.klass(Prado.WebUI.TTextBox,
 			this.observe(this.element, "change", jQuery.proxy(this.doCallback,this,options));
 	},
 
-	doCallback : function(options, event)
-	{
-		var request = new Prado.CallbackRequest(options.EventTarget, options);
+	doCallback(options, event) {
+		const request = new Prado.CallbackRequest(options.EventTarget, options);
 		request.dispatch();
 	    event.preventDefault();
 	}
@@ -98,27 +92,24 @@ Prado.WebUI.TActiveTextBox = jQuery.klass(Prado.WebUI.TTextBox,
 
 Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
 {
-	initialize : function(options)
-	{
+	initialize(options) {
 		this.options = options;
 		this.observers = new Array();
 		this.hasResults = false;
 		jQuery.extend(this.options, {
 			source: this.getUpdatedChoices.bind(this),
 			select: this.selectEntry.bind(this),
-			focus: function () {
+			focus() {
 				return false;
 			},
 			minLength: this.options.minLength,
 			frequency: this.options.frequency
 		});
-		jQuery('#'+options.ID).autocomplete(this.options)
-		.data( "ui-autocomplete")._renderItem = function( ul, item ) {
-			return jQuery( "<li>" )
-			.attr( "data-value", item.value )
-			.append( jQuery( "<div>" ).html( item.label ) )
-			.appendTo( ul );
-		};
+		jQuery(`#${options.ID}`).autocomplete(this.options)
+		.data( "ui-autocomplete")._renderItem = (ul, item) => jQuery( "<li>" )
+        .attr( "data-value", item.value )
+        .append( jQuery( "<div>" ).html( item.label ) )
+        .appendTo( ul );
 
 		if(options.AutoPostBack)
 			this.onInit(options);
@@ -126,61 +117,57 @@ Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
 		Prado.Registry[options.ID] = this;
 	},
 
-	doCallback : function(event, options)
-	{
+	doCallback(event, options) {
 		if(!this.active)
 		{
-			var request = new Prado.CallbackRequest(this.options.EventTarget, options);
+			const request = new Prado.CallbackRequest(this.options.EventTarget, options);
 			request.dispatch();
 			event.stopPropagation();
 		}
 	},
 
-	getUpdatedChoices : function(request, callback)
-	{
-        var lastTerm = this.extractLastTerm(request.term);
-		var params = new Array(lastTerm, "__TJuiAutoComplete_onSuggest__");
-		var options = jQuery.extend(this.options, {
+	getUpdatedChoices(request, callback) {
+        const lastTerm = this.extractLastTerm(request.term);
+		const params = new Array(lastTerm, "__TJuiAutoComplete_onSuggest__");
+		const options = jQuery.extend(this.options, {
 			'autocompleteCallback' : callback
 		});
 		Prado.Callback(this.options.EventTarget, params, this.onComplete.bind(this), this.options);
 	},
 
-	extractLastTerm: function(string)
-	{
-		var re = new RegExp("[" + (this.options.Separators || '') + "]");
+	extractLastTerm(string) {
+		const re = new RegExp(`[${this.options.Separators || ''}]`);
 		return string.split(re).pop().trim();
 	},
 
 	/**
 	 * Overrides parent implements, don't update if no results.
 	 */
-	selectEntry: function(event, ui) {
-		var value = event.target.value;
-		var lastTerm = this.extractLastTerm(value);
+	selectEntry(event, ui) {
+		const value = event.target.value;
+		const lastTerm = this.extractLastTerm(value);
 
 		// strip (possibly) incomplete last part
-		var previousTerms = value.substr(0, value.length - lastTerm.length);
+		const previousTerms = value.substr(0, value.length - lastTerm.length);
 		// and append selected value
 		ui.item.value = previousTerms + ui.item.value;
 
 		//ui.item.value = event.target.value;
-		var options = [ui.item.id, "__TJuiAutoComplete_onSuggestionSelected__"];
+		const options = [ui.item.id, "__TJuiAutoComplete_onSuggestionSelected__"];
 		Prado.Callback(this.options.EventTarget, options, null, this.options);
 	},
 
 
-	onComplete : function(request, result)
-  	{
-  		var that = this;
+	onComplete(request, result) {
+  		const that = this;
   		if(that.options.textCssClass===undefined)
   		{
-			jQuery.each(result, function(idx, item) {
+			jQuery.each(result, (idx, item) => {
 				result[idx]['value']=jQuery.trim(jQuery('<div/>').html(item['label']).text());
 			});
   		} else {
-			jQuery.each(result, function(idx, item) {
-				result[idx]['value']=jQuery.trim(jQuery('<div/>').html(item['label']).find('.'+that.options.textCssClass).text());
+			jQuery.each(result, (idx, item) => {
+				result[idx]['value']=jQuery.trim(jQuery('<div/>').html(item['label']).find(`.${that.options.textCssClass}`).text());
 			});
   		}
 
@@ -193,20 +180,17 @@ Prado.WebUI.TJuiAutoComplete = jQuery.klass(Prado.WebUI.TActiveTextBox,
  */
 Prado.WebUI.TTimeTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = jQuery.extend({ Interval : 1	}, options || {});
 		Prado.WebUI.TTimeTriggeredCallback.registerTimer(this);
 	},
 
-	startTimer : function()
-	{
+	startTimer() {
 		if(typeof(this.timer) == 'undefined' || this.timer == null)
 			this.timer = this.setInterval(this.onTimerEvent.bind(this),this.options.Interval*1000);
 	},
 
-	stopTimer : function()
-	{
+	stopTimer() {
 		if(typeof(this.timer) != 'undefined')
 		{
 			this.clearInterval(this.timer);
@@ -214,8 +198,7 @@ Prado.WebUI.TTimeTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	resetTimer : function()
-	{
+	resetTimer() {
 		if(typeof(this.timer) != 'undefined')
 		{
 			this.clearInterval(this.timer);
@@ -224,22 +207,19 @@ Prado.WebUI.TTimeTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	onTimerEvent : function()
-	{
-		var request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
+	onTimerEvent() {
+		const request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
 		request.dispatch();
 	},
 
-	setTimerInterval : function(value)
-	{
+	setTimerInterval(value) {
 		if (this.options.Interval != value){
 			this.options.Interval = value;
 			this.resetTimer();
 		}
 	},
 
-	onDone: function()
-	{
+	onDone() {
 		this.stopTimer();
 	}
 });
@@ -251,25 +231,21 @@ jQuery.extend(Prado.WebUI.TTimeTriggeredCallback,
 
 	timers : {},
 
-	registerTimer : function(timer)
-	{
+	registerTimer(timer) {
 		Prado.WebUI.TTimeTriggeredCallback.timers[timer.options.ID] = timer;
 	},
 
-	start : function(id)
-	{
+	start(id) {
 		if(Prado.WebUI.TTimeTriggeredCallback.timers[id])
 			Prado.WebUI.TTimeTriggeredCallback.timers[id].startTimer();
 	},
 
-	stop : function(id)
-	{
+	stop(id) {
 		if(Prado.WebUI.TTimeTriggeredCallback.timers[id])
 			Prado.WebUI.TTimeTriggeredCallback.timers[id].stopTimer();
 	},
 
-	setTimerInterval : function (id,value)
-	{
+	setTimerInterval(id, value) {
 		if(Prado.WebUI.TTimeTriggeredCallback.timers[id])
 			Prado.WebUI.TTimeTriggeredCallback.timers[id].setTimerInterval(value);
 	}
@@ -277,8 +253,7 @@ jQuery.extend(Prado.WebUI.TTimeTriggeredCallback,
 
 Prado.WebUI.ActiveListControl = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		if(this.element)
 		{
 			this.options = options;
@@ -286,9 +261,8 @@ Prado.WebUI.ActiveListControl = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	doCallback : function(event)
-	{
-		var request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
+	doCallback(event) {
+		const request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
 		request.dispatch();
 		event.preventDefault();
 	}
@@ -302,17 +276,15 @@ Prado.WebUI.TActiveListBox = jQuery.klass(Prado.WebUI.ActiveListControl);
  */
 Prado.WebUI.TEventTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options || {} ;
-		var element = jQuery('#'+options['ControlID']).get(0);
+		const element = jQuery(`#${options['ControlID']}`).get(0);
 		if(element)
 			this.observe(element, this.getEventName(element), this.doCallback.bind(this));
 	},
 
-	getEventName : function(element)
-	{
-		var name = this.options.EventName;
+	getEventName(element) {
+		const name = this.options.EventName;
    		if(typeof(name) == "undefined" && element.type)
 		{
       		switch (element.type.toLowerCase())
@@ -328,9 +300,8 @@ Prado.WebUI.TEventTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 		return typeof(name) == "undefined"  || name == "undefined" ? 'click' : name;
     },
 
-	doCallback : function(event)
-	{
-		var request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
+	doCallback(event) {
+		const request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
 		request.dispatch();
 		if(this.options.StopEvent == true)
 			event.preventDefault();
@@ -346,33 +317,29 @@ Prado.WebUI.TValueTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 
 	observing : true,
 
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options || {} ;
 		this.options.PropertyName = this.options.PropertyName || 'value';
-		var element = jQuery('#'+options['ControlID']).get(0);
+		const element = jQuery(`#${options['ControlID']}`).get(0);
 		this.value = element ? element[this.options.PropertyName] : undefined;
 		Prado.WebUI.TValueTriggeredCallback.register(this);
 		this.startObserving();
 	},
 
-	stopObserving : function()
-	{
+	stopObserving() {
 		this.clearTimeout(this.timer);
 		this.observing = false;
 	},
 
-	startObserving : function()
-	{
+	startObserving() {
 		this.timer = this.setTimeout(this.checkChanges.bind(this), this.options.Interval*1000);
 	},
 
-	checkChanges : function()
-	{
-		var element = jQuery('#'+this.options.ControlID).get(0);
+	checkChanges() {
+		const element = jQuery(`#${this.options.ControlID}`).get(0);
 		if(element)
 		{
-			var value = element[this.options.PropertyName];
+			const value = element[this.options.PropertyName];
 			if(this.value != value)
 			{
 				this.doCallback(this.value, value);
@@ -387,16 +354,14 @@ Prado.WebUI.TValueTriggeredCallback = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	doCallback : function(oldValue, newValue)
-	{
-		var request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
-		var param = {'OldValue' : oldValue, 'NewValue' : newValue};
+	doCallback(oldValue, newValue) {
+		const request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
+		const param = {'OldValue' : oldValue, 'NewValue' : newValue};
 		request.setCallbackParameter(param);
 		request.dispatch();
 	},
 
-	onDone : function()
-	{
+	onDone() {
 		if (this.observing)
 			this.stopObserving();
 	}
@@ -408,13 +373,11 @@ jQuery.extend(Prado.WebUI.TValueTriggeredCallback,
 
 	timers : {},
 
-	register : function(timer)
-	{
+	register(timer) {
 		Prado.WebUI.TValueTriggeredCallback.timers[timer.options.ID] = timer;
 	},
 
-	stop : function(id)
-	{
+	stop(id) {
 		Prado.WebUI.TValueTriggeredCallback.timers[id].stopObserving();
 	}
 });

--- a/framework/Web/Javascripts/source/prado/activecontrols/activedatepicker.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/activedatepicker.js
@@ -1,11 +1,10 @@
 /*! PRADO TActiveDatePicker javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TActiveDatePicker = jQuery.klass(Prado.WebUI.TDatePicker,
+Prado.WebUI.TActiveDatePicker = Prado.Class(Prado.WebUI.TDatePicker,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options || [];
-		this.control = jQuery('#'+options.ID).get(0);
+		this.control = document.getElementById(options.ID);
 		this.dateSlot = new Array(42);
 		this.weekSlot = new Array(6);
 		this.minimalDaysInFirstWeek	= 4;
@@ -14,10 +13,10 @@ Prado.WebUI.TActiveDatePicker = jQuery.klass(Prado.WebUI.TDatePicker,
 
 
 		//which element to trigger to show the calendar
-		var triggerEvent;
+		let triggerEvent;
 		if(this.options.Trigger)
 		{
-			this.trigger = jQuery('#'+this.options.Trigger).get(0) ;
+			this.trigger = document.getElementById(this.options.Trigger);
 			triggerEvent = this.options.TriggerEvent || "click";
 		}
 		else
@@ -32,24 +31,24 @@ Prado.WebUI.TActiveDatePicker = jQuery.klass(Prado.WebUI.TDatePicker,
 			this.positionMode = this.options.PositionMode;
 		}
 
-		jQuery.extend(this,options);
+		Object.assign(this, options);
 
 		if (this.options.ShowCalendar)
-			this.observe(this.trigger, triggerEvent, jQuery.proxy(this.show,this));
+			this.observe(this.trigger, triggerEvent, this.show.bind(this));
 
 		// Listen to change event
 		if(this.options.InputMode == "TextBox")
 		{
-			this.observe(this.control, "change", jQuery.proxy(this.onDateChanged,this));
+			this.observe(this.control, "change", this.onDateChanged.bind(this));
 		}
 		else
 		{
-			var day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
-			var month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
-			var year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
-			if (day) this.observe (day, "change", jQuery.proxy(this.onDateChanged,this));
-			if (month) this.observe (month, "change", jQuery.proxy(this.onDateChanged,this));
-			if (year) this.observe (year, "change", jQuery.proxy(this.onDateChanged,this));
+			const day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
+			const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
+			const year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
+			if (day) this.observe (day, "change", this.onDateChanged.bind(this));
+			if (month) this.observe (month, "change", this.onDateChanged.bind(this));
+			if (year) this.observe (year, "change", this.onDateChanged.bind(this));
 
 		}
 
@@ -58,20 +57,19 @@ Prado.WebUI.TActiveDatePicker = jQuery.klass(Prado.WebUI.TDatePicker,
 	// Respond to change event on the textbox or dropdown list
 	// This method raises OnDateChanged event on client side if it has been defined,
 	// and raise the callback request
-	onDateChanged : function ()
-	{
-		var date;
+	onDateChanged() {
+		let date;
 		if (this.options.InputMode == "TextBox")
 		{
 			date=this.control.value;
 		 }
 		 else
 		 {
-		 	var day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
+		 	let day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
 			if (day) day=day.selectedIndex+1;
-			var month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
+			let month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
 			if (month) month=month.selectedIndex;
-			var year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
+			let year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
 			if (year) year=year.value;
 			date=new Date(year, month, day, 0,0,0).SimpleFormat(this.Format, this);
 		}
@@ -80,7 +78,7 @@ Prado.WebUI.TActiveDatePicker = jQuery.klass(Prado.WebUI.TDatePicker,
 		if(this.options['AutoPostBack']==true)
 		{
 			// Make callback request
-			var request = new Prado.CallbackRequest(this.options.EventTarget,this.options);
+			const request = new Prado.CallbackRequest(this.options.EventTarget,this.options);
 			request.dispatch();
 		}
 	}

--- a/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
@@ -66,15 +66,14 @@ Prado.CallbackRequestManager =
 	/**
 	 * Formats the exception message for display in console.
 	 */
-	logFormatException : function(log, e)
-	{
-		log.info(e.type + " with message \""+e.message+"\" in "+e.file+"("+e.line+")");
+	logFormatException(log, e) {
+		log.info(`${e.type} with message "${e.message}" in ${e.file}(${e.line})`);
 		log.info("Stack trace:");
-		var trace = e.trace;
-		var args;
-		for(var i = 0; i<trace.length; i++)
+		const trace = e.trace;
+		let args;
+		for(let i = 0; i<trace.length; i++)
 		{
-			var msg = "#"+i+" "+trace[i].file+"("+trace[i].line+")";
+			const msg = `#${i} ${trace[i].file}(${trace[i].line})`;
 			if(i == 0)
 			{
 				if(typeof log.group === "function")
@@ -93,26 +92,25 @@ Prado.CallbackRequestManager =
 			} else {
 				args = trace[i]["args"].join(", ");
 			}
-			log.info(trace[i]["class"]+"->"+trace[i]["function"]+"("+args+")");
+			log.info(`${trace[i]["class"]}->${trace[i]["function"]}(${args})`);
 
 			if(typeof log.groupEnd === "function")
 				log.groupEnd();
 		}
-		log.info(e.version+" "+e.time);
+		log.info(`${e.version} ${e.time}`);
 	},
 
 	/**
 	 * Formats the debug message for display in console.
 	 */
-	logDebug : function(log, blocks)
-	{
-		var groupFunc = blocks.length < 10 ? 'group': 'groupCollapsed';
+	logDebug(log, blocks) {
+		const groupFunc = blocks.length < 10 ? 'group': 'groupCollapsed';
 		if(typeof log[groupFunc] === "function")
-			log[groupFunc]("Callback logs ("+blocks.length+" entries)");
+			log[groupFunc](`Callback logs (${blocks.length} entries)`);
 
-		for(var i = 0; i<blocks.length; i++)
+		for(let i = 0; i<blocks.length; i++)
 		{
-			log[blocks[i][0]]("["+blocks[i][1]+"] ["+blocks[i][2]+"] "+blocks[i][3]);
+			log[blocks[i][0]](`[${blocks[i][1]}] [${blocks[i][2]}] ${blocks[i][3]}`);
 		}
 
 		if(typeof log.groupEnd === "function")
@@ -128,13 +126,13 @@ Prado.CallbackRequestManager =
 	// jQuery on an empty object, we are going to use this as our Queue
 	ajaxQueue : jQuery({}),
 
-	ajax : function( ajaxOpts ) {
-		var jqXHR,
-			dfd = jQuery.Deferred(),
-			promise = dfd.promise();
+	ajax(ajaxOpts) {
+        let jqXHR;
+        const dfd = jQuery.Deferred();
+        const promise = dfd.promise();
 
-		// run the actual query
-		function doRequest( next ) {
+        // run the actual query
+        function doRequest( next ) {
 			// Add request data just before send to have it actual
 			ajaxOpts.data = ajaxOpts.context.getParameters();
 			jqXHR = jQuery.ajax( ajaxOpts );
@@ -143,11 +141,11 @@ Prado.CallbackRequestManager =
 				.then( next, next );
 		}
 
-		// queue our ajax request
-		Prado.CallbackRequestManager.ajaxQueue.queue( doRequest );
+        // queue our ajax request
+        Prado.CallbackRequestManager.ajaxQueue.queue( doRequest );
 
-		// add the abort method
-		promise.abort = function( statusText ) {
+        // add the abort method
+        promise.abort = statusText => {
 
 			// proxy abort to the jqXHR if it is active
 			if ( jqXHR ) {
@@ -155,8 +153,7 @@ Prado.CallbackRequestManager =
 			}
 
 			// if there wasn't already a jqXHR we need to remove from queue
-			var queue = Prado.CallbackRequestManager.ajaxQueue.queue(),
-				index = jQuery.inArray( doRequest, queue );
+			const queue = Prado.CallbackRequestManager.ajaxQueue.queue(), index = jQuery.inArray( doRequest, queue );
 
 			if ( index > -1 ) {
 				queue.splice( index, 1 );
@@ -167,8 +164,8 @@ Prado.CallbackRequestManager =
 			return promise;
 		};
 
-		return promise;
-	}
+        return promise;
+    }
 };
 
 Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
@@ -177,8 +174,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	options : {},
 	data    : '',
 
-	initialize: function(id, options)
-	{
+	initialize(id, options) {
 		this.options = {
 			RequestTimeOut : 30000, // 30 second timeout.
 			EnablePageStateUpdate : true,
@@ -204,21 +200,19 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * Sets the request options
 	 * @return {Array} request options.
 	 */
-	setOptions: function(options) {
+	setOptions(options) {
 		jQuery.extend(this.options, options || { });
 	},
 
-	getForm: function()
-	{
-		return jQuery('#'+this.options.ID).parents('form:first').get(0) || jQuery('#PRADO_PAGESTATE').get(0).form;
+	getForm() {
+		return jQuery(`#${this.options.ID}`).parents('form:first').get(0) || jQuery('#PRADO_PAGESTATE').get(0).form;
 	},
 
 	/**
 	 * Gets the url from the forms that contains the PRADO_PAGESTATE
 	 * @return {String} callback url.
 	 */
-	getCallbackUrl : function()
-	{
+	getCallbackUrl() {
 		return this.getForm().action;
 	},
 
@@ -226,16 +220,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * Sets the request parameter
 	 * @param {Object} parameter value
 	 */
-	setCallbackParameter : function(value)
-	{
+	setCallbackParameter(value) {
 		this.options['CallbackParameter'] = value;
 	},
 
 	/**
 	 * @return {Object} request paramater value.
 	 */
-	getCallbackParameter : function()
-	{
+	getCallbackParameter() {
 		return JSON.stringify(this.options['CallbackParameter']);
 	},
 
@@ -243,16 +235,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * Sets the callback request timeout.
 	 * @param {integer} timeout in  milliseconds
 	 */
-	setRequestTimeOut : function(timeout)
-	{
+	setRequestTimeOut(timeout) {
 		this.options['RequestTimeOut'] = timeout;
 	},
 
 	/**
 	 * @return {integer} request timeout in milliseconds
 	 */
-	getRequestTimeOut : function()
-	{
+	getRequestTimeOut() {
 		return this.options['RequestTimeOut'];
 	},
 
@@ -260,16 +250,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * Set true to enable validation on callback dispatch.
 	 * @param {boolean} true to validate
 	 */
-	setCausesValidation : function(validate)
-	{
+	setCausesValidation(validate) {
 		this.options['CausesValidation'] = validate;
 	},
 
 	/**
 	 * @return {boolean} validate on request dispatch
 	 */
-	getCausesValidation : function()
-	{
+	getCausesValidation() {
 		return this.options['CausesValidation'];
 	},
 
@@ -277,16 +265,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * Sets the validation group to validate during request dispatch.
 	 * @param {string} validation group name
 	 */
-	setValidationGroup : function(group)
-	{
+	setValidationGroup(group) {
 		this.options['ValidationGroup'] = group;
 	},
 
 	/**
 	 * @return {string} validation group name.
 	 */
-	getValidationGroup : function()
-	{
+	getValidationGroup() {
 		return this.options['ValidationGroup'];
 	},
 
@@ -294,21 +280,18 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * Sets the number of retries before an ajax callback is considered failed
 	 * @param {integer}
 	 */
-	setRetryLimit : function(limit)
-	{
+	setRetryLimit(limit) {
 		this.options['RetryLimit'] = limit;
 	},
 
 	/**
 	 * @return {integer} number of retries before an ajax callback is considered failed
 	 */
-	getRetryLimit : function()
-	{
+	getRetryLimit() {
 		return this.options['RetryLimit'];
 	},
 
-	dispatch: function()
-	{
+	dispatch() {
 		//trigger tinyMCE to save data.
 		if(typeof tinyMCE != "undefined")
 			tinyMCE.triggerSave();
@@ -337,8 +320,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		this.request = Prado.CallbackRequestManager.ajax(this.options);
 	},
 
-	abort : function()
-	{
+	abort() {
 		if(this.request != "undefined")
 			this.request.abort();
 	},
@@ -348,9 +330,8 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * target id. The resulting string is the request content body.
 	 * @return string request body content containing post data.
 	 */
-	getParameters : function()
-	{
-		var data = {};
+	getParameters() {
+		const data = {};
 
 		if(typeof(this.options.CallbackParameter) != "undefined")
 			data[Prado.CallbackRequestManager.FIELD_CALLBACK_PARAMETER] = this.getCallbackParameter();
@@ -359,10 +340,10 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 
 		if(this.options.PostInputs != false)
 		{
-			var form = this.getForm();
-			return jQuery('input, select, textarea').serialize() + '&' + jQuery.param(data);
+			const form = this.getForm();
+			return `${jQuery('input, select, textarea').serialize()}&${jQuery.param(data)}`;
 		} else {
-			var pagestate = jQuery("#"+Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE);
+			const pagestate = jQuery(`#${Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE}`);
 			if(pagestate)
 				data[Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE] = pagestate.val();
 			return jQuery.param(data);
@@ -379,23 +360,21 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * @param {string} boundary - Boundary id
 	 * @returns Content from given boundaries
 	 */
-	extractContent: function (boundary)
-	{
-		var tagStart = '<!--'+boundary+'-->';
-		var tagEnd = '<!--//'+boundary+'-->';
-		var start = this.data.indexOf(tagStart);
+	extractContent(boundary) {
+		const tagStart = `<!--${boundary}-->`;
+		const tagEnd = `<!--//${boundary}-->`;
+		let start = this.data.indexOf(tagStart);
 		if(start > -1)
 		{
 			start += tagStart.length;
-			var end = this.data.indexOf(tagEnd,start);
+			const end = this.data.indexOf(tagEnd,start);
 			if(end > -1)
 				return this.data.substring(start,end);
 		}
 		return null;
 	},
 
-	getLogger: function()
-	{
+	getLogger() {
 		if(typeof Logger != "undefined")
 			return Logger;
 
@@ -406,20 +385,19 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		return null;
 	},
 
-	errorHandler: function(request, textStatus, errorThrown)
-	{
-		var log;
+	errorHandler(request, textStatus, errorThrown) {
+		let log;
 		this.data = request.responseText;
 
 		if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
 		{
-			log.error("PRADO Ajax callback error:", request.status, "(" +  request.statusText + ")");
+			log.error("PRADO Ajax callback error:", request.status, `(${request.statusText})`);
 			if(request.status==500)
 			{
 				/**
 				 * Server returns 500 exception. Just log it.
 				 */
-				var errorData = this.extractContent(Prado.CallbackRequestManager.ERROR_HEADER);
+				let errorData = this.extractContent(Prado.CallbackRequestManager.ERROR_HEADER);
 				if (typeof(errorData) == "string" && errorData.length > 0)
 				{
 					errorData = jQuery.parseJSON(errorData);
@@ -441,8 +419,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 			this.options.onFailure(this,textStatus);
 	},
 
-	completeHandler: function(request, textStatus)
-	{
+	completeHandler(request, textStatus) {
 //"success", "notmodified", "error", "timeout", "abort", or "parsererror"
 		if (this.options.onComplete)
 			this.options.onComplete(this,textStatus);
@@ -451,9 +428,8 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/**
 	 * Uncaught exceptions during callback response.
 	 */
-	exceptionHandler: function(e)
-	{
-		var log;
+	exceptionHandler(e) {
+		let log;
 		if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
 		{
 			log.error("Uncaught Callback Client Exception:", e.message);
@@ -467,37 +443,36 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/**
 	 * Callback OnSuccess event,logs reponse and data to console.
 	 */
-	successHandler: function(data, textStatus, request)
-	{
-		var log;
+	successHandler(data, textStatus, request) {
+		let log;
 		this.data = data;
 
 		if(Prado.CallbackRequestManager.LOG_SUCCESS && (log = this.getLogger()))
 		{
-			log.info('HTTP '+request.status+" with response : \n");
+			log.info(`HTTP ${request.status} with response : \n`);
 
-			var tagStart = '<!--';
-			var tagEnd = '<!--//';
-			var start = request.responseText.indexOf(tagStart);
+			const tagStart = '<!--';
+			const tagEnd = '<!--//';
+			let start = request.responseText.indexOf(tagStart);
 			while(start > -1)
 			{
-				var end = request.responseText.indexOf(tagEnd,start);
+				const end = request.responseText.indexOf(tagEnd,start);
 				if(end > -1)
-					log.info(request.responseText.substring(start,end)+'\n');
+					log.info(`${request.responseText.substring(start,end)}\n`);
 				start = request.responseText.indexOf(tagStart,end+6);
 			}
 		}
 
 		if (this.options.onSuccess)
 		{
-			var customData=this.extractContent(Prado.CallbackRequestManager.DATA_HEADER);
+			let customData=this.extractContent(Prado.CallbackRequestManager.DATA_HEADER);
 			if (typeof(customData) == "string" && customData.length > 0)
 				customData = jQuery.parseJSON(customData);
 
 			this.options.onSuccess(this,customData);
 		}
 
-		var redirectUrl = this.extractContent(Prado.CallbackRequestManager.REDIRECT_HEADER);
+		const redirectUrl = this.extractContent(Prado.CallbackRequestManager.REDIRECT_HEADER);
 		if (redirectUrl)
 				document.location.href = redirectUrl;
 
@@ -506,15 +481,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		try {
 			this.updatePageState(this, data);
 			this.checkHiddenFields(this, data);
-			var obj = this;
-			this.loadAssets(this, data, function()
-				{
-					try {
-						obj.dispatchActions(obj, data);
-					} catch (e) {
-						obj.exceptionHandler(e);
-					}
-				}
+			const obj = this;
+			this.loadAssets(this, data, () => {
+                try {
+                    obj.dispatchActions(obj, data);
+                } catch (e) {
+                    obj.exceptionHandler(e);
+                }
+            }
 			);
 
 		} catch (e) {
@@ -525,21 +499,20 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/**
 	 * Updates the page state. It will update only if EnablePageStateUpdate is true.
 	 */
-	updatePageState : function(request, datain)
-	{
-		var log;
-		var pagestate = jQuery("#"+Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE);
-		var enabled = request.options.EnablePageStateUpdate;
-		var aborted = false; //typeof(self.currentRequest) == 'undefined' || self.currentRequest == null;
+	updatePageState(request, datain) {
+		let log;
+		const pagestate = jQuery(`#${Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE}`);
+		const enabled = request.options.EnablePageStateUpdate;
+		const aborted = false; //typeof(self.currentRequest) == 'undefined' || self.currentRequest == null;
 		if(enabled && !aborted && pagestate)
 		{
-			var data = this.extractContent(Prado.CallbackRequestManager.PAGESTATE_HEADER);
+			const data = this.extractContent(Prado.CallbackRequestManager.PAGESTATE_HEADER);
 			if(typeof(data) == "string" && data.length > 0)
 				pagestate.val(data);
 			else
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Missing page state:"+data);
+					log.warn(`Missing page state:${data}`);
 				//Logger.warn('## bad state: setting current request to null');
 				//self.endCurrentRequest();
 				//self.tryNextRequest();
@@ -552,12 +525,11 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		return true;
 	},
 
-	checkHiddenField: function(name, value)
-	{
-		var id = name.replace(':','_');
+	checkHiddenField(name, value) {
+		const id = name.replace(':','_');
 		if (!document.getElementById(id))
 		{
-			var field = document.createElement('input');
+			const field = document.createElement('input');
 			field.setAttribute('type','hidden');
 			field.id = id;
 			field.name = name;
@@ -566,19 +538,18 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		}
 	},
 
-	checkHiddenFields : function(request, datain)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.HIDDENFIELDLIST_HEADER);
+	checkHiddenFields(request, datain) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.HIDDENFIELDLIST_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
 			json = jQuery.parseJSON(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Invalid hidden field list:"+data);
+					log.warn(`Invalid hidden field list:${data}`);
 			} else {
-				for(var key in json)
+				for(const key in json)
 					this.checkHiddenField(key,json[key]);
 			}
 		}
@@ -587,8 +558,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/*
 	 * Checks which assets are used by the response and ensures they're loaded
 	 */
-	loadAssets : function(request, datain, callback)
-	{
+	loadAssets(request, datain, callback) {
 		/*
 
 		  ! This is the callback-based loader for stylesheets, which loads them one-by-one, and
@@ -618,10 +588,9 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/*
 	 * Checks which scripts are used by the response and ensures they're loaded
 	 */
-	loadScripts : function(request, datain, callback)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.SCRIPTLIST_HEADER);
+	loadScripts(request, datain, callback) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.SCRIPTLIST_HEADER);
 		if (!this.ScriptsToLoad) this.ScriptsToLoad = new Array();
 		this.ScriptLoadFinishedCallback = callback;
 		if (typeof(data) == "string" && data.length > 0)
@@ -630,12 +599,12 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Invalid script list:"+data);
+					log.warn(`Invalid script list:${data}`);
 			} else {
-				for(var key in json)
+				for(const key in json)
 					if (/^\d+$/.test(key))
 					{
-						var url = json[key];
+						const url = json[key];
 						if (!Prado.ScriptManager.isAssetLoaded(url))
 							this.ScriptsToLoad.push(url);
 					}
@@ -644,15 +613,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		this.loadNextScript();
 	},
 
-	loadNextScript: function()
-	{
-		var done = (!this.ScriptsToLoad || (this.ScriptsToLoad.length==0));
+	loadNextScript() {
+		const done = (!this.ScriptsToLoad || (this.ScriptsToLoad.length==0));
 		if (!done)
 			{
-				var url = this.ScriptsToLoad.shift(); var obj = this;
+				const url = this.ScriptsToLoad.shift(); const obj = this;
 				if (
 					Prado.ScriptManager.ensureAssetIsLoaded(url,
-						function() {
+						() => {
 							obj.loadNextScript();
 						}
 					)
@@ -663,55 +631,52 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 			{
 				if (this.ScriptLoadFinishedCallback)
 				{
-					var cb = this.ScriptLoadFinishedCallback;
+					const cb = this.ScriptLoadFinishedCallback;
 					this.ScriptLoadFinishedCallback = null;
 					cb();
 				}
 			}
 	},
 
-	loadStyleSheetsCode : function(request, datain)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.STYLESHEET_HEADER);
+	loadStyleSheetsCode(request, datain) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEET_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
 			json = jQuery.parseJSON(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Invalid stylesheet list:"+data);
+					log.warn(`Invalid stylesheet list:${data}`);
 			} else {
-				for(var key in json)
+				for(const key in json)
 					if (/^\d+$/.test(key))
 						Prado.StyleSheetManager.createStyleSheetCode(json[key],null);
 			}
 		}
 	},
 
-	loadStyleSheetsAsync : function(request, datain)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
+	loadStyleSheetsAsync(request, datain) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
 			json = jQuery.parseJSON(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Invalid stylesheet list:"+data);
+					log.warn(`Invalid stylesheet list:${data}`);
 			} else {
-				for(var key in json)
+				for(const key in json)
 					if (/^\d+$/.test(key))
 						Prado.StyleSheetManager.ensureAssetIsLoaded(json[key],null);
 			}
 		}
 	},
 
-	loadStyleSheets : function(request, datain, callback)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
+	loadStyleSheets(request, datain, callback) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
 		if (!this.StyleSheetsToLoad) this.StyleSheetsToLoad = new Array();
 		this.StyleSheetLoadFinishedCallback = callback;
 		if (typeof(data) == "string" && data.length > 0)
@@ -720,12 +685,12 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Invalid stylesheet list:"+data);
+					log.warn(`Invalid stylesheet list:${data}`);
 			} else {
-				for(var key in json)
+				for(const key in json)
 					if (/^\d+$/.test(key))
 					{
-						var url = json[key];
+						const url = json[key];
 						if (!Prado.StyleSheetManager.isAssetLoaded(url))
 							this.StyleSheetsToLoad.push(url);
 					}
@@ -734,15 +699,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		this.loadNextStyleSheet();
 	},
 
-	loadNextStyleSheet: function()
-	{
-		var done = (!this.StyleSheetsToLoad || (this.StyleSheetsToLoad.length==0));
+	loadNextStyleSheet() {
+		const done = (!this.StyleSheetsToLoad || (this.StyleSheetsToLoad.length==0));
 		if (!done)
 			{
-				var url = this.StyleSheetsToLoad.shift(); var obj = this;
+				const url = this.StyleSheetsToLoad.shift(); const obj = this;
 				if (
 					Prado.StyleSheetManager.ensureAssetIsLoaded(url,
-						function() {
+						() => {
 							obj.loadNextStyleSheet();
 						}
 					)
@@ -751,7 +715,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 			} else {
 				if (this.StyleSheetLoadFinishedCallback)
 				{
-					var cb = this.StyleSheetLoadFinishedCallback;
+					const cb = this.StyleSheetLoadFinishedCallback;
 					this.StyleSheetLoadFinishedCallback = null;
 					cb();
 				}
@@ -761,20 +725,19 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/**
 	 * Dispatch callback response actions.
 	 */
-	dispatchActions : function(request, datain)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.ACTION_HEADER);
+	dispatchActions(request, datain) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.ACTION_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
 			json = jQuery.parseJSON(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-					log.warn("Invalid action:"+data);
+					log.warn(`Invalid action:${data}`);
 			} else {
-				var that = this;
-				jQuery.each(json, function(idx, item){
+				const that = this;
+				jQuery.each(json, (idx, item) => {
 					that.__run(that, item);
 				});
 			}
@@ -784,10 +747,9 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/**
 	 * Output callback response debug.
 	 */
-	outputDebug : function(request, datain)
-	{
-		var log, json;
-		var data = this.extractContent(Prado.CallbackRequestManager.DEBUG_HEADER);
+	outputDebug(request, datain) {
+		let log, json;
+		const data = this.extractContent(Prado.CallbackRequestManager.DEBUG_HEADER);
 		if (typeof(data) == "string" && data.length > 0 && (log = this.getLogger()))
 		{
 			json = jQuery.parseJSON(data);
@@ -801,9 +763,8 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	/**
 	 * Prase and evaluate a Callback clien-side action
 	 */
-	__run : function(request, command)
-	{
-		for(var method in command)
+	__run(request, command) {
+		for(const method in command)
 		{
 			try {
 				method.toFunction().apply(request,command[method]);
@@ -822,9 +783,11 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
  * @param object additional request options.
  * @return Prado.CallbackRequest request that was created
  */
-Prado.Callback = function(UniqueID, parameter, onSuccess, options)
-{
-	var callback =
+// Callable as both `Prado.Callback(id, ...)` and `new Prado.Callback(id, ...)` —
+// PHP-emitted client script (TJuiDialogButton among others) uses the `new` form.
+// Must be a regular function declaration, not an arrow function, so `new` works.
+Prado.Callback = function(UniqueID, parameter, onSuccess, options) {
+	const callback =
 	{
 		'EventTarget' : UniqueID || '',
 		'CallbackParameter' : parameter || '',
@@ -833,7 +796,7 @@ Prado.Callback = function(UniqueID, parameter, onSuccess, options)
 
 	jQuery.extend(callback, options || {});
 
-	var request = new Prado.CallbackRequest(UniqueID, callback);
+	const request = new Prado.CallbackRequest(UniqueID, callback);
 	request.dispatch();
 	return request;
 };
@@ -844,12 +807,11 @@ Prado.Callback = function(UniqueID, parameter, onSuccess, options)
  * @param ui object as sent by jQuery-UI events
  * @return Prado.CallbackRequest request that was created
  */
-Prado.JuiCallback = function(UniqueID, eventType, event, ui, target)
-{
+Prado.JuiCallback = (UniqueID, eventType, event, ui, target) => {
 	// Retuns an array of all properties of the object received as parameter and their values.
 	// If a property represent a jQuery element, its id is returnet instead
-	var cleanUi = {};
-	jQuery.each( ui, function( key, value ) {
+	const cleanUi = {};
+	jQuery.each( ui, (key, value) => {
 		if(value instanceof jQuery)
 			cleanUi[key]=value[0].id;
 		else
@@ -862,7 +824,7 @@ Prado.JuiCallback = function(UniqueID, eventType, event, ui, target)
 		'offset' : target.offset()
 	};
 
-	var callback =
+	const callback =
 	{
 		'EventTarget' : UniqueID,
 		'CallbackParameter' : {
@@ -871,7 +833,7 @@ Prado.JuiCallback = function(UniqueID, eventType, event, ui, target)
 		}
 	};
 
-	var request = new Prado.CallbackRequest(UniqueID, callback);
+	const request = new Prado.CallbackRequest(UniqueID, callback);
 	request.dispatch();
 	return request;
 };
@@ -886,7 +848,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 	Prado.AssetManagerClass = jQuery.klass();
 	Prado.AssetManagerClass.prototype = {
 
-		initialize: function() {
+		initialize() {
 			this.loadedAssets = new Array();
 			this.discoverLoadedAssets();
 		},
@@ -896,13 +858,13 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 * Detect which assets are already loaded by page markup.
 		 * This is done by looking up all <asset> elements and registering the values of their src attributes.
 		 */
-		discoverLoadedAssets: function() {
+		discoverLoadedAssets() {
 
 			// wait until document has finished loading to avoid javascript errors
 			if (!document.body) return;
 
-			var assets = this.findAssetUrlsInMarkup();
-			for(var i=0;i<assets.length;i++)
+			const assets = this.findAssetUrlsInMarkup();
+			for(let i=0;i<assets.length;i++)
 				this.markAssetAsLoaded(assets[i]);
 		},
 
@@ -910,7 +872,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 * Extend url to a fully qualified url.
 		 * @param string url
 		 */
-		makeFullUrl: function(url) {
+		makeFullUrl(url) {
 
 			// this is not intended to be a fully blown url "canonicalizator",
 			// just to handle the most common and basic asset paths used by Prado
@@ -919,22 +881,22 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 
 			if (url.indexOf('://')==-1)
 			{
-				var a = document.createElement('a');
+				const a = document.createElement('a');
 				a.href = url;
 
 				if (a.href.indexOf('://')!=-1)
 					url = a.href;
 				else
 					{
-						var path = a.pathname;
-						if (path.substr(0,1)!='/') path = '/'+path;
-						url = this.baseUri.protocol+'//'+this.baseUri.host+path;
+						let path = a.pathname;
+						if (path.substr(0,1)!='/') path = `/${path}`;
+						url = `${this.baseUri.protocol}//${this.baseUri.host}${path}`;
 					}
 			}
 			return url;
 		},
 
-		isAssetLoaded: function(url) {
+		isAssetLoaded(url) {
 			url = this.makeFullUrl(url);
 			return (jQuery.inArray(url, this.loadedAssets)!=-1);
 		},
@@ -943,13 +905,13 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 * Mark asset as being already loaded
 		 * @param string url of the asset
 		 */
-		markAssetAsLoaded: function(url) {
+		markAssetAsLoaded(url) {
 			url = this.makeFullUrl(url);
 			if (jQuery.inArray(url, this.loadedAssets)==-1)
 				this.loadedAssets.push(url)
 		},
 
-		assetReadyStateChanged: function(url, element, callback, finalevent) {
+		assetReadyStateChanged(url, element, callback, finalevent) {
 			if (finalevent || (element.readyState == 'loaded') || (element.readyState == 'complete'))
 			if (!element.assetCallbackFired)
 			{
@@ -958,11 +920,11 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 			}
 		},
 
-		assetLoadFailed: function(url, element, callback) {
-			var log;
+		assetLoadFailed(url, element, callback) {
+			let log;
 			element.assetCallbackFired = true;
 			if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
-				log.error("Failed to load asset: "+url, this);
+				log.error(`Failed to load asset: ${url}`, this);
 			if (!element.assetCallbackFired)
 				callback(url,element,false);
 		},
@@ -974,10 +936,10 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 * @param string url of the asset to load
 		 * @param callback will be called when the asset has loaded (or failed to load)
 		 */
-		startAssetLoad: function(url, callback) {
+		startAssetLoad(url, callback) {
 
 			// create new <asset> element in page header
-			var asset = this.createAssetElement(url);
+			const asset = this.createAssetElement(url);
 
 			if (callback)
 			{
@@ -987,7 +949,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 				asset.assetCallbackFired = false;
 			}
 
-			var head = document.getElementsByTagName('head')[0];
+			const head = document.getElementsByTagName('head')[0];
 				head.appendChild(asset);
 
 			// mark this asset as loaded
@@ -1001,7 +963,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 * @param string url of the asset to check/load
 		 * @return boolean returns true if asset is already loaded, or false, if loading has just started. callback will be called when loading has finished.
 		 */
-		ensureAssetIsLoaded: function(url, callback) {
+		ensureAssetIsLoaded(url, callback) {
 			url = this.makeFullUrl(url);
 			if (jQuery.inArray(url, this.loadedAssets)==-1)
 			{
@@ -1018,20 +980,20 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 
 Prado.ScriptManagerClass = jQuery.klass(Prado.AssetManagerClass, {
 
-	findAssetUrlsInMarkup: function() {
-		var urls = new Array();
-		var scripts = document.getElementsByTagName('script');
-		for(var i=0;i<scripts.length;i++)
+	findAssetUrlsInMarkup() {
+		const urls = new Array();
+		const scripts = document.getElementsByTagName('script');
+		for(let i=0;i<scripts.length;i++)
 		{
-			var e = scripts[i]; var src = e.src;
+			const e = scripts[i]; const src = e.src;
 			if (src!="")
 				urls.push(src);
 		}
 		return urls;
 	},
 
-	createAssetElement: function(url) {
-		var asset = document.createElement('script');
+	createAssetElement(url) {
+		const asset = document.createElement('script');
 		asset.type = 'text/javascript';
 		asset.src = url;
 	//	asset.async = false; // HTML5 only
@@ -1042,20 +1004,20 @@ Prado.ScriptManagerClass = jQuery.klass(Prado.AssetManagerClass, {
 
 Prado.StyleSheetManagerClass = jQuery.klass(Prado.AssetManagerClass, {
 
-	findAssetUrlsInMarkup: function() {
-		var urls = new Array();
-		var scripts = document.getElementsByTagName('link');
-		for(var i=0;i<scripts.length;i++)
+	findAssetUrlsInMarkup() {
+		const urls = new Array();
+		const scripts = document.getElementsByTagName('link');
+		for(let i=0;i<scripts.length;i++)
 		{
-			var e = scripts[i]; var href = e.href;
+			const e = scripts[i]; const href = e.href;
 			if ((e.rel=="stylesheet") && (href.length>0))
 				urls.push(href);
 		}
 		return urls;
 	},
 
-	createAssetElement: function(url) {
-		var asset = document.createElement('link');
+	createAssetElement(url) {
+		const asset = document.createElement('link');
 		asset.rel = 'stylesheet';
 		asset.media = 'screen';
 		asset.setAttribute('type', 'text/css');
@@ -1064,18 +1026,18 @@ Prado.StyleSheetManagerClass = jQuery.klass(Prado.AssetManagerClass, {
 		return asset;
 	},
 
-	createStyleSheetCode: function(code) {
-		var asset = document.createElement('style');
+	createStyleSheetCode(code) {
+		const asset = document.createElement('style');
 		asset.setAttribute('type', 'text/css');
 
 		if(asset.styleSheet)
 			asset.styleSheet.cssText = code; // IE7+IE8
 		else {
-			var cssCodeNode = document.createTextNode(code);
+			const cssCodeNode = document.createTextNode(code);
 			asset.appendChild(cssCodeNode);
 		}
 
-		var head = document.getElementsByTagName('head')[0];
+		const head = document.getElementsByTagName('head')[0];
 		head.appendChild(asset);
 	}
 
@@ -1085,9 +1047,9 @@ if (typeof(Prado.ScriptManager)=="undefined") Prado.ScriptManager = new Prado.Sc
 if (typeof(Prado.StyleSheetManager)=="undefined") Prado.StyleSheetManager = new Prado.StyleSheetManagerClass();
 
 // make sure we scan for loaded scripts again when the page has been loaded
-var discover = function() {
+const discover = () => {
 	Prado.ScriptManager.discoverLoadedAssets();
 	Prado.StyleSheetManager.discoverLoadedAssets();
-}
+};
 if (window.attachEvent) window.attachEvent('onload', discover);
 else if (window.addEventListener) window.addEventListener('load', discover, false);

--- a/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
@@ -168,7 +168,42 @@ Prado.CallbackRequestManager =
     }
 };
 
-Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
+/**
+ * Serialize every `<input>`, `<select>` and `<textarea>` on the page into
+ * an application/x-www-form-urlencoded string. Matches the legacy behavior
+ * of `jQuery('input, select, textarea').serialize()` which ignored form
+ * boundaries and skipped:
+ *   - disabled controls
+ *   - elements without a `name`
+ *   - file inputs
+ *   - submit/button/image/reset inputs
+ *   - unchecked checkboxes and radios
+ */
+Prado.CallbackRequest_serializePageInputs = function() {
+	const out = [];
+	const enc = (s) => encodeURIComponent(s).replace(/%20/g, '+');
+	const skipTypes = new Set(['file', 'submit', 'reset', 'button', 'image']);
+	const fields = document.querySelectorAll('input, select, textarea');
+	for (const el of fields) {
+		if (el.disabled || !el.name) continue;
+		const tag = el.tagName.toLowerCase();
+		if (tag === 'input') {
+			const t = (el.type || 'text').toLowerCase();
+			if (skipTypes.has(t)) continue;
+			if ((t === 'checkbox' || t === 'radio') && !el.checked) continue;
+			out.push(`${enc(el.name)}=${enc(el.value)}`);
+		} else if (tag === 'select') {
+			for (const opt of el.options) {
+				if (opt.selected) out.push(`${enc(el.name)}=${enc(opt.value)}`);
+			}
+		} else { // textarea
+			out.push(`${enc(el.name)}=${enc(el.value)}`);
+		}
+	}
+	return out.join('&');
+};
+
+Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 {
 
 	options : {},
@@ -190,7 +225,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 			complete: this.completeHandler
 		};
 
-		jQuery.extend(this.options, options || {});
+		Object.assign(this.options, options || {});
 
 		if(this.options.onUninitialized)
 			this.options.onUninitialized(this,null);
@@ -201,11 +236,15 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 * @return {Array} request options.
 	 */
 	setOptions(options) {
-		jQuery.extend(this.options, options || { });
+		Object.assign(this.options, options || {});
 	},
 
 	getForm() {
-		return jQuery(`#${this.options.ID}`).parents('form:first').get(0) || jQuery('#PRADO_PAGESTATE').get(0).form;
+		const el = document.getElementById(this.options.ID);
+		const owned = el && el.closest('form');
+		if (owned) return owned;
+		const ps = document.getElementById('PRADO_PAGESTATE');
+		return ps ? ps.form : null;
 	},
 
 	/**
@@ -341,12 +380,15 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		if(this.options.PostInputs != false)
 		{
 			const form = this.getForm();
-			return `${jQuery('input, select, textarea').serialize()}&${jQuery.param(data)}`;
+			// Serialize every form-bearing input on the page (matches the legacy
+			// behavior of jQuery('input, select, textarea').serialize() which
+			// ignored form boundaries) plus the extra `data` object.
+			return `${Prado.CallbackRequest_serializePageInputs()}&${new URLSearchParams(data).toString()}`;
 		} else {
-			const pagestate = jQuery(`#${Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE}`);
+			const pagestate = document.getElementById(Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE);
 			if(pagestate)
-				data[Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE] = pagestate.val();
-			return jQuery.param(data);
+				data[Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE] = pagestate.value;
+			return new URLSearchParams(data).toString();
 		}
 	},
 
@@ -400,7 +442,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 				let errorData = this.extractContent(Prado.CallbackRequestManager.ERROR_HEADER);
 				if (typeof(errorData) == "string" && errorData.length > 0)
 				{
-					errorData = jQuery.parseJSON(errorData);
+					errorData = JSON.parse(errorData);
 					if(typeof(errorData) == "object")
 						Prado.CallbackRequestManager.logFormatException(log, errorData);
 				}
@@ -467,7 +509,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		{
 			let customData=this.extractContent(Prado.CallbackRequestManager.DATA_HEADER);
 			if (typeof(customData) == "string" && customData.length > 0)
-				customData = jQuery.parseJSON(customData);
+				customData = JSON.parse(customData);
 
 			this.options.onSuccess(this,customData);
 		}
@@ -501,14 +543,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 	 */
 	updatePageState(request, datain) {
 		let log;
-		const pagestate = jQuery(`#${Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE}`);
+		const pagestate = document.getElementById(Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE);
 		const enabled = request.options.EnablePageStateUpdate;
 		const aborted = false; //typeof(self.currentRequest) == 'undefined' || self.currentRequest == null;
 		if(enabled && !aborted && pagestate)
 		{
 			const data = this.extractContent(Prado.CallbackRequestManager.PAGESTATE_HEADER);
 			if(typeof(data) == "string" && data.length > 0)
-				pagestate.val(data);
+				pagestate.value = data;
 			else
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
@@ -543,7 +585,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		const data = this.extractContent(Prado.CallbackRequestManager.HIDDENFIELDLIST_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
@@ -595,7 +637,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		this.ScriptLoadFinishedCallback = callback;
 		if (typeof(data) == "string" && data.length > 0)
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
@@ -643,7 +685,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEET_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
@@ -661,7 +703,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
@@ -681,7 +723,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		this.StyleSheetLoadFinishedCallback = callback;
 		if (typeof(data) == "string" && data.length > 0)
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
@@ -730,14 +772,14 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		const data = this.extractContent(Prado.CallbackRequestManager.ACTION_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) != "object")
 			{
 				if(Prado.CallbackRequestManager.LOG_ERROR && (log = this.getLogger()))
 					log.warn(`Invalid action:${data}`);
 			} else {
 				const that = this;
-				jQuery.each(json, (idx, item) => {
+				json.forEach((item, idx) => {
 					that.__run(that, item);
 				});
 			}
@@ -752,7 +794,7 @@ Prado.CallbackRequest = jQuery.klass(Prado.PostBack,
 		const data = this.extractContent(Prado.CallbackRequestManager.DEBUG_HEADER);
 		if (typeof(data) == "string" && data.length > 0 && (log = this.getLogger()))
 		{
-			json = jQuery.parseJSON(data);
+			json = JSON.parse(data);
 			if(typeof(json) == "object")
 			{
 				Prado.CallbackRequestManager.logDebug(log, json);
@@ -791,10 +833,10 @@ Prado.Callback = function(UniqueID, parameter, onSuccess, options) {
 	{
 		'EventTarget' : UniqueID || '',
 		'CallbackParameter' : parameter || '',
-		'onSuccess' : onSuccess || jQuery.noop()
+		'onSuccess' : onSuccess || (() => {})
 	};
 
-	jQuery.extend(callback, options || {});
+	Object.assign(callback, options || {});
 
 	const request = new Prado.CallbackRequest(UniqueID, callback);
 	request.dispatch();
@@ -845,7 +887,7 @@ Prado.JuiCallback = (UniqueID, eventType, event, ui, target) => {
 
 if (typeof(Prado.AssetManagerClass)=="undefined") {
 
-	Prado.AssetManagerClass = jQuery.klass();
+	Prado.AssetManagerClass = Prado.Class();
 	Prado.AssetManagerClass.prototype = {
 
 		initialize() {
@@ -898,7 +940,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 
 		isAssetLoaded(url) {
 			url = this.makeFullUrl(url);
-			return (jQuery.inArray(url, this.loadedAssets)!=-1);
+			return this.loadedAssets.includes(url);
 		},
 
 		/**
@@ -907,7 +949,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 */
 		markAssetAsLoaded(url) {
 			url = this.makeFullUrl(url);
-			if (jQuery.inArray(url, this.loadedAssets)==-1)
+			if (!this.loadedAssets.includes(url))
 				this.loadedAssets.push(url)
 		},
 
@@ -965,7 +1007,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 		 */
 		ensureAssetIsLoaded(url, callback) {
 			url = this.makeFullUrl(url);
-			if (jQuery.inArray(url, this.loadedAssets)==-1)
+			if (!this.loadedAssets.includes(url))
 			{
 				this.startAssetLoad(url,callback);
 				return false;
@@ -978,7 +1020,7 @@ if (typeof(Prado.AssetManagerClass)=="undefined") {
 
 };
 
-Prado.ScriptManagerClass = jQuery.klass(Prado.AssetManagerClass, {
+Prado.ScriptManagerClass = Prado.Class(Prado.AssetManagerClass, {
 
 	findAssetUrlsInMarkup() {
 		const urls = new Array();
@@ -1002,7 +1044,7 @@ Prado.ScriptManagerClass = jQuery.klass(Prado.AssetManagerClass, {
 
 });
 
-Prado.StyleSheetManagerClass = jQuery.klass(Prado.AssetManagerClass, {
+Prado.StyleSheetManagerClass = Prado.Class(Prado.AssetManagerClass, {
 
 	findAssetUrlsInMarkup() {
 		const urls = new Array();

--- a/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/ajax3.js
@@ -178,6 +178,7 @@ Prado.CallbackRequestManager =
  *   - file inputs
  *   - submit/button/image/reset inputs
  *   - unchecked checkboxes and radios
+ * @since 4.4.0
  */
 Prado.CallbackRequest_serializePageInputs = function() {
 	const out = [];
@@ -379,7 +380,6 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 
 		if(this.options.PostInputs != false)
 		{
-			const form = this.getForm();
 			// Serialize every form-bearing input on the page (matches the legacy
 			// behavior of jQuery('input, select, textarea').serialize() which
 			// ignored form boundaries) plus the extra `data` object.
@@ -427,7 +427,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 		return null;
 	},
 
-	errorHandler(request, textStatus, errorThrown) {
+	errorHandler(request, textStatus) {
 		let log;
 		this.data = request.responseText;
 
@@ -518,15 +518,15 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 		if (redirectUrl)
 				document.location.href = redirectUrl;
 
-		this.outputDebug(this, data);
+		this.outputDebug();
 
 		try {
-			this.updatePageState(this, data);
-			this.checkHiddenFields(this, data);
+			this.updatePageState();
+			this.checkHiddenFields();
 			const obj = this;
-			this.loadAssets(this, data, () => {
+			this.loadAssets(() => {
                 try {
-                    obj.dispatchActions(obj, data);
+                    obj.dispatchActions();
                 } catch (e) {
                     obj.exceptionHandler(e);
                 }
@@ -541,10 +541,10 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 	/**
 	 * Updates the page state. It will update only if EnablePageStateUpdate is true.
 	 */
-	updatePageState(request, datain) {
+	updatePageState() {
 		let log;
 		const pagestate = document.getElementById(Prado.CallbackRequestManager.FIELD_CALLBACK_PAGESTATE);
-		const enabled = request.options.EnablePageStateUpdate;
+		const enabled = this.options.EnablePageStateUpdate;
 		const aborted = false; //typeof(self.currentRequest) == 'undefined' || self.currentRequest == null;
 		if(enabled && !aborted && pagestate)
 		{
@@ -580,7 +580,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 		}
 	},
 
-	checkHiddenFields(request, datain) {
+	checkHiddenFields() {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.HIDDENFIELDLIST_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
@@ -600,7 +600,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 	/*
 	 * Checks which assets are used by the response and ensures they're loaded
 	 */
-	loadAssets(request, datain, callback) {
+	loadAssets(callback) {
 		/*
 
 		  ! This is the callback-based loader for stylesheets, which loads them one-by-one, and
@@ -620,17 +620,17 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 
 		*/
 
-		this.loadStyleSheetsCode(request,datain);
+		this.loadStyleSheetsCode();
 
-		this.loadStyleSheetsAsync(request,datain);
+		this.loadStyleSheetsAsync();
 
-		this.loadScripts(request,datain,callback);
+		this.loadScripts(callback);
 	},
 
 	/*
 	 * Checks which scripts are used by the response and ensures they're loaded
 	 */
-	loadScripts(request, datain, callback) {
+	loadScripts(callback) {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.SCRIPTLIST_HEADER);
 		if (!this.ScriptsToLoad) this.ScriptsToLoad = new Array();
@@ -680,7 +680,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 			}
 	},
 
-	loadStyleSheetsCode(request, datain) {
+	loadStyleSheetsCode() {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEET_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
@@ -698,7 +698,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 		}
 	},
 
-	loadStyleSheetsAsync(request, datain) {
+	loadStyleSheetsAsync() {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
@@ -716,7 +716,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 		}
 	},
 
-	loadStyleSheets(request, datain, callback) {
+	loadStyleSheets(callback) {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.STYLESHEETLIST_HEADER);
 		if (!this.StyleSheetsToLoad) this.StyleSheetsToLoad = new Array();
@@ -767,7 +767,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 	/**
 	 * Dispatch callback response actions.
 	 */
-	dispatchActions(request, datain) {
+	dispatchActions() {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.ACTION_HEADER);
 		if (typeof(data) == "string" && data.length > 0)
@@ -779,9 +779,9 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 					log.warn(`Invalid action:${data}`);
 			} else {
 				const that = this;
-				json.forEach((item, idx) => {
+				for (const item of json) {
 					that.__run(that, item);
-				});
+				}
 			}
 		}
 	},
@@ -789,7 +789,7 @@ Prado.CallbackRequest = Prado.Class(Prado.PostBack,
 	/**
 	 * Output callback response debug.
 	 */
-	outputDebug(request, datain) {
+	outputDebug() {
 		let log, json;
 		const data = this.extractContent(Prado.CallbackRequestManager.DEBUG_HEADER);
 		if (typeof(data) == "string" && data.length > 0 && (log = this.getLogger()))

--- a/framework/Web/Javascripts/source/prado/activecontrols/inlineeditor.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/inlineeditor.js
@@ -50,7 +50,7 @@ Prado.WebUI.TInPlaceTextBox = Prado.Class(Prado.WebUI.Control,
     	return false;
 	},
 
-	exitEditMode(evt) {
+	exitEditMode(_evt) {
 		this.isEditing = false;
 		this.isSaving = false;
 		this.editField.disabled = false;
@@ -157,7 +157,7 @@ Prado.WebUI.TInPlaceTextBox = Prado.Class(Prado.WebUI.Control,
 			this.options.onEnterEditMode(this,null);
 	},
 
-	onTextBoxBlur(e) {
+	onTextBoxBlur(_e) {
 		const text = this.element.innerHTML;
 		if(this.options.AutoPostBack && text != this.editField.value)
 		{

--- a/framework/Web/Javascripts/source/prado/activecontrols/inlineeditor.js
+++ b/framework/Web/Javascripts/source/prado/activecontrols/inlineeditor.js
@@ -1,22 +1,21 @@
 /*! PRADO TInPlaceTextBox javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TInPlaceTextBox = Prado.Class(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 
 		this.isSaving = false;
 		this.isEditing = false;
 		this.editField = null;
 		this.readOnly = options.ReadOnly;
 
-		this.options = jQuery.extend(
+		this.options = Object.assign(
 		{
 			LoadTextFromSource : false,
 			TextMode : 'SingleLine'
 
 		}, options || {});
-		this.element = jQuery('#'+this.options.ID).get(0);
+		this.element = document.getElementById(this.options.ID);
 		Prado.WebUI.TInPlaceTextBox.register(this);
 		this.createEditorInput();
 		this.initializeListeners();
@@ -25,20 +24,18 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 	/**
 	 * Initialize the listeners.
 	 */
-	initializeListeners : function()
-	{
+	initializeListeners() {
 		this.onclickListener = this.enterEditMode.bind(this);
 		this.observe(this.element, 'click', this.onclickListener);
 		if (this.options.ExternalControl)
-			this.observe(jQuery('#'+this.options.ExternalControl).get(0), 'click', this.onclickListener);
+			this.observe(document.getElementById(this.options.ExternalControl), 'click', this.onclickListener);
 	},
 
 	/**
 	 * Changes the panel to an editable input.
 	 * @param {Event} evt event source
 	 */
-	enterEditMode :  function(evt)
-	{
+	enterEditMode(evt) {
 	    if (this.isSaving || this.isEditing || this.readOnly) return;
 	    this.isEditing = true;
 		this.onEnterEditMode();
@@ -47,14 +44,13 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 		this.editField.disabled = false;
 		if(this.options.LoadTextOnEdit)
 			this.loadExternalText();
-		jQuery(this.editField).focus();
+		this.editField.focus();
 		if (evt)
 			evt.preventDefault();
     	return false;
 	},
 
-	exitEditMode : function(evt)
-	{
+	exitEditMode(evt) {
 		this.isEditing = false;
 		this.isSaving = false;
 		this.editField.disabled = false;
@@ -62,35 +58,31 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 		this.showLabel();
 	},
 
-	showTextBox : function()
-	{
-		jQuery(this.element).hide();
-		jQuery(this.editField).show();
+	showTextBox() {
+		this.element.style.display = 'none';
+		this.editField.style.display = '';
 	},
 
-	showLabel : function()
-	{
-		jQuery(this.element).show();
-		jQuery(this.editField).hide();
+	showLabel() {
+		this.element.style.display = '';
+		this.editField.style.display = 'none';
 	},
 
 	/**
 	 * Create the edit input field.
 	 */
-	createEditorInput : function()
-	{
+	createEditorInput() {
 		if(this.editField == null)
 			this.createTextBox();
 
 		this.editField.value = this.getText();
 	},
 
-	loadExternalText : function()
-	{
+	loadExternalText() {
 		this.editField.disabled = true;
 		this.onLoadingText();
-		var options = new Array('__InlineEditor_loadExternalText__', this.getText());
-		var request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
+		const options = new Array('__InlineEditor_loadExternalText__', this.getText());
+		const request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
 		request.setCausesValidation(false);
 		request.setCallbackParameter(options);
 		request.options.onSuccess = this.onloadExternalTextSuccess.bind(this);
@@ -101,10 +93,9 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 	/**
 	 * Create a new input textbox or textarea
 	 */
-	createTextBox : function()
-	{
-		var cssClass= this.element.className || '';
-		var inputName = this.options.EventTarget;
+	createTextBox() {
+		const cssClass= this.element.className || '';
+		const inputName = this.options.EventTarget;
 
 		if(this.options.TextMode == 'SingleLine')
 		{
@@ -134,14 +125,13 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 		//handle return key within single line textbox
 		if(this.options.TextMode == 'SingleLine')
 		{
-			this.observe(this.editField, "keydown", function(e)
-			{
+			this.observe(this.editField, "keydown", e => {
 				 if(e.keyCode == 13) //KEY_RETURN
 		        {
-					var target = e.target;
+					const target = e.target;
 					if(target)
 					{
-						jQuery(target).trigger("blur");
+						target.blur();
 						e.preventDefault();
 					}
 				}
@@ -155,23 +145,20 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 	/**
 	 * @return {String} panel inner html text.
 	 */
-	getText: function()
-	{
+	getText() {
     	return this.element.innerHTML;
   	},
 
 	/**
 	 * Edit mode entered, calls optional event handlers.
 	 */
-	onEnterEditMode : function()
-	{
+	onEnterEditMode() {
 		if(typeof(this.options.onEnterEditMode) == "function")
 			this.options.onEnterEditMode(this,null);
 	},
 
-	onTextBoxBlur : function(e)
-	{
-		var text = this.element.innerHTML;
+	onTextBoxBlur(e) {
+		const text = this.element.innerHTML;
 		if(this.options.AutoPostBack && text != this.editField.value)
 		{
 			if(this.isEditing)
@@ -186,8 +173,7 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	onKeyPressed : function(e)
-	{
+	onKeyPressed(e) {
 		if (e.keyCode == 27) //KEY_ESC
 		{
 			this.editField.value = this.getText();
@@ -204,9 +190,8 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 	 * When the text input value has changed.
 	 * @param {String} original text
 	 */
-	onTextChanged : function(text)
-	{
-		var request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
+	onTextChanged(text) {
+		const request = new Prado.CallbackRequest(this.options.EventTarget, this.options);
 		request.setCallbackParameter(text);
 		request.options.onSuccess = this.onTextChangedSuccess.bind(this);
 		request.options.onFailure = this.onTextChangedFailure.bind(this);
@@ -220,23 +205,20 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 	/**
 	 * When loading external text.
 	 */
-	onLoadingText : function()
-	{
+	onLoadingText() {
 		//Logger.info("on loading text");
 	},
 
-	onloadExternalTextSuccess : function(request, parameter)
-	{
+	onloadExternalTextSuccess(request, parameter) {
 		this.isEditing = true;
 		this.editField.disabled = false;
 		this.editField.value = this.getText();
-		jQuery(this.editField).focus();
+		this.editField.focus();
 		if(typeof(this.options.onSuccess)=="function")
 			this.options.onSuccess(request, parameter);
 	},
 
-	onloadExternalTextFailure : function(request, parameter)
-	{
+	onloadExternalTextFailure(request, parameter) {
 		this.isSaving = false;
 		this.isEditing = false;
 		this.showLabel();
@@ -249,8 +231,7 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 	 * @param {Object} sender
 	 * @param {Object} parameter
 	 */
-	onTextChangedSuccess : function(sender, parameter)
-	{
+	onTextChangedSuccess(sender, parameter) {
 		this.isSaving = false;
 		this.isEditing = false;
 		if(this.options.AutoHide)
@@ -261,8 +242,7 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 			this.options.onSuccess(sender,parameter);
 	},
 
-	onTextChangedFailure : function(sender, parameter)
-	{
+	onTextChangedFailure(sender, parameter) {
 		this.editField.disabled = false;
 		this.isSaving = false;
 		this.isEditing = false;
@@ -272,20 +252,18 @@ Prado.WebUI.TInPlaceTextBox = jQuery.klass(Prado.WebUI.Control,
 });
 
 
-jQuery.extend(Prado.WebUI.TInPlaceTextBox,
+Object.assign(Prado.WebUI.TInPlaceTextBox,
 {
 	//class methods
 
 	textboxes : {},
 
-	register : function(obj)
-	{
+	register(obj) {
 		Prado.WebUI.TInPlaceTextBox.textboxes[obj.options.TextBoxID] = obj;
 	},
 
-	setDisplayTextBox : function(id,value)
-	{
-		var textbox = Prado.WebUI.TInPlaceTextBox.textboxes[id];
+	setDisplayTextBox(id, value) {
+		const textbox = Prado.WebUI.TInPlaceTextBox.textboxes[id];
 		if(textbox)
 		{
 			if(value)
@@ -297,9 +275,8 @@ jQuery.extend(Prado.WebUI.TInPlaceTextBox,
 		}
 	},
 
-	setReadOnly : function(id, value)
-	{
-		var textbox = Prado.WebUI.TInPlaceTextBox.textboxes[id];
+	setReadOnly(id, value) {
+		const textbox = Prado.WebUI.TInPlaceTextBox.textboxes[id];
 		if (textbox)
 		{
 			textbox.readOnly=value;

--- a/framework/Web/Javascripts/source/prado/activefileupload/activefileupload.js
+++ b/framework/Web/Javascripts/source/prado/activefileupload/activefileupload.js
@@ -1,19 +1,18 @@
 /*! PRADO TActiveFileUpload javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TActiveFileUpload = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TActiveFileUpload = Prado.Class(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options || {};
 		Prado.WebUI.TActiveFileUpload.register(this);
 
-		this.input = jQuery('#'+options.inputID).get(0);
-		this.flag = jQuery('#'+options.flagID).get(0);
-		this.form = jQuery('#'+options.formID).get(0);
+		this.input = document.getElementById(options.inputID);
+		this.flag = document.getElementById(options.flagID);
+		this.form = document.getElementById(options.formID);
 
-		this.indicator = jQuery('#'+options.indicatorID).get(0);
-		this.complete = jQuery('#'+options.completeID).get(0);
-		this.error = jQuery('#'+options.errorID).get(0);
+		this.indicator = document.getElementById(options.indicatorID);
+		this.complete = document.getElementById(options.completeID);
+		this.error = document.getElementById(options.errorID);
 
 		// set up events
 		if (options.autoPostBack){
@@ -21,7 +20,7 @@ Prado.WebUI.TActiveFileUpload = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	fileChanged : function(){
+	fileChanged() {
 		// ie11 fix
 		if(this.input.value=='') return;
 		// show the upload indicator, and hide the complete and error indicators (if they areSn't already).
@@ -36,7 +35,7 @@ Prado.WebUI.TActiveFileUpload = jQuery.klass(Prado.WebUI.Control,
 		this.oldFormMethod = this.form.method;
 		this.oldFormEnctype = this.form.enctype;
 
-		this.form.action += (this.form.action.indexOf('?')!=-1 ? '&' : '?')+'TActiveFileUpload_InputId='+this.options.inputID+'&TActiveFileUpload_TargetId='+this.options.targetID;
+		this.form.action += `${this.form.action.indexOf('?')!=-1 ? '&' : '?'}TActiveFileUpload_InputId=${this.options.inputID}&TActiveFileUpload_TargetId=${this.options.targetID}`;
 		this.form.target = this.options.targetID;
 		this.form.method = 'POST';
 		this.form.enctype = 'multipart/form-data';
@@ -48,22 +47,22 @@ Prado.WebUI.TActiveFileUpload = jQuery.klass(Prado.WebUI.Control,
 		this.form.enctype = this.oldFormEnctype;
 	},
 
-	finishUpload : function(options){
+	finishUpload(options) {
 
 		if (this.options.targetID == options.targetID)
 		{
 			this.finishoptions = options;
-			var e = this;
-			var callback =
+			const e = this;
+			const callback =
 			{
 				'CallbackParameter' : options || '',
 				'onSuccess' : function() { e.finishCallBack(true); },
 				'onFailure' : function() { e.finishCallBack(false); }
 			};
 
-			jQuery.extend(callback, this.options);
+			Object.assign(callback, this.options);
 
-			var request = new Prado.CallbackRequest(this.options.EventTarget, callback);
+			const request = new Prado.CallbackRequest(this.options.EventTarget, callback);
 			request.dispatch();
 		}
 		else
@@ -71,7 +70,7 @@ Prado.WebUI.TActiveFileUpload = jQuery.klass(Prado.WebUI.Control,
 
 	},
 
-	finishCallBack : function(success){
+	finishCallBack(success) {
 		// hide the display indicator.
 		this.flag.value = '';
 		this.indicator.style.display = 'none';
@@ -86,23 +85,21 @@ Prado.WebUI.TActiveFileUpload = jQuery.klass(Prado.WebUI.Control,
 
 });
 
-jQuery.extend(Prado.WebUI.TActiveFileUpload,
+Object.assign(Prado.WebUI.TActiveFileUpload,
 {
 	//class methods
 
 	controls : {},
 
-	register : function(control)
-	{
+	register(control) {
 		Prado.WebUI.TActiveFileUpload.controls[control.options.ID] = control;
 	},
 
-	onFileUpload : function(options)
-	{
+	onFileUpload(options) {
 		Prado.WebUI.TActiveFileUpload.controls[options.clientID].finishUpload(options);
 	},
 
-	fileChanged : function(controlID){
+	fileChanged(controlID) {
 		Prado.WebUI.TActiveFileUpload.controls[controlID].fileChanged();
 	}
 });

--- a/framework/Web/Javascripts/source/prado/activefileupload/activefileupload.js
+++ b/framework/Web/Javascripts/source/prado/activefileupload/activefileupload.js
@@ -75,7 +75,7 @@ Prado.WebUI.TActiveFileUpload = Prado.Class(Prado.WebUI.Control,
 		this.flag.value = '';
 		this.indicator.style.display = 'none';
 			// show the complete indicator.
-			if (/^[0\[\],]+$/.test(this.finishoptions.errorCode) && success) {
+			if (/^[0[\],]+$/.test(this.finishoptions.errorCode) && success) {
 				this.complete.style.display = '';
 				this.input.value = '';
 			} else {

--- a/framework/Web/Javascripts/source/prado/colorpicker/colorpicker.js
+++ b/framework/Web/Javascripts/source/prado/colorpicker/colorpicker.js
@@ -1,110 +1,116 @@
 /*! PRADO TColorPicker javascript file | github.com/pradosoft/prado */
 
+// Compute viewport-relative offset of an element (jQuery.fn.offset equivalent).
+const _cpOffset = (el) => {
+	const rect = el.getBoundingClientRect();
+	return { top: rect.top + window.pageYOffset, left: rect.left + window.pageXOffset };
+};
+
 //-------------------- ricoColor.js
 if(typeof(Rico) == "undefined") Rico = {};
 
-Rico.Color = jQuery.klass();
+Rico.Color = Prado.Class();
 
 Rico.Color.prototype = {
 
-   initialize: function(red, green, blue) {
+   initialize(red, green, blue) {
       this.rgb = { r: red, g : green, b : blue };
    },
 
-   setRed: function(r) {
+   setRed(r) {
       this.rgb.r = r;
    },
 
-   setGreen: function(g) {
+   setGreen(g) {
       this.rgb.g = g;
    },
 
-   setBlue: function(b) {
+   setBlue(b) {
       this.rgb.b = b;
    },
 
-   setHue: function(h) {
+   setHue(h) {
 
       // get an HSB model, and set the new hue...
-      var hsb = this.asHSB();
+      const hsb = this.asHSB();
       hsb.h = h;
 
       // convert back to RGB...
       this.rgb = Rico.Color.HSBtoRGB(hsb.h, hsb.s, hsb.b);
    },
 
-   setSaturation: function(s) {
+   setSaturation(s) {
       // get an HSB model, and set the new hue...
-      var hsb = this.asHSB();
+      const hsb = this.asHSB();
       hsb.s = s;
 
       // convert back to RGB and set values...
       this.rgb = Rico.Color.HSBtoRGB(hsb.h, hsb.s, hsb.b);
    },
 
-   setBrightness: function(b) {
+   setBrightness(b) {
       // get an HSB model, and set the new hue...
-      var hsb = this.asHSB();
+      const hsb = this.asHSB();
       hsb.b = b;
 
       // convert back to RGB and set values...
       this.rgb = Rico.Color.HSBtoRGB( hsb.h, hsb.s, hsb.b );
    },
 
-   darken: function(percent) {
-      var hsb  = this.asHSB();
+   darken(percent) {
+      const hsb  = this.asHSB();
       this.rgb = Rico.Color.HSBtoRGB(hsb.h, hsb.s, Math.max(hsb.b - percent,0));
    },
 
-   brighten: function(percent) {
-      var hsb  = this.asHSB();
+   brighten(percent) {
+      const hsb  = this.asHSB();
       this.rgb = Rico.Color.HSBtoRGB(hsb.h, hsb.s, Math.min(hsb.b + percent,1));
    },
 
-   blend: function(other) {
+   blend(other) {
       this.rgb.r = Math.floor((this.rgb.r + other.rgb.r)/2);
       this.rgb.g = Math.floor((this.rgb.g + other.rgb.g)/2);
       this.rgb.b = Math.floor((this.rgb.b + other.rgb.b)/2);
    },
 
-   isBright: function() {
-      var hsb = this.asHSB();
+   isBright() {
+      const hsb = this.asHSB();
       return this.asHSB().b > 0.5;
    },
 
-   isDark: function() {
+   isDark() {
       return ! this.isBright();
    },
 
-   asRGB: function() {
-      return "rgb(" + this.rgb.r + "," + this.rgb.g + "," + this.rgb.b + ")";
+   asRGB() {
+      return `rgb(${this.rgb.r},${this.rgb.g},${this.rgb.b})`;
    },
 
-   asHex: function() {
-      return "#" + this.toColorPart(this.rgb.r) + this.toColorPart(this.rgb.g) + this.toColorPart(this.rgb.b);
+   asHex() {
+      return `#${this.toColorPart(this.rgb.r)}${this.toColorPart(this.rgb.g)}${this.toColorPart(this.rgb.b)}`;
    },
 
-   asHSB: function() {
+   asHSB() {
       return Rico.Color.RGBtoHSB(this.rgb.r, this.rgb.g, this.rgb.b);
    },
 
-   toString: function() {
+   toString() {
       return this.asHex();
    },
 
-   toColorPart: function(number) {
+   toColorPart(number) {
         number = (number > 255 ? 255 : (number < 0 ? 0 : number));
-        var hex = number.toString(16);
-        return hex.length < 2 ? "0" + hex : hex;
+        const hex = number.toString(16);
+        return hex.length < 2 ? `0${hex}` : hex;
     }
 };
 
-Rico.Color.createFromHex = function(hexCode) {
+Rico.Color.createFromHex = hexCode => {
 
    if ( hexCode.indexOf('#') == 0 )
       hexCode = hexCode.substring(1);
 
-   var red = "ff", green = "ff", blue="ff";
+   let red = "ff", green = "ff", blue="ff";
    if(hexCode.length > 4)
 	{
 	   red   = hexCode.substring(0,2);
@@ -113,9 +119,9 @@ Rico.Color.createFromHex = function(hexCode) {
 	}
 	else if(hexCode.length > 0 & hexCode.length < 4)
 	{
-	  var r = hexCode.substring(0,1);
-	  var g = hexCode.substring(1,2);
-	  var b = hexCode.substring(2);
+	  const r = hexCode.substring(0,1);
+	  const g = hexCode.substring(1,2);
+	  const b = hexCode.substring(2);
 	  red = r+r;
 	  green = g+g;
 	  blue = b+b;
@@ -127,9 +133,9 @@ Rico.Color.createFromHex = function(hexCode) {
  * Factory method for creating a color from the background of
  * an HTML element.
  */
-Rico.Color.createColorFromBackground = function(elem) {
+Rico.Color.createColorFromBackground = elem => {
 
-   var actualColor = jQuery(elem).css("background-color");
+   const actualColor = window.getComputedStyle(elem).backgroundColor;
   if ( actualColor == "transparent" && elem.parent )
       return Rico.Color.createColorFromBackground(elem.parent);
 
@@ -137,8 +143,8 @@ Rico.Color.createColorFromBackground = function(elem) {
       return new Rico.Color(255,255,255);
 
    if ( actualColor.indexOf("rgb(") == 0 ) {
-      var colors = actualColor.substring(4, actualColor.length - 1 );
-      var colorArray = colors.split(",");
+      const colors = actualColor.substring(4, actualColor.length - 1 );
+      const colorArray = colors.split(",");
       return new Rico.Color( parseInt( colorArray[0] ),
                             parseInt( colorArray[1] ),
                             parseInt( colorArray[2] )  );
@@ -151,11 +157,11 @@ Rico.Color.createColorFromBackground = function(elem) {
       return new Rico.Color(255,255,255);
 };
 
-Rico.Color.HSBtoRGB = function(hue, saturation, brightness) {
+Rico.Color.HSBtoRGB = (hue, saturation, brightness) => {
 
-   var red   = 0;
-	var green = 0;
-	var blue  = 0;
+   let red   = 0;
+	let green = 0;
+	let blue  = 0;
 
    if (saturation == 0) {
       red = parseInt(brightness * 255.0 + 0.5);
@@ -163,11 +169,11 @@ Rico.Color.HSBtoRGB = function(hue, saturation, brightness) {
 	   blue = red;
 	}
 	else {
-      var h = (hue - Math.floor(hue)) * 6.0;
-      var f = h - Math.floor(h);
-      var p = brightness * (1.0 - saturation);
-      var q = brightness * (1.0 - saturation * f);
-      var t = brightness * (1.0 - (saturation * (1.0 - f)));
+      const h = (hue - Math.floor(hue)) * 6.0;
+      const f = h - Math.floor(h);
+      const p = brightness * (1.0 - saturation);
+      const q = brightness * (1.0 - saturation * f);
+      const t = brightness * (1.0 - (saturation * (1.0 - f)));
 
       switch (parseInt(h)) {
          case 0:
@@ -206,17 +212,17 @@ Rico.Color.HSBtoRGB = function(hue, saturation, brightness) {
    return { r : parseInt(red), g : parseInt(green) , b : parseInt(blue) };
 };
 
-Rico.Color.RGBtoHSB = function(r, g, b) {
+Rico.Color.RGBtoHSB = (r, g, b) => {
 
-   var hue;
-   var saturation;
-   var brightness;
+   let hue;
+   let saturation;
+   let brightness;
 
-   var cmax = (r > g) ? r : g;
+   let cmax = (r > g) ? r : g;
    if (b > cmax)
       cmax = b;
 
-   var cmin = (r < g) ? r : g;
+   let cmin = (r < g) ? r : g;
    if (b < cmin)
       cmin = b;
 
@@ -229,9 +235,9 @@ Rico.Color.RGBtoHSB = function(r, g, b) {
    if (saturation == 0)
       hue = 0;
    else {
-      var redc   = (cmax - r)/(cmax - cmin);
-    	var greenc = (cmax - g)/(cmax - cmin);
-    	var bluec  = (cmax - b)/(cmax - cmin);
+      const redc   = (cmax - r)/(cmax - cmin);
+    	const greenc = (cmax - g)/(cmax - cmin);
+    	const bluec  = (cmax - b)/(cmax - cmin);
 
     	if (r == cmax)
     	   hue = bluec - greenc;
@@ -248,11 +254,10 @@ Rico.Color.RGBtoHSB = function(r, g, b) {
    return { h : hue, s : saturation, b : brightness };
 };
 
-Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
+Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 
-	onInit : function(options)
-	{
-		var basics =
+	onInit(options) {
+		const basics =
 		{
 			Palette : 'Small',
 			ClassName : 'TColorPicker',
@@ -260,35 +265,33 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 			OKButtonText : 'OK',
 			CancelButtonText : 'Cancel',
 			ShowColorPicker : true
-		}
+		};
 
 		this.element = null;
 		this.showing = false;
 
-		options = jQuery.extend(basics, options);
+		options = Object.assign(basics, options);
 		this.options = options;
-		this.input = jQuery('#'+options['ID']).get(0);
-		this.button = jQuery('#'+options['ID']+'_button').get(0);
-		this._buttonOnClick = jQuery.proxy(this.buttonOnClick, this);
+		this.input = document.getElementById(options['ID']);
+		this.button = document.getElementById(`${options['ID']}_button`);
+		this._buttonOnClick = this.buttonOnClick.bind(this);
 		if(options['ShowColorPicker'])
 			this.observe(this.button, "click", this._buttonOnClick);
-		this.observe(this.input, "change", jQuery.proxy(this.updatePicker, this));
+		this.observe(this.input, "change", this.updatePicker.bind(this));
 
 		Prado.Registry[options.ID] = this;
 	},
 
-	updatePicker : function(e)
-	{
-		var color = Rico.Color.createFromHex(this.input.value);
+	updatePicker(e) {
+		const color = Rico.Color.createFromHex(this.input.value);
 		this.button.style.backgroundColor = color.toString();
 	},
 
-	buttonOnClick : function(event)
-	{
-		var mode = this.options['Mode'];
+	buttonOnClick(event) {
+		const mode = this.options['Mode'];
 		if(this.element == null)
 		{
-			var constructor = mode == "Basic" ? "getBasicPickerContainer": "getFullPickerContainer"
+			const constructor = mode == "Basic" ? "getBasicPickerContainer": "getFullPickerContainer";
 			this.element = this[constructor](this.options['ID'], this.options['Palette'])
 			this.input.parentNode.appendChild(this.element);
 			this.element.style.display = "none";
@@ -299,22 +302,20 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		this.show(mode);
 	},
 
-	show : function(type)
-	{
+	show(type) {
 		if(!this.showing)
 		{
-			var controlOffset = jQuery(this.input).offset();
-			var parentOffset = jQuery(this.input).offsetParent().offset();
+			const controlOffset = _cpOffset(this.input);
+			const parent = this.input.offsetParent || document.body;
+			const parentOffset = _cpOffset(parent);
 
-			jQuery(this.element).css({
-				top: controlOffset['top'] - parentOffset['top'] + this.input.offsetHeight - 1,
-				left: controlOffset['left'] - parentOffset['left'],
-				display: "block"
-			});
+			this.element.style.top = `${controlOffset.top - parentOffset.top + this.input.offsetHeight - 1}px`;
+			this.element.style.left = `${controlOffset.left - parentOffset.left}px`;
+			this.element.style.display = 'block';
 
 			//observe for clicks on the document body
-			this._documentClickEvent = jQuery.bind(this.hideOnClick, this, type);
-			this._documentKeyDownEvent = jQuery.bind(this.keyPressed, this, type);
+			this._documentClickEvent = this.hideOnClick.bind(this, type);
+			this._documentKeyDownEvent = this.keyPressed.bind(this, type);
 			this.observe(document.body, "click", this._documentClickEvent);
 			this.observe(document,"keydown", this._documentKeyDownEvent);
 			this.showing = true;
@@ -322,15 +323,14 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 			if(type == "Full")
 			{
 				this.observeMouseMovement();
-				var color = Rico.Color.createFromHex(this.input.value);
+				const color = Rico.Color.createFromHex(this.input.value);
 				this.inputs.oldColor.style.backgroundColor = color.asHex();
 				this.setColor(color,true);
 			}
 		}
 	},
 
-	hide : function(event)
-	{
+	hide(event) {
 		if(this.showing)
 		{
 			this.element.style.display = "none";
@@ -346,18 +346,16 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		}
 	},
 
-	keyPressed : function(event,type)
-	{
+	keyPressed(event, type) {
 		// esc
 		if(event.keyCode == 27)
 			this.hide(event,type);
 	},
 
-	hideOnClick : function(ev)
-	{
+	hideOnClick(ev) {
 		if(!this.showing) return;
-		var el = ev.target;
-		var within = false;
+		let el = ev.target;
+		let within = false;
 		do
 		{	within = within || String(el.className).indexOf('FullColorPicker') > -1
 			within = within || el == this.button;
@@ -369,68 +367,61 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		if(!within) this.hide(ev);
 	},
 
-	getBasicPickerContainer : function(pickerID, palette)
-	{
-		var div;
-		var table;
-		var tbody;
-		var tr;
-		var td;
+	getBasicPickerContainer(pickerID, palette) {
+		let div;
+		let table;
+		let tbody;
+		let tr;
+		let td;
 
 		// main div
 		div = document.createElement("div");
-		div.className = this.options['ClassName']+" BasicColorPicker";
-		div.id = pickerID+"_picker";
+		div.className = `${this.options['ClassName']} BasicColorPicker`;
+		div.id = `${pickerID}_picker`;
 
 		table = document.createElement("table");
-		table.className = 'basic_colors palette_'+palette;
+		table.className = `basic_colors palette_${palette}`;
 		div.appendChild(table);
 
 		tbody = document.createElement("tbody");
 		table.appendChild(tbody);
 
-		var colors = Prado.WebUI.TColorPicker.palettes[palette];
-		var pickerOnClick = this.cellOnClick.bind(this);
-		var obj=this;
-		jQuery.each(colors, function(idx, color)
-		{
-			var row = document.createElement("tr");
-			jQuery.each(color, function(idx, c)
-			{
-				var td = document.createElement("td");
-				var img = document.createElement("img");
+		const colors = Prado.WebUI.TColorPicker.palettes[palette];
+		const pickerOnClick = this.cellOnClick.bind(this);
+		const obj=this;
+		for (const color of colors) {
+			const row = document.createElement("tr");
+			for (const c of color) {
+				const td = document.createElement("td");
+				const img = document.createElement("img");
 				img.src=Prado.WebUI.TColorPicker.UIImages['button.gif'];
 				img.width=16;
 				img.height=16;
-				img.style.backgroundColor = "#"+c;
+				img.style.backgroundColor = `#${c}`;
 				obj.observe(img,"click", pickerOnClick);
-				obj.observe(img,"mouseover", function(e)
-				{
-					jQuery(e.target).addClass("pickerhover");
+				obj.observe(img,"mouseover", e => {
+					e.target.classList.add("pickerhover");
 				});
-				obj.observe(img,"mouseout", function(e)
-				{
-					jQuery(e.target).removeClass("pickerhover");
+				obj.observe(img,"mouseout", e => {
+					e.target.classList.remove("pickerhover");
 				});
 				td.appendChild(img);
 				row.appendChild(td);
-			});
+			}
 			table.childNodes[0].appendChild(row);
-		});
+		}
 		return div;
 	},
 
-	cellOnClick : function(e)
-	{
-		var el = e.target;
+	cellOnClick(e) {
+		const el = e.target;
 		if(el.tagName.toLowerCase() != "img")
 			return;
-		var color = Rico.Color.createColorFromBackground(el);
+		const color = Rico.Color.createColorFromBackground(el);
 		this.updateColor(color);
 	},
 
-	updateColor : function(color)
-	{
+	updateColor(color) {
 		this.input.value = color.toString().toUpperCase();
 		this.button.style.backgroundColor = color.toString();
 		if(typeof(this.onChange) == "function")
@@ -439,15 +430,14 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 			this.options.OnColorSelected(this,color);
 	},
 
-	getFullPickerContainer : function(pickerID)
-	{
+	getFullPickerContainer(pickerID) {
 		//create the buttons
-		var okBtn = document.createElement("input");
+		const okBtn = document.createElement("input");
 		okBtn.className = 'button';
 		okBtn.type = 'button';
 		okBtn.value = this.options.OKButtonText;
 
-		var cancelBtn = document.createElement("input");
+		const cancelBtn = document.createElement("input");
 		cancelBtn.className = 'button';
 		cancelBtn.type = 'button';
 		cancelBtn.value = this.options.CancelButtonText;
@@ -459,14 +449,13 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		};
 
 		//create the 6 inputs
-		var inputs = {};
-		jQuery.each(['H','S','V','R','G','B'], function(idx, type)
-		{
+		const inputs = {};
+		for (const type of ['H','S','V','R','G','B']) {
 			inputs[type] = document.createElement("input");
 			inputs[type].type='text';
 			inputs[type].size='3';
 			inputs[type].maxlength='3';
-		});
+		}
 
 		//create the HEX input
 		inputs['HEX'] = document.createElement("input");
@@ -477,17 +466,17 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 
 		this.inputs = inputs;
 
-		var images = Prado.WebUI.TColorPicker.UIImages;
+		const images = Prado.WebUI.TColorPicker.UIImages;
 
 		this.inputs['currentColor'] = document.createElement("span");
 		this.inputs['currentColor'].className='currentColor';
 		this.inputs['oldColor'] = document.createElement("span");
 		this.inputs['oldColor'].className='oldColor';
 
-		var inputsTable = document.createElement("table");
+		const inputsTable = document.createElement("table");
 		inputsTable.className='inputs';
 
-		var tbody = document.createElement("tbody");
+		let tbody = document.createElement("tbody");
 		inputsTable.appendChild(tbody);
 
 		var tr = document.createElement("tr");
@@ -508,22 +497,22 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		this.internalAddRow(tbody, 'B:', this.inputs['B']);
 		this.internalAddRow(tbody, '#', this.inputs['HEX'], null, 'gap');
 
-		var UIimages =
+		const UIimages =
 		{
 			selector : document.createElement("span"),
 			background : document.createElement("span"),
 			slider : document.createElement("span"),
 			hue : document.createElement("span")
-		}
+		};
 
 		UIimages['selector'].className='selector';
 		UIimages['background'].className='colorpanel';
 		UIimages['slider'].className='slider';
 		UIimages['hue'].className='strip';
 
-		this.inputs = jQuery.extend(this.inputs, UIimages);
+		this.inputs = Object.assign(this.inputs, UIimages);
 
-		var pickerTable = document.createElement("table");
+		const pickerTable = document.createElement("table");
 		tbody=document.createElement("tbody");
 		pickerTable.appendChild(tbody);
 
@@ -558,16 +547,15 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		td.appendChild(this.buttons['OK']);
 		td.appendChild(this.buttons['Cancel']);
 
-		var div = document.createElement('div');
-		div.className=this.options['ClassName']+" FullColorPicker";
-		div.id=pickerID+"_picker";
+		const div = document.createElement('div');
+		div.className=`${this.options['ClassName']} FullColorPicker`;
+		div.id=`${pickerID}_picker`;
 		div.appendChild(pickerTable);
 		return div;
 	},
 
-	internalAddRow : function(tbody, label1, object2, label2, className)
-	{
-		var tr = document.createElement("tr");
+	internalAddRow(tbody, label1, object2, label2, className) {
+		const tr = document.createElement("tr");
 		tbody.appendChild(tr);
 
 		var td= document.createElement("td");
@@ -585,17 +573,16 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 			td.appendChild(document.createTextNode(label2));
 	},
 
-	initializeFullPicker : function()
-	{
-		var color = Rico.Color.createFromHex(this.input.value);
+	initializeFullPicker() {
+		const color = Rico.Color.createFromHex(this.input.value);
 		this.inputs.oldColor.style.backgroundColor = color.asHex();
 		this.setColor(color,true);
 
-		var i = 0;
-		for(var type in this.inputs)
+		let i = 0;
+		for(const type in this.inputs)
 		{
 			this.observe(this.inputs[type], "change",
-				jQuery.proxy(this.onInputChanged,this,type));
+				this.onInputChanged.bind(this, type));
 			i++;
 
 			if(i > 6) break;
@@ -618,12 +605,11 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 
 		this.observeMouseMovement();
 
-		this.observe(this.buttons.Cancel, "click", jQuery.proxy(this.hide,this,this.options['Mode']));
+		this.observe(this.buttons.Cancel, "click", this.hide.bind(this, this.options['Mode']));
 		this.observe(this.buttons.OK, "click", this.onOKClicked.bind(this));
 	},
 
-	observeMouseMovement : function()
-	{
+	observeMouseMovement() {
 		if(!this._observingMouseMove)
 		{
 			this.observe(document.body, "mousemove", this._onMouseMove);
@@ -631,29 +617,25 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		}
 	},
 
-	onColorMouseDown : function(ev)
-	{
+	onColorMouseDown(ev) {
 		this.isMouseDownOnColor = true;
 		this.onMouseMove(ev);
 		ev.stopPropagation();
 	},
 
-	onHueMouseDown : function(ev)
-	{
+	onHueMouseDown(ev) {
 		this.isMouseDownOnHue = true;
 		this.onMouseMove(ev);
 		ev.stopPropagation();
 	},
 
-	onMouseUp : function(ev)
-	{
+	onMouseUp(ev) {
 		this.isMouseDownOnColor = false;
 		this.isMouseDownOnHue = false;
 		ev.stopPropagation();
 	},
 
-	onMouseMove : function(ev)
-	{
+	onMouseMove(ev) {
 		if(this.isMouseDownOnColor)
 			this.changeSV(ev);
 		if(this.isMouseDownOnHue)
@@ -661,78 +643,74 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		ev.stopPropagation();
 	},
 
-	changeSV : function(ev)
-	{
-		var px = ev.pageX;
-		var py = ev.pageY;
-		var pos = jQuery(this.inputs.background).offset();
+	changeSV(ev) {
+		const px = ev.pageX;
+		const py = ev.pageY;
+		const pos = _cpOffset(this.inputs.background);
 
-		var x = this.truncate(px - pos['left'],0,255);
-		var y = this.truncate(py - pos['top'],0,255);
+		const x = this.truncate(px - pos['left'],0,255);
+		const y = this.truncate(py - pos['top'],0,255);
 
 
-		var s = x/255;
-		var b = (255-y)/255;
+		const s = x/255;
+		const b = (255-y)/255;
 
-		var current_s = parseInt(this.inputs.S.value);
-		var current_b = parseInt(this.inputs.V.value);
+		const current_s = parseInt(this.inputs.S.value);
+		const current_b = parseInt(this.inputs.V.value);
 
 		if(current_s == parseInt(s*100) && current_b == parseInt(b*100)) return;
 
-		var h = this.truncate(this.inputs.H.value,0,360)/360;
+		const h = this.truncate(this.inputs.H.value,0,360)/360;
 
-		var color = new Rico.Color();
+		const color = new Rico.Color();
 		color.rgb = Rico.Color.HSBtoRGB(h,s,b);
 
 
-		this.inputs.selector.style.left = x+"px";
-		this.inputs.selector.style.top = y+"px";
+		this.inputs.selector.style.left = `${x}px`;
+		this.inputs.selector.style.top = `${y}px`;
 
 		this.inputs.currentColor.style.backgroundColor = color.asHex();
 
 		return this.setColor(color);
 	},
 
-	changeH : function(ev)
-	{
-		var py = ev.pageY;
-		var pos = jQuery(this.inputs.background).offset();
-		var y = this.truncate(py - pos['top'],0,255);
+	changeH(ev) {
+		const py = ev.pageY;
+		const pos = _cpOffset(this.inputs.background);
+		const y = this.truncate(py - pos['top'],0,255);
 
-		var h = (255-y)/255;
-		var current_h = this.truncate(this.inputs.H.value,0,360);
+		const h = (255-y)/255;
+		let current_h = this.truncate(this.inputs.H.value,0,360);
 		current_h = current_h == 0 ? 360 : current_h;
 		if(current_h == parseInt(h*360)) return;
 
-		var s = parseInt(this.inputs.S.value)/100;
-		var b = parseInt(this.inputs.V.value)/100;
-		var color = new Rico.Color();
+		const s = parseInt(this.inputs.S.value)/100;
+		const b = parseInt(this.inputs.V.value)/100;
+		const color = new Rico.Color();
 		color.rgb = Rico.Color.HSBtoRGB(h,s,b);
 
-		var hue = new Rico.Color(color.rgb.r,color.rgb.g,color.rgb.b);
+		const hue = new Rico.Color(color.rgb.r,color.rgb.g,color.rgb.b);
 		hue.setSaturation(1); hue.setBrightness(1);
 
 		this.inputs.background.style.backgroundColor = hue.asHex();
 		this.inputs.currentColor.style.backgroundColor = color.asHex();
 
-		this.inputs.slider.style.top = this.truncate(y,0,255)+"px";
+		this.inputs.slider.style.top = `${this.truncate(y,0,255)}px`;
 		return this.setColor(color);
 
 	},
 
-	onOKClicked : function(ev)
-	{
-		var r = this.truncate(this.inputs.R.value,0,255);///255;
-		var g = this.truncate(this.inputs.G.value,0,255);///255;
-		var b = this.truncate(this.inputs.B.value,0,255);///255;
-		var color = new Rico.Color(r,g,b);
+	onOKClicked(ev) {
+		const r = this.truncate(this.inputs.R.value,0,255);///255;
+		const g = this.truncate(this.inputs.G.value,0,255);///255;
+		const b = this.truncate(this.inputs.B.value,0,255);///255;
+		const color = new Rico.Color(r,g,b);
 		this.updateColor(color);
 		this.inputs.oldColor.style.backgroundColor = color.asHex();
 		this.hide(ev);
 	},
 
-	onInputChanged : function(ev, type)
-	{
+	onInputChanged(ev, type) {
 		if(this.isMouseDownOnColor || isMouseDownOnHue)
 			return;
 
@@ -758,9 +736,8 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		}
 	},
 
-	setColor : function(color, update)
-	{
-		var hsb = color.asHSB();
+	setColor(color, update) {
+		const hsb = color.asHSB();
 
 		this.inputs.H.value = parseInt(hsb.h*360);
 		this.inputs.S.value = parseInt(hsb.s*100);
@@ -770,40 +747,38 @@ Prado.WebUI.TColorPicker = jQuery.klass(Prado.WebUI.Control, {
 		this.inputs.B.value = color.rgb.b;
 		this.inputs.HEX.value = color.asHex().substring(1).toUpperCase();
 
-		var images = Prado.WebUI.TColorPicker.UIImages;
+		const images = Prado.WebUI.TColorPicker.UIImages;
 
 		if(color.isBright())
-			jQuery(this.inputs.selector).removeClass('target_white');
+			this.inputs.selector.classList.remove('target_white');
 		else
-			jQuery(this.inputs.selector).addClass('target_white');
+			this.inputs.selector.classList.add('target_white');
 
 		if(update)
 			this.updateSelectors(color);
 	},
 
-	updateSelectors : function(color)
-	{
-		var hsb = color.asHSB();
-		var pos = [hsb.s*255, hsb.b*255, hsb.h*255];
+	updateSelectors(color) {
+		const hsb = color.asHSB();
+		const pos = [hsb.s*255, hsb.b*255, hsb.h*255];
 
-		this.inputs.selector.style.left = this.truncate(pos[0],0,255)+"px";
-		this.inputs.selector.style.top = this.truncate(255-pos[1],0,255)+"px";
-		this.inputs.slider.style.top = this.truncate(255-pos[2],0,255)+"px";
+		this.inputs.selector.style.left = `${this.truncate(pos[0],0,255)}px`;
+		this.inputs.selector.style.top = `${this.truncate(255-pos[1],0,255)}px`;
+		this.inputs.slider.style.top = `${this.truncate(255-pos[2],0,255)}px`;
 
-		var hue = new Rico.Color(color.rgb.r,color.rgb.g,color.rgb.b);
+		const hue = new Rico.Color(color.rgb.r,color.rgb.g,color.rgb.b);
 		hue.setSaturation(1); hue.setBrightness(1);
 		this.inputs.background.style.backgroundColor = hue.asHex();
 		this.inputs.currentColor.style.backgroundColor = color.asHex();
 	},
 
-	truncate : function(value, min, max)
-	{
+	truncate(value, min, max) {
 		value = parseInt(value);
 		return value < min ? min : value > max ? max : value;
 	}
 });
 
-jQuery.extend(Prado.WebUI.TColorPicker,
+Object.assign(Prado.WebUI.TColorPicker,
 {
 	palettes:
 	{
@@ -830,4 +805,3 @@ jQuery.extend(Prado.WebUI.TColorPicker,
 //		'hue.gif' : 'hue.gif'
 	}
 });
-

--- a/framework/Web/Javascripts/source/prado/colorpicker/colorpicker.js
+++ b/framework/Web/Javascripts/source/prado/colorpicker/colorpicker.js
@@ -1,6 +1,9 @@
 /*! PRADO TColorPicker javascript file | github.com/pradosoft/prado */
 
-// Compute viewport-relative offset of an element (jQuery.fn.offset equivalent).
+/**
+ * Compute viewport-relative offset of an element (jQuery.fn.offset equivalent).
+ * @since 4.4.0
+ */
 const _cpOffset = (el) => {
 	const rect = el.getBoundingClientRect();
 	return { top: rect.top + window.pageYOffset, left: rect.left + window.pageXOffset };
@@ -74,7 +77,6 @@ Rico.Color.prototype = {
    },
 
    isBright() {
-      const hsb = this.asHSB();
       return this.asHSB().b > 0.5;
    },
 
@@ -282,12 +284,12 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 		Prado.Registry[options.ID] = this;
 	},
 
-	updatePicker(e) {
+	updatePicker(_e) {
 		const color = Rico.Color.createFromHex(this.input.value);
 		this.button.style.backgroundColor = color.toString();
 	},
 
-	buttonOnClick(event) {
+	buttonOnClick(_event) {
 		const mode = this.options['Mode'];
 		if(this.element == null)
 		{
@@ -330,7 +332,7 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 		}
 	},
 
-	hide(event) {
+	hide(_event) {
 		if(this.showing)
 		{
 			this.element.style.display = "none";
@@ -368,22 +370,16 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 	},
 
 	getBasicPickerContainer(pickerID, palette) {
-		let div;
-		let table;
-		let tbody;
-		let tr;
-		let td;
-
 		// main div
-		div = document.createElement("div");
+		let div = document.createElement("div");
 		div.className = `${this.options['ClassName']} BasicColorPicker`;
 		div.id = `${pickerID}_picker`;
 
-		table = document.createElement("table");
+		const table = document.createElement("table");
 		table.className = `basic_colors palette_${palette}`;
 		div.appendChild(table);
 
-		tbody = document.createElement("tbody");
+		const tbody = document.createElement("tbody");
 		table.appendChild(tbody);
 
 		const colors = Prado.WebUI.TColorPicker.palettes[palette];
@@ -466,7 +462,8 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 
 		this.inputs = inputs;
 
-		const images = Prado.WebUI.TColorPicker.UIImages;
+		// images currently unused but kept for any UIImages-driven theming.
+		const _images = Prado.WebUI.TColorPicker.UIImages;
 
 		this.inputs['currentColor'] = document.createElement("span");
 		this.inputs['currentColor'].className='currentColor';
@@ -479,10 +476,10 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 		let tbody = document.createElement("tbody");
 		inputsTable.appendChild(tbody);
 
-		var tr = document.createElement("tr");
+		let tr = document.createElement("tr");
 		tbody.appendChild(tr);
 
-		var td= document.createElement("td");
+		let td = document.createElement("td");
 		tr.appendChild(td);
 		td.className='currentcolor';
 		td.colSpan=2;
@@ -516,32 +513,32 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 		tbody=document.createElement("tbody");
 		pickerTable.appendChild(tbody);
 
-		var tr = document.createElement("tr");
+		tr = document.createElement("tr");
 		tr.className='selection';
 		tbody.appendChild(tr);
 
-		var td= document.createElement("td");
+		td = document.createElement("td");
 		tr.appendChild(td);
 		td.className='colors';
 		td.appendChild(UIimages['selector']);
 		td.appendChild(UIimages['background']);
 
-		var td= document.createElement("td");
+		td = document.createElement("td");
 		tr.appendChild(td);
 		td.className='hue';
 		td.appendChild(UIimages['slider']);
 		td.appendChild(UIimages['hue']);
 
-		var td= document.createElement("td");
+		td = document.createElement("td");
 		tr.appendChild(td);
 		td.className='inputs';
 		td.appendChild(inputsTable);
 
-		var tr = document.createElement("tr");
+		tr = document.createElement("tr");
 		tr.className='options';
 		tbody.appendChild(tr);
 
-		var td= document.createElement("td");
+		td = document.createElement("td");
 		tr.appendChild(td);
 		td.colSpan=3;
 		td.appendChild(this.buttons['OK']);
@@ -558,13 +555,13 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 		const tr = document.createElement("tr");
 		tbody.appendChild(tr);
 
-		var td= document.createElement("td");
+		let td = document.createElement("td");
 		if(className!==undefined && className!==null)
 			td.className=className;
 		tr.appendChild(td);
 		td.appendChild(document.createTextNode(label1));
 
-		var td= document.createElement("td");
+		td = document.createElement("td");
 		if(className!==undefined && className!==null)
 			td.className=className;
 		tr.appendChild(td);
@@ -711,27 +708,30 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 	},
 
 	onInputChanged(ev, type) {
-		if(this.isMouseDownOnColor || isMouseDownOnHue)
+		if(this.isMouseDownOnColor || this.isMouseDownOnHue)
 			return;
 
-
+		// All locals are var-declared at the top of the function body so each
+		// switch arm can assign without retriggering no-redeclare on the
+		// fall-through-style `case "H": case "S":` heads.
+		var h, s, b, r, g, color;
 		switch(type)
 		{
 			case "H": case "S": case "V":
-				var h = this.truncate(this.inputs.H.value,0,360)/360;
-				var s = this.truncate(this.inputs.S.value,0,100)/100;
-				var b = this.truncate(this.inputs.V.value,0,100)/100;
-				var color = new Rico.Color();
+				h = this.truncate(this.inputs.H.value,0,360)/360;
+				s = this.truncate(this.inputs.S.value,0,100)/100;
+				b = this.truncate(this.inputs.V.value,0,100)/100;
+				color = new Rico.Color();
 				color.rgb = Rico.Color.HSBtoRGB(h,s,b);
 				return this.setColor(color,true);
 			case "R": case "G": case "B":
-				var r = this.truncate(this.inputs.R.value,0,255);///255;
-				var g = this.truncate(this.inputs.G.value,0,255);///255;
-				var b = this.truncate(this.inputs.B.value,0,255);///255;
-				var color = new Rico.Color(r,g,b);
+				r = this.truncate(this.inputs.R.value,0,255);///255;
+				g = this.truncate(this.inputs.G.value,0,255);///255;
+				b = this.truncate(this.inputs.B.value,0,255);///255;
+				color = new Rico.Color(r,g,b);
 				return this.setColor(color,true);
 			case "HEX":
-				var color = Rico.Color.createFromHex(this.inputs.HEX.value);
+				color = Rico.Color.createFromHex(this.inputs.HEX.value);
 				return this.setColor(color,true);
 		}
 	},
@@ -747,7 +747,8 @@ Prado.WebUI.TColorPicker = Prado.Class(Prado.WebUI.Control, {
 		this.inputs.B.value = color.rgb.b;
 		this.inputs.HEX.value = color.asHex().substring(1).toUpperCase();
 
-		const images = Prado.WebUI.TColorPicker.UIImages;
+		// images currently unused but kept for any UIImages-driven theming.
+		const _images = Prado.WebUI.TColorPicker.UIImages;
 
 		if(color.isBright())
 			this.inputs.selector.classList.remove('target_white');

--- a/framework/Web/Javascripts/source/prado/controls/accordion.js
+++ b/framework/Web/Javascripts/source/prado/controls/accordion.js
@@ -14,9 +14,12 @@
  * http://creativecommons.org/licenses/by-sa/3.0/us/
  */
 
-// Small native height-animation helper. Animates element height between two
-// values using requestAnimationFrame; calls done() on completion. Used where
-// the accordion previously called jQuery.fn.animate({height}, duration[, cb]).
+/**
+ * Small native height-animation helper. Animates element height between two
+ * values using requestAnimationFrame; calls done() on completion. Used where
+ * the accordion previously called jQuery.fn.animate({height}, duration[, cb]).
+ * @since 4.4.0
+ */
 const _accAnimateHeight = (el, from, to, duration, done) => {
 	if (!duration || duration <= 0) {
 		el.style.height = `${to}px`;
@@ -79,7 +82,7 @@ Prado.WebUI.TAccordion = Prado.Class(Prado.WebUI.Control,
 		}
 	},
 
-	elementClicked(viewID, event) {
+	elementClicked(viewID, _event) {
 		let i = 0;
 		for(const index in this.options.Views)
 		{

--- a/framework/Web/Javascripts/source/prado/controls/accordion.js
+++ b/framework/Web/Javascripts/source/prado/controls/accordion.js
@@ -16,59 +16,56 @@
 
 Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
 {
-    	onInit : function(options)
-	{
-		this.accordion = jQuery('#'+options.ID).get(0);
-		this.options = options;
-		this.hiddenField = jQuery('#'+options.ID+'_1').get(0);
+    	onInit(options) {
+            this.accordion = jQuery(`#${options.ID}`).get(0);
+            this.options = options;
+            this.hiddenField = jQuery(`#${options.ID}_1`).get(0);
 
-		if (this.options.maxHeight)
+            if (this.options.maxHeight)
+            {
+                this.maxHeight = this.options.maxHeight;
+            } else {
+                this.maxHeight = 0;
+                this.checkMaxHeight();
+            }
+
+            this.currentView = null;
+            this.oldView = null;
+
+            let i = 0;
+            for(const view in this.options.Views)
+            {
+                const header = jQuery(`#${view}_0`).get(0);
+                if(header)
+                {
+                    this.observe(header, "click", jQuery.proxy(this.elementClicked,this,view));
+                    if(this.hiddenField.value == i)
+                    {
+                        this.currentView = view;
+                        if(jQuery(`#${this.currentView}`).height() != this.maxHeight)
+                            jQuery(`#${this.currentView}`).css({height: `${this.maxHeight}px`});
+                    }
+                }
+                i++;
+            }
+        },
+
+	checkMaxHeight() {
+		for(const viewID in this.options.Views)
 		{
-			this.maxHeight = this.options.maxHeight;
-		} else {
-			this.maxHeight = 0;
-			this.checkMaxHeight();
-		}
-
-		this.currentView = null;
-		this.oldView = null;
-
-		var i = 0;
-		for(var view in this.options.Views)
-		{
-			var header = jQuery('#'+view+'_0').get(0);
-			if(header)
-			{
-				this.observe(header, "click", jQuery.proxy(this.elementClicked,this,view));
-				if(this.hiddenField.value == i)
-				{
-					this.currentView = view;
-					if(jQuery('#'+this.currentView).height() != this.maxHeight)
-						jQuery('#'+this.currentView).css({height: this.maxHeight+"px"});
-				}
-			}
-			i++;
-		}
-	},
-
-	checkMaxHeight: function()
-	{
-		for(var viewID in this.options.Views)
-		{
-			var view = jQuery('#'+viewID);
+			const view = jQuery(`#${viewID}`);
 			if(view.height() > this.maxHeight)
  				this.maxHeight = view.height();
 		}
 	},
 
-	elementClicked : function(viewID, event)
-	{
-		var i = 0;
-		for(var index in this.options.Views)
+	elementClicked(viewID, event) {
+		let i = 0;
+		for(const index in this.options.Views)
 		{
-			if (jQuery('#'+index).get(0))
+			if (jQuery(`#${index}`).get(0))
 			{
-				var header = jQuery('#'+index+'_0').get(0);
+				const header = jQuery(`#${index}_0`).get(0);
 				if(index == viewID)
 				{
 					this.oldView = this.currentView;
@@ -85,29 +82,29 @@ Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
 			{
 				this.animate();
 			} else {
-				jQuery('#'+this.currentView).css({ height: this.maxHeight+"px" });
-				jQuery('#'+this.currentView).show();
-				jQuery('#'+this.oldView).hide();
+				jQuery(`#${this.currentView}`).css({ height: `${this.maxHeight}px` });
+				jQuery(`#${this.currentView}`).show();
+				jQuery(`#${this.oldView}`).hide();
 
-				jQuery('#'+this.oldView+'_0').removeClass().addClass(this.options.HeaderCssClass);
-				jQuery('#'+this.currentView+'_0').removeClass().addClass(this.options.ActiveHeaderCssClass);
+				jQuery(`#${this.oldView}_0`).removeClass().addClass(this.options.HeaderCssClass);
+				jQuery(`#${this.currentView}_0`).removeClass().addClass(this.options.ActiveHeaderCssClass);
 			}
 		}
 	},
 
-	animate: function() {
-		jQuery('#'+this.oldView+'_0').removeClass().addClass(this.options.HeaderCssClass);
-		jQuery('#'+this.currentView+'_0').removeClass().addClass(this.options.ActiveHeaderCssClass);
+	animate() {
+		jQuery(`#${this.oldView}_0`).removeClass().addClass(this.options.HeaderCssClass);
+		jQuery(`#${this.currentView}_0`).removeClass().addClass(this.options.ActiveHeaderCssClass);
 
-		jQuery('#'+this.oldView).animate(
+		jQuery(`#${this.oldView}`).animate(
 			{height: 0},
 			this.options.Duration,
 			function() {
 				jQuery(this).hide()
 			}
 		);
-		jQuery('#'+this.currentView).css({height: 0}).show().animate(
-			{height: this.maxHeight+'px'},
+		jQuery(`#${this.currentView}`).css({height: 0}).show().animate(
+			{height: `${this.maxHeight}px`},
 			this.options.Duration
 		);
 	}

--- a/framework/Web/Javascripts/source/prado/controls/accordion.js
+++ b/framework/Web/Javascripts/source/prado/controls/accordion.js
@@ -14,12 +14,31 @@
  * http://creativecommons.org/licenses/by-sa/3.0/us/
  */
 
-Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
+// Small native height-animation helper. Animates element height between two
+// values using requestAnimationFrame; calls done() on completion. Used where
+// the accordion previously called jQuery.fn.animate({height}, duration[, cb]).
+const _accAnimateHeight = (el, from, to, duration, done) => {
+	if (!duration || duration <= 0) {
+		el.style.height = `${to}px`;
+		if (done) done();
+		return;
+	}
+	const start = performance.now();
+	const step = (now) => {
+		const t = Math.min(1, (now - start) / duration);
+		el.style.height = `${from + (to - from) * t}px`;
+		if (t < 1) requestAnimationFrame(step);
+		else if (done) done();
+	};
+	requestAnimationFrame(step);
+};
+
+Prado.WebUI.TAccordion = Prado.Class(Prado.WebUI.Control,
 {
     	onInit(options) {
-            this.accordion = jQuery(`#${options.ID}`).get(0);
+            this.accordion = document.getElementById(options.ID);
             this.options = options;
-            this.hiddenField = jQuery(`#${options.ID}_1`).get(0);
+            this.hiddenField = document.getElementById(`${options.ID}_1`);
 
             if (this.options.maxHeight)
             {
@@ -35,15 +54,16 @@ Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
             let i = 0;
             for(const view in this.options.Views)
             {
-                const header = jQuery(`#${view}_0`).get(0);
+                const header = document.getElementById(`${view}_0`);
                 if(header)
                 {
-                    this.observe(header, "click", jQuery.proxy(this.elementClicked,this,view));
+                    this.observe(header, "click", this.elementClicked.bind(this, view));
                     if(this.hiddenField.value == i)
                     {
                         this.currentView = view;
-                        if(jQuery(`#${this.currentView}`).height() != this.maxHeight)
-                            jQuery(`#${this.currentView}`).css({height: `${this.maxHeight}px`});
+                        const cur = document.getElementById(this.currentView);
+                        if(cur && cur.offsetHeight != this.maxHeight)
+                            cur.style.height = `${this.maxHeight}px`;
                     }
                 }
                 i++;
@@ -53,9 +73,9 @@ Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
 	checkMaxHeight() {
 		for(const viewID in this.options.Views)
 		{
-			const view = jQuery(`#${viewID}`);
-			if(view.height() > this.maxHeight)
- 				this.maxHeight = view.height();
+			const view = document.getElementById(viewID);
+			if(view && view.offsetHeight > this.maxHeight)
+ 				this.maxHeight = view.offsetHeight;
 		}
 	},
 
@@ -63,9 +83,8 @@ Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
 		let i = 0;
 		for(const index in this.options.Views)
 		{
-			if (jQuery(`#${index}`).get(0))
+			if (document.getElementById(index))
 			{
-				const header = jQuery(`#${index}_0`).get(0);
 				if(index == viewID)
 				{
 					this.oldView = this.currentView;
@@ -78,35 +97,41 @@ Prado.WebUI.TAccordion = jQuery.klass(Prado.WebUI.Control,
 		}
 		if(this.oldView != this.currentView)
 		{
+			const cur = document.getElementById(this.currentView);
+			const old = document.getElementById(this.oldView);
+			const oldHdr = document.getElementById(`${this.oldView}_0`);
+			const curHdr = document.getElementById(`${this.currentView}_0`);
 			if(this.options.Duration > 0)
 			{
 				this.animate();
 			} else {
-				jQuery(`#${this.currentView}`).css({ height: `${this.maxHeight}px` });
-				jQuery(`#${this.currentView}`).show();
-				jQuery(`#${this.oldView}`).hide();
+				if (cur) {
+					cur.style.height = `${this.maxHeight}px`;
+					cur.style.display = '';
+				}
+				if (old) old.style.display = 'none';
 
-				jQuery(`#${this.oldView}_0`).removeClass().addClass(this.options.HeaderCssClass);
-				jQuery(`#${this.currentView}_0`).removeClass().addClass(this.options.ActiveHeaderCssClass);
+				if (oldHdr) { oldHdr.className = ''; oldHdr.classList.add(this.options.HeaderCssClass); }
+				if (curHdr) { curHdr.className = ''; curHdr.classList.add(this.options.ActiveHeaderCssClass); }
 			}
 		}
 	},
 
 	animate() {
-		jQuery(`#${this.oldView}_0`).removeClass().addClass(this.options.HeaderCssClass);
-		jQuery(`#${this.currentView}_0`).removeClass().addClass(this.options.ActiveHeaderCssClass);
+		const oldHdr = document.getElementById(`${this.oldView}_0`);
+		const curHdr = document.getElementById(`${this.currentView}_0`);
+		if (oldHdr) { oldHdr.className = ''; oldHdr.classList.add(this.options.HeaderCssClass); }
+		if (curHdr) { curHdr.className = ''; curHdr.classList.add(this.options.ActiveHeaderCssClass); }
 
-		jQuery(`#${this.oldView}`).animate(
-			{height: 0},
-			this.options.Duration,
-			function() {
-				jQuery(this).hide()
-			}
-		);
-		jQuery(`#${this.currentView}`).css({height: 0}).show().animate(
-			{height: `${this.maxHeight}px`},
-			this.options.Duration
-		);
+		const old = document.getElementById(this.oldView);
+		const cur = document.getElementById(this.currentView);
+		if (old) {
+			_accAnimateHeight(old, old.offsetHeight, 0, this.options.Duration, () => { old.style.display = 'none'; });
+		}
+		if (cur) {
+			cur.style.height = '0px';
+			cur.style.display = '';
+			_accAnimateHeight(cur, 0, this.maxHeight, this.options.Duration);
+		}
 	}
 });
-

--- a/framework/Web/Javascripts/source/prado/controls/controls.js
+++ b/framework/Web/Javascripts/source/prado/controls/controls.js
@@ -4,11 +4,10 @@ Prado.WebUI = jQuery.klass();
 
 Prado.WebUI.Control = jQuery.klass({
 
-	initialize : function(options)
-	{
+	initialize(options) {
 	    this.registered = false;
 		this.ID = options.ID;
-		this.element = jQuery("#" + this.ID).get(0);
+		this.element = jQuery(`#${this.ID}`).get(0);
 		this.observers = new Array();
 		this.intervals = new Array();
 
@@ -30,18 +29,16 @@ Prado.WebUI.Control = jQuery.klass({
 	 * Registers the control wrapper in the Prado client side control registry
 	 * @param array control wrapper options
 	 */
-	register : function(options)
-	{
+	register(options) {
 		return Prado.Registry[options.ID] = this;
 	},
 
 	/**
 	 * De-registers the control wrapper in the Prado client side control registry
 	 */
-	deregister : function()
-	{
+	deregister() {
 		// extra check so we don't ever deregister another wrapper
-		var value = Prado.Registry[this.ID];
+		const value = Prado.Registry[this.ID];
 		if (value===this)
 		{
 			delete Prado.Registry[this.ID];
@@ -56,8 +53,7 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @param object reference to the old wrapper
 	 * @param array control wrapper options
 	 */
-	replace : function(oldwrapper, options)
-	{
+	replace(oldwrapper, options) {
 		// if there's some advanced state management in the wrapper going on, then
 		// this method could be used either to copy the current state of the control
 		// from the old wrapper to this new one (which then could live on, while the old
@@ -84,9 +80,8 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @param string event name to observe
          * @param handler event handler function
 	 */
-	observe: function(element, eventName, handler, options)
-	{
-		var e = { _element: element, _eventName: eventName, _handler: handler };
+	observe(element, eventName, handler, options) {
+		const e = { _element: element, _eventName: eventName, _handler: handler };
 		this.observers.push(e);
 		return jQuery(e._element).bind(e._eventName, options, e._handler);
 	},
@@ -98,13 +93,12 @@ Prado.WebUI.Control = jQuery.klass({
          * @param handler event handler function
 	 * @result int false if the event handler is not installed, or 1-based index when installed
 	 */
-	findObserver: function(element, eventName, handler)
-	{
-		var e = { _element: element, _eventName: eventName, _handler: handler };
-		var idx = -1;
-		for(var i=0;i<this.observers.length;i++)
+	findObserver(element, eventName, handler) {
+		const e = { _element: element, _eventName: eventName, _handler: handler };
+		let idx = -1;
+		for(let i=0;i<this.observers.length;i++)
 		{
-			var o = this.observers[i];
+			const o = this.observers[i];
 			if ((o._element===element) && (o._eventName===eventName) && (o._handler===handler))
 			{
 				idx = i;
@@ -121,9 +115,8 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @param string event name observed
          * @param handler event handler function
 	 */
-	stopObserving: function(element, eventName, handler)
-	{
-		var idx = this.findObserver(element,eventName,handler);
+	stopObserving(element, eventName, handler) {
+		const idx = this.findObserver(element,eventName,handler);
 		if (idx!=-1)
 			this.observers.splice(idx, 1);
 		else
@@ -139,15 +132,14 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @param int number of milliseconds to wait before executing
 	 * @return int unique ID that can be used to cancel the scheduled execution
 	 */
-	setTimeout: function(func, delay)
-	{
+	setTimeout(func, delay) {
 		if (!jQuery.isFunction(func))
 		{
-			var expr = func;
-			func = function() { return eval(expr); }
+			const expr = func;
+			func = () => eval(expr)
 		};
-		var obj = this;
-		return window.setTimeout(function() {
+		let obj = this;
+		return window.setTimeout(() => {
 			if (!obj.isLingering())
 				func();
 			obj = null;
@@ -158,8 +150,7 @@ Prado.WebUI.Control = jQuery.klass({
 	 * Cancels a previously scheduled code snippet or function
 	 * @param int unique ID returned by setTimeout()
 	 */
-	clearTimeout: function(timeoutid)
-	{
+	clearTimeout(timeoutid) {
 		return window.clearTimeout(timeoutid);
 	},
 
@@ -170,11 +161,10 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @param int number of milliseconds to wait before executing
 	 * @return int unique ID that can be used to cancel the interval (see clearInterval() method)
 	 */
-	setInterval: function(func, delay)
-	{
-		if (!jQuery.isFunction(func)) func = function() { eval(func); };
-		var obj = this;
-		var h = window.setInterval(function() {
+	setInterval(func, delay) {
+		if (!jQuery.isFunction(func)) func = () => { eval(func); };
+		const obj = this;
+		const h = window.setInterval(() => {
 			if (!obj.isLingering())
 				func();
 		},delay);
@@ -186,8 +176,7 @@ Prado.WebUI.Control = jQuery.klass({
 	 * Deregisters a snipper or function previously registered with setInterval()
 	 * @param int unique ID of interval (returned by setInterval() previously)
 	 */
-	clearInterval: function(intervalid)
-	{
+	clearInterval(intervalid) {
 		window.clearInterval(intervalid);
 		this.intervals.splice( jQuery.inArray(intervalid, this.intervals), 1 );
 	},
@@ -196,8 +185,7 @@ Prado.WebUI.Control = jQuery.klass({
 	 * Tells whether this is a wrapper that has already been deregistered and is lingering
 	 * @return bool true if object
 	 */
-	isLingering: function()
-	{
+	isLingering() {
 		return !this.registered;
 	},
 
@@ -205,8 +193,7 @@ Prado.WebUI.Control = jQuery.klass({
 	 * Deinitializes the control wrapper by calling the onDone method and the deregistering it
 	 * @param array control wrapper options
 	 */
-	deinitialize : function()
-	{
+	deinitialize() {
 		if (this.registered)
 			{
 				if(this.onDone)
@@ -219,7 +206,7 @@ Prado.WebUI.Control = jQuery.klass({
 				// automatically deregister all installed observers
 				while (this.observers.length>0)
 				{
-					var e = this.observers.pop();
+					const e = this.observers.pop();
 					jQuery(e._element).unbind(e._eventName, e._handler);
 				}
 			}
@@ -235,8 +222,7 @@ Prado.WebUI.Control = jQuery.klass({
 
 Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
 
-	onInit : function(options)
-	{
+	onInit(options) {
 		this._elementOnClick = null;
 
 		if (!this.element)
@@ -253,10 +239,9 @@ Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
 			}
 	},
 
-	elementClicked : function(options, event)
-	{
-		var src = event.target;
-		var doPostBack = true;
+	elementClicked(options, event) {
+		const src = event.target;
+		let doPostBack = true;
 		var onclicked = null;
 
 		if(this._elementOnClick)
@@ -275,8 +260,7 @@ Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
 		}
 	},
 
-	onPostBack : function(options, event)
-	{
+	onPostBack(options, event) {
 		new Prado.PostBack(options, event);
 	}
 
@@ -298,8 +282,7 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 	 * Override parent onPostBack function, tried to add hidden forms
 	 * inputs to capture x,y clicked point.
 	 */
-	onPostBack : function(options, event)
-	{
+	onPostBack(options, event) {
 		this.addXYInput(options, event);
 		new Prado.PostBack(options, event);
 		this.removeXYInput(options, event);
@@ -310,30 +293,29 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 	 * @param event DOM click event.
 	 * @param array image button options.
 	 */
-	addXYInput : function(options, event)
-	{
-		var imagePos = jQuery(this.element).offset();
-		var clickedPos = [event.clientX, event.clientY];
-		var x = clickedPos[0]-imagePos['left']+1;
-		var y = clickedPos[1]-imagePos['top']+1;
+	addXYInput(options, event) {
+		const imagePos = jQuery(this.element).offset();
+		const clickedPos = [event.clientX, event.clientY];
+		let x = clickedPos[0]-imagePos['left']+1;
+		let y = clickedPos[1]-imagePos['top']+1;
 		x = x < 0 ? 0 : x;
 		y = y < 0 ? 0 : y;
-		var id = this.element.id;
-		var name = options['EventTarget'];
-		var form = this.element.form || jQuery('#PRADO_PAGESTATE').get(0).form;
+		const id = this.element.id;
+		const name = options['EventTarget'];
+		const form = this.element.form || jQuery('#PRADO_PAGESTATE').get(0).form;
 
-		var input=null;
+		let input=null;
 		input = document.createElement("input");
 		input.setAttribute("type", "hidden");
-		input.setAttribute("id", id+"_x");
-		input.setAttribute("name", name+"_x");
+		input.setAttribute("id", `${id}_x`);
+		input.setAttribute("name", `${name}_x`);
 		input.setAttribute("value", x);
 		form.appendChild(input);
 
 		input = document.createElement("input");
 		input.setAttribute("type", "hidden");
-		input.setAttribute("id", id+"_y");
-		input.setAttribute("name", name+"_y");
+		input.setAttribute("id", `${id}_y`);
+		input.setAttribute("name", `${name}_y`);
 		input.setAttribute("value", y);
 		form.appendChild(input);
 	},
@@ -343,11 +325,10 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 	 * @param event DOM click event.
 	 * @param array image button options.
 	 */
-	removeXYInput : function(options, event)
-	{
-		var id = this.element.id;
-		jQuery('#'+id+'_x').remove();
-		jQuery('#'+id+'_y').remove();
+	removeXYInput(options, event) {
+		const id = this.element.id;
+		jQuery(`#${id}_x`).remove();
+		jQuery(`#${id}_y`).remove();
 	}
 });
 
@@ -357,9 +338,8 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
  */
 Prado.WebUI.TRadioButton = jQuery.klass(Prado.WebUI.PostBackControl,
 {
-	initialize : function($super, options)
-	{
-		this.element = jQuery("#" + options['ID']).get(0);
+	initialize($super, options) {
+		this.element = jQuery(`#${options['ID']}`).get(0);
 		if(this.element)
 		{
 			if(!this.element.checked)
@@ -371,8 +351,7 @@ Prado.WebUI.TRadioButton = jQuery.klass(Prado.WebUI.PostBackControl,
 
 Prado.WebUI.TTextBox = jQuery.klass(Prado.WebUI.PostBackControl,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options=options;
 		if(this.options['TextMode'] != 'MultiLine')
 			this.observe(this.element, "keydown", this.handleReturnKey.bind(this));
@@ -380,16 +359,14 @@ Prado.WebUI.TTextBox = jQuery.klass(Prado.WebUI.PostBackControl,
 			this.observe(this.element, "change", jQuery.proxy(this.doPostback,this,options));
 	},
 
-	doPostback : function(options, event)
-	{
+	doPostback(options, event) {
 		new Prado.PostBack(options, event);
 	},
 
-	handleReturnKey : function(e)
-	{
+	handleReturnKey(e) {
 		 if(e.keyCode == 13) // KEY_RETURN
         {
-			var target = e.target;
+			const target = e.target;
 			if(target)
 			{
 				if(this.options['AutoPostBack']==true)
@@ -412,13 +389,11 @@ Prado.WebUI.TTextBox = jQuery.klass(Prado.WebUI.PostBackControl,
 
 Prado.WebUI.TListControl = jQuery.klass(Prado.WebUI.PostBackControl,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 			this.observe(this.element, "change", jQuery.proxy(this.doPostback,this,options));
 	},
 
-	doPostback : function(options, event)
-	{
+	doPostback(options, event) {
 		new Prado.PostBack(options, event);
 	}
 });
@@ -428,22 +403,20 @@ Prado.WebUI.TDropDownList = jQuery.klass(Prado.WebUI.TListControl);
 
 Prado.WebUI.DefaultButton = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options;
-		this.observe(jQuery('#'+options['Panel']), "keydown", jQuery.proxy(this.triggerEvent,this));
+		this.observe(jQuery(`#${options['Panel']}`), "keydown", jQuery.proxy(this.triggerEvent,this));
 	},
 
-	triggerEvent : function(ev)
-	{
-		var enterPressed = ev.keyCode == 13;
-		var isTextArea = ev.target.tagName.toLowerCase() == "textarea";
-		var isHyperLink = ev.target.tagName.toLowerCase() == "a" && ev.target.hasAttribute("href");
-		var isValidButton = ev.target.tagName.toLowerCase() == "input" &&  ev.target.type.toLowerCase() == "submit";
+	triggerEvent(ev) {
+		const enterPressed = ev.keyCode == 13;
+		const isTextArea = ev.target.tagName.toLowerCase() == "textarea";
+		const isHyperLink = ev.target.tagName.toLowerCase() == "a" && ev.target.hasAttribute("href");
+		const isValidButton = ev.target.tagName.toLowerCase() == "input" &&  ev.target.type.toLowerCase() == "submit";
 
 		if(enterPressed && !isTextArea && !isValidButton && !isHyperLink)
 		{
-			var defaultButton = jQuery('#'+this.options['Target']);
+			const defaultButton = jQuery(`#${this.options['Target']}`);
 			if(defaultButton)
 			{
 				this.triggered = true;
@@ -456,23 +429,22 @@ Prado.WebUI.DefaultButton = jQuery.klass(Prado.WebUI.Control,
 
 Prado.WebUI.TTextHighlighter = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options;
 
-		var code = jQuery('#'+this.options.ID+'_code');
-		var btn;
+		const code = jQuery(`#${this.options.ID}_code`);
+		let btn;
 
 		if(this.options.copycode)
 		{
-			jQuery('#'+this.options.ID).css({
+			jQuery(`#${this.options.ID}`).css({
 				'position': 'relative'
 			});
 			btn = jQuery('<input type="button">')
 				.addClass("copycode")
 				.val('Copy code')
 				.attr({
-					'id': '#'+this.options.ID+'_copy',
+					'id': `#${this.options.ID}_copy`,
 					'data-clipboard-text': code.text()
 				})
 				.css({
@@ -481,7 +453,7 @@ Prado.WebUI.TTextHighlighter = jQuery.klass(Prado.WebUI.Control,
 					'right': '0'
 					});
 
-			var clipboard = new ClipboardJS(jQuery(btn).get(0));
+			const clipboard = new ClipboardJS(jQuery(btn).get(0));
 		}
 
 		hljs.configure({
@@ -495,7 +467,7 @@ Prado.WebUI.TTextHighlighter = jQuery.klass(Prado.WebUI.Control,
 
 		if(this.options.copycode)
 		{
-			btn.prependTo('#'+this.options.ID);
+			btn.prependTo(`#${this.options.ID}`);
 		}
 	}
 });
@@ -503,14 +475,13 @@ Prado.WebUI.TTextHighlighter = jQuery.klass(Prado.WebUI.Control,
 
 Prado.WebUI.TCheckBoxList = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
-		for(var i = 0; i<options.ItemCount; i++)
+	onInit(options) {
+		for(let i = 0; i<options.ItemCount; i++)
 		{
-			var checkBoxOptions = jQuery.extend({}, options,
+			const checkBoxOptions = jQuery.extend({}, options,
 			{
-				ID : options.ID+"_c"+i,
-				EventTarget : options.ListName+"$c"+i
+				ID : `${options.ID}_c${i}`,
+				EventTarget : `${options.ListName}$c${i}`
 			});
 			new Prado.WebUI.TCheckBox(checkBoxOptions);
 		}
@@ -519,14 +490,13 @@ Prado.WebUI.TCheckBoxList = jQuery.klass(Prado.WebUI.Control,
 
 Prado.WebUI.TRadioButtonList = jQuery.klass(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
-		for(var i = 0; i<options.ItemCount; i++)
+	onInit(options) {
+		for(let i = 0; i<options.ItemCount; i++)
 		{
-			var radioButtonOptions = jQuery.extend({}, options,
+			const radioButtonOptions = jQuery.extend({}, options,
 			{
-				ID : options.ID+"_c"+i,
-				EventTarget : options.ListName+"$c"+i
+				ID : `${options.ID}_c${i}`,
+				EventTarget : `${options.ListName}$c${i}`
 			});
 			new Prado.WebUI.TRadioButton(radioButtonOptions);
 		}

--- a/framework/Web/Javascripts/source/prado/controls/controls.js
+++ b/framework/Web/Javascripts/source/prado/controls/controls.js
@@ -45,6 +45,7 @@ Prado.WebUI.Control = Prado.Class({
 			return value;
 		}
 		else
+			// eslint-disable-next-line no-debugger
 			debugger; // invoke debugger - this should never happen
 	},
 
@@ -118,6 +119,7 @@ Prado.WebUI.Control = Prado.Class({
 		if (idx!=-1)
 			this.observers.splice(idx, 1);
 		else
+			// eslint-disable-next-line no-debugger
 			debugger; // shouldn't happen
 
 		if (target) target.removeEventListener(eventName, handler);
@@ -131,9 +133,12 @@ Prado.WebUI.Control = Prado.Class({
 	 * @return int unique ID that can be used to cancel the scheduled execution
 	 */
 	setTimeout(func, delay) {
+		// Accept a code string (Prado-emitted client script may pass JS source
+		// here); evaluate it lazily in the timeout callback.
 		if (typeof func !== 'function')
 		{
 			const expr = func;
+			// eslint-disable-next-line no-eval
 			func = () => eval(expr)
 		};
 		let obj = this;
@@ -160,8 +165,10 @@ Prado.WebUI.Control = Prado.Class({
 	 * @return int unique ID that can be used to cancel the interval (see clearInterval() method)
 	 */
 	setInterval(func, delay) {
+		// Same code-string fallback as setTimeout above.
 		if (typeof func !== 'function') {
 			const expr = func;
+			// eslint-disable-next-line no-eval
 			func = () => { eval(expr); };
 		}
 		const obj = this;
@@ -213,6 +220,7 @@ Prado.WebUI.Control = Prado.Class({
 				}
 			}
 		else
+			// eslint-disable-next-line no-debugger
 			debugger; // shouldn't happen
 
 		this.deregister();
@@ -228,6 +236,7 @@ Prado.WebUI.PostBackControl = Prado.Class(Prado.WebUI.Control, {
 		this._elementOnClick = null;
 
 		if (!this.element)
+			// eslint-disable-next-line no-debugger
 			debugger; // element not found
 		else
 			{
@@ -244,11 +253,11 @@ Prado.WebUI.PostBackControl = Prado.Class(Prado.WebUI.Control, {
 	elementClicked(options, event) {
 		const src = event.target;
 		let doPostBack = true;
-		var onclicked = null;
+		let onclicked = null;
 
 		if(this._elementOnClick)
 		{
-			var onclicked = this._elementOnClick(event);
+			onclicked = this._elementOnClick(event);
 			if(typeof(onclicked) == "boolean")
 				doPostBack = onclicked;
 		}
@@ -328,7 +337,7 @@ Prado.WebUI.TImageButton = Prado.Class(Prado.WebUI.PostBackControl,
 	 * @param event DOM click event.
 	 * @param array image button options.
 	 */
-	removeXYInput(options, event) {
+	removeXYInput(_options, _event) {
 		const id = this.element.id;
 		const ex = document.getElementById(`${id}_x`);
 		const ey = document.getElementById(`${id}_y`);
@@ -463,7 +472,8 @@ Prado.WebUI.TTextHighlighter = Prado.Class(Prado.WebUI.Control,
 			btn.style.margin = '5px';
 			btn.style.right = '0';
 
-			const clipboard = new ClipboardJS(btn);
+			// Constructed for its side effect (binding clipboard behavior to btn).
+			new ClipboardJS(btn);
 		}
 
 		hljs.configure({

--- a/framework/Web/Javascripts/source/prado/controls/controls.js
+++ b/framework/Web/Javascripts/source/prado/controls/controls.js
@@ -1,13 +1,13 @@
 /*! PRADO controls javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI = jQuery.klass();
+Prado.WebUI = Prado.Class();
 
-Prado.WebUI.Control = jQuery.klass({
+Prado.WebUI.Control = Prado.Class({
 
 	initialize(options) {
 	    this.registered = false;
 		this.ID = options.ID;
-		this.element = jQuery(`#${this.ID}`).get(0);
+		this.element = document.getElementById(this.ID);
 		this.observers = new Array();
 		this.intervals = new Array();
 
@@ -75,37 +75,34 @@ Prado.WebUI.Control = jQuery.klass({
 
 	/**
 	 * Registers an event observer which will be automatically disposed of when the wrapper
-	 * is deregistered
-	 * @param element DOM element reference or id to attach the event handler to
+	 * is deregistered.
+	 * @param element DOM element reference or id string to attach the event handler to
 	 * @param string event name to observe
-         * @param handler event handler function
+	 * @param handler event handler function
 	 */
-	observe(element, eventName, handler, options) {
-		const e = { _element: element, _eventName: eventName, _handler: handler };
-		this.observers.push(e);
-		return jQuery(e._element).bind(e._eventName, options, e._handler);
+	observe(element, eventName, handler) {
+		const target = (typeof element === 'string') ? document.getElementById(element) : element;
+		if (!target) return;
+		this.observers.push({ _element: target, _eventName: eventName, _handler: handler });
+		target.addEventListener(eventName, handler);
 	},
 
 	/**
 	 * Checks whether an event observer is installed and returns its index
 	 * @param element DOM element reference or id the event handler was attached to
 	 * @param string event name observed
-         * @param handler event handler function
-	 * @result int false if the event handler is not installed, or 1-based index when installed
+	 * @param handler event handler function
+	 * @result int -1 if not installed, otherwise the index in observers
 	 */
 	findObserver(element, eventName, handler) {
-		const e = { _element: element, _eventName: eventName, _handler: handler };
-		let idx = -1;
+		const target = (typeof element === 'string') ? document.getElementById(element) : element;
 		for(let i=0;i<this.observers.length;i++)
 		{
 			const o = this.observers[i];
-			if ((o._element===element) && (o._eventName===eventName) && (o._handler===handler))
-			{
-				idx = i;
-				break;
-			}
+			if ((o._element===target) && (o._eventName===eventName) && (o._handler===handler))
+				return i;
 		}
-		return idx;
+		return -1;
 	},
 
 
@@ -113,16 +110,17 @@ Prado.WebUI.Control = jQuery.klass({
 	 * Degisters an event observer from the list of automatically disposed handlers
 	 * @param element DOM element reference or id the event handler was attached to
 	 * @param string event name observed
-         * @param handler event handler function
+	 * @param handler event handler function
 	 */
 	stopObserving(element, eventName, handler) {
-		const idx = this.findObserver(element,eventName,handler);
+		const idx = this.findObserver(element, eventName, handler);
+		const target = (typeof element === 'string') ? document.getElementById(element) : element;
 		if (idx!=-1)
 			this.observers.splice(idx, 1);
 		else
 			debugger; // shouldn't happen
 
-		return jQuery(element).unbind(eventName, handler);
+		if (target) target.removeEventListener(eventName, handler);
 	},
 
 	/**
@@ -133,7 +131,7 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @return int unique ID that can be used to cancel the scheduled execution
 	 */
 	setTimeout(func, delay) {
-		if (!jQuery.isFunction(func))
+		if (typeof func !== 'function')
 		{
 			const expr = func;
 			func = () => eval(expr)
@@ -162,7 +160,10 @@ Prado.WebUI.Control = jQuery.klass({
 	 * @return int unique ID that can be used to cancel the interval (see clearInterval() method)
 	 */
 	setInterval(func, delay) {
-		if (!jQuery.isFunction(func)) func = () => { eval(func); };
+		if (typeof func !== 'function') {
+			const expr = func;
+			func = () => { eval(expr); };
+		}
 		const obj = this;
 		const h = window.setInterval(() => {
 			if (!obj.isLingering())
@@ -178,7 +179,8 @@ Prado.WebUI.Control = jQuery.klass({
 	 */
 	clearInterval(intervalid) {
 		window.clearInterval(intervalid);
-		this.intervals.splice( jQuery.inArray(intervalid, this.intervals), 1 );
+		const idx = this.intervals.indexOf(intervalid);
+		if (idx !== -1) this.intervals.splice(idx, 1);
 	},
 
 	/**
@@ -207,7 +209,7 @@ Prado.WebUI.Control = jQuery.klass({
 				while (this.observers.length>0)
 				{
 					const e = this.observers.pop();
-					jQuery(e._element).unbind(e._eventName, e._handler);
+					if (e._element) e._element.removeEventListener(e._eventName, e._handler);
 				}
 			}
 		else
@@ -220,7 +222,7 @@ Prado.WebUI.Control = jQuery.klass({
 
 });
 
-Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
+Prado.WebUI.PostBackControl = Prado.Class(Prado.WebUI.Control, {
 
 	onInit(options) {
 		this._elementOnClick = null;
@@ -235,7 +237,7 @@ Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
 					this._elementOnClick = this.element.onclick.bind(this.element);
 					this.element.onclick = null;
 				}
-				this.observe(this.element, "click", jQuery.proxy(this.elementClicked,this,options));
+				this.observe(this.element, "click", this.elementClicked.bind(this, options));
 			}
 	},
 
@@ -250,7 +252,7 @@ Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
 			if(typeof(onclicked) == "boolean")
 				doPostBack = onclicked;
 		}
-		if(doPostBack && !jQuery(src).is(':disabled'))
+		if(doPostBack && !src.disabled)
 			this.onPostBack(options,event);
 		if(typeof(onclicked) == "boolean" && !onclicked)
 		{
@@ -266,17 +268,17 @@ Prado.WebUI.PostBackControl = jQuery.klass(Prado.WebUI.Control, {
 
 });
 
-Prado.WebUI.TButton = jQuery.klass(Prado.WebUI.PostBackControl);
-Prado.WebUI.TLinkButton = jQuery.klass(Prado.WebUI.PostBackControl);
-Prado.WebUI.TCheckBox = jQuery.klass(Prado.WebUI.PostBackControl);
-Prado.WebUI.TBulletedList = jQuery.klass(Prado.WebUI.PostBackControl);
-Prado.WebUI.TImageMap = jQuery.klass(Prado.WebUI.PostBackControl);
+Prado.WebUI.TButton = Prado.Class(Prado.WebUI.PostBackControl);
+Prado.WebUI.TLinkButton = Prado.Class(Prado.WebUI.PostBackControl);
+Prado.WebUI.TCheckBox = Prado.Class(Prado.WebUI.PostBackControl);
+Prado.WebUI.TBulletedList = Prado.Class(Prado.WebUI.PostBackControl);
+Prado.WebUI.TImageMap = Prado.Class(Prado.WebUI.PostBackControl);
 
 /**
  * TImageButton client-side behaviour. With validation, Firefox needs
  * to capture the x,y point of the clicked image in hidden form fields.
  */
-Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
+Prado.WebUI.TImageButton = Prado.Class(Prado.WebUI.PostBackControl,
 {
 	/**
 	 * Override parent onPostBack function, tried to add hidden forms
@@ -294,7 +296,8 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 	 * @param array image button options.
 	 */
 	addXYInput(options, event) {
-		const imagePos = jQuery(this.element).offset();
+		const rect = this.element.getBoundingClientRect();
+		const imagePos = { top: rect.top + window.pageYOffset, left: rect.left + window.pageXOffset };
 		const clickedPos = [event.clientX, event.clientY];
 		let x = clickedPos[0]-imagePos['left']+1;
 		let y = clickedPos[1]-imagePos['top']+1;
@@ -302,7 +305,7 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 		y = y < 0 ? 0 : y;
 		const id = this.element.id;
 		const name = options['EventTarget'];
-		const form = this.element.form || jQuery('#PRADO_PAGESTATE').get(0).form;
+		const form = this.element.form || document.getElementById('PRADO_PAGESTATE').form;
 
 		let input=null;
 		input = document.createElement("input");
@@ -327,8 +330,10 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 	 */
 	removeXYInput(options, event) {
 		const id = this.element.id;
-		jQuery(`#${id}_x`).remove();
-		jQuery(`#${id}_y`).remove();
+		const ex = document.getElementById(`${id}_x`);
+		const ey = document.getElementById(`${id}_y`);
+		if (ex) ex.remove();
+		if (ey) ey.remove();
 	}
 });
 
@@ -336,10 +341,10 @@ Prado.WebUI.TImageButton = jQuery.klass(Prado.WebUI.PostBackControl,
 /**
  * Radio button, only initialize if not already checked.
  */
-Prado.WebUI.TRadioButton = jQuery.klass(Prado.WebUI.PostBackControl,
+Prado.WebUI.TRadioButton = Prado.Class(Prado.WebUI.PostBackControl,
 {
 	initialize($super, options) {
-		this.element = jQuery(`#${options['ID']}`).get(0);
+		this.element = document.getElementById(options['ID']);
 		if(this.element)
 		{
 			if(!this.element.checked)
@@ -349,14 +354,14 @@ Prado.WebUI.TRadioButton = jQuery.klass(Prado.WebUI.PostBackControl,
 });
 
 
-Prado.WebUI.TTextBox = jQuery.klass(Prado.WebUI.PostBackControl,
+Prado.WebUI.TTextBox = Prado.Class(Prado.WebUI.PostBackControl,
 {
 	onInit(options) {
 		this.options=options;
 		if(this.options['TextMode'] != 'MultiLine')
 			this.observe(this.element, "keydown", this.handleReturnKey.bind(this));
 		if(this.options['AutoPostBack']==true)
-			this.observe(this.element, "change", jQuery.proxy(this.doPostback,this,options));
+			this.observe(this.element, "change", this.doPostback.bind(this, options));
 	},
 
 	doPostback(options, event) {
@@ -371,14 +376,14 @@ Prado.WebUI.TTextBox = jQuery.klass(Prado.WebUI.PostBackControl,
 			{
 				if(this.options['AutoPostBack']==true)
 				{
-					jQuery(target).trigger( "change" );
+					target.dispatchEvent(new Event('change', { bubbles: true }));
 					e.stopPropagation();
 				}
 				else
 				{
 					if(this.options['CausesValidation'] && typeof(Prado.Validation) != "undefined")
 					{
-						if(!Prado.Validation.validate(this.options['FormID'], this.options['ValidationGroup'], jQuery(this.options['ID'])))
+						if(!Prado.Validation.validate(this.options['FormID'], this.options['ValidationGroup'], document.getElementById(this.options['ID'])))
 							return e.stopPropagation();
 					}
 				}
@@ -387,10 +392,10 @@ Prado.WebUI.TTextBox = jQuery.klass(Prado.WebUI.PostBackControl,
 	}
 });
 
-Prado.WebUI.TListControl = jQuery.klass(Prado.WebUI.PostBackControl,
+Prado.WebUI.TListControl = Prado.Class(Prado.WebUI.PostBackControl,
 {
 	onInit(options) {
-			this.observe(this.element, "change", jQuery.proxy(this.doPostback,this,options));
+			this.observe(this.element, "change", this.doPostback.bind(this, options));
 	},
 
 	doPostback(options, event) {
@@ -398,14 +403,14 @@ Prado.WebUI.TListControl = jQuery.klass(Prado.WebUI.PostBackControl,
 	}
 });
 
-Prado.WebUI.TListBox = jQuery.klass(Prado.WebUI.TListControl);
-Prado.WebUI.TDropDownList = jQuery.klass(Prado.WebUI.TListControl);
+Prado.WebUI.TListBox = Prado.Class(Prado.WebUI.TListControl);
+Prado.WebUI.TDropDownList = Prado.Class(Prado.WebUI.TListControl);
 
-Prado.WebUI.DefaultButton = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.DefaultButton = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		this.options = options;
-		this.observe(jQuery(`#${options['Panel']}`), "keydown", jQuery.proxy(this.triggerEvent,this));
+		this.observe(document.getElementById(options['Panel']), "keydown", this.triggerEvent.bind(this));
 	},
 
 	triggerEvent(ev) {
@@ -416,88 +421,93 @@ Prado.WebUI.DefaultButton = jQuery.klass(Prado.WebUI.Control,
 
 		if(enterPressed && !isTextArea && !isValidButton && !isHyperLink)
 		{
-			const defaultButton = jQuery(`#${this.options['Target']}`);
+			const defaultButton = document.getElementById(this.options['Target']);
 			if(defaultButton)
 			{
 				this.triggered = true;
-				defaultButton.trigger(this.options['Event']);
+				// For a click on a form control, call the native .click() method
+				// (rather than dispatching a synthetic Event) so the browser
+				// runs the default activation behavior — including submitting
+				// the form when the target is <input type=submit> / <button>.
+				// A synthetic Event(click) does not trigger form submission.
+				const evtName = this.options['Event'];
+				if (evtName === 'click' && typeof defaultButton.click === 'function')
+					defaultButton.click();
+				else
+					defaultButton.dispatchEvent(new Event(evtName, { bubbles: true }));
 				ev.preventDefault();
 			}
 		}
 	}
 });
 
-Prado.WebUI.TTextHighlighter = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TTextHighlighter = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		this.options = options;
 
-		const code = jQuery(`#${this.options.ID}_code`);
+		const code = document.getElementById(`${this.options.ID}_code`);
+		const host = document.getElementById(this.options.ID);
 		let btn;
 
 		if(this.options.copycode)
 		{
-			jQuery(`#${this.options.ID}`).css({
-				'position': 'relative'
-			});
-			btn = jQuery('<input type="button">')
-				.addClass("copycode")
-				.val('Copy code')
-				.attr({
-					'id': `#${this.options.ID}_copy`,
-					'data-clipboard-text': code.text()
-				})
-				.css({
-					'position': 'absolute',
-					'margin': '5px',
-					'right': '0'
-					});
+			if (host) host.style.position = 'relative';
+			btn = document.createElement('input');
+			btn.type = 'button';
+			btn.className = 'copycode';
+			btn.value = 'Copy code';
+			btn.id = `${this.options.ID}_copy`;
+			btn.setAttribute('data-clipboard-text', code.textContent);
+			btn.style.position = 'absolute';
+			btn.style.margin = '5px';
+			btn.style.right = '0';
 
-			const clipboard = new ClipboardJS(jQuery(btn).get(0));
+			const clipboard = new ClipboardJS(btn);
 		}
 
 		hljs.configure({
 			tabReplace: options.tabsize || '    '
 		})
-		hljs.highlightBlock(code.get(0));
+		hljs.highlightBlock(code);
 
 		if(this.options.linenum) {
-			hljs.lineNumbersBlock(code.get(0));
+			hljs.lineNumbersBlock(code);
 		}
 
-		if(this.options.copycode)
+		if(this.options.copycode && host)
 		{
-			btn.prependTo(`#${this.options.ID}`);
+			host.insertBefore(btn, host.firstChild);
 		}
 	}
 });
 
 
-Prado.WebUI.TCheckBoxList = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TCheckBoxList = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		for(let i = 0; i<options.ItemCount; i++)
 		{
-			const checkBoxOptions = jQuery.extend({}, options,
-			{
+			const checkBoxOptions = {
+				...options,
 				ID : `${options.ID}_c${i}`,
 				EventTarget : `${options.ListName}$c${i}`
-			});
+			};
 			new Prado.WebUI.TCheckBox(checkBoxOptions);
 		}
 	}
 });
 
-Prado.WebUI.TRadioButtonList = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TRadioButtonList = Prado.Class(Prado.WebUI.Control,
 {
 	onInit(options) {
 		for(let i = 0; i<options.ItemCount; i++)
 		{
-			const radioButtonOptions = jQuery.extend({}, options,
-			{
+			const radioButtonOptions = {
+				...options,
 				ID : `${options.ID}_c${i}`,
 				EventTarget : `${options.ListName}$c${i}`
-			});
+			};
 			new Prado.WebUI.TRadioButton(radioButtonOptions);
 		}
 	}

--- a/framework/Web/Javascripts/source/prado/controls/htmlarea.js
+++ b/framework/Web/Javascripts/source/prado/controls/htmlarea.js
@@ -8,23 +8,20 @@
  *
 */
 
-Prado.WebUI.THtmlArea = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.THtmlArea = Prado.Class(Prado.WebUI.Control,
 {
-	initialize: function($super, options)
-	{
+	initialize($super, options) {
 		options.ID = options.EditorOptions.elements;
 		$super(options);
 	},
 
-    onInit : function(options)
-	{
+    onInit(options) {
 		this.options = options;
 		this.registerAjaxHook();
 		this.registerInstance();
 	},
 
-	registerInstance: function()
-	{
+	registerInstance() {
 		if (typeof tinyMCE_GZ == 'undefined')
 			{
 				if (typeof tinyMCE == 'undefined')
@@ -59,29 +56,25 @@ Prado.WebUI.THtmlArea = jQuery.klass(Prado.WebUI.Control,
 				}
 	},
 
-	compressedScriptsLoaded: function()
-	{
+	compressedScriptsLoaded() {
 		Prado.WebUI.THtmlArea.tinyMCELoadState = 255;
-		var wrapper;
+		let wrapper;
 		while(Prado.WebUI.THtmlArea.pendingRegistrations.length>0)
 			if (wrapper = Prado.Registry[Prado.WebUI.THtmlArea.pendingRegistrations.pop()])
 				wrapper.initInstance();
 	},
 
-	initInstance: function()
-	{
+	initInstance() {
 		tinyMCE.init(this.options.EditorOptions);
 	},
 
-	checkInstance: function()
-	{
+	checkInstance() {
 		if (!document.getElementById(this.ID))
 			this.deinitialize();
 	},
 
-	removePreviousInstance: function()
-	{
-		for(var i=0;i<tinyMCE.editors.length;i++)
+	removePreviousInstance() {
+		for(let i=0;i<tinyMCE.editors.length;i++)
 			if (tinyMCE.editors[i].id==this.ID)
 			{
 				tinyMCE.editors.splice(i,1); // ugly hack, but works
@@ -91,35 +84,36 @@ Prado.WebUI.THtmlArea = jQuery.klass(Prado.WebUI.Control,
 			}
 	},
 
-	registerAjaxHook: function()
-	{
-		jQuery(document).on('ajaxComplete', this.ajaxresponder.bind(this));
+	registerAjaxHook() {
+		this._ajaxHandler = this.ajaxresponder.bind(this);
+		document.addEventListener('prado:ajaxComplete', this._ajaxHandler);
 	},
 
 
-	deRegisterAjaxHook: function()
-	{
-		jQuery(document).off('ajaxComplete', this.ajaxresponder.bind(this));
+	deRegisterAjaxHook() {
+		if (this._ajaxHandler) {
+			document.removeEventListener('prado:ajaxComplete', this._ajaxHandler);
+			this._ajaxHandler = null;
+		}
 	},
 
-	ajaxresponder: function(request)
-	{
+	ajaxresponder(request) {
 		this.checkInstance();
 	},
 
-	onDone: function()
-	{
+	onDone() {
 		// check for previous tinyMCE registration, and try to remove it gracefully first
-		var prev = tinyMCE.get(this.ID);
+		const prev = tinyMCE.get(this.ID);
 		if (prev)
 		try
 		{
 			tinyMCE.execCommand('mceFocus', false, this.ID);
 			// when removed, tinyMCE restores its content to the textarea. If the textarea content has been
 			// updated in this same callback, it will be overwritten with the old content. Workaround this.
-			var curtext = jQuery('#'+this.ID).get(0).value;
+			const ta = document.getElementById(this.ID);
+			const curtext = ta.value;
 			tinyMCE.execCommand('mceRemoveControl', false, this.ID);
-			jQuery('#'+this.ID).get(0).value = curtext;
+			ta.value = curtext;
 		}
 		catch (e)
 		{
@@ -133,10 +127,8 @@ Prado.WebUI.THtmlArea = jQuery.klass(Prado.WebUI.Control,
 	}
 });
 
-jQuery.extend(Prado.WebUI.THtmlArea,
+Object.assign(Prado.WebUI.THtmlArea,
 {
 	pendingRegistrations : [],
 	tinyMCELoadState : 0
 });
-
-

--- a/framework/Web/Javascripts/source/prado/controls/htmlarea.js
+++ b/framework/Web/Javascripts/source/prado/controls/htmlarea.js
@@ -60,7 +60,7 @@ Prado.WebUI.THtmlArea = Prado.Class(Prado.WebUI.Control,
 		Prado.WebUI.THtmlArea.tinyMCELoadState = 255;
 		let wrapper;
 		while(Prado.WebUI.THtmlArea.pendingRegistrations.length>0)
-			if (wrapper = Prado.Registry[Prado.WebUI.THtmlArea.pendingRegistrations.pop()])
+			if ((wrapper = Prado.Registry[Prado.WebUI.THtmlArea.pendingRegistrations.pop()]))
 				wrapper.initInstance();
 	},
 
@@ -97,7 +97,7 @@ Prado.WebUI.THtmlArea = Prado.Class(Prado.WebUI.Control,
 		}
 	},
 
-	ajaxresponder(request) {
+	ajaxresponder(_request) {
 		this.checkInstance();
 	},
 
@@ -115,7 +115,7 @@ Prado.WebUI.THtmlArea = Prado.Class(Prado.WebUI.Control,
 			tinyMCE.execCommand('mceRemoveControl', false, this.ID);
 			ta.value = curtext;
 		}
-		catch (e)
+		catch (_e)
 		{
 			// suppress error here in case editor can't be properly removed
 			// (happens when <textarea> has been removed from DOM tree without deinitialzing the tinyMCE editor first)

--- a/framework/Web/Javascripts/source/prado/controls/htmlarea5.js
+++ b/framework/Web/Javascripts/source/prado/controls/htmlarea5.js
@@ -47,7 +47,7 @@ Prado.WebUI.THtmlArea5 = Prado.Class(Prado.WebUI.Control,
 		}
 	},
 
-	ajaxresponder(request) {
+	ajaxresponder(_request) {
 		this.checkInstance();
 	},
 

--- a/framework/Web/Javascripts/source/prado/controls/htmlarea5.js
+++ b/framework/Web/Javascripts/source/prado/controls/htmlarea5.js
@@ -8,23 +8,20 @@
  *
 */
 
-Prado.WebUI.THtmlArea5 = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.THtmlArea5 = Prado.Class(Prado.WebUI.Control,
 {
-	initialize: function($super, options)
-	{
+	initialize($super, options) {
 		$super(options);
 	},
 
-    onInit : function(options)
-	{
+    onInit(options) {
 		this.options = options;
 		this.registerAjaxHook();
 		tinyMCE.init(this.options.EditorOptions);
 	},
 
-	removePreviousInstance: function()
-	{
-		for(var i=0;i<tinyMCE.editors.length;i++)
+	removePreviousInstance() {
+		for(let i=0;i<tinyMCE.editors.length;i++)
 			if (tinyMCE.editors[i].id==this.ID)
 			{
 				tinyMCE.editors.splice(i,1); // ugly hack, but works
@@ -32,40 +29,40 @@ Prado.WebUI.THtmlArea5 = jQuery.klass(Prado.WebUI.Control,
 			}
 	},
 
-	checkInstance: function()
-	{
+	checkInstance() {
 		if (!document.getElementById(this.ID))
 			this.deinitialize();
 	},
 
-	registerAjaxHook: function()
-	{
-		jQuery(document).on('ajaxComplete', this.ajaxresponder.bind(this));
+	registerAjaxHook() {
+		this._ajaxHandler = this.ajaxresponder.bind(this);
+		document.addEventListener('prado:ajaxComplete', this._ajaxHandler);
 	},
 
 
-	deRegisterAjaxHook: function()
-	{
-		jQuery(document).off('ajaxComplete', this.ajaxresponder.bind(this));
+	deRegisterAjaxHook() {
+		if (this._ajaxHandler) {
+			document.removeEventListener('prado:ajaxComplete', this._ajaxHandler);
+			this._ajaxHandler = null;
+		}
 	},
 
-	ajaxresponder: function(request)
-	{
+	ajaxresponder(request) {
 		this.checkInstance();
 	},
 
-	onDone: function()
-	{
+	onDone() {
 		// check for previous tinyMCE registration, and try to remove it gracefully first
-		var prev = tinyMCE.get(this.ID);
+		const prev = tinyMCE.get(this.ID);
 		if (prev)
 		{
 			tinyMCE.execCommand('mceFocus', false, this.ID);
 			// when removed, tinyMCE restores its content to the textarea. If the textarea content has been
 			// updated in this same callback, it will be overwritten with the old content. Workaround this.
-			var curtext = jQuery('#'+this.ID).get(0).value;
+			const ta = document.getElementById(this.ID);
+			const curtext = ta.value;
 			prev.remove();
-			jQuery('#'+this.ID).get(0).value = curtext;
+			ta.value = curtext;
 		}
 
 		// doublecheck editor instance here and remove manually from tinyMCE-registry if neccessary

--- a/framework/Web/Javascripts/source/prado/controls/keyboard.js
+++ b/framework/Web/Javascripts/source/prado/controls/keyboard.js
@@ -1,9 +1,8 @@
 /*! PRADO TKeyboard javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TKeyboard = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TKeyboard = Prado.Class(Prado.WebUI.Control,
 {
-	onInit : function(options)
-    {
+	onInit(options) {
 		this.cssClass = options['CssClass'];
         this.forControl = document.getElementById(options['ForControl']);
         this.autoHide = options['AutoHide'];
@@ -26,7 +25,7 @@ Prado.WebUI.TKeyboard = jQuery.klass(Prado.WebUI.Control,
             this.forControl.keyboard = this;
             this.forControl.onfocus = function() {this.keyboard.show(); };
             this.forControl.onblur = function() {if (this.keyboard.flagHover == false) this.keyboard.hide();};
-            this.forControl.onkeydown = function(e) {if (!e) e = window.event; var key = (e.keyCode)?e.keyCode:e.which; if(key == 9)  this.keyboard.hide();;};
+            this.forControl.onkeydown = function(e) {if (!e) e = window.event; const key = (e.keyCode)?e.keyCode:e.which; if(key == 9)  this.keyboard.hide();;};
             this.forControl.onselect = this.saveSelection;
             this.forControl.onclick = this.saveSelection;
             this.forControl.onkeyup = this.saveSelection;
@@ -40,77 +39,66 @@ Prado.WebUI.TKeyboard = jQuery.klass(Prado.WebUI.Control,
         if (!this.autoHide) this.show();
     },
 
-	isObject : function(a)
-	{
+	isObject(a) {
 		return (typeof a == 'object' && !!a) || typeof a == 'function';
 	},
 
-	createElement : function(tagName, attributes, parent)
-    {
-        var tagElement = document.createElement(tagName);
+	createElement(tagName, attributes, parent) {
+        const tagElement = document.createElement(tagName);
         if (this.isObject(attributes)) for (attribute in attributes) tagElement[attribute] = attributes[attribute];
         if (this.isObject(parent)) parent.appendChild(tagElement);
         return tagElement;
     },
 
-	onmouseover : function()
-	{
+	onmouseover() {
 		this.className += ' Hover';
 	},
 
-	onmouseout : function()
-	{
+	onmouseout() {
 		this.className = this.className.replace(/( Hover| Active)/ig, '');
 	},
 
-    onmousedown : function()
-    {
+    onmousedown() {
     	this.className += ' Active';
 	},
 
-    onmouseup : function()
-    {
+    onmouseup() {
     	this.className = this.className.replace(/( Active)/ig, '');
     	this.keyboard.type(this.innerHTML);
 	},
 
-	render : function()
-    {
-        this.tagKeyboard = this.createElement('div', {className: this.cssClass, onselectstart: function() {return false;}}, this.element);
+	render() {
+        this.tagKeyboard = this.createElement('div', {className: this.cssClass, onselectstart() {return false;}}, this.element);
         this.tagKeyboard.keyboard = this;
 
-        for (var line = 0; line < this.keys.length; line++)
+        for (let line = 0; line < this.keys.length; line++)
         {
-            var tagLine = this.createElement('div', {className: 'Line'}, this.tagKeyboard);
-            for (var key = 0; key < this.keys[line].length; key++)
+            const tagLine = this.createElement('div', {className: 'Line'}, this.tagKeyboard);
+            for (let key = 0; key < this.keys[line].length; key++)
             {
-                var split = this.keys[line][key].split(' ');
-                var tagKey = this.createElement('div', {className: 'Key ' + split[2]}, tagLine);
-                var tagKey1 = this.createElement('div', {className: 'Key1', innerHTML: split[0], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
-                var tagKey2 = this.createElement('div', {className: 'Key2', innerHTML: split[1], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
+                const split = this.keys[line][key].split(' ');
+                const tagKey = this.createElement('div', {className: `Key ${split[2]}`}, tagLine);
+                const tagKey1 = this.createElement('div', {className: 'Key1', innerHTML: split[0], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
+                const tagKey2 = this.createElement('div', {className: 'Key2', innerHTML: split[1], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
             }
         }
     },
 
-    isShown : function()
-    {
+    isShown() {
         return (this.tagKeyboard.style.visibility.toLowerCase() == 'visible');
     },
 
-    show : function()
-    {
+    show() {
         if (this.isShown() == false) this.tagKeyboard.style.visibility = 'visible';
     },
 
-    hide : function()
-    {
+    hide() {
         if (this.isShown() == true && this.autoHide) {this.tagKeyboard.style.visibility = 'hidden'; }
     },
 
-    type : function(key)
-    {
-        var input = this.forControl;
-        var command = key.toLowerCase();
+    type(key) {
+        const input = this.forControl;
+        const command = key.toLowerCase();
 
         if (command == 'exit') {this.hide();}
         else if (input != 'undefined' && input != null && command == 'bksp') {this.insert(input, 'bksp');}
@@ -127,8 +115,7 @@ Prado.WebUI.TKeyboard = jQuery.klass(Prado.WebUI.Control,
         if (command != 'exit') input.focus();
     },
 
-    saveSelection : function()
-    {
+    saveSelection() {
         if (this.keyboard.forControl.createTextRange)
         {
             this.keyboard.selection = document.selection.createRange().duplicate();
@@ -136,8 +123,7 @@ Prado.WebUI.TKeyboard = jQuery.klass(Prado.WebUI.Control,
         }
     },
 
-    insert : function(field, value)
-    {
+    insert(field, value) {
         if (this.forControl.createTextRange && this.selection)
         {
             if (value == 'bksp') {this.selection.moveStart("character", -1); this.selection.text = '';}
@@ -147,10 +133,10 @@ Prado.WebUI.TKeyboard = jQuery.klass(Prado.WebUI.Control,
         }
         else
         {
-            var selectStart = this.forControl.selectionStart;
-            var selectEnd = this.forControl.selectionEnd;
-            var start = (this.forControl.value).substring(0, selectStart);
-            var end = (this.forControl.value).substring(selectEnd, this.forControl.textLength);
+            let selectStart = this.forControl.selectionStart;
+            const selectEnd = this.forControl.selectionEnd;
+            let start = (this.forControl.value).substring(0, selectStart);
+            let end = (this.forControl.value).substring(selectEnd, this.forControl.textLength);
 
             if (value == 'bksp') {start = start.substring(0, start.length - 1); selectStart -= 1; value = '';}
             if (value == 'del') {end = end.substring(1, end.length); value = '';}

--- a/framework/Web/Javascripts/source/prado/controls/keyboard.js
+++ b/framework/Web/Javascripts/source/prado/controls/keyboard.js
@@ -45,7 +45,7 @@ Prado.WebUI.TKeyboard = Prado.Class(Prado.WebUI.Control,
 
 	createElement(tagName, attributes, parent) {
         const tagElement = document.createElement(tagName);
-        if (this.isObject(attributes)) for (attribute in attributes) tagElement[attribute] = attributes[attribute];
+        if (this.isObject(attributes)) for (const attribute in attributes) tagElement[attribute] = attributes[attribute];
         if (this.isObject(parent)) parent.appendChild(tagElement);
         return tagElement;
     },
@@ -78,8 +78,9 @@ Prado.WebUI.TKeyboard = Prado.Class(Prado.WebUI.Control,
             {
                 const split = this.keys[line][key].split(' ');
                 const tagKey = this.createElement('div', {className: `Key ${split[2]}`}, tagLine);
-                const tagKey1 = this.createElement('div', {className: 'Key1', innerHTML: split[0], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
-                const tagKey2 = this.createElement('div', {className: 'Key2', innerHTML: split[1], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
+                // tagKey1/tagKey2 are appended to tagKey for their side effect.
+                this.createElement('div', {className: 'Key1', innerHTML: split[0], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
+                this.createElement('div', {className: 'Key2', innerHTML: split[1], keyboard: this, onmouseover: this.onmouseover, onmouseout: this.onmouseout, onmousedown: this.onmousedown, onmouseup: this.onmouseup}, tagKey);
             }
         }
     },

--- a/framework/Web/Javascripts/source/prado/controls/slider.js
+++ b/framework/Web/Javascripts/source/prado/controls/slider.js
@@ -5,21 +5,30 @@
  * This clas is mainly based on Scriptaculous Slider control (http://script.aculo.us)
  */
 
-Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
+// Compute viewport-relative offset of an element (jQuery.fn.offset equivalent).
+const _sliderOffset = (el) => {
+	const rect = el.getBoundingClientRect();
+	return { top: rect.top + window.pageYOffset, left: rect.left + window.pageXOffset };
+};
+
+// Visibility check (jQuery's :visible filter equivalent).
+const _sliderVisible = (el) =>
+	!!(el && (el.offsetWidth || el.offsetHeight || el.getClientRects().length));
+
+Prado.WebUI.TSlider = Prado.Class(Prado.WebUI.PostBackControl,
 {
-	onInit : function (options)
-	{
-		var slider = this;
+	onInit(options) {
+		const slider = this;
 		this.options=options || {};
-		this.track = jQuery('#'+options.ID+'_track').get(0);
-		this.handle =jQuery('#'+options.ID+'_handle').get(0);
-		this.progress = jQuery('#'+options.ID+'_progress').get(0);
+		this.track = document.getElementById(`${options.ID}_track`);
+		this.handle = document.getElementById(`${options.ID}_handle`);
+		this.progress = document.getElementById(`${options.ID}_progress`);
 		this.axis  = this.options.axis || 'horizontal';
 		this.range = this.options.range || [0, 1];
 		this.value = 0;
 		this.maximum   = this.options.maximum || this.range[1];
 		this.minimum   = this.options.minimum || this.range[0];
-		this.hiddenField=jQuery('#'+this.options.ID+'_1').get(0);
+		this.hiddenField = document.getElementById(`${this.options.ID}_1`);
 		this.trackInitialized=false;
 
 		this.initializeTrack();
@@ -54,12 +63,11 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		this.initialized=true;
 
 		if(this.options['AutoPostBack']==true)
-			this.observe(this.hiddenField, "change", jQuery.proxy(this.doPostback,this,options));
+			this.observe(this.hiddenField, "change", this.doPostback.bind(this, options));
 	},
 
-	initializeTrack : function()
-	{
-		if(this.trackInitialized || !$(this.track).is(":visible"))
+	initializeTrack() {
+		if(this.trackInitialized || !_sliderVisible(this.track))
 			return;
 
 		// Will be used to align the handle onto the track, if necessary
@@ -75,33 +83,32 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		this.trackInitialized=true;
 	},
 
-	doPostback : function(options, event)
-	{
+	doPostback(options, event) {
 		new Prado.PostBack(options, event);
 	},
 
-	setDisabled: function(){
+	setDisabled() {
 		this.disabled = true;
 	},
-	setEnabled: function(){
+	setEnabled() {
 		this.disabled = false;
 	},
-	getNearestValue: function(value){
+	getNearestValue(value) {
 		if(this.allowedValues){
-			var max = Math.max.apply( Math, this.allowedValues );
-			var min = Math.min.apply( Math, this.allowedValues );
+			const max = Math.max.apply( Math, this.allowedValues );
+			const min = Math.min.apply( Math, this.allowedValues );
 			if(value >= max) return(max);
 			if(value <= min) return(min);
 
-			var offset = Math.abs(this.allowedValues[0] - value);
-			var newValue = this.allowedValues[0];
-			jQuery.each(this.allowedValues, function(idx, v) {
-				var currentOffset = Math.abs(v - value);
+			let offset = Math.abs(this.allowedValues[0] - value);
+			let newValue = this.allowedValues[0];
+			for (const v of this.allowedValues) {
+				const currentOffset = Math.abs(v - value);
 				if(currentOffset <= offset){
 					newValue = v;
 					offset = currentOffset;
 				}
-			});
+			}
 			return newValue;
 		}
 		if(value > this.range[1]) return this.range[1];
@@ -109,12 +116,12 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		return value;
 	},
 
-	setValue: function(sliderValue){
+	setValue(sliderValue) {
 		if(!this.active) {
 			this.updateStyles();
 		}
 		this.value = this.getNearestValue(sliderValue);
-		var pixelValue= this.translateToPx(this.value);
+		const pixelValue= this.translateToPx(this.value);
 		this.handle.style[this.isVertical() ? 'top' : 'left'] =	pixelValue;
 		if (this.progress)
 			this.progress.style[this.isVertical() ? 'height' : 'width'] = pixelValue;
@@ -123,24 +130,24 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		if(!this.dragging || !this.event) this.updateFinished();
 	},
 
-	setValueBy: function(delta) {
+	setValueBy(delta) {
     	this.setValue(this.value + delta);
 	},
 
-	translateToPx: function(value) {
-		return Math.round(
-      		((this.trackLength-this.handleLength)/(this.range[1]-this.range[0])) * (value - this.range[0])) + "px";
+	translateToPx(value) {
+		return `${Math.round(
+    ((this.trackLength-this.handleLength)/(this.range[1]-this.range[0])) * (value - this.range[0]))}px`;
 	},
 
-	translateToValue: function(offset) {
+	translateToValue(offset) {
 		return ((offset/(this.trackLength-this.handleLength) * (this.range[1]-this.range[0])) + this.range[0]);
 	},
 
-	minimumOffset: function(){
+	minimumOffset() {
 		return(this.isVertical() ? this.alignY : this.alignX);
   	},
 
-	maximumOffset: function(){
+	maximumOffset() {
 		return(this.isVertical() ?
 			(this.track.offsetHeight != 0 ? this.track.offsetHeight :
 				this.track.style.height.replace(/px$/,"")) - this.alignY :
@@ -148,38 +155,38 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 				this.track.style.width.replace(/px$/,"")) - this.alignX);
 	},
 
-	isVertical:  function(){
+	isVertical() {
 		return (this.axis == 'vertical');
 	},
 
-	updateStyles: function() {
+	updateStyles() {
 		if (this.active)
-			jQuery(this.handle).addClass('selected');
+			this.handle.classList.add('selected');
 		else
-			jQuery(this.handle).removeClass('selected');
+			this.handle.classList.remove('selected');
 	},
 
-	startDrag: function(event) {
+	startDrag(event) {
 		if (event.which === 1) {
 			this.initializeTrack();
 			// left click
 			if(!this.disabled){
 				this.active = true;
-				var handle = event.target;
-				var pointer  = [event.pageX, event.pageY];
-				var track = handle;
+				const handle = event.target;
+				const pointer  = [event.pageX, event.pageY];
+				const track = handle;
 				if(track==this.track) {
-					var offsets  = jQuery(this.track).offset();
+					var offsets  = _sliderOffset(this.track);
 					this.event = event;
 					this.setValue(this.translateToValue(
 						(this.isVertical() ? pointer[1]-offsets['top'] : pointer[0]-offsets['left'])-(this.handleLength/2)
 					));
-					var offsets  = jQuery(this.handle).offset();
+					var offsets  = _sliderOffset(this.handle);
 					this.offsetX = (pointer[0] - offsets['left']);
 					this.offsetY = (pointer[1] - offsets['top']);
 				} else {
 					this.updateStyles();
-					var offsets  = jQuery(this.handle).offset();
+					var offsets  = _sliderOffset(this.handle);
 					this.offsetX = (pointer[0] - offsets['left']);
 					this.offsetY = (pointer[1] - offsets['top']);
 				}
@@ -188,7 +195,7 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		}
 	},
 
-	update: function(event) {
+	update(event) {
 		if(this.active) {
 			if(!this.dragging) this.dragging = true;
 			this.draw(event);
@@ -196,9 +203,9 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		}
 	},
 
-	draw: function(event) {
-		var pointer = [event.pageX, event.pageY];
-		var offsets = jQuery(this.track).offset();
+	draw(event) {
+		const pointer = [event.pageX, event.pageY];
+		const offsets = _sliderOffset(this.track);
 		pointer[0] -= this.offsetX + offsets['left'];
 		pointer[1] -= this.offsetY + offsets['top'];
 		this.event = event;
@@ -207,7 +214,7 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 			this.options.onSlide(this.value, this);
 	},
 
-	endDrag: function(event) {
+	endDrag(event) {
 		if(this.active && this.dragging) {
 			this.finishDrag(event, true);
 			event.stopPropagation();
@@ -216,13 +223,13 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		this.dragging = false;
 	},
 
-	finishDrag: function(event, success) {
+	finishDrag(event, success) {
 		this.active = false;
 		this.dragging = false;
 		this.updateFinished();
 	},
 
-	updateFinished: function() {
+	updateFinished() {
 		this.hiddenField.value=this.value;
 		this.updateStyles();
 		if(this.initialized && this.options.onChange)
@@ -230,7 +237,7 @@ Prado.WebUI.TSlider = jQuery.klass(Prado.WebUI.PostBackControl,
 		this.event = null;
 		if (this.options['AutoPostBack']==true)
 		{
-			jQuery(this.hiddenField).trigger("change");
+			this.hiddenField.dispatchEvent(new Event('change', { bubbles: true }));
 		}
 	}
 

--- a/framework/Web/Javascripts/source/prado/controls/slider.js
+++ b/framework/Web/Javascripts/source/prado/controls/slider.js
@@ -5,13 +5,19 @@
  * This clas is mainly based on Scriptaculous Slider control (http://script.aculo.us)
  */
 
-// Compute viewport-relative offset of an element (jQuery.fn.offset equivalent).
+/**
+ * Compute viewport-relative offset of an element (jQuery.fn.offset equivalent).
+ * @since 4.4.0
+ */
 const _sliderOffset = (el) => {
 	const rect = el.getBoundingClientRect();
 	return { top: rect.top + window.pageYOffset, left: rect.left + window.pageXOffset };
 };
 
-// Visibility check (jQuery's :visible filter equivalent).
+/**
+ * Visibility check (jQuery's :visible filter equivalent).
+ * @since 4.4.0
+ */
 const _sliderVisible = (el) =>
 	!!(el && (el.offsetWidth || el.offsetHeight || el.getClientRects().length));
 
@@ -175,18 +181,19 @@ Prado.WebUI.TSlider = Prado.Class(Prado.WebUI.PostBackControl,
 				const handle = event.target;
 				const pointer  = [event.pageX, event.pageY];
 				const track = handle;
+				let offsets;
 				if(track==this.track) {
-					var offsets  = _sliderOffset(this.track);
+					offsets = _sliderOffset(this.track);
 					this.event = event;
 					this.setValue(this.translateToValue(
 						(this.isVertical() ? pointer[1]-offsets['top'] : pointer[0]-offsets['left'])-(this.handleLength/2)
 					));
-					var offsets  = _sliderOffset(this.handle);
+					offsets = _sliderOffset(this.handle);
 					this.offsetX = (pointer[0] - offsets['left']);
 					this.offsetY = (pointer[1] - offsets['top']);
 				} else {
 					this.updateStyles();
-					var offsets  = _sliderOffset(this.handle);
+					offsets = _sliderOffset(this.handle);
 					this.offsetX = (pointer[0] - offsets['left']);
 					this.offsetY = (pointer[1] - offsets['top']);
 				}
@@ -223,7 +230,7 @@ Prado.WebUI.TSlider = Prado.Class(Prado.WebUI.PostBackControl,
 		this.dragging = false;
 	},
 
-	finishDrag(event, success) {
+	finishDrag(_event, _success) {
 		this.active = false;
 		this.dragging = false;
 		this.updateFinished();

--- a/framework/Web/Javascripts/source/prado/controls/tabpanel.js
+++ b/framework/Web/Javascripts/source/prado/controls/tabpanel.js
@@ -1,60 +1,64 @@
 /*! PRADO TTabPanel javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TTabPanel = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TTabPanel = Prado.Class(Prado.WebUI.Control,
 {
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.views = options.Views;
 		this.viewsvis = options.ViewsVis;
-		this.hiddenField = jQuery("#"+options.ID+'_1').get(0);
+		this.hiddenField = document.getElementById(`${options.ID}_1`);
 		this.activeCssClass = options.ActiveCssClass;
 		this.normalCssClass = options.NormalCssClass;
-		var length = options.Views.length;
-		for(var i = 0; i<length; i++)
+		const length = options.Views.length;
+		for(let i = 0; i<length; i++)
 		{
-			var item = options.Views[i];
-			var element = jQuery("#"+item+'_0').get(0);
+			const item = options.Views[i];
+			const element = document.getElementById(`${item}_0`);
 			if (element && options.ViewsVis[i])
 			{
-				this.observe(element, "click", jQuery.proxy(this.elementClicked,this,item));
+				this.observe(element, "click", this.elementClicked.bind(this, item));
 				if (options.AutoSwitch)
-					this.observe(element, "mouseenter", jQuery.proxy(this.elementClicked,this,item));
+					this.observe(element, "mouseenter", this.elementClicked.bind(this, item));
 			}
 
 			if(element)
 			{
-				var view = jQuery("#"+options.Views[i]).get(0);
+				const view = document.getElementById(options.Views[i]);
 				if (view)
 					if(this.hiddenField.value == i)
 					{
-						jQuery(element).addClass(this.activeCssClass).removeClass(this.normalCssClass);
-						jQuery(view).show();
+						element.classList.add(this.activeCssClass);
+						element.classList.remove(this.normalCssClass);
+						view.style.display = '';
 					} else {
-						jQuery(element).addClass(this.normalCssClass).removeClass(this.activeCssClass);
-						jQuery(view).hide();
+						element.classList.add(this.normalCssClass);
+						element.classList.remove(this.activeCssClass);
+						view.style.display = 'none';
 					}
 			}
 		}
 	},
 
-	elementClicked : function(viewID, event)
-	{
-		var length = this.views.length;
-		for(var i = 0; i<length; i++)
+	elementClicked(viewID, event) {
+		const length = this.views.length;
+		for(let i = 0; i<length; i++)
 		{
-			var item = this.views[i];
-			if (jQuery("#"+item))
+			const item = this.views[i];
+			const tab = document.getElementById(`${item}_0`);
+			const view = document.getElementById(item);
+			if (tab && view)
 			{
 				if(item == viewID)
 				{
-					jQuery("#"+item+'_0').removeClass(this.normalCssClass).addClass(this.activeCssClass);
-					jQuery("#"+item).show();
+					tab.classList.remove(this.normalCssClass);
+					tab.classList.add(this.activeCssClass);
+					view.style.display = '';
 					this.hiddenField.value=i;
 				}
 				else
 				{
-					jQuery("#"+item+'_0').removeClass(this.activeCssClass).addClass(this.normalCssClass);
-					jQuery("#"+item).hide();
+					tab.classList.remove(this.activeCssClass);
+					tab.classList.add(this.normalCssClass);
+					view.style.display = 'none';
 				}
 			}
 		}

--- a/framework/Web/Javascripts/source/prado/controls/tabpanel.js
+++ b/framework/Web/Javascripts/source/prado/controls/tabpanel.js
@@ -38,7 +38,7 @@ Prado.WebUI.TTabPanel = Prado.Class(Prado.WebUI.Control,
 		}
 	},
 
-	elementClicked(viewID, event) {
+	elementClicked(viewID, _event) {
 		const length = this.views.length;
 		for(let i = 0; i<length; i++)
 		{

--- a/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
+++ b/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
@@ -32,15 +32,16 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 		Prado.Registry[options.ID] = this;
 
 		//which element to trigger to show the calendar
+		let triggerEvent;
 		if(this.options.Trigger)
 		{
 			this.trigger = document.getElementById(this.options.Trigger);
-			var triggerEvent = this.options.TriggerEvent || "click";
+			triggerEvent = this.options.TriggerEvent || "click";
 		}
 		else
 		{
 			this.trigger  = this.control;
-			var triggerEvent = this.options.TriggerEvent || "focus";
+			triggerEvent = this.options.TriggerEvent || "focus";
 		}
 
 		// Popup position
@@ -127,8 +128,8 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 		tr.appendChild(td);
 		this._monthSelect = document.createElement("select");
 		this._monthSelect.className = "months";
-	    for (var i = 0 ; i < this.MonthNames.length ; i++) {
-	        var opt = document.createElement("option");
+	    for (let i = 0 ; i < this.MonthNames.length ; i++) {
+	        const opt = document.createElement("option");
 	        opt.innerHTML = this.MonthNames[i];
 	        opt.value = i;
 	        if (i == this.selectedDate.getMonth()) {
@@ -146,8 +147,8 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 		td.className = "labelContainer";
 		tr.appendChild(td);
 		this._yearSelect = document.createElement("select");
-		for(var i=this.FromYear; i <= this.UpToYear; ++i) {
-			var opt = document.createElement("option");
+		for(let i = this.FromYear; i <= this.UpToYear; ++i) {
+			const opt = document.createElement("option");
 			opt.innerHTML = i;
 			opt.value = i;
 			if (i == this.selectedDate.getFullYear()) {
@@ -185,7 +186,7 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 		tr = document.createElement("tr");
 		thead.appendChild(tr);
 
-		for(i=0; i < 7; ++i) {
+		for(let i = 0; i < 7; ++i) {
 			td = document.createElement("th");
 			text = document.createTextNode(this.ShortWeekDayNames[(i+this.FirstDayOfWeek)%7]);
 			td.appendChild(text);
@@ -440,7 +441,9 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 			const day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
 			const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
 			const year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
-			var date = this.selectedDate;
+			// Reassigns the `date` parameter; in DropDownList mode we always
+			// take the picker's currently-selected date as the source of truth.
+			date = this.selectedDate;
 			if(day)
 			{
 				day.selectedIndex = date.getDate()-1;
@@ -530,13 +533,13 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 		if(this.options.InputMode == "TextBox")
 			return this.control.offsetHeight;
 
-		var control = Prado.WebUI.TDatePicker.getDayListControl(this.control);
+		let control = Prado.WebUI.TDatePicker.getDayListControl(this.control);
 		if(control) return control.offsetHeight;
 
-		var control = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
+		control = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
 		if(control) return control.offsetHeight;
 
-		var control = Prado.WebUI.TDatePicker.getYearListControl(this.control);
+		control = Prado.WebUI.TDatePicker.getYearListControl(this.control);
 		if(control) return control.offsetHeight;
 		return 0;
 	},
@@ -652,7 +655,9 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 			d1 = new Date(d1.getFullYear(), d1.getMonth(), d1.getDate()+1);
 		}
 
-		const lastDateIndex = index;
+		// Index of the last in-month date slot. Currently unused but kept
+		// available for any future "last filled cell" computations.
+		const _lastDateIndex = index;
 
 	    while(index < 42) {
 			this.dateSlot[index].value = -1;
@@ -677,7 +682,7 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 
 		let options = this._monthSelect.options;
 		const m = this.selectedDate.getMonth();
-		for(var i=0; i < options.length; ++i) {
+		for(let i = 0; i < options.length; ++i) {
 			options[i].selected = false;
 			if (options[i].value == m) {
 				options[i].selected = true;
@@ -686,7 +691,7 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 
 		options = this._yearSelect.options;
 		const year = this.selectedDate.getFullYear();
-		for(var i=0; i < options.length; ++i) {
+		for(let i = 0; i < options.length; ++i) {
 			options[i].selected = false;
 			if (options[i].value == year) {
 				options[i].selected = true;
@@ -702,20 +707,16 @@ Object.assign(Prado.WebUI.TDatePicker,
 	 * @return Date the date from drop down list options.
 	 */
 	getDropDownDate(control) {
-		const now=new Date();
-		var year=now.getFullYear();
-		var month=now.getMonth();
-		var day=1;
-
+		const now = new Date();
 		const month_list = Prado.WebUI.TDatePicker.getMonthListControl(control);
 	 	const day_list = Prado.WebUI.TDatePicker.getDayListControl(control);
 	 	const year_list = Prado.WebUI.TDatePicker.getYearListControl(control);
 
-		var day = day_list ? day_list.value : 1;
-		var month = month_list ? month_list.value : now.getMonth();
-		var year = year_list ? year_list.value : now.getFullYear();
+		const day   = day_list   ? day_list.value   : 1;
+		const month = month_list ? month_list.value : now.getMonth();
+		const year  = year_list  ? year_list.value  : now.getFullYear();
 
-		return new Date(year,month,day, 0, 0, 0);
+		return new Date(year, month, day, 0, 0, 0);
 	},
 
 	getYearListControl(control) {

--- a/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
+++ b/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
@@ -441,8 +441,8 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 			const day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
 			const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
 			const year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
-			// Reassigns the `date` parameter; in DropDownList mode we always
-			// take the picker's currently-selected date as the source of truth.
+			// Reassign the `date` parameter; in DropDownList mode the picker's
+			// currently-selected date is the source of truth.
 			date = this.selectedDate;
 			if(day)
 			{
@@ -549,24 +549,35 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 
 		if(!this.showing)
 		{
-			// Position relative to the offsetParent (native equivalent of
-			// jQuery `$(control).offset() - $(control).offsetParent().offset()`).
-			const top = this.control.offsetTop;
+			// Position the calendar relative to the input's offsetParent.
+			// `el.offsetTop`/`offsetLeft` is the native equivalent of
+			// jQuery's `$(control).offset() - $(control).offsetParent().offset()`
+			// and is unaffected by document scroll or body margin (which broke
+			// the previous jQuery-based math on pages with a non-zero body
+			// margin — the calendar would render slightly *above* the input,
+			// and the next test action would hit a calendar cell instead of
+			// the following input).
+			const top  = this.control.offsetTop;
 			const left = this.control.offsetLeft;
 
 			if(this.positionMode=='Top')
 			{
 				this._calDiv.style.display = 'block';
 				// _calDiv must be visible to get its offsetHeight
-				this._calDiv.style.top = `${top - this._calDiv.offsetHeight}px`;
+				this._calDiv.style.top  = `${top - this._calDiv.offsetHeight}px`;
 				this._calDiv.style.left = `${left}px`;
 			} else {
-				this._calDiv.style.top = `${top + this.getDatePickerOffsetHeight() - 1}px`;
+				this._calDiv.style.top  = `${top + this.getDatePickerOffsetHeight() - 1}px`;
 				this._calDiv.style.left = `${left}px`;
 				this._calDiv.style.display = 'block';
 			}
 
-			this.documentClickEvent = this.hideOnClick.bind(this);
+			// `jQuery.bind(fn, this)` was a low-pro shim helper removed in step 3
+			// of the JS modernization. Use the native Function.prototype.bind.
+			// Without these, the document-body click handler was never attached
+			// and the calendar never closed on outside clicks — leaving the
+			// calendar overlay intercepting subsequent test actions.
+			this.documentClickEvent   = this.hideOnClick.bind(this);
 			this.documentKeyDownEvent = this.keyPressed.bind(this);
 			this.observe(document.body, "click", this.documentClickEvent);
 			const date = this.getDateFromInput();
@@ -594,7 +605,7 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 		let within = false;
 		do
 		{
-			within = within || (el.className && el.classList && el.classList.contains(`TDatePicker_${this.CalendarStyle}`));
+			within = within || (el.className && el.classList.contains(`TDatePicker_${this.CalendarStyle}`));
 			within = within || el == this.trigger;
 			within = within || el == this.control;
 			if(within) break;
@@ -655,8 +666,8 @@ Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 			d1 = new Date(d1.getFullYear(), d1.getMonth(), d1.getDate()+1);
 		}
 
-		// Index of the last in-month date slot. Currently unused but kept
-		// available for any future "last filled cell" computations.
+		// Index of the last in-month date slot; kept available for any future
+		// "last filled cell" computations but currently unused.
 		const _lastDateIndex = index;
 
 	    while(index < 42) {

--- a/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
+++ b/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
@@ -1,6 +1,6 @@
 /*! PRADO TDatePicker javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TDatePicker = Prado.Class(Prado.WebUI.Control,
 {
 	MonthNames : [	"January",		"February",		"March",	"April",
 		"May",			"June",			"July",		"August",
@@ -23,7 +23,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 	onInit(options) {
 		this.options = options || [];
-		this.control = jQuery(`#${options.ID}`).get(0);
+		this.control = document.getElementById(options.ID);
 		this.dateSlot = new Array(42);
 		this.weekSlot = new Array(6);
 		this.minimalDaysInFirstWeek	= 4;
@@ -34,7 +34,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		//which element to trigger to show the calendar
 		if(this.options.Trigger)
 		{
-			this.trigger = jQuery(`#${this.options.Trigger}`).get(0);
+			this.trigger = document.getElementById(this.options.Trigger);
 			var triggerEvent = this.options.TriggerEvent || "click";
 		}
 		else
@@ -49,27 +49,27 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			this.positionMode = this.options.PositionMode;
 		}
 
-		jQuery.extend(this,options);
+		Object.assign(this,options);
 		// generate default date _after_ extending options
 		this.selectedDate = this.newDate();
 
-		this.observe(this.trigger, triggerEvent, jQuery.proxy(this.show,this));
+		this.observe(this.trigger, triggerEvent, this.show.bind(this));
 
 		// Listen to change event if needed
 		if (typeof(this.options.OnDateChanged) == "function")
 		{
 			if(this.options.InputMode == "TextBox")
 			{
-				this.observe(this.control, "change", jQuery.proxy(this.onDateChanged,this));
+				this.observe(this.control, "change", this.onDateChanged.bind(this));
 			}
 			else
 			{
 				const day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
 				const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
 				const year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
-				this.observe (day, "change", jQuery.proxy(this.onDateChanged,this));
-				this.observe (month, "change", jQuery.proxy(this.onDateChanged,this));
-				this.observe (year, "change", jQuery.proxy(this.onDateChanged,this));
+				this.observe (day, "change", this.onDateChanged.bind(this));
+				this.observe (month, "change", this.onDateChanged.bind(this));
+				this.observe (year, "change", this.onDateChanged.bind(this));
 
 			}
 
@@ -214,8 +214,8 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 				tmp.data = text;
 				this.dateSlot[(week*7)+day] = tmp;
 
-				this.observe(td, "mouseover", jQuery.proxy(this.hover,this));
-				this.observe(td, "mouseout", jQuery.proxy(this.hover,this));
+				this.observe(td, "mouseover", this.hover.bind(this));
+				this.observe(td, "mouseout", this.hover.bind(this));
 
 			}
 		}
@@ -239,21 +239,21 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		this.updateHeader();
 
 		// hook up events
-		this.observe(previousMonth, "click", jQuery.proxy(this.prevMonth,this));
-		this.observe(nextMonth, "click", jQuery.proxy(this.nextMonth,this));
-		this.observe(todayButton, "click", jQuery.proxy(this.selectToday,this));
-		//Event.observe(clearButton, "click", jQuery.proxy(this.clearSelection,this));
-		this.observe(this._monthSelect, "change", jQuery.proxy(this.monthSelect,this));
-		this.observe(this._yearSelect, "change", jQuery.proxy(this.yearSelect,this));
+		this.observe(previousMonth, "click", this.prevMonth.bind(this));
+		this.observe(nextMonth, "click", this.nextMonth.bind(this));
+		this.observe(todayButton, "click", this.selectToday.bind(this));
+		//Event.observe(clearButton, "click", this.clearSelection.bind(this));
+		this.observe(this._monthSelect, "change", this.monthSelect.bind(this));
+		this.observe(this._yearSelect, "change", this.yearSelect.bind(this));
 
 		// ie, opera
-		this.observe(this._calDiv, "mousewheel", jQuery.proxy(this.mouseWheelChange,this));
+		this.observe(this._calDiv, "mousewheel", this.mouseWheelChange.bind(this));
 		// ff
-		this.observe(this._calDiv, "DOMMouseScroll", jQuery.proxy(this.mouseWheelChange,this));
+		this.observe(this._calDiv, "DOMMouseScroll", this.mouseWheelChange.bind(this));
 
-		this.observe(calendarBody, "click", jQuery.proxy(this.selectDate,this));
+		this.observe(calendarBody, "click", this.selectDate.bind(this));
 
-		jQuery(this.control).focus();
+		this.control.focus();
 
 	},
 
@@ -421,12 +421,12 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 					obj.changeeventtimer = null;
 				}
 				obj.changeeventtimer = setTimeout(
-					() => { obj.changeeventtimer = null; jQuery(element).trigger("change"); },
+					() => { obj.changeeventtimer = null; element.dispatchEvent(new Event('change', { bubbles: true })); },
 					1500
 				);
 			}
 		else
-			jQuery(element).trigger("change");
+			element.dispatchEvent(new Event('change', { bubbles: true }));
 	},
 
 	onChange(ref, date, capevents) {
@@ -546,25 +546,21 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 		if(!this.showing)
 		{
-			const controlOffset = jQuery(this.control).offset();
-			const parentOffset = jQuery(this.control).offsetParent().offset();
+			// Position relative to the offsetParent (native equivalent of
+			// jQuery `$(control).offset() - $(control).offsetParent().offset()`).
+			const top = this.control.offsetTop;
+			const left = this.control.offsetLeft;
 
 			if(this.positionMode=='Top')
 			{
-				jQuery(this._calDiv).css({
-					display: "block"
-				});
+				this._calDiv.style.display = 'block';
 				// _calDiv must be visible to get its offsetHeight
-				jQuery(this._calDiv).css({
-					top: controlOffset['top'] - parentOffset['top'] - this._calDiv.offsetHeight,
-					left: controlOffset['left'] - parentOffset['left'],
-				});
+				this._calDiv.style.top = `${top - this._calDiv.offsetHeight}px`;
+				this._calDiv.style.left = `${left}px`;
 			} else {
-				jQuery(this._calDiv).css({
-					top: controlOffset['top'] - parentOffset['top'] + this.getDatePickerOffsetHeight() - 1,
-					left: controlOffset['left'] - parentOffset['left'],
-					display: "block"
-				});
+				this._calDiv.style.top = `${top + this.getDatePickerOffsetHeight() - 1}px`;
+				this._calDiv.style.left = `${left}px`;
+				this._calDiv.style.display = 'block';
 			}
 
 			this.documentClickEvent = this.hideOnClick.bind(this);
@@ -595,7 +591,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		let within = false;
 		do
 		{
-			within = within || (el.className && jQuery(el).hasClass(`TDatePicker_${this.CalendarStyle}`));
+			within = within || (el.className && el.classList && el.classList.contains(`TDatePicker_${this.CalendarStyle}`));
 			within = within || el == this.trigger;
 			within = within || el == this.control;
 			if(within) break;
@@ -671,9 +667,9 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		if(ev.target.tagName)
 		{
 			if(ev.type == "mouseover")
-				jQuery(ev.target).addClass("hover");
+				ev.target.classList.add("hover");
 			else
-				jQuery(ev.target).removeClass("hover");
+				ev.target.classList.remove("hover");
 		}
 	},
 
@@ -700,7 +696,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 	}
 });
 
-jQuery.extend(Prado.WebUI.TDatePicker,
+Object.assign(Prado.WebUI.TDatePicker,
 {
 	/**
 	 * @return Date the date from drop down list options.
@@ -723,14 +719,14 @@ jQuery.extend(Prado.WebUI.TDatePicker,
 	},
 
 	getYearListControl(control) {
-		return jQuery(`#${control.id}_year`).get(0);
+		return document.getElementById(`${control.id}_year`);
 	},
 
 	getMonthListControl(control) {
-		return jQuery(`#${control.id}_month`).get(0);
+		return document.getElementById(`${control.id}_month`);
 	},
 
 	getDayListControl(control) {
-		return jQuery(`#${control.id}_day`).get(0);
+		return document.getElementById(`${control.id}_day`);
 	}
 });

--- a/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
+++ b/framework/Web/Javascripts/source/prado/datepicker/datepicker.js
@@ -21,10 +21,9 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 	FromYear : new Date().getFullYear() - 10, UpToYear: new Date().getFullYear() + 5,
 
-	onInit : function(options)
-	{
+	onInit(options) {
 		this.options = options || [];
-		this.control = jQuery('#'+options.ID).get(0);
+		this.control = jQuery(`#${options.ID}`).get(0);
 		this.dateSlot = new Array(42);
 		this.weekSlot = new Array(6);
 		this.minimalDaysInFirstWeek	= 4;
@@ -35,7 +34,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		//which element to trigger to show the calendar
 		if(this.options.Trigger)
 		{
-			this.trigger = jQuery('#'+this.options.Trigger).get(0);
+			this.trigger = jQuery(`#${this.options.Trigger}`).get(0);
 			var triggerEvent = this.options.TriggerEvent || "click";
 		}
 		else
@@ -65,9 +64,9 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			}
 			else
 			{
-				var day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
-				var month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
-				var year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
+				const day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
+				const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
+				const year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
 				this.observe (day, "change", jQuery.proxy(this.onDateChanged,this));
 				this.observe (month, "change", jQuery.proxy(this.onDateChanged,this));
 				this.observe (year, "change", jQuery.proxy(this.onDateChanged,this));
@@ -79,20 +78,19 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 	},
 
-	create : function()
-	{
+	create() {
 		if(typeof(this._calDiv) != "undefined")
 			return;
 
-		var div;
-		var table;
-		var tbody;
-		var tr;
-		var td;
+		let div;
+		let table;
+		let tbody;
+		let tr;
+		let td;
 
 		// Create the top-level div element
 		this._calDiv = document.createElement("div");
-		this._calDiv.className = "TDatePicker_"+this.CalendarStyle+" "+this.ClassName;
+		this._calDiv.className = `TDatePicker_${this.CalendarStyle} ${this.ClassName}`;
 		this._calDiv.style.display = "none";
 		this._calDiv.style.position = "absolute"
 
@@ -113,7 +111,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 		// Previous Month Button
 		td = document.createElement("td");
-		var previousMonth = document.createElement("input");
+		const previousMonth = document.createElement("input");
 		previousMonth.className = "prevMonthButton button";
 		previousMonth.type = "button"
 		previousMonth.value = "<<";
@@ -161,7 +159,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 
 		td = document.createElement("td");
-		var nextMonth = document.createElement("input");
+		const nextMonth = document.createElement("input");
 		nextMonth.className = "nextMonthButton button";
 		nextMonth.type = "button";
 		nextMonth.value = ">>";
@@ -172,17 +170,17 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		div = document.createElement("div");
 		div.className = "calendarBody";
 		this._calDiv.appendChild(div);
-		var calendarBody = div;
+		const calendarBody = div;
 
 		// Create the inside of calendar body
 
-		var text;
+		let text;
 		table = document.createElement("table");
 		table.align="center";
 		table.className = "grid";
 
 	    div.appendChild(table);
-		var thead = document.createElement("thead");
+		const thead = document.createElement("thead");
 		table.appendChild(thead);
 		tr = document.createElement("tr");
 		thead.appendChild(tr);
@@ -199,18 +197,18 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		tbody = document.createElement("tbody");
 		table.appendChild(tbody);
 
-		for(var week=0; week<6; ++week) {
+		for(let week=0; week<6; ++week) {
 			tr = document.createElement("tr");
 			tbody.appendChild(tr);
 
-		for(var day=0; day<7; ++day) {
+		for(let day=0; day<7; ++day) {
 				td = document.createElement("td");
 				td.className = "calendarDate";
 				text = document.createTextNode(String.fromCharCode(160));
 				td.appendChild(text);
 
 				tr.appendChild(td);
-				var tmp = new Object();
+				const tmp = new Object();
 				tmp.tag = "DATE";
 				tmp.value = -1;
 				tmp.data = text;
@@ -227,11 +225,11 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		div.className = "calendarFooter";
 		this._calDiv.appendChild(div);
 
-		var todayButton = document.createElement("input");
+		const todayButton = document.createElement("input");
 		todayButton.type="button";
 		todayButton.className = "todayButton";
-		var today = this.newDate();
-		var buttonText = today.SimpleFormat(this.Format,this);
+		const today = this.newDate();
+		const buttonText = today.SimpleFormat(this.Format,this);
 		todayButton.value = buttonText;
 		div.appendChild(todayButton);
 
@@ -259,11 +257,10 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 	},
 
-	keyPressed : function(ev)
-	{
+	keyPressed(ev) {
 		if(!this.showing) return;
 		if (!ev) ev = document.parentWindow.event;
-		var kc = ev.keyCode != null ? ev.keyCode : ev.charCode;
+		const kc = ev.keyCode != null ? ev.keyCode : ev.charCode;
 
 		// return, space, tab
 		if(kc == 13 || kc == 32 || kc == 9)
@@ -279,20 +276,19 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			this.hide();
 		}
 
-		var getDaysPerMonth = function (nMonth, nYear)
-		{
+		const getDaysPerMonth = (nMonth, nYear) => {
 			nMonth = (nMonth + 12) % 12;
-	        var days= [31,28,31,30,31,30,31,31,30,31,30,31];
-			var res = days[nMonth];
+	        const days= [31,28,31,30,31,30,31,31,30,31,30,31];
+			let res = days[nMonth];
 			if (nMonth == 1) //feburary, leap years has 29
                 res += nYear % 4 == 0 && !(nYear % 400 == 0) ? 1 : 0;
 	        return res;
-		}
+		};
 
 		if(kc < 37 || kc > 40) return true;
 
-		var current = this.selectedDate;
-		var d = current.valueOf();
+		const current = this.selectedDate;
+		let d = current.valueOf();
 		if(kc == 37) // left
 		{
 			if(ev.ctrlKey || ev.shiftKey) // -1 month
@@ -337,9 +333,8 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		ev.preventDefault();
 	},
 
-	selectDate : function(ev)
-	{
-		var el = ev.target;
+	selectDate(ev) {
+		let el = ev.target;
 		while (el.nodeType != 1)
 			el = el.parentNode;
 
@@ -350,8 +345,8 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		if (el == null || el.tagName == null || el.tagName.toLowerCase() != "td")
 			return;
 
-		var d = this.newDate(this.selectedDate);
-		var n = Number(el.firstChild.data);
+		const d = this.newDate(this.selectedDate);
+		const n = Number(el.firstChild.data);
 		if (isNaN(n) || n <= 0 || n == null)
 			return;
 
@@ -360,72 +355,65 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		this.hide();
 	},
 
-	selectToday : function()
-	{
+	selectToday() {
 		if(this.selectedDate.toISODate() == this.newDate().toISODate())
 			this.hide();
 
 		this.setSelectedDate(this.newDate());
 	},
 
-	clearSelection : function()
-	{
+	clearSelection() {
 		this.setSelectedDate(this.newDate());
 		this.hide();
 	},
 
-	monthSelect : function(ev)
-	{
+	monthSelect(ev) {
 		this.setMonth(ev.target.value);
 	},
 
-	yearSelect : function(ev)
-	{
+	yearSelect(ev) {
 		this.setYear(ev.target.value);
 	},
 
-	mouseWheelChange : function (event)
-	{
-		var delta = 0;
+	mouseWheelChange(event) {
+		let delta = 0;
 		if (!event) event = document.parentWindow.event;
 		if (event.wheelDelta) {
 			delta = event.wheelDelta/120;
 			if (window.opera) delta = -delta;
 		} else if (event.detail) { delta = -event.detail/3;     }
 
-		var d = this.newDate(this.selectedDate);
-		var m = d.getMonth() + Math.round(delta);
+		const d = this.newDate(this.selectedDate);
+		const m = d.getMonth() + Math.round(delta);
 		this.setMonth(m,true);
 		return false;
 	},
 
 	// Respond to change event on the textbox or dropdown list
 	// This method raises OnDateChanged event on client side if it has been defined
-	onDateChanged : function ()
-	{
+	onDateChanged() {
 		if (this.options.OnDateChanged)
 		{
-		 	var date;
+		 	let date;
 		 	if (this.options.InputMode == "TextBox")
 		 	{
 		 		date=this.control.value;
 		 	}
 		 	else
 		 	{
-		 		var day = Prado.WebUI.TDatePicker.getDayListControl(this.control).selectedIndex+1;
-				var month = Prado.WebUI.TDatePicker.getMonthListControl(this.control).selectedIndex;
-				var year = Prado.WebUI.TDatePicker.getYearListControl(this.control).value;
+		 		const day = Prado.WebUI.TDatePicker.getDayListControl(this.control).selectedIndex+1;
+				const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control).selectedIndex;
+				const year = Prado.WebUI.TDatePicker.getYearListControl(this.control).value;
 				date=new Date(year, month, day, 0,0,0).SimpleFormat(this.Format, this);
 			}
 			this.options.OnDateChanged(this, date);
 		}
 	},
 
-	fireChangeEvent: function(element, capped)
-	{
+	fireChangeEvent(element, capped) {
 		if (capped)
 			{
-				var obj = this;
+				const obj = this;
 
 				if (typeof(obj.changeeventtimer)!="undefined")
 				{
@@ -433,7 +421,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 					obj.changeeventtimer = null;
 				}
 				obj.changeeventtimer = setTimeout(
-					function() { obj.changeeventtimer = null; jQuery(element).trigger("change"); },
+					() => { obj.changeeventtimer = null; jQuery(element).trigger("change"); },
 					1500
 				);
 			}
@@ -441,8 +429,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			jQuery(element).trigger("change");
 	},
 
-	onChange : function(ref, date, capevents)
-	{
+	onChange(ref, date, capevents) {
 		if(this.options.InputMode == "TextBox")
 		{
 			this.control.value = this.formatDate();
@@ -450,9 +437,9 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		}
 		else
 		{
-			var day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
-			var month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
-			var year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
+			const day = Prado.WebUI.TDatePicker.getDayListControl(this.control);
+			const month = Prado.WebUI.TDatePicker.getMonthListControl(this.control);
+			const year = Prado.WebUI.TDatePicker.getYearListControl(this.control);
 			var date = this.selectedDate;
 			if(day)
 			{
@@ -464,9 +451,9 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			}
 			if(year)
 			{
-				var years = year.options;
-				var currentYear = date.getFullYear();
-				for(var i = 0; i < years.length; i++)
+				const years = year.options;
+				const currentYear = date.getFullYear();
+				for(let i = 0; i < years.length; i++)
 					years[i].selected = years[i].value.toInteger() == currentYear;
 			}
 
@@ -476,13 +463,11 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	formatDate : function()
-	{
+	formatDate() {
 		return this.selectedDate ? this.selectedDate.SimpleFormat(this.Format,this) : '';
 	},
 
-	newDate : function(date)
-	{
+	newDate(date) {
 		if(!date)
 			date = new Date();
 		if(typeof(date) == "string" || typeof(date) == "number")
@@ -490,13 +475,12 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		return new Date(Math.min(Math.max(date.getFullYear(),this.FromYear),this.UpToYear), date.getMonth(), date.getDate(), 0,0,0);
 	},
 
-	setSelectedDate : function(date, capevents)
-	{
+	setSelectedDate(date, capevents) {
 		if (date == null)
 			return;
-		var old=this.selectedDate;
+		const old=this.selectedDate;
 		this.selectedDate = this.newDate(date);
-		var dateChanged=(old - this.selectedDate != 0) || ( this.options.InputMode == "TextBox" && this.control.value != this.formatDate());
+		const dateChanged=(old - this.selectedDate != 0) || ( this.options.InputMode == "TextBox" && this.control.value != this.formatDate());
 
 		this.updateHeader();
 		this.update();
@@ -504,53 +488,45 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			this.onChange(this, date, capevents);
 	},
 
-	getElement : function()
-	{
+	getElement() {
 		return this._calDiv;
 	},
 
-	getSelectedDate : function ()
-	{
+	getSelectedDate() {
 		return this.selectedDate == null ? null : this.newDate(this.selectedDate);
 	},
 
-	setYear : function(year)
-	{
-		var d = this.newDate(this.selectedDate);
+	setYear(year) {
+		const d = this.newDate(this.selectedDate);
 		d.setFullYear(year);
 		this.setSelectedDate(d);
 	},
 
-	setMonth : function (month, capevents)
-	{
-		var d = this.newDate(this.selectedDate);
+	setMonth(month, capevents) {
+		const d = this.newDate(this.selectedDate);
 		d.setDate(Math.min(d.getDate(), this.getDaysPerMonth(month,d.getFullYear())));
 		d.setMonth(month);
 		this.setSelectedDate(d,capevents);
 	},
 
-	nextMonth : function ()
-	{
+	nextMonth() {
 		this.setMonth(this.selectedDate.getMonth()+1);
 	},
 
-	prevMonth : function ()
-	{
+	prevMonth() {
 		this.setMonth(this.selectedDate.getMonth()-1);
 	},
 
-	getDaysPerMonth : function (month, year)
-	{
+	getDaysPerMonth(month, year) {
 		month = (Number(month)+12) % 12;
-        var days = [31,28,31,30,31,30,31,31,30,31,30,31];
-		var res = days[month];
+        const days = [31,28,31,30,31,30,31,31,30,31,30,31];
+		let res = days[month];
 		if (month == 1 && ((!(year % 4) && (year % 100)) || !(year % 400))) //feburary, leap years has 29
             res++;
         return res;
 	},
 
-	getDatePickerOffsetHeight : function()
-	{
+	getDatePickerOffsetHeight() {
 		if(this.options.InputMode == "TextBox")
 			return this.control.offsetHeight;
 
@@ -565,14 +541,13 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		return 0;
 	},
 
-	show : function()
-	{
+	show() {
 		this.create();
 
 		if(!this.showing)
 		{
-			var controlOffset = jQuery(this.control).offset();
-			var parentOffset = jQuery(this.control).offsetParent().offset();
+			const controlOffset = jQuery(this.control).offset();
+			const parentOffset = jQuery(this.control).offsetParent().offset();
 
 			if(this.positionMode=='Top')
 			{
@@ -592,10 +567,10 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 				});
 			}
 
-			this.documentClickEvent = jQuery.bind(this.hideOnClick, this);
-			this.documentKeyDownEvent = jQuery.bind(this.keyPressed, this);
+			this.documentClickEvent = this.hideOnClick.bind(this);
+			this.documentKeyDownEvent = this.keyPressed.bind(this);
 			this.observe(document.body, "click", this.documentClickEvent);
-			var date = this.getDateFromInput();
+			const date = this.getDateFromInput();
 			if(date)
 			{
 				this.selectedDate = date;
@@ -606,8 +581,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	getDateFromInput : function()
-	{
+	getDateFromInput() {
 		if(this.options.InputMode == "TextBox")
 			return Date.SimpleParse(this.control.value, this.Format);
 		else
@@ -615,14 +589,13 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 	},
 
 	//hide the calendar when clicked outside any calendar
-	hideOnClick : function(ev)
-	{
+	hideOnClick(ev) {
 		if(!this.showing) return;
-		var el = ev.target;
-		var within = false;
+		let el = ev.target;
+		let within = false;
 		do
 		{
-			within = within || (el.className && jQuery(el).hasClass("TDatePicker_"+this.CalendarStyle));
+			within = within || (el.className && jQuery(el).hasClass(`TDatePicker_${this.CalendarStyle}`));
 			within = within || el == this.trigger;
 			within = within || el == this.control;
 			if(within) break;
@@ -633,8 +606,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 	},
 
 
-	hide : function()
-	{
+	hide() {
 		if(this.showing)
 		{
 			this._calDiv.style.display = "none";
@@ -644,23 +616,22 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	update : function()
-	{
+	update() {
 		// Calculate the number of days in the month for the selected date
-		var date = this.selectedDate;
-		var today = (this.newDate()).toISODate();
+		const date = this.selectedDate;
+		const today = (this.newDate()).toISODate();
 
-		var selected = date.toISODate();
-		var d1 = new Date(date.getFullYear(), date.getMonth(), 1);
-		var d2 = new Date(date.getFullYear(), date.getMonth()+1, 1);
-		var monthLength = Math.round((d2 - d1) / (24 * 60 * 60 * 1000));
+		const selected = date.toISODate();
+		let d1 = new Date(date.getFullYear(), date.getMonth(), 1);
+		const d2 = new Date(date.getFullYear(), date.getMonth()+1, 1);
+		const monthLength = Math.round((d2 - d1) / (24 * 60 * 60 * 1000));
 
 		// Find out the weekDay index for the first of this month
-		var firstIndex = (d1.getDay() - this.FirstDayOfWeek) % 7 ;
+		let firstIndex = (d1.getDay() - this.FirstDayOfWeek) % 7;
 	    if (firstIndex < 0)
 	    	firstIndex += 7;
 
-		var index = 0;
+		let index = 0;
 		while (index < firstIndex) {
 			this.dateSlot[index].value = -1;
 			this.dateSlot[index].data.data = String.fromCharCode(160);
@@ -668,9 +639,9 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			index++;
 		}
 
-	    for (var i = 1; i <= monthLength; i++, index++) {
-			var slot = this.dateSlot[index];
-			var slotNode = slot.data.parentNode;
+	    for (let i = 1; i <= monthLength; i++, index++) {
+			const slot = this.dateSlot[index];
+			const slotNode = slot.data.parentNode;
 			slot.value = i;
 			slot.data.data = i;
 			slotNode.className = "date";
@@ -685,7 +656,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 			d1 = new Date(d1.getFullYear(), d1.getMonth(), d1.getDate()+1);
 		}
 
-		var lastDateIndex = index;
+		const lastDateIndex = index;
 
 	    while(index < 42) {
 			this.dateSlot[index].value = -1;
@@ -696,8 +667,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 
 	},
 
-	hover : function(ev)
-	{
+	hover(ev) {
 		if(ev.target.tagName)
 		{
 			if(ev.type == "mouseover")
@@ -707,10 +677,10 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	updateHeader : function () {
+	updateHeader() {
 
-		var options = this._monthSelect.options;
-		var m = this.selectedDate.getMonth();
+		let options = this._monthSelect.options;
+		const m = this.selectedDate.getMonth();
 		for(var i=0; i < options.length; ++i) {
 			options[i].selected = false;
 			if (options[i].value == m) {
@@ -719,7 +689,7 @@ Prado.WebUI.TDatePicker = jQuery.klass(Prado.WebUI.Control,
 		}
 
 		options = this._yearSelect.options;
-		var year = this.selectedDate.getFullYear();
+		const year = this.selectedDate.getFullYear();
 		for(var i=0; i < options.length; ++i) {
 			options[i].selected = false;
 			if (options[i].value == year) {
@@ -735,16 +705,15 @@ jQuery.extend(Prado.WebUI.TDatePicker,
 	/**
 	 * @return Date the date from drop down list options.
 	 */
-	getDropDownDate : function(control)
-	{
-		var now=new Date();
+	getDropDownDate(control) {
+		const now=new Date();
 		var year=now.getFullYear();
 		var month=now.getMonth();
 		var day=1;
 
-		var month_list = Prado.WebUI.TDatePicker.getMonthListControl(control);
-	 	var day_list = Prado.WebUI.TDatePicker.getDayListControl(control);
-	 	var year_list = Prado.WebUI.TDatePicker.getYearListControl(control);
+		const month_list = Prado.WebUI.TDatePicker.getMonthListControl(control);
+	 	const day_list = Prado.WebUI.TDatePicker.getDayListControl(control);
+	 	const year_list = Prado.WebUI.TDatePicker.getYearListControl(control);
 
 		var day = day_list ? day_list.value : 1;
 		var month = month_list ? month_list.value : now.getMonth();
@@ -753,18 +722,15 @@ jQuery.extend(Prado.WebUI.TDatePicker,
 		return new Date(year,month,day, 0, 0, 0);
 	},
 
-	getYearListControl : function(control)
-	{
-		return jQuery('#'+control.id+"_year").get(0);
+	getYearListControl(control) {
+		return jQuery(`#${control.id}_year`).get(0);
 	},
 
-	getMonthListControl : function(control)
-	{
-		return jQuery('#'+control.id+"_month").get(0);
+	getMonthListControl(control) {
+		return jQuery(`#${control.id}_month`).get(0);
 	},
 
-	getDayListControl : function(control)
-	{
-		return jQuery('#'+control.id+"_day").get(0);
+	getDayListControl(control) {
+		return jQuery(`#${control.id}_day`).get(0);
 	}
 });

--- a/framework/Web/Javascripts/source/prado/logger/logger.js
+++ b/framework/Web/Javascripts/source/prado/logger/logger.js
@@ -15,39 +15,39 @@ Use it all you want. Just remember to give me some credit :)
 // Custom Event
 // ------------
 
-CustomEvent = jQuery.klass({
-  initialize : function() {
+CustomEvent = Prado.Class({
+  initialize() {
   	this.listeners = []
   },
 
-	addListener : function(method) {
+	addListener(method) {
 		this.listeners.push(method)
 	},
 
-	removeListener : function(method) {
-		var foundIndexes = this._findListenerIndexes(method)
+	removeListener(method) {
+		const foundIndexes = this._findListenerIndexes(method);
 
-		for(var i = 0; i < foundIndexes.length; i++) {
+		for(let i = 0; i < foundIndexes.length; i++) {
 			this.listeners.splice(foundIndexes[i], 1)
 		}
 	},
 
-	dispatch : function(handler) {
-		for(var i = 0; i < this.listeners.length; i++) {
+	dispatch(handler) {
+		for(let i = 0; i < this.listeners.length; i++) {
 			try {
 				this.listeners[i](handler)
 			}
 			catch (e) {
-				alert("Could not run the listener " + this.listeners[i] + ". " + e)
+				alert(`Could not run the listener ${this.listeners[i]}. ${e}`)
 			}
 		}
 	},
 
 	// Private Methods
 	// ---------------
-	_findListenerIndexes : function(method) {
-		var indexes = []
-		for(var i = 0; i < this.listeners.length; i++) {
+	_findListenerIndexes(method) {
+		const indexes = [];
+		for(let i = 0; i < this.listeners.length; i++) {
 			if (this.listeners[i] == method) {
 				indexes.push(i)
 			}
@@ -62,41 +62,41 @@ CustomEvent = jQuery.klass({
 // ------
 
 var Cookie = {
-	set : function(name, value, expirationInDays, path) {
-		var cookie = escape(name) + "=" + escape(value)
+	set(name, value, expirationInDays, path) {
+		let cookie = `${escape(name)}=${escape(value)}`;
 
 		if (expirationInDays) {
-			var date = new Date()
+			const date = new Date();
 			date.setDate(date.getDate() + expirationInDays)
-			cookie += "; expires=" + date.toGMTString()
+			cookie += `; expires=${date.toGMTString()}`
 		}
 
 		if (path) {
-			cookie += ";path=" + path
+			cookie += `;path=${path}`
 		}
 
 		document.cookie = cookie
 
 		if (value && (expirationInDays == undefined || expirationInDays > 0) && !this.get(name)) {
-			Logger.error("Cookie (" + name + ") was not set correctly... The value was " + value.toString().length + " charachters long (This may be over the cookie limit)");
+			Logger.error(`Cookie (${name}) was not set correctly... The value was ${value.toString().length} charachters long (This may be over the cookie limit)`);
 		}
 	},
 
-	get : function(name) {
-		var pattern = "(^|;)\\s*" + escape(name) + "=([^;]+)"
+	get(name) {
+		const pattern = `(^|;)\\s*${escape(name)}=([^;]+)`;
 
-		var m = document.cookie.match(pattern)
+		const m = document.cookie.match(pattern);
 		if (m && m[2]) {
 			return unescape(m[2])
 		}
 		else return null
 	},
 
-	getAll : function() {
-		var cookies = document.cookie.split(';')
-		var cookieArray = []
+	getAll() {
+		const cookies = document.cookie.split(';');
+		const cookieArray = [];
 
-		for (var i = 0; i < cookies.length; i++) {
+		for (let i = 0; i < cookies.length; i++) {
 			try {
 				var name = unescape(cookies[i].match(/^\s*([^=]+)/m)[1])
 				var value = unescape(cookies[i].match(/=(.*$)/m)[1])
@@ -105,10 +105,10 @@ var Cookie = {
 				continue
 			}
 
-			cookieArray.push({name : name, value : value})
+			cookieArray.push({name, value})
 
 			if (cookieArray[name] != undefined) {
-				Logger.waring("Trying to retrieve cookie named(" + name + "). There appears to be another property with this name though.");
+				Logger.waring(`Trying to retrieve cookie named(${name}). There appears to be another property with this name though.`);
 			}
 
 			cookieArray[name] = value
@@ -117,14 +117,14 @@ var Cookie = {
 		return cookieArray
 	},
 
-	clear : function(name) {
+	clear(name) {
 		this.set(name, "", -1)
 	},
 
-	clearAll : function() {
-		var cookies = this.getAll()
+	clearAll() {
+		const cookies = this.getAll();
 
-		for(var i = 0; i < cookies.length; i++) {
+		for(let i = 0; i < cookies.length; i++) {
 			this.clear(cookies[i].name)
 		}
 
@@ -143,51 +143,51 @@ Logger = {
 
 
 	// Logger output
-  log : function(message, tag) {
-	  var logEntry = new LogEntry(message, tag || "info")
+  log(message, tag) {
+	  const logEntry = new LogEntry(message, tag || "info");
 		this.logEntries.push(logEntry)
 		this.onupdate.dispatch(logEntry)
 	},
 
-	info : function(message) {
+	info(message) {
 		this.log(message, 'info')
 		if(typeof(console) != "undefined")
 			console.info(message);
 	},
 
-	debug : function(message) {
+	debug(message) {
 		this.log(message, 'debug')
 		if(typeof(console) != "undefined")
 			console.debug(message);
 	},
 
-	warn : function(message) {
+	warn(message) {
 	  this.log(message, 'warning')
 		if(typeof(console) != "undefined")
 			console.warn(message);
 	},
 
-	error : function(message, error) {
-	  this.log(message + ": \n" + error, 'error')
+	error(message, error) {
+	  this.log(`${message}: \n${error}`, 'error')
 		if(typeof(console) != "undefined")
-			console.error(message + ": \n" + error);
+			console.error(`${message}: \n${error}`);
 
 	},
 
-	clear : function () {
+	clear() {
 		this.logEntries = []
 		this.onclear.dispatch()
 	}
 };
 
-LogEntry = jQuery.klass({
-    initialize : function(message, tag) {
+LogEntry = Prado.Class({
+    initialize(message, tag) {
       this.message = message
       this.tag = tag
     }
 });
 
-LogConsole = jQuery.klass({
+LogConsole = Prado.Class({
 
   // Properties
   // ----------
@@ -199,14 +199,14 @@ LogConsole = jQuery.klass({
   // Methods
   // -------
 
-  initialize : function(toggleKey) {
+  initialize(toggleKey) {
     this.outputCount = 0
     this.tagPattern = Cookie.get('tagPattern') || ".*"
 
   	// I hate writing javascript in HTML... but what's a better alternative
     this.logElement = document.createElement('div')
     document.body.appendChild(this.logElement)
-    jQuery(this.logElement).hide();
+    this.logElement.style.display = 'none';
 
 	this.logElement.style.position = "absolute"
     this.logElement.style.left = '0px'
@@ -246,8 +246,8 @@ LogConsole = jQuery.klass({
     this.tagFilterElement.value = this.tagPattern
     this.tagFilterElement.setAttribute('autocomplete', 'off') // So Firefox doesn't flip out
 
-    jQuery(this.tagFilterElement).on('keyup', this.updateTags.bind(this));
-    jQuery(this.tagFilterElement).on('click', function() {this.tagFilterElement.select()}.bind(this));
+    this.tagFilterElement.addEventListener('keyup', this.updateTags.bind(this));
+    this.tagFilterElement.addEventListener('click', () => {this.tagFilterElement.select()});
 
     // Add outputElement
     this.outputElement = document.createElement('div')
@@ -270,8 +270,8 @@ LogConsole = jQuery.klass({
     this.inputElement.value = 'Type command here'
     this.inputElement.setAttribute('autocomplete', 'off') // So Firefox doesn't flip out
 
-    jQuery(this.inputElement).on('keyup', this.handleInput.bind(this));
-    jQuery(this.inputElement).on('click', function() {this.inputElement.select()}.bind(this));
+    this.inputElement.addEventListener('keyup', this.handleInput.bind(this));
+    this.inputElement.addEventListener('click', () => {this.inputElement.select()});
 
 	if(document.all && !window.opera)
 	{
@@ -282,9 +282,8 @@ LogConsole = jQuery.klass({
 		this.logElement.style.position="fixed";
 		this.logElement.style.bottom="0px";
 	}
-	var self=this;
-	jQuery(document).on('keydown', function(e)
-	{
+	const self=this;
+	document.addEventListener('keydown', e => {
 		if((e.altKey==true) && e.keyCode == toggleKey ) //Alt+J | Ctrl+J
 			self.toggle();
 	});
@@ -294,16 +293,16 @@ LogConsole = jQuery.klass({
     Logger.onclear.addListener(this.clear.bind(this))
 
     // Preload log element with the log entries that have been entered
-		for (var i = 0; i < Logger.logEntries.length; i++) {
+		for (let i = 0; i < Logger.logEntries.length; i++) {
   		this.logUpdate(Logger.logEntries[i])
   	}
 
   	// Feed all errors into the logger (For some unknown reason I can only get this to work
   	// with an inline event declaration)
-  	jQuery(window).on('error', function(msg, url, lineNumber) {Logger.error("Error in (" + (url || location) + ") on line "+lineNumber+"", msg)});
+  	window.addEventListener('error', e => {Logger.error(`Error in (${e.filename || location}) on line ${e.lineno}`, e.message)});
 
     // Allow acess key link
-    var accessElement = document.createElement('span')
+    const accessElement = document.createElement('span');
     accessElement.innerHTML = '<button style="position:absolute;top:-100px" onclick="javascript:logConsole.toggle()" accesskey="d"></button>'
   	document.body.appendChild(accessElement)
 
@@ -312,7 +311,7 @@ LogConsole = jQuery.klass({
 		}
 	},
 
-	toggle : function() {
+	toggle() {
 	  if (this.logElement.style.display == 'none') {
 		  this.show();
 		}
@@ -321,8 +320,8 @@ LogConsole = jQuery.klass({
 		}
 	},
 
-	show : function() {
-	  jQuery(this.logElement).show();
+	show() {
+	  this.logElement.style.display = '';
 	  this.outputElement.scrollTop = this.outputElement.scrollHeight // Scroll to bottom when toggled
 	  if(document.all && !window.opera)
 		  this.repositionWindow();
@@ -331,15 +330,15 @@ LogConsole = jQuery.klass({
  	  this.hidden = false;
 	},
 
-	hide : function() {
+	hide() {
 	  this.hidden = true;
-	  jQuery(this.logElement).hide();
+	  this.logElement.style.display = 'none';
 	  Cookie.set('ConsoleVisible', 'false');
 	},
 
-	output : function(message, style) {
+	output(message, style) {
 			// If we are at the bottom of the window, then keep scrolling with the output
-			var shouldScroll = (this.outputElement.scrollTop + (2 * this.outputElement.clientHeight)) >= this.outputElement.scrollHeight
+			const shouldScroll = (this.outputElement.scrollTop + (2 * this.outputElement.clientHeight)) >= this.outputElement.scrollHeight;
 
 			this.outputCount++
 	  	style = (style ? style += ';' : '')
@@ -350,15 +349,15 @@ LogConsole = jQuery.klass({
 	  	message = message || "undefined"
 	  	message = message.toString().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 
-	  	this.outputElement.innerHTML += "<pre style='" + style + "'>" + message + "</pre>"
+	  	this.outputElement.innerHTML += `<pre style='${style}'>${message}</pre>`
 
 	  	if (shouldScroll) {
 				this.outputElement.scrollTop = this.outputElement.scrollHeight
 			}
 	},
 
-	updateTags : function() {
-		var pattern = this.tagFilterElement.value
+	updateTags() {
+		const pattern = this.tagFilterElement.value;
 
 		if (this.tagPattern == pattern) return
 
@@ -376,23 +375,23 @@ LogConsole = jQuery.klass({
 
 		// Go through each log entry again
 		this.outputCount = 0;
-		for (var i = 0; i < Logger.logEntries.length; i++) {
+		for (let i = 0; i < Logger.logEntries.length; i++) {
   		this.logUpdate(Logger.logEntries[i])
   	}
 	},
 
-	repositionWindow : function() {
-		var offset = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop
-		var pageHeight = self.innerHeight || document.documentElement.clientHeight || document.body.clientHeight
-		this.logElement.style.top = (offset + pageHeight - Element.getHeight(this.logElement)) + "px"
+	repositionWindow() {
+		const offset = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
+		const pageHeight = self.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
+		this.logElement.style.top = `${offset + pageHeight - Element.getHeight(this.logElement)}px`
 	},
 
 	// Event Handlers
 	// --------------
 
-	logUpdate : function(logEntry) {
+	logUpdate(logEntry) {
 		if (logEntry.tag.search(new RegExp(this.tagPattern, 'igm')) == -1) return
-		var style = ''
+		let style = '';
 	  if (logEntry.tag.search(/error/) != -1) style += 'color:red'
 	  else if (logEntry.tag.search(/warning/) != -1) style += 'color:orange'
 	  else if (logEntry.tag.search(/debug/) != -1) style += 'color:green'
@@ -402,13 +401,13 @@ LogConsole = jQuery.klass({
 		this.output(logEntry.message, style)
 	},
 
-	clear : function(e) {
+	clear(e) {
 		this.outputElement.innerHTML = ""
 	},
 
-	handleInput : function(e) {
+	handleInput(e) {
 		if (e.keyCode == 13 ) {
-	  	var command = this.inputElement.value
+	  	const command = this.inputElement.value;
 
 	  	switch(command) {
 	    	case "clear":
@@ -416,13 +415,13 @@ LogConsole = jQuery.klass({
 	      		break
 
 	    	default:
-	      	var consoleOutput = ""
+	      	var consoleOutput = "";
 
 	      	try {
 	        	consoleOutput = eval(this.inputElement.value)
 	      	}
 	      	catch (e) {
-	        	Logger.error("Problem parsing input <" + command + ">", e)
+	        	Logger.error(`Problem parsing input <${command}>`, e)
 	        	break
 					}
 
@@ -463,49 +462,46 @@ LogConsole = jQuery.klass({
 // -------------------------
 function inspect(o)
 {
-	var objtype = typeof(o);
+	const objtype = typeof(o);
 	if (objtype == "undefined") {
 		return "undefined";
 	} else if (objtype == "number" || objtype == "boolean") {
-		return o + "";
+		return `${o}`;
 	} else if (o === null) {
 		return "null";
 	}
 
 	 try {
-            var ostring = (o + "");
+            var ostring = (`${o}`);
         } catch (e) {
-            return "[" + typeof(o) + "]";
+            return `[${typeof(o)}]`;
         }
 
 	if (typeof(o) == "function")
 	{
             o = ostring.replace(/^\s+/, "");
-            var idx = o.indexOf("{");
+            const idx = o.indexOf("{");
             if (idx != -1) {
-                o = o.substr(0, idx) + "{...}";
+                o = `${o.substr(0, idx)}{...}`;
             }
 			return o;
        }
 
-	var reprString = function (o)
-	{
-		return ('"' + o.replace(/(["\\])/g, '\\$1') + '"'
-			).replace(/[\f]/g, "\\f"
-			).replace(/[\b]/g, "\\b"
-			).replace(/[\n]/g, "\\n"
-			).replace(/[\t]/g, "\\t"
-			).replace(/[\r]/g, "\\r");
-	};
+	const reprString = o => (`"${o.replace(/(["\\])/g, '\\$1')}"`
+        ).replace(/[\f]/g, "\\f"
+        ).replace(/[\b]/g, "\\b"
+        ).replace(/[\n]/g, "\\n"
+        ).replace(/[\t]/g, "\\t"
+        ).replace(/[\r]/g, "\\r");
 
 	if (objtype == "string") {
 		return reprString(o);
 	}
 	// recurse
-	var me = arguments.callee;
+	const me = arguments.callee;
 	// short-circuit for objects that support "json" serialization
 	// if they return "self" then just pass-through...
-	var newObj;
+	let newObj;
 	if (typeof(o.__json__) == "function") {
 		newObj = o.__json__();
 		if (o !== newObj) {
@@ -521,22 +517,22 @@ function inspect(o)
 	// array
 	if (objtype != "function" && typeof(o.length) == "number") {
 		var res = [];
-		for (var i = 0; i < o.length; i++) {
+		for (let i = 0; i < o.length; i++) {
 			var val = me(o[i]);
 			if (typeof(val) != "string") {
 				val = "undefined";
 			}
 			res.push(val);
 		}
-		return "[" + res.join(", ") + "]";
+		return `[${res.join(", ")}]`;
 	}
 
 	// generic object code path
 	res = [];
-	for (var k in o) {
-		var useKey;
+	for (const k in o) {
+		let useKey;
 		if (typeof(k) == "number") {
-			useKey = '"' + k + '"';
+			useKey = `"${k}"`;
 		} else if (typeof(k) == "string") {
 			useKey = reprString(k);
 		} else {
@@ -548,13 +544,13 @@ function inspect(o)
 			// skip non-serializable values
 			continue;
 		}
-		res.push(useKey + ":" + val);
+		res.push(`${useKey}:${val}`);
 	}
-	return "{" + res.join(", ") + "}";
+	return `{${res.join(", ")}}`;
 };
 
 Array.prototype.contains = function(object) {
-	for(var i = 0; i < this.length; i++) {
+	for(let i = 0; i < this.length; i++) {
 		if (object == this[i]) return true
 	}
 
@@ -592,21 +588,21 @@ Prado.Inspector =
 	displaying : '',
 	nameList : new Array(),
 
-	format : function(str) {
+	format(str) {
 		if(typeof(str) != "string") return str;
 		str=str.replace(/</g,"&lt;");
 		str=str.replace(/>/g,"&gt;");
 		return str;
 	},
 
-	parseJS : function(obj) {
-		var name;
+	parseJS(obj) {
+		let name;
 		if(typeof obj == "string") {  name = obj; obj = eval(obj); }
 		win= typeof obj == 'undefined' ? window : obj;
 		this.displaying = name ? name : win.toString();
 		for(js in win) {
 			try {
-				if(win[js] && js.toString().indexOf("Inspector")==-1 && (win[js]+"").indexOf("[native code]")==-1) {
+				if(win[js] && js.toString().indexOf("Inspector")==-1 && (`${win[js]}`).indexOf("[native code]")==-1) {
 
 					t=typeof(win[js]);
 					if(!this.objs[t.toString()]) {
@@ -615,7 +611,7 @@ Prado.Inspector =
 						this.nameList[t] = new Array();
 					}
 					this.nameList[t].push(js);
-					this.objs[t][js] = this.format(win[js]+"");
+					this.objs[t][js] = this.format(`${win[js]}`);
 				}
 			} catch(err) { }
 		}
@@ -624,12 +620,12 @@ Prado.Inspector =
 			this.nameList[this.types[i]].sort();
 	},
 
-	show : function(objID) {
+	show(objID) {
 		this.d.getElementById(objID).style.display=this.hidden[objID]?"none":"block";
 		this.hidden[objID]=this.hidden[objID]?0:1;
 	},
 
-	changeSpan : function(spanID) {
+	changeSpan(spanID) {
 		if(this.d.getElementById(spanID).innerHTML.indexOf("+")>-1){
 			this.d.getElementById(spanID).innerHTML="[-]";
 		} else {
@@ -637,44 +633,43 @@ Prado.Inspector =
 		}
 	},
 
-	buildInspectionLevel : function()
-	{
-		var display = this.displaying;
-		var list = display.split(".");
-		var links = ["<a href=\"javascript:var_dump()\">[object Window]</a>"];
-		var name = '';
+	buildInspectionLevel() {
+		const display = this.displaying;
+		const list = display.split(".");
+		const links = ["<a href=\"javascript:var_dump()\">[object Window]</a>"];
+		let name = '';
 		if(display.indexOf("[object ") >= 0) return links.join(".");
-		for(var i = 0; i < list.length; i++)
+		for(let i = 0; i < list.length; i++)
 		{
 			name += (name.length ? "." : "") + list[i];
-			links[i+1] = "<a href=\"javascript:var_dump('"+name+"')\">"+list[i]+"</a>";
+			links[i+1] = `<a href="javascript:var_dump('${name}')">${list[i]}</a>`;
 		}
 		return links.join(".");
 	},
 
-	buildTree : function() {
-		mHTML = "<div>Inspecting "+this.buildInspectionLevel()+"</div>";
+	buildTree() {
+		mHTML = `<div>Inspecting ${this.buildInspectionLevel()}</div>`;
 		mHTML +="<ul class=\"topLevel\">";
 		this.types.sort();
-		var so_objIndex=0;
+		let so_objIndex=0;
 		for(i=0;i<this.types.length;i++)
 		{
-			mHTML+="<li style=\"cursor:pointer;\" onclick=\"Prado.Inspector.show('ul"+i+"');Prado.Inspector.changeSpan('sp" + i + "')\"><span id=\"sp" + i + "\">[+]</span><b>" + this.types[i] + "</b> (" + this.nameList[this.types[i]].length + ")</li><ul style=\"display:none;\" id=\"ul"+i+"\">";
-			this.hidden["ul"+i]=0;
+			mHTML+=`<li style="cursor:pointer;" onclick="Prado.Inspector.show('ul${i}');Prado.Inspector.changeSpan('sp${i}')"><span id="sp${i}">[+]</span><b>${this.types[i]}</b> (${this.nameList[this.types[i]].length})</li><ul style="display:none;" id="ul${i}">`;
+			this.hidden[`ul${i}`]=0;
 			for(e=0;e<this.nameList[this.types[i]].length;e++)
 			{
-				var prop = this.nameList[this.types[i]][e];
-				var value = this.objs[this.types[i]][prop]
-				var more = "";
+				const prop = this.nameList[this.types[i]][e];
+				const value = this.objs[this.types[i]][prop];
+				let more = "";
 				if(value.indexOf("[object ") >= 0 && /^[a-zA-Z_]/.test(prop))
 				{
 					if(this.displaying.indexOf("[object ") < 0)
-						more = " <a href=\"javascript:var_dump('"+this.displaying+"."+prop+"')\"><b>more</b></a>";
+						more = ` <a href="javascript:var_dump('${this.displaying}.${prop}')"><b>more</b></a>`;
 					else if(this.displaying.indexOf("[object Window]") >= 0)
-						more = " <a href=\"javascript:var_dump('"+prop+"')\"><b>more</b></a>";
+						more = ` <a href="javascript:var_dump('${prop}')"><b>more</b></a>`;
 				}
-				mHTML+="<li style=\"cursor:pointer;\" onclick=\"Prado.Inspector.show('mul" + so_objIndex + "');Prado.Inspector.changeSpan('sk" + so_objIndex + "')\"><span id=\"sk" + so_objIndex + "\">[+]</span>" + prop + "</li><ul id=\"mul" + so_objIndex + "\" style=\"display:none;\"><li style=\"list-style-type:none;\"><pre>" + value + more + "</pre></li></ul>";
-				this.hidden["mul"+so_objIndex]=0;
+				mHTML+=`<li style="cursor:pointer;" onclick="Prado.Inspector.show('mul${so_objIndex}');Prado.Inspector.changeSpan('sk${so_objIndex}')"><span id="sk${so_objIndex}">[+]</span>${prop}</li><ul id="mul${so_objIndex}" style="display:none;"><li style="list-style-type:none;"><pre>${value}${more}</pre></li></ul>`;
+				this.hidden[`mul${so_objIndex}`]=0;
 				so_objIndex++;
 			}
 			mHTML+="</ul>";
@@ -683,20 +678,19 @@ Prado.Inspector =
 		this.d.getElementById("so_mContainer").innerHTML =mHTML;
 	},
 
-	handleKeyEvent : function(e) {
+	handleKeyEvent(e) {
 		keyCode=document.all?window.event.keyCode:e.keyCode;
 		if(keyCode==27) {
 			this.cleanUp();
 		}
 	},
 
-	cleanUp : function()
-	{
+	cleanUp() {
 		if(this.d.getElementById("so_mContainer"))
 		{
 			this.d.body.removeChild(this.d.getElementById("so_mContainer"));
 			this.d.body.removeChild(this.d.getElementById("so_mStyle"));
-			jQuery(this.d).unbind("keydown", this.dKeyDownEvent);
+			this.d.removeEventListener("keydown", this.dKeyDownEvent);
 			this.types = new Array();
 			this.objs = new Array();
 			this.hidden = new Array();
@@ -705,8 +699,7 @@ Prado.Inspector =
 
 	disabled : document.all && !this.opera,
 
-	inspect : function(obj)
-	{
+	inspect(obj) {
 		if(this.disabled)return alert("Sorry, this only works in Mozilla and Firefox currently.");
 		this.cleanUp();
 		mObj=this.d.body.appendChild(this.d.createElement("div"));
@@ -716,7 +709,7 @@ Prado.Inspector =
 		sObj.type="text/css";
 		sObj.innerHTML = this.style;
 		this.dKeyDownEvent = this.handleKeyEvent.bind(this);
-		jQuery(this.d).on("keydown", this.dKeyDownEvent);
+		this.d.addEventListener("keydown", this.dKeyDownEvent);
 
 		this.parseJS(obj);
 		this.buildTree();

--- a/framework/Web/Javascripts/source/prado/logger/logger.js
+++ b/framework/Web/Javascripts/source/prado/logger/logger.js
@@ -101,7 +101,7 @@ var Cookie = {
 				var name = unescape(cookies[i].match(/^\s*([^=]+)/m)[1])
 				var value = unescape(cookies[i].match(/=(.*$)/m)[1])
 			}
-			catch (e) {
+			catch (_e) {
 				continue
 			}
 
@@ -364,7 +364,7 @@ LogConsole = Prado.Class({
 		try {
 			new RegExp(pattern)
 		}
-		catch (e) {
+		catch (_e) {
 			return
 		}
 
@@ -401,7 +401,7 @@ LogConsole = Prado.Class({
 		this.output(logEntry.message, style)
 	},
 
-	clear(e) {
+	clear(_e) {
 		this.outputElement.innerHTML = ""
 	},
 
@@ -418,6 +418,8 @@ LogConsole = Prado.Class({
 	      	var consoleOutput = "";
 
 	      	try {
+				// Console REPL — eval is the whole point.
+				// eslint-disable-next-line no-eval
 	        	consoleOutput = eval(this.inputElement.value)
 	      	}
 	      	catch (e) {
@@ -473,7 +475,7 @@ function inspect(o)
 
 	 try {
             var ostring = (`${o}`);
-        } catch (e) {
+        } catch (_e) {
             return `[${typeof(o)}]`;
         }
 
@@ -557,7 +559,9 @@ Array.prototype.contains = function(object) {
 	return false
 };
 
-// Helper Alias for simple logging
+// Helper Alias for simple logging. Used by PHP-emitted client scripts and
+// external consumers, hence the global declaration.
+// eslint-disable-next-line no-unused-vars
 var puts = function() {return Logger.log(arguments[0], arguments[1])};
 
 /*************************************
@@ -597,14 +601,16 @@ Prado.Inspector =
 
 	parseJS(obj) {
 		let name;
+		// Resolve a dotted path like "Prado.Registry.foo" to the live object.
+		// eslint-disable-next-line no-eval
 		if(typeof obj == "string") {  name = obj; obj = eval(obj); }
-		win= typeof obj == 'undefined' ? window : obj;
+		const win = typeof obj == 'undefined' ? window : obj;
 		this.displaying = name ? name : win.toString();
-		for(js in win) {
+		for(const js in win) {
 			try {
 				if(win[js] && js.toString().indexOf("Inspector")==-1 && (`${win[js]}`).indexOf("[native code]")==-1) {
 
-					t=typeof(win[js]);
+					const t = typeof(win[js]);
 					if(!this.objs[t.toString()]) {
 						this.types[this.types.length]=t;
 						this.objs[t]={};
@@ -613,10 +619,10 @@ Prado.Inspector =
 					this.nameList[t].push(js);
 					this.objs[t][js] = this.format(`${win[js]}`);
 				}
-			} catch(err) { }
+			} catch(_err) { /* ignore properties whose enumeration throws (e.g. cross-origin) */ }
 		}
 
-		for(i=0;i<this.types.length;i++)
+		for(let i = 0; i<this.types.length; i++)
 			this.nameList[this.types[i]].sort();
 	},
 
@@ -648,15 +654,15 @@ Prado.Inspector =
 	},
 
 	buildTree() {
-		mHTML = `<div>Inspecting ${this.buildInspectionLevel()}</div>`;
+		let mHTML = `<div>Inspecting ${this.buildInspectionLevel()}</div>`;
 		mHTML +="<ul class=\"topLevel\">";
 		this.types.sort();
 		let so_objIndex=0;
-		for(i=0;i<this.types.length;i++)
+		for(let i = 0; i<this.types.length; i++)
 		{
 			mHTML+=`<li style="cursor:pointer;" onclick="Prado.Inspector.show('ul${i}');Prado.Inspector.changeSpan('sp${i}')"><span id="sp${i}">[+]</span><b>${this.types[i]}</b> (${this.nameList[this.types[i]].length})</li><ul style="display:none;" id="ul${i}">`;
 			this.hidden[`ul${i}`]=0;
-			for(e=0;e<this.nameList[this.types[i]].length;e++)
+			for(let e = 0; e<this.nameList[this.types[i]].length; e++)
 			{
 				const prop = this.nameList[this.types[i]][e];
 				const value = this.objs[this.types[i]][prop];
@@ -679,7 +685,7 @@ Prado.Inspector =
 	},
 
 	handleKeyEvent(e) {
-		keyCode=document.all?window.event.keyCode:e.keyCode;
+		const keyCode = document.all ? window.event.keyCode : e.keyCode;
 		if(keyCode==27) {
 			this.cleanUp();
 		}
@@ -702,9 +708,9 @@ Prado.Inspector =
 	inspect(obj) {
 		if(this.disabled)return alert("Sorry, this only works in Mozilla and Firefox currently.");
 		this.cleanUp();
-		mObj=this.d.body.appendChild(this.d.createElement("div"));
+		const mObj = this.d.body.appendChild(this.d.createElement("div"));
 		mObj.id="so_mContainer";
-		sObj=this.d.body.appendChild(this.d.createElement("style"));
+		const sObj = this.d.body.appendChild(this.d.createElement("style"));
 		sObj.id="so_mStyle";
 		sObj.type="text/css";
 		sObj.innerHTML = this.style;
@@ -714,7 +720,7 @@ Prado.Inspector =
 		this.parseJS(obj);
 		this.buildTree();
 
-		cObj=mObj.appendChild(this.d.createElement("div"));
+		const cObj = mObj.appendChild(this.d.createElement("div"));
 		cObj.className="credits";
 		cObj.innerHTML = "<b>[esc] to <a href=\"javascript:Prado.Inspector.cleanUp();\">close</a></b><br />Javascript Object Tree V2.0.";
 
@@ -732,12 +738,16 @@ Prado.Inspector =
 			"#so_mContainer .credits a { font:9px verdana; font-weight:bold; color:#004465; text-decoration:none; background-color:transparent; }"
 };
 
-//similar function to var_dump in PHP, brings up the javascript object tree UI.
+// Similar function to var_dump in PHP, brings up the javascript object tree UI.
+// Called from PHP-emitted client scripts and from the dev console, hence the
+// global declaration despite no in-file consumer.
+// eslint-disable-next-line no-unused-vars
 function var_dump(obj)
 {
 	Prado.Inspector.inspect(obj);
 }
 
-//similar function to print_r for PHP
+// Similar function to print_r for PHP. External consumers only.
+// eslint-disable-next-line no-unused-vars
 var print_r = inspect;
 

--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -1,266 +1,70 @@
 /*! PRADO main js file | github.com/pradosoft/prado */
 
 /*
- * Polyfill for ECMAScript5's bind() function.
- * ----------
- * Adds compatible .bind() function; needed for Internet Explorer < 9
- * Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+ * Prado.Class — minimal class factory backed by native ES classes.
+ *
+ * Usage:
+ *   const A = Prado.Class({ initialize() { ... }, foo() { ... } });
+ *   const B = Prado.Class(A, { initialize($super, opts) { $super(opts); ... } });
+ *   new B(options);
+ *
+ * Properties named `initialize` run as the constructor. Methods whose first
+ * parameter is `$super` receive a bound reference to the parent's same-named
+ * method as their first argument (low-pro-style super injection, retained
+ * for backward compatibility with existing Prado controls).
+ *
+ * Also aliased as `jQuery.klass` for compatibility with the 4.x call sites.
  */
+(() => {
+  const SUPER_RE = /^[\s(]*(?:function[^(]*|[A-Za-z_$][\w$]*)\(\s*\$super\b/;
+  const wantsSuper = (fn) => typeof fn === 'function' && SUPER_RE.test(Function.prototype.toString.call(fn));
 
-if (!Function.prototype.bind) {
-  Function.prototype.bind = function (oThis) {
-    if (typeof this !== "function") {
-      // closest thing possible to the ECMAScript 5 internal IsCallable function
-      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-    }
-
-    var aArgs = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP = function () {},
-        fBound = function () {
-          return fToBind.apply(this instanceof fNOP && oThis
-                                 ? this
-                                 : oThis,
-                               aArgs.concat(Array.prototype.slice.call(arguments)));
+  const installMethods = (klass, source) => {
+    const parentProto = klass.superclass && klass.superclass.prototype;
+    for (const name of Object.keys(source)) {
+      const value = source[name];
+      if (parentProto && wantsSuper(value)) {
+        const method = value;
+        klass.prototype[name] = function (...args) {
+          const $super = parentProto[name].bind(this);
+          return method.call(this, $super, ...args);
         };
-
-    fNOP.prototype = this.prototype;
-    fBound.prototype = new fNOP();
-
-    return fBound;
-  };
-}
-
-/*
- * Low Pro JQ
- * ----------
- *
- * Author: Dan Webb (dan@danwebb.net)
- * GIT: github.com:danwrong/low-pro-for-jquery.git
- * Download: http://github.com/danwrong/low-pro-for-jquery/tree/master/src/lowpro.jquery.js?raw=true
- *
- * A jQuery port of the Low Pro behavior framework that was originally written for Prototype.
- *
- * Prado actually uses it as a base to emulate OOP subclassing, inheritance and contructor events.
- * The "behaviour" and the "Remote" bits are not used and have been commented out.
- */
-
-(function($) {
-
-  var addMethods = function(source) {
-    var ancestor   = this.superclass && this.superclass.prototype;
-    var properties = $.keys(source);
-
-    if (!$.keys({ toString: true }).length) properties.push("toString", "valueOf");
-
-    for (var i = 0, length = properties.length; i < length; i++) {
-      var property = properties[i], value = source[property];
-      if (ancestor && $.isFunction(value) && $.argumentNames(value)[0] == "$super") {
-
-        var method = value, value = $.extend($.wrap((function(m) {
-          return function() { return ancestor[m].apply(this, arguments) };
-        })(property), method), {
-          valueOf:  function() { return method },
-          toString: function() { return method.toString() }
-        });
+      } else {
+        klass.prototype[name] = value;
       }
-      this.prototype[property] = value;
     }
-
-    return this;
   };
 
-  $.extend({
-    keys: function(obj) {
-      var keys = [];
-      for (var key in obj) keys.push(key);
-      return keys;
-    },
+  const Class = (...args) => {
+    let parent = null;
+    if (typeof args[0] === 'function') parent = args.shift();
 
-    argumentNames: function(func) {
-      var names = func.toString().match(/^[\s\(]*function[^(]*\((.*?)\)/)[1].split(/, ?/);
-      return names.length == 1 && !names[0] ? [] : names;
-    },
+    // Function constructor (not `class` keyword) so the prototype slot stays
+    // writable — existing controls (ajax3.js, colorpicker.js) do wholesale
+    // `Class.prototype = {...}` assignment and rely on that.
+    const klass = function (...ctorArgs) {
+      this.initialize(...ctorArgs);
+    };
 
-    bind: function(func, scope) {
-      return function() {
-        return func.apply(scope, $.makeArray(arguments));
-      };
-    },
-
-    wrap: function(func, wrapper) {
-      var __method = func;
-      return function() {
-        return wrapper.apply(this, [$.bind(__method, this)].concat($.makeArray(arguments)));
-      };
-    },
-
-    klass: function() {
-      var parent = null, properties = $.makeArray(arguments);
-      if ($.isFunction(properties[0])) parent = properties.shift();
-
-      var klass = function() {
-        this.initialize.apply(this, arguments);
-      };
-
-      klass.superclass = parent;
-      klass.subclasses = [];
-      klass.addMethods = addMethods;
-
-      if (parent) {
-        var subclass = function() { };
-        subclass.prototype = parent.prototype;
-        klass.prototype = new subclass;
-        parent.subclasses.push(klass);
-      }
-
-      for (var i = 0; i < properties.length; i++)
-        klass.addMethods(properties[i]);
-
-      if (!klass.prototype.initialize)
-        klass.prototype.initialize = function() {};
-
+    if (parent) {
+      klass.prototype = Object.create(parent.prototype);
       klass.prototype.constructor = klass;
+    }
+    klass.superclass = parent;
+    klass.subclasses = [];
+    if (parent) (parent.subclasses ||= []).push(klass);
 
-      return klass;
-    },
-    delegate: function(rules) {
-      return function(e) {
-        var target = $(e.target), parent = null;
-        for (var selector in rules) {
-          if (target.is(selector) || ((parent = target.parents(selector)) && parent.length > 0)) {
-            return rules[selector].apply(this, [parent || target].concat($.makeArray(arguments)));
-          }
-          parent = null;
-        }
-      };
-    }
-  });
-/*
-  var bindEvents = function(instance) {
-    for (var member in instance) {
-      if (member.match(/^on(.+)/) && typeof instance[member] == 'function') {
-        instance.element.live(RegExp.$1, {'behavior': instance}, instance[member]);
-      }
-    }
+    for (const props of args) installMethods(klass, props);
+
+    if (!klass.prototype.initialize) klass.prototype.initialize = function () {};
+    return klass;
   };
 
-  var behaviorWrapper = function(behavior) {
-    return $.klass(behavior, {
-      initialize: function($super, element, args) {
-        this.element = element;
-        if ($super) $super.apply(this, args);
-      },
-      trigger: function(eventType, extraParameters) {
-        var parameters = [this].concat(extraParameters);
-        this.element.trigger(eventType, parameters);
-      }
-    });
-  };
-
-  var attachBehavior = function(el, behavior, args) {
-      var wrapper = behaviorWrapper(behavior);
-      var instance = new wrapper(el, args);
-
-      bindEvents(instance);
-
-      if (!behavior.instances) behavior.instances = [];
-
-      behavior.instances.push(instance);
-
-      return instance;
-  };
-
-
-  $.fn.extend({
-    attach: function() {
-      var args = $.makeArray(arguments), behavior = args.shift();
-      attachBehavior(this, behavior, args);
-      return this;
-    },
-    delegate: function(type, rules) {
-      return this.bind(type, $.delegate(rules));
-    },
-    attached: function(behavior) {
-      var instances = [];
-
-      if (!behavior.instances) return instances;
-
-      this.each(function(i, element) {
-        $.each(behavior.instances, function(i, instance) {
-          if (instance.element.get(0) == element) instances.push(instance);
-        });
-      });
-
-      return instances;
-    },
-    firstAttached: function(behavior) {
-      return this.attached(behavior)[0];
-    }
-  });
-
-  Remote = $.klass({
-    initialize: function(options) {
-      if (this.element.attr('nodeName') == 'FORM') this.element.attach(Remote.Form, options);
-      else this.element.attach(Remote.Link, options);
-    }
-  });
-
-  Remote.Base = $.klass({
-    initialize : function(options) {
-      this.options = $.extend(true, {}, options || {});
-    },
-    _makeRequest : function(options) {
-      $.ajax(options);
-      return false;
-    }
-  });
-
-  Remote.Link = $.klass(Remote.Base, {
-    onclick: function(e) {
-      var options = $.extend({
-        url: $(this).attr('href'),
-        type: 'GET'
-      }, this.options);
-      return e.data.behavior._makeRequest(e.data.behavior.options);
-    }
-  });
-
-  Remote.Form = $.klass(Remote.Base, {
-    onclick: function(e) {
-      var target = e.target;
-
-      if ($.inArray(target.nodeName.toLowerCase(), ['input', 'button']) >= 0 && target.type.match(/submit|image/))
-        e.data.behavior._submitButton = target;
-    },
-    onsubmit: function(e) {
-      var elm = $(this), data = elm.serializeArray();
-
-      if (e.data.behavior._submitButton) data.push({
-        name: e.data.behavior._submitButton.name,
-        value: e.data.behavior._submitButton.value
-      });
-
-      var options = $.extend({
-        url : elm.attr('action'),
-        type : elm.attr('method') || 'GET',
-        data : data
-      }, e.data.behavior.options);
-
-      e.data.behavior._makeRequest(options);
-
-      return false;
-    }
-  });
-
-  $.ajaxSetup({
-    beforeSend: function(xhr) {
-      if (!this.dataType)
-        xhr.setRequestHeader("Accept", "text/javascript, text/html, application/xml, text/xml, *\/*");
-    }
-  });
-*/
-})(jQuery);
+  // Public API. Prado namespace doesn't exist yet at this point in the file,
+  // so attach to globalThis and re-export onto Prado after it's defined below.
+  globalThis.__PradoClass = Class;
+  if (typeof jQuery !== 'undefined') jQuery.klass = Class;
+})();
 
 
 /**
@@ -279,8 +83,17 @@ var Prado =
 	 * Registry for Prado components
 	 * @var Registry
 	 */
-	Registry: {}
+	Registry: {},
+
+	/**
+	 * Class factory — native ES class with $super injection support.
+	 * Returns a class that calls initialize(...) from its constructor.
+	 * @var Class
+	 * @since 4.4.0
+	 */
+	Class: globalThis.__PradoClass
 };
+delete globalThis.__PradoClass;
 
 Prado.RequestManager =
 {
@@ -288,6 +101,17 @@ Prado.RequestManager =
 
 	FIELD_POSTBACK_PARAMETER : 'PRADO_POSTBACK_PARAMETER'
 };
+
+// Bridge jQuery's ajaxComplete event to a native 'prado:ajaxComplete' event
+// on document. Controls that need to react to AJAX completion (THtmlArea,
+// THtmlArea5, etc.) listen to the native event so they don't depend on
+// jQuery directly. When ajax3.js moves off $.ajax (step 4c), it will
+// dispatch the native event directly and this bridge will be removed.
+if (typeof jQuery !== 'undefined') {
+	jQuery(document).on('ajaxComplete', () => {
+		document.dispatchEvent(new CustomEvent('prado:ajaxComplete'));
+	});
+}
 /**
  * Performs a PostBack using javascript.
  * @function Prado.PostBack
@@ -302,28 +126,25 @@ Prado.RequestManager =
  * @... {string} EventTarget - Id of element that triggered PostBack
  * @... {string} EventParameter - EventParameter for PostBack
  */
-Prado.PostBack = jQuery.klass(
+Prado.PostBack = Prado.Class(
 {
 	options : {},
 
-	initialize: function(options, event)
-	{
-		jQuery.extend(this.options, options || {});
+	initialize(options, event) {
+		Object.assign(this.options, options || {});
 		this.event = event;
 		this.doPostBack();
 	},
 
-	getForm : function()
-	{
-		return jQuery("#" + this.options['FormID']).get(0);
+	getForm() {
+		return document.getElementById(this.options['FormID']);
 	},
 
-	doPostBack : function()
-	{
-		var form = this.getForm();
+	doPostBack() {
+		const form = this.getForm();
 		if(this.options['CausesValidation'] && typeof(Prado.Validation) != "undefined")
 		{
-			if(!Prado.Validation.validate(this.options['FormID'], this.options['ValidationGroup'], jQuery("#" + this.options['ID'])))
+			if(!Prado.Validation.validate(this.options['FormID'], this.options['ValidationGroup'], document.getElementById(this.options['ID'])))
 				return this.event.preventDefault();
 		}
 
@@ -332,10 +153,10 @@ Prado.PostBack = jQuery.klass(
 
 		if(this.options['TrackFocus'])
 		{
-			var lastFocus = jQuery('#PRADO_LASTFOCUS');
+			const lastFocus = document.getElementById('PRADO_LASTFOCUS');
 			if(lastFocus)
 			{
-				var active = document.activeElement; //where did this come from
+				const active = document.activeElement;
 				if(active)
 					lastFocus.value = active.id;
 				else
@@ -343,7 +164,7 @@ Prado.PostBack = jQuery.klass(
 			}
 		}
 
-		var input=null;
+		let input=null;
 		if(this.options.EventTarget)
 		{
 			input = document.createElement("input");
@@ -361,7 +182,14 @@ Prado.PostBack = jQuery.klass(
 			form.appendChild(input);
 		}
 
-		jQuery(form).trigger('submit');
+		if (!form) return;
+		// Match jQuery $(form).trigger('submit'): fire a cancellable submit event
+		// so handlers can preventDefault, then call form.submit() (which skips
+		// HTML5 constraint validation — important because Prado does its own
+		// validation in JS and many emitted forms don't carry HTML5 constraints
+		// that would silently abort form.requestSubmit()).
+		const evt = new Event('submit', { bubbles: true, cancelable: true });
+		if (form.dispatchEvent(evt)) form.submit();
 	}
 });
 
@@ -372,15 +200,17 @@ Prado.PostBack = jQuery.klass(
 Prado.Element =
 {
 	/**
-	 * Executes a jQuery method on a particular element.
+	 * Executes a jQuery method on a particular element. Retained as a
+	 * passthrough for PHP-side controls that emit calls like
+	 * Prado.Element.j('foo', 'fadeIn', [200]). Requires jQuery to be
+	 * loaded at the page level.
 	 * @function ?
 	 * @param {string} element - Element id
 	 * @param {string} method - method name
 	 * @param {array} value - method parameters
 	 */
-	j: function(element, method, params)
-	{
-		var obj=jQuery("#" + element);
+	j(element, method, params) {
+		const obj=jQuery(`#${element}`);
 		obj[method].apply(obj, params);
 	},
 
@@ -392,14 +222,13 @@ Prado.Element =
 	 * @param {array|boolean|string} value - Values that should be selected
 	 * @param {int} total - Number of elements
 	 */
-	select : function(element, method, value, total)
-	{
-		var el = jQuery("#" + element).get(0);
+	select(element, method, value, total) {
+		const el = document.getElementById(element);
 		if(!el) return;
-		var selection = Prado.Element.Selection;
+		const selection = Prado.Element.Selection;
 		if(typeof(selection[method]) == "function")
 		{
-			var control = selection.isSelectable(el) ? [el] : selection.getListElements(element,total);
+			const control = selection.isSelectable(el) ? [el] : selection.getListElements(element,total);
 			selection[method](control, value);
 		}
 	},
@@ -411,33 +240,32 @@ Prado.Element =
 	 * @param {string} attribute - Name of attribute
 	 * @param {string} value - Value of attribute
 	 */
-	setAttribute : function(element, attribute, value)
-	{
-		var el = jQuery("#" + element);
+	setAttribute(element, attribute, value) {
+		const el = document.getElementById(element);
 		if(!el) return;
 		// "disabled" is for <button>, <fieldset>, <input>, <optgroup>, <option>, <select>, <textarea>
 		// "readonly is for <input>, <textarea>
 		// global presence attributes: hidden, inert, popover
 		// removed 'href' and 'multiple' was a hack - they use removeAttribute now
 		if((attribute == "disabled" || attribute == "readonly" || attribute == "hidden" || attribute == "inert" || attribute == "popover") && value==false)
-			el.removeAttr(attribute);
+			el.removeAttribute(attribute);
 		else if(attribute.match(/^on/i)) //event methods
 		{
 			try
 			{
-				eval("(func = function(event){"+value+"})");
-				el.get(0)[attribute] = func;
+				eval(`(func = function(event){${value}})`);
+				el[attribute] = func;
 			}
 			catch(e)
 			{
 				debugger;
-				throw "Error in evaluating '"+value+"' for attribute "+attribute+" for element "+element;
+				throw `Error in evaluating '${value}' for attribute ${attribute} for element ${element}`;
 			}
 		}
 		else
-			el.attr(attribute, value);
+			el.setAttribute(attribute, value);
 	},
-	
+
 	/**
 	 * Removes an attribute of a DOM element.
 	 * @function ?
@@ -445,35 +273,34 @@ Prado.Element =
 	 * @param {string} attribute - Name of attribute
 	 * @since 4.3.3
 	 */
-	removeAttribute : function(element, attribute)
-	{
-		var el = jQuery("#" + element);
+	removeAttribute(element, attribute) {
+		const el = document.getElementById(element);
 		if(!el) return;
-		el.removeAttr(attribute);
+		el.removeAttribute(attribute);
 	},
 
-	scrollTo : function(element, options)
-	{
-		var op = {
-			duration : 500,
-			offset : 50
+	scrollTo(element, options) {
+		const op = { offset : 50, ...(options || {}) };
+		const el = document.getElementById(element);
+		if (!el) return;
+		const top = el.getBoundingClientRect().top + window.pageYOffset - op.offset;
+		window.scrollTo({ top, behavior: 'smooth' });
+	},
+
+	focus(element) {
+		const doFocus = () => {
+			const el = document.getElementById(element);
+			if (el) el.focus();
 		};
-		jQuery.extend(op, options || {});
-		jQuery('html, body').animate({
-			scrollTop: jQuery("#"+element).offset().top - op.offset
-		}, op.duration);
-	},
-
-	focus : function(element)
-	{
-		if(jQuery.active > 0)
-		{
-			setTimeout(function(){
-				jQuery("#"+element).focus();
-			}, 100);
-		} else {
-			jQuery("#"+element).focus();
-		}
+		// If a callback request is in flight, defer briefly so we focus the
+		// post-update DOM. Prado.CallbackRequest tracks in-flight requests
+		// in its requestQueue (see ajax3.js).
+		const pending = (typeof Prado !== 'undefined'
+			&& Prado.CallbackRequest
+			&& Prado.CallbackRequest.requestQueue
+			&& Prado.CallbackRequest.requestQueue.length) > 0;
+		if (pending) setTimeout(doFocus, 100);
+		else doFocus();
 	},
 
 	/**
@@ -483,18 +310,17 @@ Prado.Element =
 	 * @param {array[]} options - Array of options, each an array of structure
 	 *   [ "optionText" , "optionValue" , "optionGroup" ]
 	 */
-	setOptions : function(element, options)
-	{
-		var el = jQuery("#" + element).get(0);
-		var previousGroup = null;
-		var optGroup=null;
+	setOptions(element, options) {
+		const el = document.getElementById(element);
+		const previousGroup = null;
+		const optGroup=null;
 		if(el && el.tagName.toLowerCase() == "select")
 		{
 			while(el.childNodes.length > 0)
 				el.removeChild(el.lastChild);
 
-			var optDom = Prado.Element.createOptions(options);
-			for(var i = 0; i < optDom.length; i++)
+			const optDom = Prado.Element.createOptions(options);
+			for(let i = 0; i < optDom.length; i++)
 				el.appendChild(optDom[i]);
 		}
 	},
@@ -506,17 +332,16 @@ Prado.Element =
 	 *   [ "optionText" , "optionValue" , "optionGroup" ]
 	 * @returns Array of option DOM elements
 	 */
-	createOptions : function(options)
-	{
-		var previousGroup = null;
-		var optgroup=null;
-		var result = [];
-		for(var i = 0; i<options.length; i++)
+	createOptions(options) {
+		let previousGroup = null;
+		let optgroup=null;
+		const result = [];
+		for(let i = 0; i<options.length; i++)
 		{
-			var option = options[i];
+			const option = options[i];
 			if(option.length > 2)
 			{
-				var group = option[2];
+				const group = option[2];
 				if(group!=previousGroup)
 				{
 					if(previousGroup!=null && optgroup!=null)
@@ -530,7 +355,7 @@ Prado.Element =
 					previousGroup = group;
 				}
 			}
-			var opt = document.createElement('option');
+			const opt = document.createElement('option');
 			opt.text = option[0];
 			opt.innerHTML = option[0];
 			opt.value = option[1];
@@ -554,18 +379,43 @@ Prado.Element =
 	 * @param {optional string} boundary - Boundary of new content
 	 * @param {optional boolean} self - Whether to replace itself or just the inner content
 	 */
-	replace : function(element, content, boundary, self)
-	{
+	replace(element, content, boundary, self) {
 		if(boundary)
 		{
-			var result = this.extractContent(boundary);
+			const result = this.extractContent(boundary);
 			if(result != null)
 				content = result;
 		}
+		const el = document.getElementById(element);
+		if(!el) return;
 		if(self)
-		  jQuery('#'+element).replaceWith(content);
+		  el.outerHTML = content;
 		else
-		  jQuery('#'+element).html(content);
+		  el.innerHTML = content;
+		// innerHTML / outerHTML parse <script> tags but the HTML spec marks
+		// them as already-executed, so the browser refuses to run them. jQuery's
+		// .html() / .replaceWith() worked around this by re-creating script
+		// nodes. Mirror that so Prado callback responses that embed inline
+		// JavaScript continue to execute.
+		const container = self ? el.parentNode : el;
+		if (container) Prado.Element.executeScripts(container);
+	},
+
+	/**
+	 * Re-evaluate every <script> element under `root`. Used after
+	 * Prado.Element.replace() to mimic jQuery .html() / .replaceWith()
+	 * behavior, which executes inline scripts injected via innerHTML.
+	 * @function ?
+	 * @param {element} root - DOM subtree to scan
+	 */
+	executeScripts(root) {
+		const scripts = root.querySelectorAll('script');
+		for (const oldScript of scripts) {
+			const fresh = document.createElement('script');
+			for (const attr of oldScript.attributes) fresh.setAttribute(attr.name, attr.value);
+			fresh.text = oldScript.textContent;
+			oldScript.parentNode.replaceChild(fresh, oldScript);
+		}
 	},
 
 	/**
@@ -573,15 +423,14 @@ Prado.Element =
 	 * @function ?
 	 * @param {string} boundary - Boundary containing the javascript code
 	 */
-	appendScriptBlock : function(boundary)
-	{
-		var content = this.extractContent(boundary);
+	appendScriptBlock(boundary) {
+		const content = this.extractContent(boundary);
 		if(content == null)
 			return;
 
-		var el   = document.createElement("script");
+		const el   = document.createElement("script");
 		el.type  = "text/javascript";
-		el.id    = 'inline_' + boundary;
+		el.id    = `inline_${boundary}`;
 		el.text  = content;
 
 		(document.getElementsByTagName('head')[0] || document.documentElement).appendChild(el);
@@ -594,23 +443,24 @@ Prado.Element =
 	 * @param {string} content - String containing the script
 	 * @param {string} boundary - Boundary containing the script
 	 */
-	evaluateScript : function(content, boundary)
-	{
+	evaluateScript(content, boundary) {
 		if(boundary)
 		{
-			var result = this.extractContent(boundary);
+			const result = this.extractContent(boundary);
 			if(result != null)
 				content = result;
 		}
 
 		try
 		{
-			jQuery.globalEval(content);
+			// Evaluate in global scope (jQuery.globalEval equivalent).
+			// The indirect (0, eval) call forces script to run as global code.
+			(0, eval)(content);
 		}
 		catch(e)
 		{
 			if(typeof(Logger) != "undefined")
-				Logger.error('Error during evaluation of script "'+content+'"');
+				Logger.error(`Error during evaluation of script "${content}"`);
 			else
 				debugger;
 			throw e;
@@ -630,8 +480,7 @@ Prado.Element.Selection =
 	 * @param {element} el - DOM elemet
 	 * @returns true if element is selectable
 	 */
-	isSelectable : function(el)
-	{
+	isSelectable(el) {
 		if(el && el.type)
 		{
 			switch(el.type.toLowerCase())
@@ -654,8 +503,7 @@ Prado.Element.Selection =
 	 * @param {boolean} value - New value of checked attribute
 	 * @returns New value of checked attribute
 	 */
-	inputValue : function(el, value)
-	{
+	inputValue(el, value) {
 		switch(el.type.toLowerCase())
 		{
 			case 'checkbox':
@@ -672,18 +520,15 @@ Prado.Element.Selection =
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 * @param {boolean|string} value - Value of options that should be selected or boolean value of selection status
 	 */
-	selectValue : function(elements, value)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
-			jQuery.each(el.options, function(idx, option)
-			{
+	selectValue(elements, value) {
+		for (const el of elements) {
+			for (const option of el.options) {
 				if(typeof(value) == "boolean")
 					option.selected = value;
 				else if(option.value == value)
 					option.selected = true;
-			});
-		})
+			}
+		}
 	},
 
 	/**
@@ -692,13 +537,8 @@ Prado.Element.Selection =
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 * @param {string[]} value - Array of values to select
 	 */
-	selectValues : function(elements, values)
-	{
-		var selection = this;
-		jQuery.each(values, function(idx, value)
-		{
-			selection.selectValue(elements,value);
-		})
+	selectValues(elements, values) {
+		for (const value of values) this.selectValue(elements, value);
 	},
 
 	/**
@@ -707,21 +547,19 @@ Prado.Element.Selection =
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 * @param {int} index - Index of option to select
 	 */
-	selectIndex : function(elements, index)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
+	selectIndex(elements, index) {
+		for (const el of elements) {
 			if(el.type.toLowerCase() == 'select-one')
 				el.selectedIndex = index;
 			else
 			{
-				for(var i = 0; i<el.length; i++)
+				for(let i = 0; i<el.length; i++)
 				{
 					if(i == index)
 						el.options[i].selected = true;
 				}
 			}
-		})
+		}
 	},
 
 	/**
@@ -729,18 +567,11 @@ Prado.Element.Selection =
 	 * @function ?
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 */
-	selectAll : function(elements)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
+	selectAll(elements) {
+		for (const el of elements) {
 			if(el.type.toLowerCase() != 'select-one')
-			{
-				jQuery.each(el.options, function(idx, option)
-				{
-					option.selected = true;
-				})
-			}
-		})
+				for (const option of el.options) option.selected = true;
+		}
 	},
 
 	/**
@@ -748,18 +579,11 @@ Prado.Element.Selection =
 	 * @function ?
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 */
-	selectInvert : function(elements)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
+	selectInvert(elements) {
+		for (const el of elements) {
 			if(el.type.toLowerCase() != 'select-one')
-			{
-				jQuery.each(el.options, function(idx, option)
-				{
-					option.selected = !option.selected;
-				})
-			}
-		})
+				for (const option of el.options) option.selected = !option.selected;
+		}
 	},
 
 	/**
@@ -768,13 +592,8 @@ Prado.Element.Selection =
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 * @param {int[]} indices - Array of option indices to select
 	 */
-	selectIndices : function(elements, indices)
-	{
-		var selection = this;
-		jQuery.each(indices, function(idx, index)
-		{
-			selection.selectIndex(elements,index);
-		})
+	selectIndices(elements, indices) {
+		for (const index of indices) this.selectIndex(elements, index);
 	},
 
 	/**
@@ -782,12 +601,8 @@ Prado.Element.Selection =
 	 * @function ?
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 */
-	selectClear : function(elements)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
-			el.selectedIndex = -1;
-		})
+	selectClear(elements) {
+		for (const el of elements) el.selectedIndex = -1;
 	},
 
 	/**
@@ -797,13 +612,12 @@ Prado.Element.Selection =
 	 * @param {int} total - Number of list elements to return
 	 * @returns Array of list DOM elements
 	 */
-	getListElements : function(element, total)
-	{
-		var elements = new Array();
-		var el;
-		for(var i = 0; i < total; i++)
+	getListElements(element, total) {
+		const elements = new Array();
+		let el;
+		for(let i = 0; i < total; i++)
 		{
-			el = jQuery("#"+element+"_c"+i).get(0);
+			el = document.getElementById(`${element}_c${i}`);
 			if(el)
 				elements.push(el);
 		}
@@ -819,15 +633,13 @@ Prado.Element.Selection =
 	 * @param {boolean|String} value - Value that should be checked or boolean value of checked status
 	 *
 	 */
-	checkValue : function(elements, value)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
+	checkValue(elements, value) {
+		for (const el of elements) {
 			if(typeof(value) == "boolean")
 				el.checked = value;
 			else if(el.value == value)
 				el.checked = true;
-		});
+		}
 	},
 
 	/**
@@ -837,13 +649,8 @@ Prado.Element.Selection =
 	 * @param {string[]} values - Values that should be checked
 	 *
 	 */
-	checkValues : function(elements, values)
-	{
-		var selection = this;
-		jQuery(values).each(function(idx, value)
-		{
-			selection.checkValue(elements, value);
-		})
+	checkValues(elements, values) {
+		for (const value of values) this.checkValue(elements, value);
 	},
 
 	/**
@@ -852,9 +659,8 @@ Prado.Element.Selection =
 	 * @param {element[]} elements - Array of checkable DOM elements
 	 * @param {int} index - Index of element to set checked
 	 */
-	checkIndex : function(elements, index)
-	{
-		for(var i = 0; i<elements.length; i++)
+	checkIndex(elements, index) {
+		for(let i = 0; i<elements.length; i++)
 		{
 			if(i == index)
 				elements[i].checked = true;
@@ -867,13 +673,8 @@ Prado.Element.Selection =
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 * @param {int[]} indices - Array of list indices to set checked
 	 */
-	checkIndices : function(elements, indices)
-	{
-		var selection = this;
-		jQuery.each(indices, function(idx, index)
-		{
-			selection.checkIndex(elements, index);
-		})
+	checkIndices(elements, indices) {
+		for (const index of indices) this.checkIndex(elements, index);
 	},
 
 	/**
@@ -881,12 +682,8 @@ Prado.Element.Selection =
 	 * @function ?
 	 * @param {element[]} elements - Array of checkable DOM elements
 	 */
-	checkClear : function(elements)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
-			el.checked = false;
-		});
+	checkClear(elements) {
+		for (const el of elements) el.checked = false;
 	},
 
 	/**
@@ -894,12 +691,8 @@ Prado.Element.Selection =
 	 * @function ?
 	 * @param {element[]} elements - Array of checkable DOM elements
 	 */
-	checkAll : function(elements)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
-			el.checked = true;
-		})
+	checkAll(elements) {
+		for (const el of elements) el.checked = true;
 	},
 
 	/**
@@ -907,16 +700,12 @@ Prado.Element.Selection =
 	 * @function ?
 	 * @param {element[]} elements - Array of selectable DOM elements
 	 */
-	checkInvert : function(elements)
-	{
-		jQuery.each(elements, function(idx, el)
-		{
-			el.checked = !el.checked;
-		})
+	checkInvert(elements) {
+		for (const el of elements) el.checked = !el.checked;
 	}
 };
 
-jQuery.extend(String.prototype, {
+Object.assign(String.prototype, {
 
 	/**
 	 * Add padding to string
@@ -926,10 +715,10 @@ jQuery.extend(String.prototype, {
 	 * @param {string} chr - Character(s) to pad
 	 * @returns Padded string
 	 */
-	pad : function(side, len, chr) {
+	pad(side, len, chr) {
 		if (!chr) chr = ' ';
-		var s = this;
-		var left = side.toLowerCase()=='left';
+		let s = this;
+		const left = side.toLowerCase()=='left';
 		while (s.length<len) s = left? chr + s : s + chr;
 		return s;
 	},
@@ -941,7 +730,7 @@ jQuery.extend(String.prototype, {
 	 * @param {string} chr - Character(s) to pad
 	 * @returns Padded string
 	 */
-	padLeft : function(len, chr) {
+	padLeft(len, chr) {
 		return this.pad('left',len,chr);
 	},
 
@@ -952,7 +741,7 @@ jQuery.extend(String.prototype, {
 	 * @param {string} chr - Character(s) to pad
 	 * @returns Padded string
 	 */
-	padRight : function(len, chr) {
+	padRight(len, chr) {
 		return this.pad('right',len,chr);
 	},
 
@@ -962,7 +751,7 @@ jQuery.extend(String.prototype, {
 	 * @param {int} len - Minimum string length.
 	 * @returns Padded string
 	 */
-	zerofill : function(len) {
+	zerofill(len) {
 		return this.padLeft(len,'0');
 	},
 
@@ -971,7 +760,7 @@ jQuery.extend(String.prototype, {
 	 * @function {string} ?
 	 * @returns Trimmed string
 	 */
-	trim : function() {
+	trim() {
 		return this.replace(/^\s+|\s+$/g,'');
 	},
 
@@ -980,7 +769,7 @@ jQuery.extend(String.prototype, {
 	 * @function {string} ?
 	 * @returns Trimmed string
 	 */
-	trimLeft : function() {
+	trimLeft() {
 		return this.replace(/^\s+/,'');
 	},
 
@@ -989,7 +778,7 @@ jQuery.extend(String.prototype, {
 	 * @function {string} ?
 	 * @returns Trimmed string
 	 */
-	trimRight : function() {
+	trimRight() {
 		return this.replace(/\s+$/,'');
 	},
 
@@ -1002,15 +791,13 @@ jQuery.extend(String.prototype, {
 	 * @function {function} ?
 	 * @returns Reference to the corresponding function
 	 */
-	toFunction : function()
-	{
-		var commands = this.split(/\./);
-		var command = window;
-		jQuery(commands).each(function(idx, action)
-		{
+	toFunction() {
+		const commands = this.split(/\./);
+		let command = window;
+		for (const action of commands) {
 			if(command[new String(action)])
 				command=command[new String(action)];
-		});
+		}
 		if(typeof(command) == "function")
 			return command;
 		else
@@ -1018,7 +805,7 @@ jQuery.extend(String.prototype, {
 			if(typeof Logger != "undefined")
 				Logger.error("Missing function", this);
 
-			throw new Error	("Missing function '"+this+"'");
+			throw new Error	(`Missing function '${this}'`);
 		}
 	},
 
@@ -1027,12 +814,11 @@ jQuery.extend(String.prototype, {
 	 * @function {int} ?
 	 * @returns Integer, null if string does not represent an integer.
 	 */
-	toInteger : function()
-	{
-		var exp = /^\s*[-\+]?\d+\s*$/;
+	toInteger() {
+		const exp = /^\s*[-\+]?\d+\s*$/;
 		if (this.match(exp) == null)
 			return null;
-		var num = parseInt(this, 10);
+		const num = parseInt(this, 10);
 		return (isNaN(num) ? null : num);
 	},
 
@@ -1043,12 +829,11 @@ jQuery.extend(String.prototype, {
 	 * @param {string} decimalchar - Decimal character, defaults to "."
 	 * @returns Double, null if string does not represent a float value
 	 */
-	toDouble : function(decimalchar)
-	{
+	toDouble(decimalchar) {
 		if(this.length <= 0) return null;
 		decimalchar = decimalchar || ".";
-		var exp = new RegExp("^\\s*([-\\+])?(\\d+)?(\\" + decimalchar + "(\\d+))?\\s*$");
-		var m = this.match(exp);
+		const exp = new RegExp(`^\\s*([-\\+])?(\\d+)?(\\${decimalchar}(\\d+))?\\s*$`);
+		const m = this.match(exp);
 
 		if (m == null)
 			return null;
@@ -1056,8 +841,8 @@ jQuery.extend(String.prototype, {
 		m[2] = m[2] || "0";
 		m[4] = m[4] || "0";
 
-		var cleanInput = m[1] + (m[2].length>0 ? m[2] : "0") + "." + m[4];
-		var num = parseFloat(cleanInput);
+		const cleanInput = `${m[1] + (m[2].length>0 ? m[2] : "0")}.${m[4]}`;
+		const num = parseFloat(cleanInput);
 		return (isNaN(num) ? null : num);
 	},
 
@@ -1073,25 +858,22 @@ jQuery.extend(String.prototype, {
 	 * @param {string} decimalchar - Decimal character, defaults to "."
 	 * @returns Double, null if string does not represent a currency value
 	 */
-	toCurrency : function(groupchar, digits, decimalchar)
-	{
+	toCurrency(groupchar, digits, decimalchar) {
 		groupchar = groupchar || ",";
 		decimalchar = decimalchar || ".";
 		digits = typeof(digits) == "undefined" ? 2 : digits;
 
-		var exp = new RegExp("^\\s*([-\\+])?(((\\d+)\\" + groupchar + ")*)(\\d+)"
-			+ ((digits > 0) ? "(\\" + decimalchar + "(\\d{1," + digits + "}))?" : "")
-			+ "\\s*$");
-		var m = this.match(exp);
+		const exp = new RegExp(`^\\s*([-\\+])?(((\\d+)\\${groupchar})*)(\\d+)${(digits > 0) ? `(\\${decimalchar}(\\d{1,${digits}}))?` : ""}\\s*$`);
+		const m = this.match(exp);
 		if (m == null)
 			return null;
 		m[1] = m[1] || "";
 		m[2] = m[2] || "";
-		var intermed = m[2] + m[5] ;
-		var cleanInput = m[1] + intermed.replace(
-				new RegExp("(\\" + groupchar + ")", "g"), "")
-								+ ((digits > 0) ? "." + m[7] : "");
-		var num = parseFloat(cleanInput);
+		const intermed = m[2] + m[5];
+		const cleanInput = m[1] + intermed.replace(
+				new RegExp(`(\\${groupchar})`, "g"), "")
+								+ ((digits > 0) ? `.${m[7]}` : "");
+		const num = parseFloat(cleanInput);
 		return (isNaN(num) ? null : num);
 	},
 	
@@ -1101,12 +883,12 @@ jQuery.extend(String.prototype, {
 	 * @returns string with 'px' at the end
 	 * @since 4.2.0
 	 */
-	px : function() {
-		return this.endsWith('px') ? this : this + 'px';
+	px() {
+		return this.endsWith('px') ? this : `${this}px`;
 	}
 });
 
-jQuery.extend(Number.prototype,
+Object.assign(Number.prototype,
 {
 	/**
 	 * Appends 'px' at the end of the number.
@@ -1114,12 +896,12 @@ jQuery.extend(Number.prototype,
 	 * @returns string with number plus 'px' at the end
 	 * @since 4.2.0
 	 */
-	px : function() {
-		return this + 'px';
+	px() {
+		return `${this}px`;
 	}
 });
 
-jQuery.extend(Date.prototype,
+Object.assign(Date.prototype,
 {
 	/**
 	 * SimpleFormat
@@ -1128,10 +910,9 @@ jQuery.extend(Date.prototype,
 	 * @param {string} data - TODO
 	 * @returns TODO
 	 */
-	SimpleFormat: function(format, data)
-	{
+	SimpleFormat(format, data) {
 		data = data || {};
-		var bits = new Array();
+		const bits = new Array();
 		bits['d'] = this.getDate();
 		bits['dd'] = String(this.getDate()).zerofill(2);
 
@@ -1141,17 +922,17 @@ jQuery.extend(Date.prototype,
 			bits['MMM'] = data.AbbreviatedMonthNames[this.getMonth()];
 		if(data.MonthNames)
 			bits['MMMM'] = data.MonthNames[this.getMonth()];
-		var yearStr = "" + this.getFullYear();
-		yearStr = (yearStr.length == 2) ? '19' + yearStr: yearStr;
+		let yearStr = `${this.getFullYear()}`;
+		yearStr = (yearStr.length == 2) ? `19${yearStr}`: yearStr;
 		bits['yyyy'] = yearStr;
 		bits['yy'] = bits['yyyy'].toString().substr(2,2);
 
 		// do some funky regexs to replace the format string
 		// with the real values
-		var frm = new String(format);
-		for (var sect in bits)
+		let frm = new String(format);
+		for (const sect in bits)
 		{
-			var reg = new RegExp("\\b"+sect+"\\b" ,"g");
+			const reg = new RegExp(`\\b${sect}\\b` ,"g");
 			frm = frm.replace(reg, bits[sect]);
 		}
 		return frm;
@@ -1162,16 +943,15 @@ jQuery.extend(Date.prototype,
 	 * @function {string} ?
 	 * @returns TODO
 	 */
-	toISODate : function()
-	{
-		var y = this.getFullYear();
-		var m = String(this.getMonth() + 1).zerofill(2);
-		var d = String(this.getDate()).zerofill(2);
+	toISODate() {
+		const y = this.getFullYear();
+		const m = String(this.getMonth() + 1).zerofill(2);
+		const d = String(this.getDate()).zerofill(2);
 		return String(y) + String(m) + String(d);
 	}
 });
 
-jQuery.extend(Date,
+Object.assign(Date,
 {
 	/**
 	 * SimpleParse
@@ -1180,46 +960,43 @@ jQuery.extend(Date,
 	 * @param {string} data - TODO
 	 * @returns TODO
 	 */
-	SimpleParse: function(value, format)
-	{
-		var val=String(value);
+	SimpleParse(value, format) {
+		const val=String(value);
 		format=String(format);
 
 		if(val.length <= 0) return null;
 
 		if(format.length <= 0) return new Date(value);
 
-		var isInteger = function (val)
-		{
-			var digits="1234567890";
-			for (var i=0; i < val.length; i++)
+		const isInteger = val => {
+			const digits="1234567890";
+			for (let i=0; i < val.length; i++)
 			{
 				if (digits.indexOf(val.charAt(i))==-1) { return false; }
 			}
 			return true;
 		};
 
-		var getInt = function(str,i,minlength,maxlength)
-		{
-			for (var x=maxlength; x>=minlength; x--)
+		const getInt = (str, i, minlength, maxlength) => {
+			for (let x=maxlength; x>=minlength; x--)
 			{
-				var token=str.substring(i,i+x);
+				const token=str.substring(i,i+x);
 				if (token.length < minlength) { return null; }
 				if (isInteger(token)) { return token; }
 			}
 			return null;
 		};
 
-		var i_val=0;
-		var i_format=0;
-		var c="";
-		var token="";
-		var token2="";
-		var x,y;
-		var now=new Date();
-		var year=now.getFullYear();
-		var month=now.getMonth()+1;
-		var date=1;
+		let i_val=0;
+		let i_format=0;
+		let c="";
+		let token="";
+		const token2="";
+		let x, y;
+		const now=new Date();
+		let year=now.getFullYear();
+		let month=now.getMonth()+1;
+		let date=1;
 
 		while (i_format < format.length)
 		{
@@ -1284,7 +1061,7 @@ jQuery.extend(Date,
 			if (date > 30) { return null; }
 		}
 
-		var newdate=new Date(year,month-1,date, 0, 0, 0);
+		const newdate = new Date(year,month-1,date, 0, 0, 0);
 		return newdate;
 	}
 });

--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -253,12 +253,14 @@ Prado.Element =
 		{
 			try
 			{
-				eval(`(func = function(event){${value}})`);
-				el[attribute] = func;
+				// Compile the server-emitted handler body as a function of
+				// `event` and assign it to the DOM property (onclick/onchange/etc.).
+				// `new Function` keeps the closure scope local instead of leaking
+				// a global the way `eval` would.
+				el[attribute] = new Function('event', value);
 			}
-			catch(e)
+			catch(_e)
 			{
-				debugger;
 				throw `Error in evaluating '${value}' for attribute ${attribute} for element ${element}`;
 			}
 		}
@@ -312,8 +314,6 @@ Prado.Element =
 	 */
 	setOptions(element, options) {
 		const el = document.getElementById(element);
-		const previousGroup = null;
-		const optGroup=null;
 		if(el && el.tagName.toLowerCase() == "select")
 		{
 			while(el.childNodes.length > 0)
@@ -407,6 +407,7 @@ Prado.Element =
 	 * behavior, which executes inline scripts injected via innerHTML.
 	 * @function ?
 	 * @param {element} root - DOM subtree to scan
+	 * @since 4.4.0
 	 */
 	executeScripts(root) {
 		const scripts = root.querySelectorAll('script');
@@ -455,14 +456,13 @@ Prado.Element =
 		{
 			// Evaluate in global scope (jQuery.globalEval equivalent).
 			// The indirect (0, eval) call forces script to run as global code.
+			// eslint-disable-next-line no-eval
 			(0, eval)(content);
 		}
 		catch(e)
 		{
 			if(typeof(Logger) != "undefined")
 				Logger.error(`Error during evaluation of script "${content}"`);
-			else
-				debugger;
 			throw e;
 		}
 	}
@@ -815,7 +815,7 @@ Object.assign(String.prototype, {
 	 * @returns Integer, null if string does not represent an integer.
 	 */
 	toInteger() {
-		const exp = /^\s*[-\+]?\d+\s*$/;
+		const exp = /^\s*[-+]?\d+\s*$/;
 		if (this.match(exp) == null)
 			return null;
 		const num = parseInt(this, 10);
@@ -991,7 +991,6 @@ Object.assign(Date,
 		let i_format=0;
 		let c="";
 		let token="";
-		const token2="";
 		let x, y;
 		const now=new Date();
 		let year=now.getFullYear();

--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -45,6 +45,10 @@
     const klass = function (...ctorArgs) {
       this.initialize(...ctorArgs);
     };
+    // Marker the jQuery.fn.trigger bridge (below) uses to identify
+    // Prado-managed elements. More robust than checking constructor.name,
+    // which would break on minification or a future `class` keyword move.
+    klass.isPradoClass = true;
 
     if (parent) {
       klass.prototype = Object.create(parent.prototype);
@@ -57,6 +61,24 @@
     for (const props of args) installMethods(klass, props);
 
     if (!klass.prototype.initialize) klass.prototype.initialize = function () {};
+
+    // Native event-dispatch helper. New 4.4 code calls `this.trigger('foo')`
+    // instead of `jQuery(this.element).trigger('foo')` to fire an event
+    // without depending on jQuery. Uses CustomEvent so a `detail` payload is
+    // delivered to listeners. Sub-classes may override.
+    // @since 4.4.0
+    if (!klass.prototype.trigger) {
+      klass.prototype.trigger = function (eventName, detail) {
+        const el = this.element;
+        if (!el || !el.dispatchEvent || !eventName) return;
+        el.dispatchEvent(new CustomEvent(eventName, {
+          bubbles: true,
+          cancelable: true,
+          detail,
+        }));
+      };
+    }
+
     return klass;
   };
 
@@ -102,15 +124,106 @@ Prado.RequestManager =
 	FIELD_POSTBACK_PARAMETER : 'PRADO_POSTBACK_PARAMETER'
 };
 
-// Bridge jQuery's ajaxComplete event to a native 'prado:ajaxComplete' event
-// on document. Controls that need to react to AJAX completion (THtmlArea,
-// THtmlArea5, etc.) listen to the native event so they don't depend on
-// jQuery directly. When ajax3.js moves off $.ajax (step 4c), it will
-// dispatch the native event directly and this bridge will be removed.
+// jQuery compatibility bridges. Both are installed only when jQuery is
+// available on the page; when the jQuery quarantine plan ships, this whole
+// block moves into the jQuery-loading package only.
 if (typeof jQuery !== 'undefined') {
+	// Bridge jQuery's ajaxComplete event to a native 'prado:ajaxComplete'
+	// event on document. Controls that need to react to AJAX completion
+	// (THtmlArea, THtmlArea5, etc.) listen to the native event so they
+	// don't depend on jQuery directly. When ajax3.js moves off $.ajax
+	// (step 4c), it will dispatch the native event directly and this
+	// bridge will be removed.
 	jQuery(document).on('ajaxComplete', () => {
 		document.dispatchEvent(new CustomEvent('prado:ajaxComplete'));
 	});
+
+	/**
+	 * Bridge `jQuery(el).trigger(name)` to native `dispatchEvent` for
+	 * Prado-managed elements. Pre-4.4 controls registered handlers through
+	 * the jQuery event bus and fired them with `jQuery(el).trigger('name')`.
+	 * The framework's `observe` now uses native `addEventListener`, and
+	 * jQuery `.trigger()` does not reach native listeners (see
+	 * https://github.com/jquery/jquery/issues/2476), so pre-4.4 calls
+	 * become no-ops without this bridge.
+	 *
+	 * Behavior:
+	 *   - Elements not registered in `Prado.Registry` keep the original
+	 *     jQuery `.trigger()` semantics. No regression for pure-jQuery
+	 *     controls.
+	 *   - Klass-registered elements receive `el.dispatchEvent(CustomEvent)`.
+	 *     This reaches both native `addEventListener` handlers AND any
+	 *     jQuery-bound handlers (because jQuery itself attaches via
+	 *     `addEventListener` under the hood).
+	 *   - Forms get `el.submit()` after the event so they actually submit.
+	 *     `<input type="submit">` / `<button>` clicks call `el.click()` so
+	 *     the browser performs the default activation behavior (submit,
+	 *     toggle, navigate). Synthetic events alone do not fire defaults.
+	 *
+	 * @since 4.4.0
+	 */
+	const originalTrigger = jQuery.fn.trigger;
+	jQuery.fn.trigger = function (type, extraParameters) {
+		const isEventObject = type && typeof type === 'object';
+		const eventType = isEventObject ? type.type : type;
+
+		// Partition the wrapper into Prado-managed (klass) and non-klass
+		// elements. We only deviate from jQuery's behavior for klass
+		// elements; everything else goes through jQuery's own trigger
+		// pipeline exactly as before.
+		const $klass = this.filter(function () {
+			const reg = this.id && Prado.Registry[this.id];
+			return !!(reg && reg.constructor && reg.constructor.isPradoClass);
+		});
+		const $rest = this.not($klass);
+
+		// Klass path: dispatch native events, with the right activation
+		// special-cases so default behavior (form submit, focus, click)
+		// still happens.
+		$klass.each(function () {
+			const el = this;
+			if (!el.dispatchEvent || !eventType) return;
+
+			// Form submit: dispatchEvent does not submit. Match
+			// jQuery .trigger('submit') by firing the cancellable event
+			// then calling native submit() if not preventDefault'd.
+			if (eventType === 'submit' && el.tagName === 'FORM') {
+				const evt = new Event('submit', { bubbles: true, cancelable: true });
+				if (el.dispatchEvent(evt)) el.submit();
+				return;
+			}
+
+			// Activation events: jQuery .trigger('click') / 'focus' /
+			// 'blur' invoke the native method, which fires the real
+			// event AND runs the default action (form submission for
+			// submit buttons, focus state changes, etc.). dispatchEvent
+			// skips defaults because synthetic events have
+			// isTrusted === false.
+			if (
+				(eventType === 'click' || eventType === 'focus' || eventType === 'blur')
+				&& typeof el[eventType] === 'function'
+			) {
+				el[eventType]();
+				return;
+			}
+
+			const nativeEvent = (isEventObject && type instanceof Event)
+				? type
+				: new CustomEvent(eventType, {
+					bubbles: true,
+					cancelable: true,
+					detail: extraParameters,
+				});
+			el.dispatchEvent(nativeEvent);
+		});
+
+		// Non-klass path: one delegation to jQuery's original trigger on
+		// the remaining subset. Preserves all of jQuery's specialized
+		// event hooks (event.special.X) and per-event-type defaults.
+		if ($rest.length) originalTrigger.call($rest, type, extraParameters);
+
+		return this;
+	};
 }
 /**
  * Performs a PostBack using javascript.

--- a/framework/Web/Javascripts/source/prado/ratings/ratings.js
+++ b/framework/Web/Javascripts/source/prado/ratings/ratings.js
@@ -36,7 +36,7 @@ Prado.WebUI.TRatingList = Prado.Class(Prado.WebUI.Control,
 		this.setReadOnly(this.readOnly);
 	},
 
-	hover(index, ev) {
+	hover(index, _ev) {
 		if(this.readOnly==true) return;
 
 		for(let i = 0; i<this.radios.length; i++)
@@ -52,7 +52,7 @@ Prado.WebUI.TRatingList = Prado.Class(Prado.WebUI.Control,
 		this.showCaption(this.getIndexCaption(index));
 	},
 
-	recover(index, ev) {
+	recover(_index, _ev) {
 		if(this.readOnly==true) return;
 		this.showRating(this.rating);
 		this.showCaption(this.options.caption);

--- a/framework/Web/Javascripts/source/prado/ratings/ratings.js
+++ b/framework/Web/Javascripts/source/prado/ratings/ratings.js
@@ -1,31 +1,30 @@
 /*! PRADO TRatingList javascript file | github.com/pradosoft/prado */
 
-Prado.WebUI.TRatingList = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TRatingList = Prado.Class(Prado.WebUI.Control,
 {
 	selectedIndex : -1,
 	rating: -1,
 	readOnly : false,
 
-	onInit : function(options)
-	{
-		var cap = $('#'+options.CaptionID).get(0);
-		this.options = jQuery.extend(
-		{
-			caption : cap ? cap.innerHTML : ''
-		}, options || {});
+	onInit(options) {
+		const cap = document.getElementById(options.CaptionID);
+		this.options = Object.assign({}, { caption : cap ? cap.innerHTML : '' }, options || {});
 
 		this.radios = [];
+		this._handlers = [];
 
-		$('#'+options.ID).addClass(options.Style);
-		for(var i = 0; i<options.ItemCount; i++)
+		const root = document.getElementById(options.ID);
+		if (root) root.classList.add(options.Style);
+		for(let i = 0; i<options.ItemCount; i++)
 		{
-			var radio = $('#'+options.ID+"_c"+i).get(0);
-			var td = radio.parentNode.parentNode;
+			const radio = document.getElementById(`${options.ID}_c${i}`);
+			if (!radio) continue;
+			const td = radio.parentNode.parentNode;
 
-			if(radio && td.tagName.toLowerCase()=='td')
+			if(td.tagName.toLowerCase()=='td')
 			{
 				this.radios.push(radio);
-				$(td).addClass("rating");
+				td.classList.add("rating");
 			}
 		}
 
@@ -37,32 +36,29 @@ Prado.WebUI.TRatingList = jQuery.klass(Prado.WebUI.Control,
 		this.setReadOnly(this.readOnly);
 	},
 
-	hover : function(index, ev)
-	{
+	hover(index, ev) {
 		if(this.readOnly==true) return;
 
-		for(var i = 0; i<this.radios.length; i++)
+		for(let i = 0; i<this.radios.length; i++)
 		{
-			var node = this.radios[i].parentNode.parentNode;
+			const node = this.radios[i].parentNode.parentNode;
 			if(i <= index)
-				$(node).addClass('rating_hover');
+				node.classList.add('rating_hover');
 			else
-				$(node).removeClass('rating_hover');
-			$(node).removeClass("rating_selected");
-			$(node).removeClass("rating_half");
+				node.classList.remove('rating_hover');
+			node.classList.remove("rating_selected");
+			node.classList.remove("rating_half");
 		}
 		this.showCaption(this.getIndexCaption(index));
 	},
 
-	recover : function(index, ev)
-	{
+	recover(index, ev) {
 		if(this.readOnly==true) return;
 		this.showRating(this.rating);
 		this.showCaption(this.options.caption);
 	},
 
-	click : function(index, ev)
-	{
+	click(index, ev) {
 		if(this.readOnly==true) return;
 		this.selectedIndex = index;
 		this.setRating(index+1);
@@ -72,91 +68,94 @@ Prado.WebUI.TRatingList = jQuery.klass(Prado.WebUI.Control,
 		}
 	},
 
-	dispatchRequest : function(ev)
-	{
-		var requestOptions =jQuery.extend({}, this.options,
+	dispatchRequest(ev) {
+		const requestOptions = Object.assign({}, this.options,
 		{
-			ID : this.options.ID+"_c"+this.selectedIndex,
-			EventTarget : this.options.ListName+"$c"+this.selectedIndex
+			ID : `${this.options.ID}_c${this.selectedIndex}`,
+			EventTarget : `${this.options.ListName}$c${this.selectedIndex}`
 		});
 		new Prado.PostBack(requestOptions, ev);
  	},
 
-	setRating : function(value)
-	{
+	setRating(value) {
 		this.rating = value;
-		var base = Math.floor(value-1);
-		var remainder = value - base-1;
-		var halfMax = this.options.HalfRating["1"];
-		var index = remainder > halfMax ? base+1 : base;
-		for(var i = 0; i<this.radios.length; i++)
+		const base = Math.floor(value-1);
+		const remainder = value - base-1;
+		const halfMax = this.options.HalfRating["1"];
+		const index = remainder > halfMax ? base+1 : base;
+		for(let i = 0; i<this.radios.length; i++)
 			this.radios[i].checked = (i == index);
 
-		var caption = this.getIndexCaption(index);
+		const caption = this.getIndexCaption(index);
 		this.setCaption(caption);
 		this.showCaption(caption);
 
 		this.showRating(this.rating);
 	},
 
-	showRating: function(value)
-	{
-		var base = Math.floor(value-1);
-		var remainder = value - base-1;
-		var halfMin = this.options.HalfRating["0"];
-		var halfMax = this.options.HalfRating["1"];
-		var index = remainder > halfMax ? base+1 : base;
-		var hasHalf = remainder >= halfMin && remainder <= halfMax;
-		for(var i = 0; i<this.radios.length; i++)
+	showRating(value) {
+		const base = Math.floor(value-1);
+		const remainder = value - base-1;
+		const halfMin = this.options.HalfRating["0"];
+		const halfMax = this.options.HalfRating["1"];
+		const index = remainder > halfMax ? base+1 : base;
+		const hasHalf = remainder >= halfMin && remainder <= halfMax;
+		for(let i = 0; i<this.radios.length; i++)
 		{
-			var node = this.radios[i].parentNode.parentNode;
+			const node = this.radios[i].parentNode.parentNode;
 			if(i <= index)
-				$(node).addClass('rating_selected');
+				node.classList.add('rating_selected');
 			else
-				$(node).removeClass('rating_selected');
+				node.classList.remove('rating_selected');
 
 			if(i==index+1 && hasHalf)
-				$(node).addClass("rating_half");
+				node.classList.add("rating_half");
 			else
-				$(node).removeClass("rating_half");
-			$(node).removeClass("rating_hover");
+				node.classList.remove("rating_half");
+			node.classList.remove("rating_hover");
 		}
 	},
 
-	getIndexCaption : function(index)
-	{
+	getIndexCaption(index) {
 		return index > -1 ? this.radios[index].value : this.options.caption;
 	},
 
-	showCaption : function(value)
-	{
-		$('#'+this.options.CaptionID).html(value);
-		$('#'+this.options.ID).attr( "title", value);
+	showCaption(value) {
+		const cap = document.getElementById(this.options.CaptionID);
+		if (cap) cap.innerHTML = value;
+		const root = document.getElementById(this.options.ID);
+		if (root) root.setAttribute('title', value);
 	},
 
-	setCaption : function(value)
-	{
+	setCaption(value) {
 		this.options.caption = value;
 		this.showCaption(value);
 	},
 
-	setReadOnly : function(value)
-	{
+	setReadOnly(value) {
 		this.readOnly = value;
-		for(var i = 0; i<this.radios.length; i++)
+		for(let i = 0; i<this.radios.length; i++)
 		{
-			var node = this.radios[i].parentNode.parentNode;
+			const node = this.radios[i].parentNode.parentNode;
+			let h = this._handlers[i];
+			if (!h) {
+				h = this._handlers[i] = {
+					hover:   this.hover.bind(this, i),
+					recover: this.recover.bind(this, i),
+					click:   this.click.bind(this, i),
+				};
+			}
 			if(value)
 			{
-				$(node).addClass('rating_disabled');
-				$(node).off('mouseover', jQuery.proxy(this.hover, this, i));
-				$(node).off('mouseout', jQuery.proxy(this.recover, this, i));
-				$(node).off('click', jQuery.proxy(this.click, this, i));
+				node.classList.add('rating_disabled');
+				node.removeEventListener('mouseover', h.hover);
+				node.removeEventListener('mouseout',  h.recover);
+				node.removeEventListener('click',     h.click);
 			} else {
-				$(node).removeClass('rating_disabled');
-				$(node).on('mouseover', jQuery.proxy(this.hover, this, i));
-				$(node).on('mouseout', jQuery.proxy(this.recover, this, i));
-				$(node).on('click', jQuery.proxy(this.click, this, i));
+				node.classList.remove('rating_disabled');
+				node.addEventListener('mouseover', h.hover);
+				node.addEventListener('mouseout',  h.recover);
+				node.addEventListener('click',     h.click);
 			}
 		}
 
@@ -164,16 +163,15 @@ Prado.WebUI.TRatingList = jQuery.klass(Prado.WebUI.Control,
 	}
 });
 
-Prado.WebUI.TActiveRatingList = jQuery.klass(Prado.WebUI.TRatingList,
+Prado.WebUI.TActiveRatingList = Prado.Class(Prado.WebUI.TRatingList,
 {
-	dispatchRequest : function(ev)
-	{
-		var requestOptions =jQuery.extend({}, this.options,
+	dispatchRequest(ev) {
+		const requestOptions = Object.assign({}, this.options,
 		{
-			ID : this.options.ID+"_c"+this.selectedIndex,
-			EventTarget : this.options.ListName+"$c"+this.selectedIndex
+			ID : `${this.options.ID}_c${this.selectedIndex}`,
+			EventTarget : `${this.options.ListName}$c${this.selectedIndex}`
 		});
-		var request = new Prado.CallbackRequest(requestOptions.EventTarget, requestOptions);
+		const request = new Prado.CallbackRequest(requestOptions.EventTarget, requestOptions);
 		if(request.dispatch()==false)
 			ev.preventDefault();
 	}

--- a/framework/Web/Javascripts/source/prado/validator/validation3.js
+++ b/framework/Web/Javascripts/source/prado/validator/validation3.js
@@ -100,8 +100,7 @@ jQuery.extend(Prado.Validation,
 	 * @param {element} invoker - DOM element that calls for validation
 	 * @returns true if validation succeeded
 	 */
-	validate : function(formID, groupID, invoker)
-	{
+	validate(formID, groupID, invoker) {
 		formID = formID || this.getForm();
 		if(this.managers[formID])
 		{
@@ -109,7 +108,7 @@ jQuery.extend(Prado.Validation,
 		}
 		else
 		{
-			throw new Error("Form '"+formID+"' is not registered with Prado.Validation");
+			throw new Error(`Form '${formID}' is not registered with Prado.Validation`);
 		}
 	},
 
@@ -119,9 +118,8 @@ jQuery.extend(Prado.Validation,
 	 * @param {string} id - ID of DOM element to validate
 	 * @return true if all validators are valid or no validators present, false otherwise.
 	 */
-    validateControl : function(id)
-    {
-        var formId=this.getForm();
+    validateControl(id) {
+        const formId=this.getForm();
 
 		if (this.managers[formId])
         {
@@ -136,11 +134,8 @@ jQuery.extend(Prado.Validation,
 	 * @function {string} ?
 	 * @returns ID of first form.
 	 */
-	getForm : function()
-	{
-		var keys = jQuery.map(this.managers, function(value, key) {
-			return key;
-		});
+	getForm() {
+		const keys = jQuery.map(this.managers, (value, key) => key);
 		return keys.length>0 ? keys[0] : null;
 	},
 
@@ -153,8 +148,7 @@ jQuery.extend(Prado.Validation,
 	 * @param {string} groupID - ID of the ValiationGroup to validate.
 	 * @return true if form is valid
 	 */
-	isValid : function(formID, groupID)
-	{
+	isValid(formID, groupID) {
 		formID = formID || this.getForm();
 		if(this.managers[formID])
 			return this.managers[formID].isValid(groupID);
@@ -167,9 +161,8 @@ jQuery.extend(Prado.Validation,
 	 * @function ?
 	 * @param {string} groupID - ID of the ValidationGroup to reset.
 	 */
-	reset : function(groupID)
-	{
-		var formID = this.getForm();
+	reset(groupID) {
+		const formID = this.getForm();
 		if(this.managers[formID])
 			this.managers[formID].reset(groupID);
 	},
@@ -181,12 +174,11 @@ jQuery.extend(Prado.Validation,
 	 * @param {TBaseValidator} validator - Validator object
 	 * @return ValidationManager for the form
 	 */
-	addValidator : function(formID, validator)
-	{
+	addValidator(formID, validator) {
 		if(this.managers[formID])
 			this.managers[formID].addValidator(validator);
 		else
-			throw new Error("A validation manager for form '"+formID+"' needs to be created first.");
+			throw new Error(`A validation manager for form '${formID}' needs to be created first.`);
 		return this.managers[formID];
 	},
 
@@ -197,36 +189,29 @@ jQuery.extend(Prado.Validation,
 	 * @param {TValidationSummary} validator - TValidationSummary object
 	 * @return ValidationManager for the form
 	 */
-	addSummary : function(formID, validator)
-	{
+	addSummary(formID, validator) {
 		if(this.managers[formID])
 			this.managers[formID].addSummary(validator);
 		else
-			throw new Error("A validation manager for form '"+formID+"' needs to be created first.");
+			throw new Error(`A validation manager for form '${formID}' needs to be created first.`);
 		return this.managers[formID];
 	},
 
-	setErrorMessage : function(validatorID, message)
-	{
-		jQuery.each(Prado.Validation.managers, function(idx, manager)
-		{
-			jQuery.each(manager.validators, function(idx, validator)
-			{
+	setErrorMessage(validatorID, message) {
+		jQuery.each(Prado.Validation.managers, (idx, manager) => {
+			jQuery.each(manager.validators, (idx, validator) => {
 				if(validator.options.ID == validatorID)
 				{
 					validator.options.ErrorMessage = message;
-					jQuery("#" + validatorID).get(0).innerHTML = message;
+					jQuery(`#${validatorID}`).get(0).innerHTML = message;
 				}
 			});
 		});
 	},
 
-	updateActiveCustomValidator : function(validatorID, isValid)
-	{
-		jQuery.each(Prado.Validation.managers, function(idx, manager)
-		{
-			jQuery.each(manager.validators, function(idx, validator)
-			{
+	updateActiveCustomValidator(validatorID, isValid) {
+		jQuery.each(Prado.Validation.managers, (idx, manager) => {
+			jQuery.each(manager.validators, (idx, validator) => {
 				if(validator.options.ID == validatorID)
 				{
 					validator.updateIsValid(isValid);
@@ -261,8 +246,7 @@ Prado.ValidationManager.prototype =
 	 * @param {object} options - Options for initialization
 	 * @... {string} FormID - ID of form of this manager
 	 */
-	initialize : function(options)
-	{
+	initialize(options) {
 		if(!Prado.Validation.managers[options.FormID])
 		{
 			/**
@@ -292,7 +276,7 @@ Prado.ValidationManager.prototype =
 		}
 		else
 		{
-			var manager = Prado.Validation.managers[options.FormID];
+			const manager = Prado.Validation.managers[options.FormID];
 			this.validators = manager.validators;
 			this.summaries = manager.summaries;
 			this.groups = manager.groups;
@@ -306,10 +290,9 @@ Prado.ValidationManager.prototype =
 	 * @function ?
 	 * @param {string} group - ID of ValidationGroup
 	 */
-	reset : function(group)
-	{
-		var vals = this.validatorPartition(group)[0];
-		for(var i = 0; i < vals.length; i++)
+	reset(group) {
+		const vals = this.validatorPartition(group)[0];
+		for(let i = 0; i < vals.length; i++)
 			vals[i].reset();
 
 		this.updateSummary(group, true);
@@ -323,11 +306,10 @@ Prado.ValidationManager.prototype =
 	 * @param {element} source - DOM element that calls for validation
 	 * @return true if all validators are valid, false otherwise.
 	 */
-	validate : function(group, source)
-	{
-		var partition = this.validatorPartition(group);
-		var valid=true;
-		for(var i = 0; i < partition[0].length; i++)
+	validate(group, source) {
+		const partition = this.validatorPartition(group);
+		let valid=true;
+		for(let i = 0; i < partition[0].length; i++)
 		{
 			if(!partition[0][i].validate(source))
 				valid=false;
@@ -344,12 +326,11 @@ Prado.ValidationManager.prototype =
 	 * @param {string} id - ID of DOM element to validate
 	 * @return true if all validators are valid or no validators present, false otherwise.
 	 */
-    validateControl : function (id)
-    {
-        var valid = true;
+    validateControl(id) {
+        let valid = true;
         if(this.controls[id])
         {
-          jQuery.each(this.controls[id], function (idx, element) {
+          jQuery.each(this.controls[id], (idx, element) => {
             if(!element.validate(null))
               valid = false;
           });
@@ -363,9 +344,8 @@ Prado.ValidationManager.prototype =
 	 * @function ?
 	 * @param {TBaseValidator[]} validators - Array of validator objects
 	 */
-	focusOnError : function(validators)
-	{
-		for(var i = 0; i < validators.length; i++)
+	focusOnError(validators) {
+		for(let i = 0; i < validators.length; i++)
 		{
 			if(!validators[i].isValid && validators[i].options.FocusOnError)
 				return Prado.Element.focus(validators[i].options.FocusElementID);
@@ -382,8 +362,7 @@ Prado.ValidationManager.prototype =
 	 * @param {optional string} group - ID of ValidationGroup
 	 * @return Array with two arrays of validators.
 	 */
-	validatorPartition : function(group)
-	{
+	validatorPartition(group) {
 		return group ? this.validatorsInGroup(group) : this.validatorsWithoutGroup();
 	},
 
@@ -396,12 +375,11 @@ Prado.ValidationManager.prototype =
 	 * @param {optional string} groupID - ID of ValidationGroup
 	 * @return Array with two arrays of validators.
 	 */
-	validatorsInGroup : function(groupID)
-	{
+	validatorsInGroup(groupID) {
 		if(jQuery.inArray(groupID, this.groups)!=-1)
 		{
-			var trues = [], falses = [];
-			jQuery.each(this.validators, function(idx, val) {
+			const trues = [], falses = [];
+			jQuery.each(this.validators, (idx, val) => {
 				if(val.group == groupID)
 					trues.push(val);
 				else
@@ -422,10 +400,9 @@ Prado.ValidationManager.prototype =
 	 * @return Array with two arrays of validators: Array[0] has all
 	 * validators without a group, Array[1] all other validators.
 	 */
-	validatorsWithoutGroup : function()
-	{
-		var trues = [], falses = [];
-		jQuery.each(this.validators, function(idx, val) {
+	validatorsWithoutGroup() {
+		const trues = [], falses = [];
+		jQuery.each(this.validators, (idx, val) => {
 			if(!val.group)
 				trues.push(val);
 			else
@@ -442,9 +419,8 @@ Prado.ValidationManager.prototype =
 	 * @param {optional string} group - ID of ValidationGroup
 	 * @return true if all validators (in a group, if supplied) are valid.
 	 */
-	isValid : function(group)
-	{
-		for(var i = 0; i < this.validatorPartition(group)[0].length; i++)
+	isValid(group) {
+		for(let i = 0; i < this.validatorPartition(group)[0].length; i++)
 		{
 			if(!this.validatorPartition(group)[0][i].isValid)
 				return false;
@@ -458,8 +434,7 @@ Prado.ValidationManager.prototype =
 	 * @function ?
 	 * @param {TBaseValidator} validator - Validator object
 	 */
-	addValidator : function(validator)
-	{
+	addValidator(validator) {
 		// Remove previously registered validator with same ID
     // to prevent stale validators created by AJAX updates
     this.removeValidator(validator);
@@ -478,8 +453,7 @@ Prado.ValidationManager.prototype =
 	 * @function ?
 	 * @param {TValidationSummary} summary - Validation summary.
 	 */
-	addSummary : function(summary)
-	{
+	addSummary(summary) {
 		this.summaries.push(summary);
 	},
 
@@ -488,20 +462,13 @@ Prado.ValidationManager.prototype =
 	 * @function ?
 	 * @param {TBaseValidator} validator - Validator object
 	 */
-  removeValidator : function(validator)
-  {
+  removeValidator(validator) {
     // Remove from list of validators
-  	this.validators = jQuery.grep(this.validators, function(v)
-  	{
-  		return (v.options.ID!=validator.options.ID);
-  	});
+  	this.validators = jQuery.grep(this.validators, v => v.options.ID!=validator.options.ID);
 	  // Remove from global list of validators per control
     if (this.controls[validator.control.id])
     {
-      this.controls[validator.control.id] = jQuery.grep(this.controls[validator.control.id], function(v)
-      {
-        return (v.options.ID!=validator.options.ID)
-      });
+      this.controls[validator.control.id] = jQuery.grep(this.controls[validator.control.id], v => v.options.ID!=validator.options.ID);
       // Delete array if empty
       if(this.controls[validator.control.id].length == 0)
         delete this.controls[validator.control.id];
@@ -516,12 +483,8 @@ Prado.ValidationManager.prototype =
 	 * @param {optional string} group - ID of ValidationGroup
 	 * @return array list of validators with error.
 	 */
-	getValidatorsWithError : function(group)
-	{
-		return jQuery.grep(this.validatorPartition(group)[0], function(validator)
-		{
-			return !validator.isValid;
-		});
+	getValidatorsWithError(group) {
+		return jQuery.grep(this.validatorPartition(group)[0], validator => !validator.isValid);
 	},
 
 	/**
@@ -533,13 +496,11 @@ Prado.ValidationManager.prototype =
 	 * @param {optional string} group - ID of ValidationGroup
 	 * @param {boolean} refresh - Wether the summary should be refreshed
 	 */
-	updateSummary : function(group, refresh)
-	{
-		var validators = this.getValidatorsWithError(group);
-		jQuery.each(this.summaries, function(idx, summary)
-		{
-			var inGroup = group && summary.group == group;
-			var noGroup = !group || !summary.group;
+	updateSummary(group, refresh) {
+		const validators = this.getValidatorsWithError(group);
+		jQuery.each(this.summaries, (idx, summary) => {
+			const inGroup = group && summary.group == group;
+			const noGroup = !group || !summary.group;
 			if(inGroup || noGroup)
 				summary.updateSummary(validators, refresh);
 			else
@@ -587,8 +548,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @... {optional function} OnHideSummary - Called on hide event.
 	 * @... {optional function} OnShowSummary - Called on show event.
 	 */
-	initialize : function(options)
-	{
+	initialize(options) {
 		/**
 		 * Validator options
 		 * @var {object} options
@@ -603,7 +563,7 @@ Prado.WebUI.TValidationSummary.prototype =
 		 * Summary DOM element
 		 * @var {element} messages
 		 */
-		this.messages = jQuery("#" + options.ID).get(0);
+		this.messages = jQuery(`#${options.ID}`).get(0);
 		Prado.Registry[options.ID] = this;
 		if(this.messages)
 		{
@@ -623,8 +583,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @param {TBaseValidator[]} validators - List of validators that failed validation.
 	 * @param {boolean} update - true if visible summary should be updated
 	 */
-	updateSummary : function(validators, update)
-	{
+	updateSummary(validators, update) {
 		if(validators.length <= 0)
 		{
 			if(update || this.options.Refresh != false)
@@ -634,10 +593,10 @@ Prado.WebUI.TValidationSummary.prototype =
 			return;
 		}
 
-		var refresh = update || this.visible == false || this.options.Refresh != false;
+		let refresh = update || this.visible == false || this.options.Refresh != false;
 		// Also, do not refresh summary if at least 1 validator is waiting for callback response.
 		// This will avoid the flickering of summary if the validator passes its test
-		for(var i = 0; i < validators.length; i++)
+		for(let i = 0; i < validators.length; i++)
 		{
 			if(validators[i].requestDispatched)
 			{
@@ -667,8 +626,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @function ?
 	 * @param {string[]} messages - Array of error messages.
 	 */
-	updateHTMLMessages : function(messages)
-	{
+	updateHTMLMessages(messages) {
 		while(this.messages.childNodes.length > 0)
 			this.messages.removeChild(this.messages.lastChild);
 		jQuery(this.messages).append(this.formatSummary(messages));
@@ -679,10 +637,9 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @function ?
 	 * @param {string[]} messages - Array of error messages.
 	 */
-	alertMessages : function(messages)
-	{
-		var text = this.formatMessageBox(messages);
-		setTimeout(function(){ alert(text); },20);
+	alertMessages(messages) {
+		const text = this.formatMessageBox(messages);
+		setTimeout(() => { alert(text); },20);
 	},
 
 	/**
@@ -691,12 +648,10 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @param {TBaseValidator[]} validators - Array of validators.
 	 * @return Array of validator error messages.
 	 */
-	getMessages : function(validators)
-	{
-		var messages = [];
-		jQuery.each(validators, function(idx, validator)
-		{
-			var message = validator.getErrorMessage();
+	getMessages(validators) {
+		const messages = [];
+		jQuery.each(validators, (idx, validator) => {
+			const message = validator.getErrorMessage();
 			if(typeof(message) == 'string' && message.length > 0)
 				messages.push(message);
 		})
@@ -708,8 +663,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @function ?
 	 * @param {TBaseValidator[]} validators - Array of validators.
 	 */
-	hideSummary : function(validators)
-	{	if(typeof(this.options.OnHideSummary) == "function")
+	hideSummary(validators) {	if(typeof(this.options.OnHideSummary) == "function")
 		{
 			this.messages.style.visibility="visible";
 			this.options.OnHideSummary(this,validators)
@@ -728,8 +682,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @function ?
 	 * @param {TBaseValidator[]} validators - Array of validators.
 	 */
-	showSummary : function(validators)
-	{
+	showSummary(validators) {
 		this.messages.style.visibility="visible";
 		if(typeof(this.options.OnShowSummary) == "function")
 			this.options.OnShowSummary(this,validators);
@@ -749,8 +702,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @... {string} post - Text to append after each message
 	 * @... {string} first - Text to append after message list
 	 */
-	formats : function(type)
-	{
+	formats(type) {
 		switch(type)
 		{
 			case "SimpleList":
@@ -771,13 +723,11 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @param {string[]} messages - Array of error messages.
 	 * @return Formatted message
 	 */
-	formatSummary : function(messages)
-	{
-		var format = this.formats(this.options.DisplayMode);
-		var output = this.options.HeaderText ? this.options.HeaderText + format.header : "";
+	formatSummary(messages) {
+		const format = this.formats(this.options.DisplayMode);
+		let output = this.options.HeaderText ? this.options.HeaderText + format.header : "";
 		output += format.first;
-		jQuery.each(messages, function(idx, message)
-		{
+		jQuery.each(messages, (idx, message) => {
 			output += message.length > 0 ? format.pre + message + format.post : "";
 		});
 //		for(var i = 0; i < messages.length; i++)
@@ -791,25 +741,24 @@ Prado.WebUI.TValidationSummary.prototype =
 	 * @param {string[]} messages - Array of error messages.
 	 * @return Formatted message for alert
 	 */
-	formatMessageBox : function(messages)
-	{
+	formatMessageBox(messages) {
 		if(this.options.DisplayMode == 'HeaderOnly' && this.options.HeaderText)
 			return this.options.HeaderText;
 
-		var output = this.options.HeaderText ? this.options.HeaderText + "\n" : "";
-		for(var i = 0; i < messages.length; i++)
+		let output = this.options.HeaderText ? `${this.options.HeaderText}\n` : "";
+		for(let i = 0; i < messages.length; i++)
 		{
 			switch(this.options.DisplayMode)
 			{
 				case "List":
-					output += messages[i] + "\n";
+					output += `${messages[i]}\n`;
 					break;
 				case "BulletList":
                 default:
-					output += "  - " + messages[i] + "\n";
+					output += `  - ${messages[i]}\n`;
 					break;
 				case "SingleParagraph":
-					output += messages[i] + " ";
+					output += `${messages[i]} `;
 					break;
 			}
 		}
@@ -849,8 +798,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @... {optional function} OnValidationSuccess - Called after successful validation.
 	 * @... {optional function} OnValidationError - Called after validation error.
 	 */
-	initialize : function(options)
-	{
+	initialize(options) {
 		this.observers = new Array();
 		this.intervals = new Array();
 
@@ -898,12 +846,12 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 		 * DOM element of control to validate
 		 * @var {element} control
 		 */
-		this.control = jQuery("#" + options.ControlToValidate).get(0);
+		this.control = jQuery(`#${options.ControlToValidate}`).get(0);
 		/**
 		 * DOM element of validator
 		 * @var {element} message
 		 */
-		this.message = jQuery("#" + options.ID).get(0);
+		this.message = jQuery(`#${options.ID}`).get(0);
 
 		Prado.Registry[options.ID] = this;
 
@@ -926,8 +874,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @function {string} ?
 	 * @return Validation error message.
 	 */
-	getErrorMessage : function()
-	{
+	getErrorMessage() {
 		return this.options.ErrorMessage;
 	},
 
@@ -937,8 +884,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * <tt>visible</tt> property to true.
 	 * @function ?
 	 */
-	updateControl: function()
-	{
+	updateControl() {
 		this.refreshControlAndMessage();
 
 		//if(this.options.FocusOnError && !this.isValid )
@@ -951,14 +897,13 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * Updates span and input CSS class.
 	 * @function ?
 	 */
-	refreshControlAndMessage : function()
-	{
+	refreshControlAndMessage() {
 		this.visible = true;
 		if(this.message)
 		{
 			if(this.options.Display == "Dynamic")
 			{
-				var msg=this.message;
+				const msg=this.message;
 				this.isValid ? jQuery(msg).hide() : jQuery(msg).show();
 			}
 			this.message.style.visibility = this.isValid ? "hidden" : "visible";
@@ -975,9 +920,8 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {element} control - DOM element of control to validate
 	 * @param {boolean} valid - Validation state of control
 	 */
-	updateControlCssClass : function(control, valid)
-	{
-		var CssClass = this.options.ControlCssClass;
+	updateControlCssClass(control, valid) {
+		const CssClass = this.options.ControlCssClass;
 		if(typeof(CssClass) == "string" && CssClass.length > 0)
 		{
 			if(valid)
@@ -1000,8 +944,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * Hide the validator messages and remove any validation changes.
 	 * @function ?
 	 */
-	hide : function()
-	{
+	hide() {
 		this.reset();
 		this.visible = false;
 	},
@@ -1011,8 +954,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * Sets isValid = true and updates the validator display.
 	 * @function ?
 	 */
-	reset : function()
-	{
+	reset() {
 		this.isValid = true;
 		this.updateControl();
 	},
@@ -1025,11 +967,10 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {element} invoker - DOM element that triggered validation
 	 * @return Valdation state of control.
 	 */
-	validate : function(invoker)
-	{
+	validate(invoker) {
 		//try to find the control.
 		if(!this.control)
-			this.control = jQuery("#" + this.options.ControlToValidate).get(0);
+			this.control = jQuery(`#${this.options.ControlToValidate}`).get(0);
 
 		if(!this.control || this.control.disabled || !jQuery.contains(document, this.control))
 		{
@@ -1059,8 +1000,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * Updates the validation messages and the control to validate.
 	 * @param {element} invoker - DOM element that triggered validation
 	 */
-	updateValidationDisplay : function(invoker)
-	{
+	updateValidationDisplay(invoker) {
 		if(this.isValid)
 		{
 			if(typeof(this.options.OnValidationSuccess) == "function")
@@ -1096,19 +1036,17 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @function ?
 	 * @param {element} control - DOM element of control to observe
 	 */
-	observeChanges : function(control)
-	{
+	observeChanges(control) {
 		if(!control) return;
 
-		var canObserveChanges = this.options.ObserveChanges != false;
-		var currentlyObserving = this._isObserving[control.id+this.options.ID];
+		const canObserveChanges = this.options.ObserveChanges != false;
+		const currentlyObserving = this._isObserving[control.id+this.options.ID];
 
 		if(canObserveChanges && !currentlyObserving)
 		{
-			var validator = this;
+			const validator = this;
 
-			this.observe(control, 'change', function()
-			{
+			this.observe(control, 'change', () => {
 				if(validator.visible)
 				{
 					validator.validate();
@@ -1125,8 +1063,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {string} value - String that should be trimmed.
 	 * @return Trimmed string, empty string if value is not string.
 	 */
-	trim : function(value)
-	{
+	trim(value) {
 		return typeof(value) == "string" ? value.trim() : "";
 	},
 
@@ -1137,11 +1074,10 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {mixed} value - Value to convert.
 	 * @return Converted data value.
 	 */
-	convert : function(dataType, value)
-	{
+	convert(dataType, value) {
 		if(typeof(value) == "undefined")
 			value = this.getValidationValue();
-		var string = new String(value);
+		const string = new String(value);
 		switch(dataType)
 		{
 			case "Integer":
@@ -1174,8 +1110,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {optional element} control - Control to get value from (default: this.control)
 	 * @return Control value to validate
 	 */
-	 getRawValidationValue : function(control)
-	 {
+	 getRawValidationValue(control) {
 	 	if(!control)
 	 		control = this.control;
 	 	switch(this.options.ControlType)
@@ -1185,11 +1120,11 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 		case 'TDatePicker':
 	 			if(control.type == "text")
 	 			{
-	 				var value = this.trim(jQuery(control).val());
+	 				const value = this.trim(jQuery(control).val());
 
 					if(this.options.DateFormat)
 	 				{
-	 					var date = Date.SimpleParse(value, this.options.DateFormat);
+	 					const date = Date.SimpleParse(value, this.options.DateFormat);
 	 					return date == null ? value : date;
 	 				}
 	 				else
@@ -1226,9 +1161,8 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {optional element} control - Control to get value fron (default: this.control)
 	 * @return Control value to validate
 	 */
-	 getValidationValue : function(control)
-	 {
-	 	var value = this.getRawValidationValue(control);
+	 getValidationValue(control) {
+	 	const value = this.getRawValidationValue(control);
 		if(!control)
 			control = this.control;
 		switch(this.options.ControlType)
@@ -1253,12 +1187,10 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @function {string} ?
 	 * @return Value of a radio button group
 	 */
-	getRadioButtonGroupValue : function()
-	{
-		var name = this.control.name;
-		var value = "";
-		jQuery.each(document.getElementsByName(name), function(idx, el)
-		{
+	getRadioButtonGroupValue() {
+		const name = this.control.name;
+		let value = "";
+		jQuery.each(document.getElementsByName(name), (idx, el) => {
 			if(el.checked)
 				value =  el.value;
 		});
@@ -1269,9 +1201,8 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	  * Observe changes in the drop down list date picker, IE only.
 	  * @function ?
 	  */
-	 observeDatePickerChanges : function()
-	 {
- 		var DatePicker = Prado.WebUI.TDatePicker;
+	 observeDatePickerChanges() {
+ 		const DatePicker = Prado.WebUI.TDatePicker;
  		this.observeChanges(DatePicker.getDayListControl(this.control));
 		this.observeChanges(DatePicker.getMonthListControl(this.control));
 		this.observeChanges(DatePicker.getYearListControl(this.control));
@@ -1286,13 +1217,11 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @... {mixed[]} values - Array of selected values
 	 * @... {int} checks - Number of selections
 	 */
-	getSelectedValuesAndChecks : function(elements, initialValue)
-	{
-		var checked = 0;
-		var values = [];
-		var isSelected = this.isCheckBoxType(elements[0]) ? 'checked' : 'selected';
-		jQuery.each(elements, function(idx, element)
-		{
+	getSelectedValuesAndChecks(elements, initialValue) {
+		let checked = 0;
+		const values = [];
+		const isSelected = this.isCheckBoxType(elements[0]) ? 'checked' : 'selected';
+		jQuery.each(elements, (idx, element) => {
 			if(element[isSelected] && element.value != initialValue)
 			{
 				checked++;
@@ -1310,23 +1239,22 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @function {element[]} ?
 	 * @return Array of list control option DOM elements.
 	 */
-	getListElements : function()
-	{
+	getListElements() {
 		switch(this.options.ControlType)
 		{
 			case 'TCheckBoxList':
 			case 'TRadioButtonList':
 				var elements = [];
-				for(var i = 0; i < this.options.TotalItems; i++)
+				for(let i = 0; i < this.options.TotalItems; i++)
 				{
-					var element = jQuery("#" + this.options.ControlToValidate+"_c"+i).get(0);
+					var element = jQuery(`#${this.options.ControlToValidate}_c${i}`).get(0);
 					if(this.isCheckBoxType(element))
 						elements.push(element);
 				}
 				return elements;
 			case 'TListBox':
 				var elements = [];
-				var element = jQuery("#" + this.options.ControlToValidate).get(0);
+				var element = jQuery(`#${this.options.ControlToValidate}`).get(0);
 				var type;
 				if(element && (type = element.type.toLowerCase()))
 				{
@@ -1345,11 +1273,10 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @param {element} element - DOM element to check.
 	 * @return True if element is of checkbox or radio type.
 	 */
-	isCheckBoxType : function(element)
-	{
+	isCheckBoxType(element) {
 		if(element && element.type)
 		{
-			var type = element.type.toLowerCase();
+			const type = element.type.toLowerCase();
 			return type == "checkbox" || type == "radio";
 		}
 		return false;
@@ -1360,13 +1287,12 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 * @function {string} ?
 	 * @return First selected list value, initial value if none found.
 	 */
-	getFirstSelectedListValue : function()
-	{
-		var initial = "";
+	getFirstSelectedListValue() {
+		let initial = "";
 		if(typeof(this.options.InitialValue) != "undefined")
 			initial = this.options.InitialValue;
-		var elements = this.getListElements();
-		var selection = this.getSelectedValuesAndChecks(elements, initial);
+		const elements = this.getListElements();
+		const selection = this.getSelectedValuesAndChecks(elements, initial);
 		return selection.values.length > 0 ? selection.values[0] : initial;
 	}
 });
@@ -1388,10 +1314,9 @@ Prado.WebUI.TRequiredFieldValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if the input value is not empty nor equal to the initial value.
 	 */
-	evaluateIsValid : function()
-	{
-    	var a = this.getValidationValue();
-    	var b = this.trim(this.options.InitialValue);
+	evaluateIsValid() {
+    	const a = this.getValidationValue();
+    	const b = this.trim(this.options.InitialValue);
     	return(a != b);
 	}
 });
@@ -1443,20 +1368,19 @@ Prado.WebUI.TCompareValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if comparision condition is met.
 	 */
-	evaluateIsValid : function()
-	{
-		var value = this.getValidationValue();
+	evaluateIsValid() {
+		const value = this.getValidationValue();
 	    if (value.length <= 0)
 	    	return true;
 
-    	var comparee = jQuery("#" + this.options.ControlToCompare).get(0);
+    	const comparee = jQuery(`#${this.options.ControlToCompare}`).get(0);
 
 		if(comparee)
 			var compareTo = this.getValidationValue(comparee);
 		else
 			var compareTo = this.options.ValueToCompare || "";
 
-	    var isValid =  this.compare(value, compareTo);
+	    const isValid =  this.compare(value, compareTo);
 
 		if(comparee)
 		{
@@ -1477,9 +1401,8 @@ Prado.WebUI.TCompareValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @param {mixed} operand1 - First operand.
 	 * @param {mixed} operand2 - Second operand.
 	 */
-	compare : function(operand1, operand2)
-	{
-		var op1, op2;
+	compare(operand1, operand2) {
+		let op1, op2;
 		if((op1 = this.convert(this.options.DataType, operand1)) == null)
 			return false;
 		if ((op2 = this.convert(this.options.DataType, operand2)) == null)
@@ -1544,13 +1467,12 @@ Prado.WebUI.TCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if custom validation returned true.
 	 */
-	evaluateIsValid : function()
-	{
-		var value = this.getValidationValue();
-		var clientFunction = this.options.ClientValidationFunction;
+	evaluateIsValid() {
+		const value = this.getValidationValue();
+		const clientFunction = this.options.ClientValidationFunction;
 		if(typeof(clientFunction) == "string" && clientFunction.length > 0)
 		{
-			var validate = clientFunction.toFunction();
+			const validate = clientFunction.toFunction();
 			return validate(this, value);
 		}
 		return true;
@@ -1574,13 +1496,12 @@ Prado.WebUI.TActiveCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @param {element} invoker - DOM element that triggered validation
 	 * @return True if valid.
 	 */
-	validate : function(invoker)
-	{
+	validate(invoker) {
 		this.invoker = invoker;
 
 		//try to find the control.
 		if(!this.control)
-			this.control = jQuery("#" + this.options.ControlToValidate).get(0);
+			this.control = jQuery(`#${this.options.ControlToValidate}`).get(0);
 
 		if(!this.control || this.control.disabled)
 		{
@@ -1602,8 +1523,7 @@ Prado.WebUI.TActiveCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if valid.
 	 */
-	evaluateIsValid : function()
-	{
+	evaluateIsValid() {
 		return this.isValid;
 	},
 
@@ -1613,8 +1533,7 @@ Prado.WebUI.TActiveCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @param {CallbackRequest} request - CallbackRequest.
 	 * @param {string} data - Response data.
 	 */
-	updateIsValid : function(data)
-	{
+	updateIsValid(data) {
 		this.isValid = data;
 		this.requestDispatched = false;
 		if(typeof(this.options.onSuccess) == "function")
@@ -1664,9 +1583,8 @@ Prado.WebUI.TRangeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @return True if value is in range or value is empty,
 	 * false otherwhise and when type conversion failed.
 	 */
-	evaluateIsValid : function()
-	{
-		var value = this.getValidationValue();
+	evaluateIsValid() {
+		let value = this.getValidationValue();
 		if(value.length <= 0)
 			return true;
 		if(typeof(this.options.DataType) == "undefined")
@@ -1688,7 +1606,7 @@ Prado.WebUI.TRangeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 		if(value == null)
 			return false;
 
-		var valid = true;
+		let valid = true;
 
 		if(min != null)
 			valid = valid && (this.options.StrictComparison ? value > min : value >= min);
@@ -1720,14 +1638,13 @@ Prado.WebUI.TRegularExpressionValidator = jQuery.klass(Prado.WebUI.TBaseValidato
 	 * @function {boolean} ?
 	 * @return True if value matches regular expression or value is empty.
 	 */
-	evaluateIsValid : function()
-	{
-		var value = this.getRawValidationValue();
+	evaluateIsValid() {
+		const value = this.getRawValidationValue();
 		if (value.length <= 0)
 	    	return true;
 
-		var rx = new RegExp('^'+this.options.ValidationExpression+'$',this.options.PatternModifiers);
-		var matches = rx.exec(value);
+		const rx = new RegExp(`^${this.options.ValidationExpression}$`,this.options.PatternModifiers);
+		const matches = rx.exec(value);
 		return (matches != null && value == matches[0]);
 	}
 });
@@ -1756,15 +1673,14 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if number of selections and/or their values match requirements.
 	 */
-	evaluateIsValid : function()
-	{
-		var elements = this.getListElements();
+	evaluateIsValid() {
+		const elements = this.getListElements();
 		if(elements && elements.length <= 0)
 			return true;
 
 		this.observeListElements(elements);
 
-		var selection = this.getSelectedValuesAndChecks(elements);
+		const selection = this.getSelectedValuesAndChecks(elements);
 		return this.isValidList(selection.checks, selection.values);
 	},
 
@@ -1773,13 +1689,11 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function ?
 	 * @param {element[]} elements - Array of DOM elements to observe
 	 */
-	 observeListElements : function(elements)
-	 {
+	 observeListElements(elements) {
 		if(this.isCheckBoxType(elements[0]))
 		{
-			var validator = this;
-			jQuery.each(elements, function(idx, element)
-			{
+			const validator = this;
+			jQuery.each(elements, (idx, element) => {
 				validator.observeChanges(element);
 			});
 		}
@@ -1795,25 +1709,23 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @param {string[]} values - Array of required checked values
 	 * @return True if checked values and number of checks are satisfied.
 	 */
-	isValidList : function(checked, values)
-	{
-		var exists = true;
+	isValidList(checked, values) {
+		let exists = true;
 
 		//check the required values
-		var required = this.getRequiredValues();
+		const required = this.getRequiredValues();
 		if(required.length > 0)
 		{
 			if(values.length < required.length)
 				return false;
-			jQuery.each(required, function(idx, requiredValue)
-			{
+			jQuery.each(required, (idx, requiredValue) => {
 				exists = exists && (jQuery.inArray(requiredValue, values)!=-1);
 			});
 		}
 
-		var min = typeof(this.options.Min) == "undefined" ?
+		const min = typeof(this.options.Min) == "undefined" ?
 					Number.NEGATIVE_INFINITY : this.options.Min;
-		var max = typeof(this.options.Max) == "undefined" ?
+		const max = typeof(this.options.Max) == "undefined" ?
 					Number.POSITIVE_INFINITY : this.options.Max;
 		return exists && checked >= min && checked <= max;
 	},
@@ -1823,9 +1735,8 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {string[]} ?
 	 * @return Array of required values that must be selected.
 	 */
-	getRequiredValues : function()
-	{
-		var required = [];
+	getRequiredValues() {
+		let required = [];
 		if(this.options.Required && this.options.Required.length > 0)
 			required = this.options.Required.split(/,\s*/);
 		return required;
@@ -1865,9 +1776,8 @@ Prado.WebUI.TDataTypeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if value matches required data type.
 	 */
-	evaluateIsValid : function()
-	{
-		var value = this.getValidationValue();
+	evaluateIsValid() {
+		const value = this.getValidationValue();
 		if(value.length <= 0)
 			return true;
 		return this.convert(this.options.DataType, value) != null;
@@ -1888,27 +1798,25 @@ Prado.WebUI.TCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if value matches captcha text
 	 */
-	evaluateIsValid : function()
-	{
-		var a = this.getValidationValue();
-		var h = 0;
+	evaluateIsValid() {
+		let a = this.getValidationValue();
+		let h = 0;
 		if (this.options.CaseSensitive==false)
 			a = a.toUpperCase();
-		for(var i = a.length-1; i >= 0; --i)
+		for(let i = a.length-1; i >= 0; --i)
 			h += a.charCodeAt(i);
 		return h == this.options.TokenHash;
 	},
 
-	crc32 : function(str)
-	{
+	crc32(str) {
 	    function Utf8Encode(string)
 		{
 	        string = string.replace(/\r\n/g,"\n");
-	        var utftext = "";
+	        let utftext = "";
 
-	        for (var n = 0; n < string.length; n++)
+	        for (let n = 0; n < string.length; n++)
 			{
-	            var c = string.charCodeAt(n);
+	            const c = string.charCodeAt(n);
 
 	            if (c < 128) {
 	                utftext += String.fromCharCode(c);
@@ -1929,16 +1837,16 @@ Prado.WebUI.TCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 
 	    str = Utf8Encode(str);
 
-	    var table = "00000000 77073096 EE0E612C 990951BA 076DC419 706AF48F E963A535 9E6495A3 0EDB8832 79DCB8A4 E0D5E91E 97D2D988 09B64C2B 7EB17CBD E7B82D07 90BF1D91 1DB71064 6AB020F2 F3B97148 84BE41DE 1ADAD47D 6DDDE4EB F4D4B551 83D385C7 136C9856 646BA8C0 FD62F97A 8A65C9EC 14015C4F 63066CD9 FA0F3D63 8D080DF5 3B6E20C8 4C69105E D56041E4 A2677172 3C03E4D1 4B04D447 D20D85FD A50AB56B 35B5A8FA 42B2986C DBBBC9D6 ACBCF940 32D86CE3 45DF5C75 DCD60DCF ABD13D59 26D930AC 51DE003A C8D75180 BFD06116 21B4F4B5 56B3C423 CFBA9599 B8BDA50F 2802B89E 5F058808 C60CD9B2 B10BE924 2F6F7C87 58684C11 C1611DAB B6662D3D 76DC4190 01DB7106 98D220BC EFD5102A 71B18589 06B6B51F 9FBFE4A5 E8B8D433 7807C9A2 0F00F934 9609A88E E10E9818 7F6A0DBB 086D3D2D 91646C97 E6635C01 6B6B51F4 1C6C6162 856530D8 F262004E 6C0695ED 1B01A57B 8208F4C1 F50FC457 65B0D9C6 12B7E950 8BBEB8EA FCB9887C 62DD1DDF 15DA2D49 8CD37CF3 FBD44C65 4DB26158 3AB551CE A3BC0074 D4BB30E2 4ADFA541 3DD895D7 A4D1C46D D3D6F4FB 4369E96A 346ED9FC AD678846 DA60B8D0 44042D73 33031DE5 AA0A4C5F DD0D7CC9 5005713C 270241AA BE0B1010 C90C2086 5768B525 206F85B3 B966D409 CE61E49F 5EDEF90E 29D9C998 B0D09822 C7D7A8B4 59B33D17 2EB40D81 B7BD5C3B C0BA6CAD EDB88320 9ABFB3B6 03B6E20C 74B1D29A EAD54739 9DD277AF 04DB2615 73DC1683 E3630B12 94643B84 0D6D6A3E 7A6A5AA8 E40ECF0B 9309FF9D 0A00AE27 7D079EB1 F00F9344 8708A3D2 1E01F268 6906C2FE F762575D 806567CB 196C3671 6E6B06E7 FED41B76 89D32BE0 10DA7A5A 67DD4ACC F9B9DF6F 8EBEEFF9 17B7BE43 60B08ED5 D6D6A3E8 A1D1937E 38D8C2C4 4FDFF252 D1BB67F1 A6BC5767 3FB506DD 48B2364B D80D2BDA AF0A1B4C 36034AF6 41047A60 DF60EFC3 A867DF55 316E8EEF 4669BE79 CB61B38C BC66831A 256FD2A0 5268E236 CC0C7795 BB0B4703 220216B9 5505262F C5BA3BBE B2BD0B28 2BB45A92 5CB36A04 C2D7FFA7 B5D0CF31 2CD99E8B 5BDEAE1D 9B64C2B0 EC63F226 756AA39C 026D930A 9C0906A9 EB0E363F 72076785 05005713 95BF4A82 E2B87A14 7BB12BAE 0CB61B38 92D28E9B E5D5BE0D 7CDCEFB7 0BDBDF21 86D3D2D4 F1D4E242 68DDB3F8 1FDA836E 81BE16CD F6B9265B 6FB077E1 18B74777 88085AE6 FF0F6A70 66063BCA 11010B5C 8F659EFF F862AE69 616BFFD3 166CCF45 A00AE278 D70DD2EE 4E048354 3903B3C2 A7672661 D06016F7 4969474D 3E6E77DB AED16A4A D9D65ADC 40DF0B66 37D83BF0 A9BCAE53 DEBB9EC5 47B2CF7F 30B5FFE9 BDBDF21C CABAC28A 53B39330 24B4A3A6 BAD03605 CDD70693 54DE5729 23D967BF B3667A2E C4614AB8 5D681B02 2A6F2B94 B40BBE37 C30C8EA1 5A05DF1B 2D02EF8D";
-		var crc = 0;
-	    var x = 0;
-	    var y = 0;
+	    const table = "00000000 77073096 EE0E612C 990951BA 076DC419 706AF48F E963A535 9E6495A3 0EDB8832 79DCB8A4 E0D5E91E 97D2D988 09B64C2B 7EB17CBD E7B82D07 90BF1D91 1DB71064 6AB020F2 F3B97148 84BE41DE 1ADAD47D 6DDDE4EB F4D4B551 83D385C7 136C9856 646BA8C0 FD62F97A 8A65C9EC 14015C4F 63066CD9 FA0F3D63 8D080DF5 3B6E20C8 4C69105E D56041E4 A2677172 3C03E4D1 4B04D447 D20D85FD A50AB56B 35B5A8FA 42B2986C DBBBC9D6 ACBCF940 32D86CE3 45DF5C75 DCD60DCF ABD13D59 26D930AC 51DE003A C8D75180 BFD06116 21B4F4B5 56B3C423 CFBA9599 B8BDA50F 2802B89E 5F058808 C60CD9B2 B10BE924 2F6F7C87 58684C11 C1611DAB B6662D3D 76DC4190 01DB7106 98D220BC EFD5102A 71B18589 06B6B51F 9FBFE4A5 E8B8D433 7807C9A2 0F00F934 9609A88E E10E9818 7F6A0DBB 086D3D2D 91646C97 E6635C01 6B6B51F4 1C6C6162 856530D8 F262004E 6C0695ED 1B01A57B 8208F4C1 F50FC457 65B0D9C6 12B7E950 8BBEB8EA FCB9887C 62DD1DDF 15DA2D49 8CD37CF3 FBD44C65 4DB26158 3AB551CE A3BC0074 D4BB30E2 4ADFA541 3DD895D7 A4D1C46D D3D6F4FB 4369E96A 346ED9FC AD678846 DA60B8D0 44042D73 33031DE5 AA0A4C5F DD0D7CC9 5005713C 270241AA BE0B1010 C90C2086 5768B525 206F85B3 B966D409 CE61E49F 5EDEF90E 29D9C998 B0D09822 C7D7A8B4 59B33D17 2EB40D81 B7BD5C3B C0BA6CAD EDB88320 9ABFB3B6 03B6E20C 74B1D29A EAD54739 9DD277AF 04DB2615 73DC1683 E3630B12 94643B84 0D6D6A3E 7A6A5AA8 E40ECF0B 9309FF9D 0A00AE27 7D079EB1 F00F9344 8708A3D2 1E01F268 6906C2FE F762575D 806567CB 196C3671 6E6B06E7 FED41B76 89D32BE0 10DA7A5A 67DD4ACC F9B9DF6F 8EBEEFF9 17B7BE43 60B08ED5 D6D6A3E8 A1D1937E 38D8C2C4 4FDFF252 D1BB67F1 A6BC5767 3FB506DD 48B2364B D80D2BDA AF0A1B4C 36034AF6 41047A60 DF60EFC3 A867DF55 316E8EEF 4669BE79 CB61B38C BC66831A 256FD2A0 5268E236 CC0C7795 BB0B4703 220216B9 5505262F C5BA3BBE B2BD0B28 2BB45A92 5CB36A04 C2D7FFA7 B5D0CF31 2CD99E8B 5BDEAE1D 9B64C2B0 EC63F226 756AA39C 026D930A 9C0906A9 EB0E363F 72076785 05005713 95BF4A82 E2B87A14 7BB12BAE 0CB61B38 92D28E9B E5D5BE0D 7CDCEFB7 0BDBDF21 86D3D2D4 F1D4E242 68DDB3F8 1FDA836E 81BE16CD F6B9265B 6FB077E1 18B74777 88085AE6 FF0F6A70 66063BCA 11010B5C 8F659EFF F862AE69 616BFFD3 166CCF45 A00AE278 D70DD2EE 4E048354 3903B3C2 A7672661 D06016F7 4969474D 3E6E77DB AED16A4A D9D65ADC 40DF0B66 37D83BF0 A9BCAE53 DEBB9EC5 47B2CF7F 30B5FFE9 BDBDF21C CABAC28A 53B39330 24B4A3A6 BAD03605 CDD70693 54DE5729 23D967BF B3667A2E C4614AB8 5D681B02 2A6F2B94 B40BBE37 C30C8EA1 5A05DF1B 2D02EF8D";
+		let crc = 0;
+	    let x = 0;
+	    let y = 0;
 
 	    crc = crc ^ (-1);
-	    for( var i = 0, iTop = str.length; i < iTop; i++ )
+	    for( let i = 0, iTop = str.length; i < iTop; i++ )
 		{
 	        y = ( crc ^ str.charCodeAt( i ) ) & 0xFF;
-	        x = "0x" + table.substr( y * 9, 8 );
+	        x = `0x${table.substr( y * 9, 8 )}`;
 	        crc = ( crc >>> 8 ) ^ x;
 	    }
 	    return crc ^ (-1);
@@ -1954,21 +1862,19 @@ Prado.WebUI.TCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  */
 Prado.WebUI.TReCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 {
-	onInit : function()
-	{
-		var obj = this;
-		var elements = document.getElementsByName(this.options.ResponseFieldName);
+	onInit() {
+		const obj = this;
+		const elements = document.getElementsByName(this.options.ResponseFieldName);
 		if (elements)
 		 if (elements.length>=1)
 		 {
-		  this.observe(elements[0],'change',function() { obj.responseChanged() });
-		  this.observe(elements[0],'keydown',function() { obj.responseChanged() });
+		  this.observe(elements[0],'change',() => { obj.responseChanged() });
+		  this.observe(elements[0],'keydown',() => { obj.responseChanged() });
 		 }
 	},
 
-	responseChanged: function()
-	{
-		var field = jQuery("#" + this.options.ID+'_1').get(0);
+	responseChanged() {
+		const field = jQuery(`#${this.options.ID}_1`).get(0);
 		if (field.value=='1') return;
 		field.value = '1';
 		Prado.Validation.validateControl(this.options.ID);
@@ -1979,9 +1885,8 @@ Prado.WebUI.TReCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @function {boolean} ?
 	 * @return True if the captcha has validate, False otherwise.
 	 */
-	evaluateIsValid : function()
-	{
-		return (jQuery("#" + this.options.ID+'_1').get(0).value=='1');
+	evaluateIsValid() {
+		return jQuery(`#${this.options.ID}_1`).get(0).value=='1';
 	}
 });
 
@@ -1992,9 +1897,8 @@ Prado.WebUI.TReCaptcha2Instances = {};
 /**
  * Render callback; called by google's js when loaded
  */
-TReCaptcha2_onloadCallback = function()
-{
-	jQuery.each(Prado.WebUI.TReCaptcha2Instances, function(index, item) {
+TReCaptcha2_onloadCallback = () => {
+	jQuery.each(Prado.WebUI.TReCaptcha2Instances, (index, item) => {
     	item.build();
 	});
 }
@@ -2007,39 +1911,35 @@ TReCaptcha2_onloadCallback = function()
  */
 Prado.WebUI.TReCaptcha2 = jQuery.klass(Prado.WebUI.Control,
 {
-    onInit: function(options)
-    {
+    onInit(options) {
         for (key in options) { this[key] = options[key]; }
         this.options['callback'] = jQuery.proxy(this.callback,this);
         this.options['expired-callback'] = jQuery.proxy(this.callbackExpired,this);
 
         Prado.WebUI.TReCaptcha2Instances[this.element.id] = this;
     },
-    build: function()
-    {
+    build() {
        if (grecaptcha !== undefined) this.widgetId = grecaptcha.render(this.element, this.options);
     },
-    callback: function(response)
-    {
-        var responseField = jQuery('#' + this.ID + ' textarea').attr('id');
-        var params = {
+    callback(response) {
+        const responseField = jQuery(`#${this.ID} textarea`).attr('id');
+        const params = {
             widgetId: this.widgetId,
-            response: response,
-            responseField: responseField,
+            response,
+            responseField,
             onCallback: this.onCallback
         };
-        var request = new Prado.CallbackRequest(this.EventTarget,this);
+        const request = new Prado.CallbackRequest(this.EventTarget,this);
         request.setCallbackParameter(params);
         request.dispatch();
     },
-    callbackExpired: function()
-    {
-        var responseField = jQuery('#' + this.ID + ' textarea').attr('id');
-        var params = {
-            responseField: responseField,
+    callbackExpired() {
+        const responseField = jQuery(`#${this.ID} textarea`).attr('id');
+        const params = {
+            responseField,
             onCallbackExpired: this.onCallbackExpired
         };
-        var request = new Prado.CallbackRequest(this.EventTarget,this);
+        const request = new Prado.CallbackRequest(this.EventTarget,this);
         request.setCallbackParameter(params);
         request.dispatch();
     }
@@ -2058,10 +1958,9 @@ Prado.WebUI.TReCaptcha2Validator = jQuery.klass(Prado.WebUI.TBaseValidator,
      * @function {boolean} ?
      * @return True if the captcha has validate, False otherwise.
      */
-    evaluateIsValid : function()
-    {
-        var a = this.getValidationValue();
-        var b = this.trim(this.options.InitialValue);
+    evaluateIsValid() {
+        const a = this.getValidationValue();
+        const b = this.trim(this.options.InitialValue);
         return(a != b);
     }
 });

--- a/framework/Web/Javascripts/source/prado/validator/validation3.js
+++ b/framework/Web/Javascripts/source/prado/validator/validation3.js
@@ -1097,7 +1097,7 @@ Prado.WebUI.TBaseValidator = Prado.Class(Prado.WebUI.Control,
 					return value;
 				else
 				{
-					var value = Date.SimpleParse(string, this.options.DateFormat);
+					value = Date.SimpleParse(string, this.options.DateFormat);
 					if(value && typeof(value.getTime) == "function")
 						return value.getTime();
 					else
@@ -1154,6 +1154,7 @@ Prado.WebUI.TBaseValidator = Prado.Class(Prado.WebUI.Control,
 			case 'TRadioButton':
 				if(this.options.GroupName)
 					return this.getRadioButtonGroupValue();
+				// falls through
 			case 'TReCaptcha2':
  			default:
 	 			return control.value;
@@ -1247,22 +1248,24 @@ Prado.WebUI.TBaseValidator = Prado.Class(Prado.WebUI.Control,
 	 * @return Array of list control option DOM elements.
 	 */
 	getListElements() {
+		// Locals hoisted to the top of the function body so each switch arm
+		// can assign without retriggering no-redeclare across cases.
+		var elements, element, type;
 		switch(this.options.ControlType)
 		{
 			case 'TCheckBoxList':
 			case 'TRadioButtonList':
-				var elements = [];
+				elements = [];
 				for(let i = 0; i < this.options.TotalItems; i++)
 				{
-					var element = document.getElementById(`${this.options.ControlToValidate}_c${i}`);
+					element = document.getElementById(`${this.options.ControlToValidate}_c${i}`);
 					if(this.isCheckBoxType(element))
 						elements.push(element);
 				}
 				return elements;
 			case 'TListBox':
-				var elements = [];
-				var element = document.getElementById(this.options.ControlToValidate);
-				var type;
+				elements = [];
+				element = document.getElementById(this.options.ControlToValidate);
 				if(element && (type = element.type.toLowerCase()))
 				{
 					if(type == "select-one" || type == "select-multiple")
@@ -1382,10 +1385,11 @@ Prado.WebUI.TCompareValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 
     	const comparee = document.getElementById(this.options.ControlToCompare);
 
+		let compareTo;
 		if(comparee)
-			var compareTo = this.getValidationValue(comparee);
+			compareTo = this.getValidationValue(comparee);
 		else
-			var compareTo = this.options.ValueToCompare || "";
+			compareTo = this.options.ValueToCompare || "";
 
 	    const isValid =  this.compare(value, compareTo);
 
@@ -1597,16 +1601,17 @@ Prado.WebUI.TRangeValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 		if(typeof(this.options.DataType) == "undefined")
 			this.options.DataType = "String";
 
+		let min, max;
 		if(this.options.DataType != "StringLength")
 		{
-			var min = this.convert(this.options.DataType, this.options.MinValue || null);
-			var max = this.convert(this.options.DataType, this.options.MaxValue || null);
+			min = this.convert(this.options.DataType, this.options.MinValue || null);
+			max = this.convert(this.options.DataType, this.options.MaxValue || null);
 			value = this.convert(this.options.DataType, value);
 		}
 		else
 		{
-			var min = this.options.MinValue || 0;
-			var max = this.options.MaxValue || Number.POSITIVE_INFINITY;
+			min = this.options.MinValue || 0;
+			max = this.options.MaxValue || Number.POSITIVE_INFINITY;
 			value = value.length;
 		}
 
@@ -1918,7 +1923,7 @@ TReCaptcha2_onloadCallback = () => {
 Prado.WebUI.TReCaptcha2 = Prado.Class(Prado.WebUI.Control,
 {
     onInit(options) {
-        for (key in options) { this[key] = options[key]; }
+        for (const key in options) { this[key] = options[key]; }
         this.options['callback'] = this.callback.bind(this);
         this.options['expired-callback'] = this.callbackExpired.bind(this);
 

--- a/framework/Web/Javascripts/source/prado/validator/validation3.js
+++ b/framework/Web/Javascripts/source/prado/validator/validation3.js
@@ -61,7 +61,7 @@
  * @module validation
  */
 
-Prado.Validation =  jQuery.klass();
+Prado.Validation =  Prado.Class();
 
 /**
  * Global Validation Object.
@@ -81,7 +81,7 @@ Prado.Validation =  jQuery.klass();
  *
  * @object {static} Prado.Validation
  */
-jQuery.extend(Prado.Validation,
+Object.assign(Prado.Validation,
 {
 	/**
 	 * Hash of registered validation managers
@@ -135,7 +135,7 @@ jQuery.extend(Prado.Validation,
 	 * @returns ID of first form.
 	 */
 	getForm() {
-		const keys = jQuery.map(this.managers, (value, key) => key);
+		const keys = Object.keys(this.managers);
 		return keys.length>0 ? keys[0] : null;
 	},
 
@@ -198,26 +198,27 @@ jQuery.extend(Prado.Validation,
 	},
 
 	setErrorMessage(validatorID, message) {
-		jQuery.each(Prado.Validation.managers, (idx, manager) => {
-			jQuery.each(manager.validators, (idx, validator) => {
+		for (const manager of Object.values(Prado.Validation.managers)) {
+			for (const validator of manager.validators) {
 				if(validator.options.ID == validatorID)
 				{
 					validator.options.ErrorMessage = message;
-					jQuery(`#${validatorID}`).get(0).innerHTML = message;
+					const el = document.getElementById(validatorID);
+					if (el) el.innerHTML = message;
 				}
-			});
-		});
+			}
+		}
 	},
 
 	updateActiveCustomValidator(validatorID, isValid) {
-		jQuery.each(Prado.Validation.managers, (idx, manager) => {
-			jQuery.each(manager.validators, (idx, validator) => {
+		for (const manager of Object.values(Prado.Validation.managers)) {
+			for (const validator of manager.validators) {
 				if(validator.options.ID == validatorID)
 				{
 					validator.updateIsValid(isValid);
 				}
-			});
-		});
+			}
+		}
 	}
 });
 
@@ -231,7 +232,7 @@ jQuery.extend(Prado.Validation,
  *
  * @class Prado.ValidationManager
  */
-Prado.ValidationManager = jQuery.klass();
+Prado.ValidationManager = Prado.Class();
 Prado.ValidationManager.prototype =
 {
 	/**
@@ -315,7 +316,13 @@ Prado.ValidationManager.prototype =
 				valid=false;
 		}
 		this.focusOnError(partition[0]);
-		jQuery(partition[1]).hide();
+		// The original implementation here was `jQuery(partition[1]).hide()`.
+		// partition[1] is an array of TBaseValidator instances, not DOM nodes;
+		// jQuery iterated them and tried to set style.display on each but
+		// validators aren't DOM elements so the call was effectively a no-op.
+		// Validators outside the current group keep their existing visibility,
+		// which is the behavior the test suite relies on. Intentionally
+		// leaving this as a no-op to preserve that semantics.
 		this.updateSummary(group, true);
 		return valid;
 	},
@@ -330,10 +337,10 @@ Prado.ValidationManager.prototype =
         let valid = true;
         if(this.controls[id])
         {
-          jQuery.each(this.controls[id], (idx, element) => {
+          for (const element of this.controls[id]) {
             if(!element.validate(null))
               valid = false;
-          });
+          }
         }
 
         return valid;
@@ -376,15 +383,15 @@ Prado.ValidationManager.prototype =
 	 * @return Array with two arrays of validators.
 	 */
 	validatorsInGroup(groupID) {
-		if(jQuery.inArray(groupID, this.groups)!=-1)
+		if(this.groups.includes(groupID))
 		{
 			const trues = [], falses = [];
-			jQuery.each(this.validators, (idx, val) => {
+			for (const val of this.validators) {
 				if(val.group == groupID)
 					trues.push(val);
 				else
 					falses.push(val);
-			});
+			}
 			return [trues, falses];
 		}
 		else
@@ -402,12 +409,12 @@ Prado.ValidationManager.prototype =
 	 */
 	validatorsWithoutGroup() {
 		const trues = [], falses = [];
-		jQuery.each(this.validators, (idx, val) => {
+		for (const val of this.validators) {
 			if(!val.group)
 				trues.push(val);
 			else
 				falses.push(val);
-		});
+		}
 		return [trues, falses];
 	},
 
@@ -440,7 +447,7 @@ Prado.ValidationManager.prototype =
     this.removeValidator(validator);
 
 		this.validators.push(validator);
-		if(validator.group && jQuery.inArray(validator.group, this.groups)==-1)
+		if(validator.group && !this.groups.includes(validator.group))
 			this.groups.push(validator.group);
 
     if(typeof this.controls[validator.control.id] === 'undefined')
@@ -464,11 +471,11 @@ Prado.ValidationManager.prototype =
 	 */
   removeValidator(validator) {
     // Remove from list of validators
-  	this.validators = jQuery.grep(this.validators, v => v.options.ID!=validator.options.ID);
+  	this.validators = this.validators.filter(v => v.options.ID!=validator.options.ID);
 	  // Remove from global list of validators per control
     if (this.controls[validator.control.id])
     {
-      this.controls[validator.control.id] = jQuery.grep(this.controls[validator.control.id], v => v.options.ID!=validator.options.ID);
+      this.controls[validator.control.id] = this.controls[validator.control.id].filter(v => v.options.ID!=validator.options.ID);
       // Delete array if empty
       if(this.controls[validator.control.id].length == 0)
         delete this.controls[validator.control.id];
@@ -484,7 +491,7 @@ Prado.ValidationManager.prototype =
 	 * @return array list of validators with error.
 	 */
 	getValidatorsWithError(group) {
-		return jQuery.grep(this.validatorPartition(group)[0], validator => !validator.isValid);
+		return this.validatorPartition(group)[0].filter(validator => !validator.isValid);
 	},
 
 	/**
@@ -498,14 +505,14 @@ Prado.ValidationManager.prototype =
 	 */
 	updateSummary(group, refresh) {
 		const validators = this.getValidatorsWithError(group);
-		jQuery.each(this.summaries, (idx, summary) => {
+		for (const summary of this.summaries) {
 			const inGroup = group && summary.group == group;
 			const noGroup = !group || !summary.group;
 			if(inGroup || noGroup)
 				summary.updateSummary(validators, refresh);
 			else
 				summary.hideSummary(true);
-		});
+		}
 	}
 };
 
@@ -528,7 +535,7 @@ Prado.ValidationManager.prototype =
  *
  * @class Prado.WebUI.TValidationSummary
  */
-Prado.WebUI.TValidationSummary = jQuery.klass();
+Prado.WebUI.TValidationSummary = Prado.Class();
 Prado.WebUI.TValidationSummary.prototype =
 {
 	/**
@@ -563,7 +570,7 @@ Prado.WebUI.TValidationSummary.prototype =
 		 * Summary DOM element
 		 * @var {element} messages
 		 */
-		this.messages = jQuery(`#${options.ID}`).get(0);
+		this.messages = document.getElementById(options.ID);
 		Prado.Registry[options.ID] = this;
 		if(this.messages)
 		{
@@ -629,7 +636,7 @@ Prado.WebUI.TValidationSummary.prototype =
 	updateHTMLMessages(messages) {
 		while(this.messages.childNodes.length > 0)
 			this.messages.removeChild(this.messages.lastChild);
-		jQuery(this.messages).append(this.formatSummary(messages));
+		this.messages.insertAdjacentHTML('beforeend', this.formatSummary(messages));
 	},
 
 	/**
@@ -650,11 +657,11 @@ Prado.WebUI.TValidationSummary.prototype =
 	 */
 	getMessages(validators) {
 		const messages = [];
-		jQuery.each(validators, (idx, validator) => {
+		for (const validator of validators) {
 			const message = validator.getErrorMessage();
 			if(typeof(message) == 'string' && message.length > 0)
 				messages.push(message);
-		})
+		}
 		return messages;
 	},
 
@@ -672,7 +679,7 @@ Prado.WebUI.TValidationSummary.prototype =
 		{
 			this.messages.style.visibility="hidden";
 			if(this.options.Display == "None" || this.options.Display == "Dynamic")
-				jQuery(this.messages).hide();
+				this.messages.style.display = 'none';
 		}
 		this.visible = false;
 	},
@@ -687,7 +694,7 @@ Prado.WebUI.TValidationSummary.prototype =
 		if(typeof(this.options.OnShowSummary) == "function")
 			this.options.OnShowSummary(this,validators);
 		else
-			jQuery(this.messages).show();
+			this.messages.style.display = '';
 		this.visible = true;
 	},
 
@@ -727,9 +734,9 @@ Prado.WebUI.TValidationSummary.prototype =
 		const format = this.formats(this.options.DisplayMode);
 		let output = this.options.HeaderText ? this.options.HeaderText + format.header : "";
 		output += format.first;
-		jQuery.each(messages, (idx, message) => {
+		for (const message of messages) {
 			output += message.length > 0 ? format.pre + message + format.post : "";
-		});
+		}
 //		for(var i = 0; i < messages.length; i++)
 	//		output += (messages[i].length>0) ? format.pre + messages[i] + format.post : "";
 		output += format.last;
@@ -777,7 +784,7 @@ Prado.WebUI.TValidationSummary.prototype =
  *
  * @class Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TBaseValidator = Prado.Class(Prado.WebUI.Control,
 {
 	/**
 	 * Initialize TBaseValidator.
@@ -846,12 +853,12 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 		 * DOM element of control to validate
 		 * @var {element} control
 		 */
-		this.control = jQuery(`#${options.ControlToValidate}`).get(0);
+		this.control = document.getElementById(options.ControlToValidate);
 		/**
 		 * DOM element of validator
 		 * @var {element} message
 		 */
-		this.message = jQuery(`#${options.ID}`).get(0);
+		this.message = document.getElementById(options.ID);
 
 		Prado.Registry[options.ID] = this;
 
@@ -904,7 +911,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 			if(this.options.Display == "Dynamic")
 			{
 				const msg=this.message;
-				this.isValid ? jQuery(msg).hide() : jQuery(msg).show();
+				msg.style.display = this.isValid ? 'none' : '';
 			}
 			this.message.style.visibility = this.isValid ? "hidden" : "visible";
 		}
@@ -929,13 +936,13 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 				if (control.lastValidator == this.options.ID)
 				{
 					control.lastValidator = null;
-					jQuery(control).removeClass(CssClass);
+					control.classList.remove(CssClass);
 				}
 			}
 			else
 			{
 				control.lastValidator = this.options.ID;
-				jQuery(control).addClass(CssClass);
+				control.classList.add(CssClass);
 			}
 		}
 	},
@@ -970,9 +977,9 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	validate(invoker) {
 		//try to find the control.
 		if(!this.control)
-			this.control = jQuery(`#${this.options.ControlToValidate}`).get(0);
+			this.control = document.getElementById(this.options.ControlToValidate);
 
-		if(!this.control || this.control.disabled || !jQuery.contains(document, this.control))
+		if(!this.control || this.control.disabled || !document.contains(this.control))
 		{
 			this.isValid = true;
 			return this.isValid;
@@ -1120,7 +1127,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	 		case 'TDatePicker':
 	 			if(control.type == "text")
 	 			{
-	 				const value = this.trim(jQuery(control).val());
+	 				const value = this.trim(control.value);
 
 					if(this.options.DateFormat)
 	 				{
@@ -1149,7 +1156,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 					return this.getRadioButtonGroupValue();
 			case 'TReCaptcha2':
  			default:
-	 			return jQuery(control).val();
+	 			return control.value;
 	 	}
 	 },
 
@@ -1190,10 +1197,10 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 	getRadioButtonGroupValue() {
 		const name = this.control.name;
 		let value = "";
-		jQuery.each(document.getElementsByName(name), (idx, el) => {
+		for (const el of document.getElementsByName(name)) {
 			if(el.checked)
 				value =  el.value;
-		});
+		}
 		return value;
 	},
 
@@ -1221,13 +1228,13 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 		let checked = 0;
 		const values = [];
 		const isSelected = this.isCheckBoxType(elements[0]) ? 'checked' : 'selected';
-		jQuery.each(elements, (idx, element) => {
+		for (const element of elements) {
 			if(element[isSelected] && element.value != initialValue)
 			{
 				checked++;
 				values.push(element.value);
 			}
-		});
+		}
 		return {'checks' : checked, 'values' : values};
 	},
 
@@ -1247,14 +1254,14 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
 				var elements = [];
 				for(let i = 0; i < this.options.TotalItems; i++)
 				{
-					var element = jQuery(`#${this.options.ControlToValidate}_c${i}`).get(0);
+					var element = document.getElementById(`${this.options.ControlToValidate}_c${i}`);
 					if(this.isCheckBoxType(element))
 						elements.push(element);
 				}
 				return elements;
 			case 'TListBox':
 				var elements = [];
-				var element = jQuery(`#${this.options.ControlToValidate}`).get(0);
+				var element = document.getElementById(this.options.ControlToValidate);
 				var type;
 				if(element && (type = element.type.toLowerCase()))
 				{
@@ -1307,7 +1314,7 @@ Prado.WebUI.TBaseValidator = jQuery.klass(Prado.WebUI.Control,
  * @class Prado.WebUI.TRequiredFieldValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TRequiredFieldValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TRequiredFieldValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Evaluate validation state
@@ -1347,7 +1354,7 @@ Prado.WebUI.TRequiredFieldValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TCompareValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TCompareValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TCompareValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Additional constructor options.
@@ -1373,7 +1380,7 @@ Prado.WebUI.TCompareValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	    if (value.length <= 0)
 	    	return true;
 
-    	const comparee = jQuery(`#${this.options.ControlToCompare}`).get(0);
+    	const comparee = document.getElementById(this.options.ControlToCompare);
 
 		if(comparee)
 			var compareTo = this.getValidationValue(comparee);
@@ -1452,7 +1459,7 @@ Prado.WebUI.TCompareValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TCustomValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TCustomValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Additional constructor options.
@@ -1485,7 +1492,7 @@ Prado.WebUI.TCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TActiveCustomValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TActiveCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TActiveCustomValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Override the parent implementation to store the invoker, in order to
@@ -1501,7 +1508,7 @@ Prado.WebUI.TActiveCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 
 		//try to find the control.
 		if(!this.control)
-			this.control = jQuery(`#${this.options.ControlToValidate}`).get(0);
+			this.control = document.getElementById(this.options.ControlToValidate);
 
 		if(!this.control || this.control.disabled)
 		{
@@ -1565,7 +1572,7 @@ Prado.WebUI.TActiveCustomValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TRangeValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TRangeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TRangeValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Additional constructor options.
@@ -1623,7 +1630,7 @@ Prado.WebUI.TRangeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TRegularExpressionValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TRegularExpressionValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TRegularExpressionValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Additional constructor option.
@@ -1666,7 +1673,7 @@ Prado.WebUI.TEmailAddressValidator = Prado.WebUI.TRegularExpressionValidator;
  * @class Prado.WebUI.TListControlValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TListControlValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Evaluate validation state
@@ -1692,10 +1699,9 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 observeListElements(elements) {
 		if(this.isCheckBoxType(elements[0]))
 		{
-			const validator = this;
-			jQuery.each(elements, (idx, element) => {
-				validator.observeChanges(element);
-			});
+			for (const element of elements) {
+				this.observeChanges(element);
+			}
 		}
 	 },
 
@@ -1718,9 +1724,9 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 		{
 			if(values.length < required.length)
 				return false;
-			jQuery.each(required, (idx, requiredValue) => {
-				exists = exists && (jQuery.inArray(requiredValue, values)!=-1);
-			});
+			for (const requiredValue of required) {
+				exists = exists && values.includes(requiredValue);
+			}
 		}
 
 		const min = typeof(this.options.Min) == "undefined" ?
@@ -1761,7 +1767,7 @@ Prado.WebUI.TListControlValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TDataTypeValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TDataTypeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TDataTypeValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Additional constructor option.
@@ -1791,7 +1797,7 @@ Prado.WebUI.TDataTypeValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TCaptchaValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TCaptchaValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	/**
 	 * Evaluate validation state
@@ -1860,7 +1866,7 @@ Prado.WebUI.TCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
  * @class Prado.WebUI.TReCaptchaValidator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TReCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TReCaptchaValidator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
 	onInit() {
 		const obj = this;
@@ -1874,7 +1880,7 @@ Prado.WebUI.TReCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	},
 
 	responseChanged() {
-		const field = jQuery(`#${this.options.ID}_1`).get(0);
+		const field = document.getElementById(`${this.options.ID}_1`);
 		if (field.value=='1') return;
 		field.value = '1';
 		Prado.Validation.validateControl(this.options.ID);
@@ -1886,7 +1892,7 @@ Prado.WebUI.TReCaptchaValidator = jQuery.klass(Prado.WebUI.TBaseValidator,
 	 * @return True if the captcha has validate, False otherwise.
 	 */
 	evaluateIsValid() {
-		return jQuery(`#${this.options.ID}_1`).get(0).value=='1';
+		return document.getElementById(`${this.options.ID}_1`).value=='1';
 	}
 });
 
@@ -1898,9 +1904,9 @@ Prado.WebUI.TReCaptcha2Instances = {};
  * Render callback; called by google's js when loaded
  */
 TReCaptcha2_onloadCallback = () => {
-	jQuery.each(Prado.WebUI.TReCaptcha2Instances, (index, item) => {
-    	item.build();
-	});
+	for (const item of Object.values(Prado.WebUI.TReCaptcha2Instances)) {
+		item.build();
+	}
 }
 
 /**
@@ -1909,12 +1915,12 @@ TReCaptcha2_onloadCallback = () => {
  * @class Prado.WebUI.TReCaptcha2
  * @extends Prado.WebUI.Control
  */
-Prado.WebUI.TReCaptcha2 = jQuery.klass(Prado.WebUI.Control,
+Prado.WebUI.TReCaptcha2 = Prado.Class(Prado.WebUI.Control,
 {
     onInit(options) {
         for (key in options) { this[key] = options[key]; }
-        this.options['callback'] = jQuery.proxy(this.callback,this);
-        this.options['expired-callback'] = jQuery.proxy(this.callbackExpired,this);
+        this.options['callback'] = this.callback.bind(this);
+        this.options['expired-callback'] = this.callbackExpired.bind(this);
 
         Prado.WebUI.TReCaptcha2Instances[this.element.id] = this;
     },
@@ -1922,7 +1928,7 @@ Prado.WebUI.TReCaptcha2 = jQuery.klass(Prado.WebUI.Control,
        if (grecaptcha !== undefined) this.widgetId = grecaptcha.render(this.element, this.options);
     },
     callback(response) {
-        const responseField = jQuery(`#${this.ID} textarea`).attr('id');
+        const responseField = document.querySelector(`#${this.ID} textarea`)?.id;
         const params = {
             widgetId: this.widgetId,
             response,
@@ -1934,7 +1940,7 @@ Prado.WebUI.TReCaptcha2 = jQuery.klass(Prado.WebUI.Control,
         request.dispatch();
     },
     callbackExpired() {
-        const responseField = jQuery(`#${this.ID} textarea`).attr('id');
+        const responseField = document.querySelector(`#${this.ID} textarea`)?.id;
         const params = {
             responseField,
             onCallbackExpired: this.onCallbackExpired
@@ -1951,7 +1957,7 @@ Prado.WebUI.TReCaptcha2 = jQuery.klass(Prado.WebUI.Control,
  * @class Prado.WebUI.TReCaptcha2Validator
  * @extends Prado.WebUI.TBaseValidator
  */
-Prado.WebUI.TReCaptcha2Validator = jQuery.klass(Prado.WebUI.TBaseValidator,
+Prado.WebUI.TReCaptcha2Validator = Prado.Class(Prado.WebUI.TBaseValidator,
 {
     /**
      * Evaluate validation state

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,6 +27,15 @@ export default defineConfig({
 	testDir: './tests/playwright',
 	testMatch: '**/*.spec.js',
 
+	/*
+	 * Clear Prado's published asset caches before the run.
+	 * TAssetManager publishes framework JS/CSS into
+	 * vendor/pradosoft/prado-demos/<demo>/assets/<hash>/ once and never
+	 * invalidates that cache on source edits — without this step, tests
+	 * silently run against stale prado.min.js and report false failures.
+	 */
+	globalSetup: './tests/playwright/global-setup.js',
+
 	/* Maximum time one test can run (mirrors phpunit max_execution_time=1200) */
 	timeout: 120_000,
 

--- a/tests/harness/issues/protected/pages/Issue1154TriggerBridge.page
+++ b/tests/harness/issues/protected/pages/Issue1154TriggerBridge.page
@@ -1,0 +1,433 @@
+<com:TContent ID="Content">
+
+<h1>Issue 1154 &mdash; jQuery.fn.trigger bridge</h1>
+
+<p>
+This page exercises every branch of the bridge installed in <code>prado.js</code>
+that maps <code>jQuery(el).trigger(name)</code> to native <code>dispatchEvent</code>
+for Prado-managed (klass) elements. The Playwright spec drives this page via
+<code>page.evaluate()</code>, calling helpers attached to <code>window.__bridge</code>.
+</p>
+
+<!-- ─── Plain DOM probes the spec wraps with helpers ─── -->
+<input type="text" id="probePlain" />
+<input type="text" id="probeKlass" />
+<input type="text" id="probeText" />
+<input type="text" id="probeMulti1" />
+<input type="text" id="probeMulti2" />
+<input type="text" id="probeFocus" />
+<button type="button" id="probeButton">btn</button>
+<div id="probeCustom"></div>
+<!-- Note: the <form> probes are appended to document.body at runtime
+	 from the helper script below, OUTSIDE the page-wrapping Prado form.
+	 (HTML5 unwraps nested forms, so we can't author the form here.) -->
+
+
+<!-- ─── Visible result tape (for tests that prefer reading the DOM) ─── -->
+<pre id="bridgeResults" style="background:#eee; padding:6px; min-height:1em;"></pre>
+
+<com:TClientScript>
+// Wait until prado.js + jQuery are loaded.
+(function ready(fn) {
+	if (document.readyState !== 'loading') fn();
+	else document.addEventListener('DOMContentLoaded', fn);
+})(function () {
+	// ─── Helpers ────────────────────────────────────────────────────────────
+	var results = document.getElementById('bridgeResults');
+	function record(label) {
+		results.textContent = results.textContent
+			? results.textContent + '\n' + label
+			: label;
+	}
+	function reset() { results.textContent = ''; }
+
+	// Bare-bones klass control: registers itself in Prado.Registry under
+	// options.ID, exposes the element as `this.element`. Mirrors what
+	// Prado.WebUI.Control does without dragging controls.js in.
+	function makeKlass(id) {
+		var K = jQuery.klass({
+			initialize: function (opts) {
+				this.options = opts;
+				this.ID = opts.ID;
+				this.element = document.getElementById(opts.ID);
+				Prado.Registry[opts.ID] = this;
+			}
+		});
+		return new K({ ID: id });
+	}
+
+	// Build form probes outside the Prado-controlled page area so they're
+	// not stripped by HTML5 form unwrapping. Append directly to body.
+	var form = document.createElement('form');
+	form.id = 'bridgeForm';
+	form.method = 'get';
+	form.action = '?page=Issue1154TriggerBridge&submitted=1';
+	var submitBtn = document.createElement('input');
+	submitBtn.type = 'submit';
+	submitBtn.id = 'probeSubmit';
+	submitBtn.value = 'submit';
+	form.appendChild(submitBtn);
+	// Append OUTSIDE the Prado wrapper form. document.documentElement works
+	// because the Prado form is just one of body's children.
+	document.documentElement.appendChild(form);
+
+	// Pre-register every probe element as a klass control. probePlain stays
+	// non-klass so we can exercise the passthrough branch.
+	var klassInputs = ['probeKlass', 'probeText', 'probeMulti1', 'probeFocus',
+		'probeButton', 'probeCustom', 'bridgeForm', 'probeSubmit'];
+	var instances = {};
+	klassInputs.forEach(function (id) { instances[id] = makeKlass(id); });
+
+	// ─── window.__bridge: the API the spec drives ──────────────────────────
+	window.__bridge = {
+		reset: reset,
+		results: function () { return results.textContent; },
+		count: 0,
+		// Marker assertions: spec reads these via page.evaluate().
+		isPradoClassMarker: function (id) {
+			var inst = Prado.Registry[id];
+			return !!(inst && inst.constructor && inst.constructor.isPradoClass);
+		},
+		// Prado.Class.prototype.trigger tests ───────────────────────────────
+		probeKlass_triggerHelper: function (evtName, detail) {
+			var got = null;
+			var handler = function (e) { got = { type: e.type, detail: e.detail }; };
+			var el = document.getElementById('probeKlass');
+			el.addEventListener(evtName, handler);
+			instances.probeKlass.trigger(evtName, detail);
+			el.removeEventListener(evtName, handler);
+			return got;
+		},
+		// Bridge — addEventListener handler fires when jQuery.trigger called
+		klassChange_fires: function () {
+			var fired = 0;
+			var el = document.getElementById('probeKlass');
+			var h = function () { fired++; };
+			el.addEventListener('change', h);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', h);
+			return fired;
+		},
+		// Bridge — jQuery.on handler also fires on klass element
+		klassChange_jq_on_fires: function () {
+			var fired = 0;
+			var $el = jQuery('#probeKlass');
+			var h = function () { fired++; };
+			$el.on('change.tb', h);
+			$el.trigger('change');
+			$el.off('change.tb', h);
+			return fired;
+		},
+		// Bridge — mixed handlers: both fire (once each)
+		klassChange_mixed: function () {
+			var n = 0, j = 0;
+			var el = document.getElementById('probeKlass');
+			var native = function () { n++; };
+			var jqh = function () { j++; };
+			el.addEventListener('change', native);
+			jQuery(el).on('change.tb', jqh);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', native);
+			jQuery(el).off('change.tb', jqh);
+			return { native: n, jq: j };
+		},
+		// Bridge — non-klass passthrough
+		nonKlass_passthrough: function () {
+			var fired = 0;
+			var $el = jQuery('#probePlain');
+			$el.on('change.tb', function () { fired++; });
+			$el.trigger('change');
+			$el.off('change.tb');
+			return fired;
+		},
+		// Bridge — registry slot exists but is not a klass instance
+		registry_not_klass: function () {
+			// Plant a non-klass entry, ensure passthrough still works.
+			var saved = Prado.Registry['probeText'];
+			Prado.Registry['probeText'] = { not: 'a klass' };
+			var fired = 0;
+			var $el = jQuery('#probeText');
+			$el.on('change.tb', function () { fired++; });
+			$el.trigger('change');
+			$el.off('change.tb');
+			Prado.Registry['probeText'] = saved;
+			return fired;
+		},
+		// Bridge — CustomEvent detail payload
+		customDetail: function (payload) {
+			var got = null;
+			var el = document.getElementById('probeCustom');
+			var h = function (e) { got = e.detail; };
+			el.addEventListener('mything', h);
+			jQuery(el).trigger('mything', payload);
+			el.removeEventListener('mything', h);
+			return got;
+		},
+		// Bridge — uses CustomEvent (not plain Event)
+		usesCustomEvent: function () {
+			var got = null;
+			var el = document.getElementById('probeCustom');
+			var h = function (e) { got = e instanceof CustomEvent; };
+			el.addEventListener('thing', h);
+			jQuery(el).trigger('thing', 'p');
+			el.removeEventListener('thing', h);
+			return got;
+		},
+		// Bridge — real Event instance is dispatched verbatim
+		realEventPassthrough: function () {
+			var got = null;
+			var el = document.getElementById('probeCustom');
+			var h = function (e) { got = e; };
+			el.addEventListener('keydown', h);
+			var real = new Event('keydown', { bubbles: true });
+			jQuery(el).trigger(real);
+			el.removeEventListener('keydown', h);
+			return got === real;
+		},
+		// Bridge — chainability: returns the jQuery wrapper
+		chainability: function () {
+			var $el = jQuery('#probeKlass');
+			var ret = $el.trigger('change');
+			return ret === $el;
+		},
+		// Bridge — multi-element selector with klass + non-klass mix
+		multiset: function () {
+			var a = 0, b = 0;
+			var elA = document.getElementById('probeMulti1'); // klass
+			var elB = document.getElementById('probePlain');  // non-klass
+			elA.addEventListener('change', function () { a++; });
+			jQuery(elB).on('change.tb', function () { b++; });
+			jQuery('#probeMulti1, #probePlain').trigger('change');
+			jQuery(elB).off('change.tb');
+			return { klassFired: a, plainFired: b };
+		},
+		// Bridge — focus activation: jQuery.trigger('focus') calls el.focus()
+		focusActivation: function () {
+			var el = document.getElementById('probeFocus');
+			document.body.focus();          // ensure not already focused
+			jQuery(el).trigger('focus');
+			return document.activeElement === el;
+		},
+		// Bridge — blur activation
+		blurActivation: function () {
+			var el = document.getElementById('probeFocus');
+			el.focus();                      // make sure it has focus first
+			jQuery(el).trigger('blur');
+			return document.activeElement !== el;
+		},
+		// Bridge — submit on klass FORM: form.submit() is invoked
+		submitInvoked: function () {
+			var form = document.getElementById('bridgeForm');
+			var calls = 0;
+			var origSubmit = form.submit;
+			form.submit = function () { calls++; };
+			jQuery(form).trigger('submit');
+			form.submit = origSubmit;
+			return calls;
+		},
+		// Bridge — submit on klass FORM with preventDefault stops submission
+		submitPrevented: function () {
+			var form = document.getElementById('bridgeForm');
+			var canceller = function (e) { e.preventDefault(); };
+			form.addEventListener('submit', canceller);
+			var calls = 0;
+			var origSubmit = form.submit;
+			form.submit = function () { calls++; };
+			jQuery(form).trigger('submit');
+			form.submit = origSubmit;
+			form.removeEventListener('submit', canceller);
+			return calls;
+		},
+		// Bridge — submit on klass FORM dispatches the submit event before
+		// calling form.submit(), so handlers see the event in order.
+		submitEventFires: function () {
+			var form = document.getElementById('bridgeForm');
+			var ordering = [];
+			var handler = function () { ordering.push('event'); };
+			form.addEventListener('submit', handler);
+			var origSubmit = form.submit;
+			form.submit = function () { ordering.push('submit'); };
+			jQuery(form).trigger('submit');
+			form.submit = origSubmit;
+			form.removeEventListener('submit', handler);
+			return ordering;
+		},
+		// Bridge — click on klass submit-button invokes el.click(), which
+		// the browser routes to default activation (form submit).
+		clickActivation: function () {
+			var btn = document.getElementById('probeSubmit');
+			var calls = 0;
+			var origClick = btn.click.bind(btn);
+			btn.click = function () { calls++; };
+			jQuery(btn).trigger('click');
+			btn.click = origClick;
+			return calls;
+		},
+		// Bridge — empty / undefined event name is a no-op for klass elements
+		emptyEventName: function () {
+			var fired = 0;
+			var el = document.getElementById('probeKlass');
+			el.addEventListener('change', function () { fired++; });
+			try { jQuery(el).trigger(''); } catch (e) {}
+			try { jQuery(el).trigger(undefined); } catch (e) {}
+			return fired;
+		},
+		// Bridge — handler order: addEventListener-then-jq.on fires native first
+		handlerOrder: function () {
+			var order = [];
+			var el = document.getElementById('probeKlass');
+			var n = function () { order.push('native'); };
+			var j = function () { order.push('jquery'); };
+			el.addEventListener('change', n);
+			jQuery(el).on('change.tb', j);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', n);
+			jQuery(el).off('change.tb', j);
+			return order;
+		},
+
+		// ─── Exactly-once dispatch coverage ────────────────────────────────
+		// Each helper returns the full set of call counts so the spec
+		// can assert the exact multiplicities, ruling out any spurious
+		// extra calls slipped in by the bridge.
+
+		exactlyOnce_native: function () {
+			var c = 0;
+			var el = document.getElementById('probeKlass');
+			var fn = function () { c++; };
+			el.addEventListener('change', fn);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', fn);
+			return c;
+		},
+		exactlyOnce_jq: function () {
+			var c = 0;
+			var el = document.getElementById('probeKlass');
+			var fn = function () { c++; };
+			jQuery(el).on('change.t', fn);
+			jQuery(el).trigger('change');
+			jQuery(el).off('change.t', fn);
+			return c;
+		},
+		exactlyOnce_threeNative: function () {
+			var a = 0, b = 0, c = 0;
+			var el = document.getElementById('probeKlass');
+			var fa = function () { a++; }, fb = function () { b++; }, fc = function () { c++; };
+			el.addEventListener('change', fa);
+			el.addEventListener('change', fb);
+			el.addEventListener('change', fc);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', fa);
+			el.removeEventListener('change', fb);
+			el.removeEventListener('change', fc);
+			return [a, b, c];
+		},
+		exactlyOnce_threeJq: function () {
+			var a = 0, b = 0, c = 0;
+			var el = document.getElementById('probeKlass');
+			var fa = function () { a++; }, fb = function () { b++; }, fc = function () { c++; };
+			jQuery(el).on('change.t1', fa);
+			jQuery(el).on('change.t2', fb);
+			jQuery(el).on('change.t3', fc);
+			jQuery(el).trigger('change');
+			jQuery(el).off('change.t1', fa);
+			jQuery(el).off('change.t2', fb);
+			jQuery(el).off('change.t3', fc);
+			return [a, b, c];
+		},
+		exactlyOnce_matrix: function () {
+			var n1 = 0, n2 = 0, j1 = 0, j2 = 0;
+			var el = document.getElementById('probeKlass');
+			var fn1 = function () { n1++; }, fn2 = function () { n2++; };
+			var fj1 = function () { j1++; }, fj2 = function () { j2++; };
+			el.addEventListener('change', fn1);
+			el.addEventListener('change', fn2);
+			jQuery(el).on('change.t1', fj1);
+			jQuery(el).on('change.t2', fj2);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', fn1);
+			el.removeEventListener('change', fn2);
+			jQuery(el).off('change.t1', fj1);
+			jQuery(el).off('change.t2', fj2);
+			return { n1: n1, n2: n2, j1: j1, j2: j2, total: n1 + n2 + j1 + j2 };
+		},
+		exactlyOnce_addEventListenerDedupe: function () {
+			var c = 0;
+			var el = document.getElementById('probeKlass');
+			var fn = function () { c++; };
+			el.addEventListener('change', fn);
+			el.addEventListener('change', fn); // browser spec: no-op
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', fn);
+			return c;
+		},
+		exactlyOnce_jqDoesNotDedupe: function () {
+			var c = 0;
+			var el = document.getElementById('probeKlass');
+			var fn = function () { c++; };
+			jQuery(el).on('change.t1', fn);
+			jQuery(el).on('change.t2', fn);
+			jQuery(el).trigger('change');
+			jQuery(el).off('change.t1', fn);
+			jQuery(el).off('change.t2', fn);
+			return c;
+		},
+		exactlyOnce_threeTriggers: function () {
+			var n = 0, j = 0;
+			var el = document.getElementById('probeKlass');
+			var fn = function () { n++; }, fj = function () { j++; };
+			el.addEventListener('change', fn);
+			jQuery(el).on('change.t', fj);
+			jQuery(el).trigger('change');
+			jQuery(el).trigger('change');
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', fn);
+			jQuery(el).off('change.t', fj);
+			return { native: n, jq: j };
+		},
+		exactlyOnce_distinctEventNames: function () {
+			var c = 0, i = 0;
+			var el = document.getElementById('probeKlass');
+			var fc = function () { c++; }, fi = function () { i++; };
+			el.addEventListener('change', fc);
+			jQuery(el).on('input.t', fi);
+			jQuery(el).trigger('change');
+			el.removeEventListener('change', fc);
+			jQuery(el).off('input.t', fi);
+			return { change: c, input: i };
+		},
+		exactlyOnce_stopPropagation: function () {
+			// Confirms the native event flow path is the only one in use —
+			// stopPropagation in a native handler must stop jQuery-bound
+			// bubble-phase handlers on an ancestor.
+			var childCalls = 0, parentCalls = 0;
+			var parent = document.createElement('div');
+			parent.id = 'sp_parent';
+			var child = document.createElement('input');
+			child.id = 'sp_child';
+			parent.appendChild(child);
+			document.documentElement.appendChild(parent);
+			// klass-register the child.
+			var K = jQuery.klass({
+				initialize: function (opts) {
+					this.options = opts;
+					this.element = document.getElementById(opts.ID);
+					Prado.Registry[opts.ID] = this;
+				}
+			});
+			new K({ ID: 'sp_child' });
+			child.addEventListener('change', function (e) { childCalls++; e.stopPropagation(); });
+			jQuery(parent).on('change.sp', function () { parentCalls++; });
+			jQuery(child).trigger('change');
+			jQuery(parent).off('change.sp');
+			parent.remove();
+			delete Prado.Registry['sp_child'];
+			return { child: childCalls, parent: parentCalls };
+		}
+	};
+
+	record('ready');
+});
+</com:TClientScript>
+
+</com:TContent>

--- a/tests/harness/issues/protected/pages/Issue1154TriggerBridge.php
+++ b/tests/harness/issues/protected/pages/Issue1154TriggerBridge.php
@@ -1,0 +1,17 @@
+<?php
+
+class Issue1154TriggerBridge extends TPage
+{
+	public function onLoad($param)
+	{
+		parent::onLoad($param);
+		// The page is plain HTML (no com:T controls), so Prado wouldn't
+		// otherwise register jQuery / prado.js. Force it.
+		$cs = $this->getPage()->getClientScript();
+		$cs->registerPradoScript('jquery');
+		$cs->registerPradoScript('prado');
+	}
+
+	// The `submitted` query param visible on the URL after a real form
+	// submission is the assertion target for the navigation-based tests.
+}

--- a/tests/js/controls/accordion.test.js
+++ b/tests/js/controls/accordion.test.js
@@ -191,38 +191,31 @@ describe('TAccordion maxHeight initialisation', () => {
 // ─── checkMaxHeight ────────────────────────────────────────────────────────────
 
 describe('TAccordion.checkMaxHeight', () => {
-	it('keeps maxHeight at 0 in jsdom (no real layout)', () => {
+	it('picks up the stubbed offsetHeight from buildDOM (100 per view)', () => {
 		const { accordion } = makeAccordion(['v0', 'v1'], 0);
 		accordion.maxHeight = 0;
 		accordion.checkMaxHeight();
-		// jQuery .height() returns 0 in jsdom; maxHeight should remain 0.
-		expect(accordion.maxHeight).toBe(0);
+		// buildDOM stubs offsetHeight=100 on each view element.
+		expect(accordion.maxHeight).toBe(100);
 	});
 
 	it('updates maxHeight to the tallest panel when heights differ', () => {
-		// We need to control jQuery's .height() response.
-		const { accordion, options } = makeAccordion(['v0', 'v1'], 0);
-		// Stub height() to return different values per element.
-		const orig = global.jQuery.fn.height;
-		global.jQuery.fn.height = function () {
-			if (this.attr('id') === 'v0') return 80;
-			if (this.attr('id') === 'v1') return 120;
-			return 0;
-		};
+		const { accordion } = makeAccordion(['v0', 'v1'], 0);
+		// Override the stubbed offsetHeight on each panel.
+		Object.defineProperty(document.getElementById('v0'), 'offsetHeight', { configurable: true, value: 80 });
+		Object.defineProperty(document.getElementById('v1'), 'offsetHeight', { configurable: true, value: 120 });
 		accordion.maxHeight = 0;
 		accordion.checkMaxHeight();
-		global.jQuery.fn.height = orig;
 		expect(accordion.maxHeight).toBe(120);
 	});
 
 	it('does not decrease maxHeight if all panels are shorter', () => {
 		const { accordion } = makeAccordion(['v0', 'v1'], 0);
-		const orig = global.jQuery.fn.height;
-		global.jQuery.fn.height = function () { return 50; };
+		Object.defineProperty(document.getElementById('v0'), 'offsetHeight', { configurable: true, value: 50 });
+		Object.defineProperty(document.getElementById('v1'), 'offsetHeight', { configurable: true, value: 50 });
 		accordion.maxHeight = 200;
 		// checkMaxHeight only raises, never lowers.
 		accordion.checkMaxHeight();
-		global.jQuery.fn.height = orig;
 		// 50 < 200 so maxHeight stays at 200.
 		expect(accordion.maxHeight).toBe(200);
 	});

--- a/tests/js/controls/controls.test.js
+++ b/tests/js/controls/controls.test.js
@@ -1008,7 +1008,7 @@ describe('Prado.WebUI.TListControl', () => {
 		// spy on the Prado.PostBack constructor that doPostback delegates to.
 		const spy = vi.spyOn(global.Prado, 'PostBack').mockImplementation(function () {});
 		new TListControl(postBackOptions('tlc2'));
-		jQuery(el).trigger('change');
+		el.dispatchEvent(new Event('change', { bubbles: true }));
 		expect(spy).toHaveBeenCalledTimes(1);
 		spy.mockRestore();
 	});
@@ -1059,7 +1059,7 @@ describe('Prado.WebUI.TDropDownList', () => {
 		// Same pre-binding issue as TListControl: spy on Prado.PostBack.
 		const spy = vi.spyOn(global.Prado, 'PostBack').mockImplementation(function () {});
 		new TDropDownList(postBackOptions('tddl2'));
-		jQuery(el).trigger('change');
+		el.dispatchEvent(new Event('change', { bubbles: true }));
 		expect(spy).toHaveBeenCalledTimes(1);
 		spy.mockRestore();
 	});

--- a/tests/js/controls/slider.test.js
+++ b/tests/js/controls/slider.test.js
@@ -924,8 +924,8 @@ describe('TSlider without a progress element', () => {
 
 		global.jQuery.fn.is = origIs;
 
-		// jQuery('#nonexistent').get(0) returns undefined, not null.
-	expect(slider.progress).toBeUndefined();
+		// document.getElementById of a missing id returns null.
+	expect(slider.progress).toBeNull();
 	});
 });
 

--- a/tests/js/controls/tabpanel.test.js
+++ b/tests/js/controls/tabpanel.test.js
@@ -336,7 +336,7 @@ describe('TTabPanel tab click via DOM event', () => {
 		}
 		const options = buildDOM(['tab0', 'tab1'], 0, null, { AutoSwitch: true });
 		new TTabPanel(options);
-		global.jQuery('#tab1_0').trigger('mouseenter');
+		document.getElementById('tab1_0').dispatchEvent(new Event('mouseenter', { bubbles: true }));
 		expect(global.jQuery('#tab1').css('display')).not.toBe('none');
 		expect(global.jQuery('#tab0').css('display')).toBe('none');
 	});

--- a/tests/js/datepicker/activedatepicker.test.js
+++ b/tests/js/datepicker/activedatepicker.test.js
@@ -477,7 +477,7 @@ describe('TActiveDatePicker change-event wiring — TextBox mode', () => {
 		const picker = new TActiveDatePicker(makeOptions(id, { InputMode: 'TextBox', OnDateChanged: cb }));
 
 		picker.control.value = '2024-08-01';
-		jQuery(picker.control).trigger('change');
+		picker.control.dispatchEvent(new Event('change', { bubbles: true }));
 
 		expect(cb).toHaveBeenCalledTimes(1);
 	});
@@ -487,7 +487,7 @@ describe('TActiveDatePicker change-event wiring — TextBox mode', () => {
 		const picker = new TActiveDatePicker(makeOptions(id, { InputMode: 'TextBox', OnDateChanged: cb }));
 
 		picker.control.value = '2025-12-25';
-		jQuery(picker.control).trigger('change');
+		picker.control.dispatchEvent(new Event('change', { bubbles: true }));
 
 		expect(cb.mock.calls[0][1]).toBe('2025-12-25');
 	});
@@ -527,30 +527,30 @@ describe('TActiveDatePicker change-event wiring — DropDownList mode', () => {
 	it('fires OnDateChanged when the day dropdown changes', () => {
 		const cb = vi.fn();
 		makeDropDownPicker(baseId, { OnDateChanged: cb });
-		jQuery(document.getElementById(`${baseId}_day`)).trigger('change');
+		document.getElementById(`${baseId}_day`).dispatchEvent(new Event('change', { bubbles: true }));
 		expect(cb).toHaveBeenCalledTimes(1);
 	});
 
 	it('fires OnDateChanged when the month dropdown changes', () => {
 		const cb = vi.fn();
 		makeDropDownPicker(baseId, { OnDateChanged: cb });
-		jQuery(document.getElementById(`${baseId}_month`)).trigger('change');
+		document.getElementById(`${baseId}_month`).dispatchEvent(new Event('change', { bubbles: true }));
 		expect(cb).toHaveBeenCalledTimes(1);
 	});
 
 	it('fires OnDateChanged when the year dropdown changes', () => {
 		const cb = vi.fn();
 		makeDropDownPicker(baseId, { OnDateChanged: cb });
-		jQuery(document.getElementById(`${baseId}_year`)).trigger('change');
+		document.getElementById(`${baseId}_year`).dispatchEvent(new Event('change', { bubbles: true }));
 		expect(cb).toHaveBeenCalledTimes(1);
 	});
 
 	it('each dropdown fires independently (no cross-contamination)', () => {
 		const cb = vi.fn();
 		makeDropDownPicker(baseId, { OnDateChanged: cb });
-		jQuery(document.getElementById(`${baseId}_day`)).trigger('change');
-		jQuery(document.getElementById(`${baseId}_month`)).trigger('change');
-		jQuery(document.getElementById(`${baseId}_year`)).trigger('change');
+		document.getElementById(`${baseId}_day`).dispatchEvent(new Event('change', { bubbles: true }));
+		document.getElementById(`${baseId}_month`).dispatchEvent(new Event('change', { bubbles: true }));
+		document.getElementById(`${baseId}_year`).dispatchEvent(new Event('change', { bubbles: true }));
 		expect(cb).toHaveBeenCalledTimes(3);
 	});
 });

--- a/tests/js/datepicker/datepicker.test.js
+++ b/tests/js/datepicker/datepicker.test.js
@@ -1378,7 +1378,7 @@ describe('TDatePicker OnDateChanged callback — TextBox mode', () => {
 		picker.create();
 
 		picker.control.value = '2024-07-04';
-		jQuery(picker.control).trigger('change');
+		picker.control.dispatchEvent(new Event('change', { bubbles: true }));
 
 		expect(cb).toHaveBeenCalledTimes(1);
 		const [ref, dateStr] = cb.mock.calls[0];

--- a/tests/js/prado/klass.test.js
+++ b/tests/js/prado/klass.test.js
@@ -5,6 +5,13 @@
  * The factory backs every PRADO control. This file verifies the inheritance
  * chain and the $super call mechanism (retained from the original low-pro
  * shim for backward compatibility with existing controls).
+ *
+ * The internal low-pro helpers `$.argumentNames`, `$.bind`, `$.wrap`,
+ * `$.delegate` were removed in step 3 of the JS modernization (see the
+ * `Prado.Class` factory rewrite). They were private helpers that backed
+ * the old klass implementation and were never part of the public API;
+ * tests for them lived here only because the shim was vendored verbatim
+ * from low-pro-for-jquery. They are intentionally not tested.
  */
 
 import '../adapters/prado-core.js'; // side-effect: loads prado.js + jQuery extensions

--- a/tests/js/prado/klass.test.js
+++ b/tests/js/prado/klass.test.js
@@ -1,61 +1,13 @@
 /**
- * Tests for the $.klass OOP system and supporting utilities.
+ * Tests for the Prado.Class / jQuery.klass OOP factory.
  * Source: framework/Web/Javascripts/source/prado/prado.js
  *
- * $.klass, $.argumentNames, $.bind, $.wrap, $.delegate are the backbone
- * of every PRADO control. This file verifies the inheritance chain, the
- * $super call mechanism, and the utility functions that support it.
+ * The factory backs every PRADO control. This file verifies the inheritance
+ * chain and the $super call mechanism (retained from the original low-pro
+ * shim for backward compatibility with existing controls).
  */
 
 import '../adapters/prado-core.js'; // side-effect: loads prado.js + jQuery extensions
-
-// ─── $.argumentNames ─────────────────────────────────────────────────────────
-
-describe('$.argumentNames', () => {
-	it('returns an empty array for a zero-argument function', () => {
-		expect($.argumentNames(function () {})).toEqual([]);
-	});
-
-	it('returns argument names for a single-argument function', () => {
-		expect($.argumentNames(function (a) {})).toEqual(['a']); // eslint-disable-line no-unused-vars
-	});
-
-	it('returns all argument names for a multi-argument function', () => {
-		expect($.argumentNames(function (a, b, c) {})).toEqual(['a', 'b', 'c']); // eslint-disable-line no-unused-vars
-	});
-
-	it('handles a function whose first argument is $super', () => {
-		expect($.argumentNames(function ($super, x) {})[0]).toBe('$super'); // eslint-disable-line no-unused-vars
-	});
-});
-
-// ─── $.bind ──────────────────────────────────────────────────────────────────
-
-describe('$.bind', () => {
-	it('calls the function with the given scope', () => {
-		const scope = { value: 42 };
-		const fn = $.bind(function () { return this.value; }, scope);
-		expect(fn()).toBe(42);
-	});
-
-	it('forwards arguments', () => {
-		const scope = {};
-		const fn = $.bind(function (a, b) { return a + b; }, scope);
-		expect(fn(3, 4)).toBe(7);
-	});
-});
-
-// ─── $.wrap ──────────────────────────────────────────────────────────────────
-
-describe('$.wrap', () => {
-	it('passes the original function as the first argument to the wrapper', () => {
-		const original = function () { return 'original'; };
-		const wrapped = $.wrap(original, function (orig) {
-			return 'wrapped(' + orig() + ')';
-		});
-		expect(wrapped()).toBe('wrapped(original)');
-	});
-});
 
 // ─── $.klass — basic construction ────────────────────────────────────────────
 
@@ -156,33 +108,5 @@ describe('$.klass — $super call chain', () => {
 
 	it('$super chains correctly through two levels', () => {
 		expect(new GrandChild().greet()).toBe('Hello from Base + Child + GrandChild');
-	});
-});
-
-// ─── $.delegate ───────────────────────────────────────────────────────────────
-
-describe('$.delegate', () => {
-	it('calls the matching rule when target matches selector directly', () => {
-		let called = false;
-		const handler = $.delegate({ 'button': function () { called = true; } });
-
-		const btn = document.createElement('button');
-		document.body.appendChild(btn);
-		handler.call(document.body, { target: btn });
-		document.body.removeChild(btn);
-
-		expect(called).toBe(true);
-	});
-
-	it('does not call any rule when no selector matches', () => {
-		let called = false;
-		const handler = $.delegate({ 'button': function () { called = true; } });
-
-		const div = document.createElement('div');
-		document.body.appendChild(div);
-		handler.call(document.body, { target: div });
-		document.body.removeChild(div);
-
-		expect(called).toBe(false);
 	});
 });

--- a/tests/js/prado/postback.test.js
+++ b/tests/js/prado/postback.test.js
@@ -145,7 +145,9 @@ describe('Prado.PostBack.doPostBack', () => {
 			fakeEvent,
 		);
 
-		expect(validate).toHaveBeenCalledWith('testForm', undefined, expect.anything());
+		// 3rd arg is the trigger element via document.getElementById(options.ID);
+		// null is expected when no fixture element with that id exists.
+		expect(validate).toHaveBeenCalledWith('testForm', undefined, null);
 		expect(submits).toHaveLength(1);
 	});
 

--- a/tests/js/prado/postback.test.js
+++ b/tests/js/prado/postback.test.js
@@ -147,6 +147,9 @@ describe('Prado.PostBack.doPostBack', () => {
 
 		// 3rd arg is the trigger element via document.getElementById(options.ID);
 		// null is expected when no fixture element with that id exists.
+		// (Pre-PR #1154, Prado.PostBack passed a jQuery wrapper here, which
+		// matched expect.anything(); the de-jQuery rewrite returns a raw DOM
+		// element or null.)
 		expect(validate).toHaveBeenCalledWith('testForm', undefined, null);
 		expect(submits).toHaveLength(1);
 	});

--- a/tests/js/prado/trigger-bridge.test.js
+++ b/tests/js/prado/trigger-bridge.test.js
@@ -1,0 +1,570 @@
+/**
+ * Tests for the jQuery.fn.trigger → native dispatchEvent bridge and the
+ * companion Prado.Class.prototype.trigger helper.
+ *
+ * Source: framework/Web/Javascripts/source/prado/prado.js
+ *
+ * Why these tests exist:
+ *   PR #1154 changed Prado's `observe` from `jQuery(el).bind(...)` to
+ *   `addEventListener(...)`. jQuery's `.trigger()` only walks its own
+ *   handler list and does NOT dispatch a real DOM event for non-activation
+ *   events (see jquery/jquery#2476), so every downstream control still
+ *   calling `jQuery(this.control).trigger('change')` became a no-op against
+ *   handlers registered through the framework. The bridge in prado.js fixes
+ *   that by detecting Prado-managed elements (via Prado.Registry +
+ *   `constructor.isPradoClass`) and dispatching a native CustomEvent.
+ *
+ *   These tests cover:
+ *     1. The factory marker (every Prado.Class constructor is tagged).
+ *     2. Prado.Class.prototype.trigger (the new native helper).
+ *     3. The jQuery.fn.trigger bridge:
+ *        - the failure mode that pre-existed without the bridge
+ *        - the fix the bridge provides
+ *        - non-klass elements stay on the original jQuery code path
+ *        - activation events (click / focus / blur) run defaults
+ *        - form submit goes through el.submit()
+ *        - CustomEvent detail payload survives
+ *        - passing a real Event object is dispatched verbatim
+ *        - elements without an id / not in the registry / without
+ *          dispatchEvent fall back to the original trigger
+ */
+
+import '../adapters/prado-core.js';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const newId = (() => {
+	let n = 0;
+	return (prefix = 'tb') => `${prefix}_${++n}`;
+})();
+
+function makeEl(tag = 'input') {
+	const el = document.createElement(tag);
+	el.id = newId();
+	document.body.appendChild(el);
+	return el;
+}
+
+// Construct a klass-registered control wired to a real DOM element. Mirrors
+// what Prado.WebUI.Control does (registers `this.element` in Prado.Registry
+// under `options.ID`) without dragging in the whole controls.js machinery.
+function makeKlassControl(el, extra = {}) {
+	const K = $.klass(Object.assign({
+		initialize(opts) {
+			this.options = opts;
+			this.ID = opts.ID;
+			this.element = document.getElementById(opts.ID);
+			Prado.Registry[opts.ID] = this;
+		},
+	}, extra));
+	return new K({ ID: el.id });
+}
+
+function cleanupRegistry() {
+	for (const k of Object.keys(Prado.Registry)) delete Prado.Registry[k];
+}
+
+afterEach(() => {
+	cleanupRegistry();
+	// Remove any leftover elements from earlier tests.
+	while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+});
+
+// ─── 1. Factory marker ────────────────────────────────────────────────────────
+
+describe('Prado.Class — isPradoClass marker', () => {
+	it('tags every constructor produced by the factory', () => {
+		const K = $.klass({});
+		expect(K.isPradoClass).toBe(true);
+	});
+
+	it('tags subclasses too (single-level inheritance)', () => {
+		const A = $.klass({});
+		const B = $.klass(A, {});
+		expect(B.isPradoClass).toBe(true);
+	});
+
+	it('tags subclasses at any inheritance depth', () => {
+		const A = $.klass({});
+		const B = $.klass(A, {});
+		const C = $.klass(B, {});
+		expect(C.isPradoClass).toBe(true);
+	});
+
+	it('marker survives the prototype-replacement pattern used by AssetManager and Rico.Color', () => {
+		// ajax3.js does `Prado.AssetManagerClass = $.klass(); Prado.AssetManagerClass.prototype = {...}`
+		const K = $.klass();
+		K.prototype = { initialize() {}, foo() { return 1; } };
+		// The marker lives on the constructor, not on the prototype, so a
+		// wholesale prototype assignment must not remove it.
+		expect(K.isPradoClass).toBe(true);
+	});
+
+	it('does NOT tag plain (non-Prado) constructors', () => {
+		function NotAKlass() {}
+		expect(NotAKlass.isPradoClass).toBeUndefined();
+		// Also: instances of plain classes have a constructor without the marker.
+		expect(new NotAKlass().constructor.isPradoClass).toBeUndefined();
+	});
+});
+
+// ─── 2. Prado.Class.prototype.trigger ─────────────────────────────────────────
+
+describe('Prado.Class.prototype.trigger', () => {
+	it('is installed on every klass prototype', () => {
+		const K = $.klass({});
+		expect(typeof new K().trigger).toBe('function');
+	});
+
+	it('dispatches a CustomEvent on this.element', () => {
+		const el = makeEl();
+		const inst = makeKlassControl(el);
+		let received = null;
+		el.addEventListener('change', (e) => { received = e; });
+
+		inst.trigger('change');
+
+		expect(received).not.toBeNull();
+		expect(received.type).toBe('change');
+		expect(received instanceof CustomEvent).toBe(true);
+		expect(received.bubbles).toBe(true);
+		expect(received.cancelable).toBe(true);
+	});
+
+	it('passes the detail payload through', () => {
+		const el = makeEl();
+		const inst = makeKlassControl(el);
+		let received = null;
+		el.addEventListener('mything', (e) => { received = e.detail; });
+
+		inst.trigger('mything', { foo: 42, bar: 'baz' });
+
+		expect(received).toEqual({ foo: 42, bar: 'baz' });
+	});
+
+	it('is a no-op when this.element is missing (degraded init)', () => {
+		const K = $.klass({ initialize() {} });
+		const inst = new K();
+		// No element attached; should not throw.
+		expect(() => inst.trigger('change')).not.toThrow();
+	});
+
+	it('is a no-op when eventName is empty / undefined', () => {
+		const el = makeEl();
+		const inst = makeKlassControl(el);
+		const spy = vi.fn();
+		el.addEventListener('change', spy);
+
+		inst.trigger();
+		inst.trigger('');
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('does not override a subclass that defines its own trigger', () => {
+		const Base = $.klass({});
+		const Derived = $.klass(Base, {
+			trigger(eventName) { return `custom-${eventName}`; },
+		});
+		const inst = new Derived();
+		expect(inst.trigger('foo')).toBe('custom-foo');
+	});
+});
+
+// ─── 3. jQuery.fn.trigger bridge ──────────────────────────────────────────────
+
+describe('jQuery.fn.trigger bridge — the bug from PR #1154', () => {
+	// Reproduces the original failure: framework's `observe` uses
+	// addEventListener (since PR #1154), but downstream controls still call
+	// jQuery(el).trigger(name). Without the bridge, native handlers never fire.
+
+	it('FIXED: native addEventListener handler fires when jQuery.trigger is called on a klass element', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const handler = vi.fn();
+		// This is how Prado.WebUI.Control.observe registers handlers post-#1154.
+		el.addEventListener('change', handler);
+
+		// This is what legacy custom controls do to fire the event.
+		jQuery(el).trigger('change');
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler.mock.calls[0][0].type).toBe('change');
+	});
+
+	it('jQuery-bound handlers also fire (jQuery itself routes via addEventListener)', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const handler = vi.fn();
+		jQuery(el).on('change', handler);
+
+		jQuery(el).trigger('change');
+
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('mixed handler setup: addEventListener + jQuery.on both fire on a klass element', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const native = vi.fn();
+		const jq = vi.fn();
+		el.addEventListener('change', native);
+		jQuery(el).on('change', jq);
+
+		jQuery(el).trigger('change');
+
+		expect(native).toHaveBeenCalledTimes(1);
+		expect(jq).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('jQuery.fn.trigger bridge — passes through for non-klass elements', () => {
+	it('falls back to jQuery original trigger when element is not in Prado.Registry', () => {
+		const el = makeEl();
+		// No makeKlassControl(el) — element is not klass-registered.
+		const handler = vi.fn();
+		jQuery(el).on('change', handler);
+
+		jQuery(el).trigger('change');
+
+		// jQuery's own pipeline still runs.
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back when element has no id', () => {
+		const el = document.createElement('input'); // not appended, no id
+		document.body.appendChild(el);
+		const handler = vi.fn();
+		jQuery(el).on('change', handler);
+
+		jQuery(el).trigger('change');
+
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back when registry entry exists but is not a Prado.Class instance', () => {
+		const el = makeEl();
+		// Plant a non-klass object into the registry under this id.
+		Prado.Registry[el.id] = { not: 'a klass' };
+		const handler = vi.fn();
+		jQuery(el).on('change', handler);
+
+		jQuery(el).trigger('change');
+
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('jQuery.fn.trigger bridge — activation events (defaults must fire)', () => {
+	it('"click" on a klass element calls el.click() so default activation runs', () => {
+		const el = makeEl('button');
+		makeKlassControl(el);
+		const clickSpy = vi.spyOn(el, 'click');
+
+		jQuery(el).trigger('click');
+
+		expect(clickSpy).toHaveBeenCalledTimes(1);
+		clickSpy.mockRestore();
+	});
+
+	it('"focus" on a klass element calls el.focus() so the element actually focuses', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const focusSpy = vi.spyOn(el, 'focus');
+
+		jQuery(el).trigger('focus');
+
+		expect(focusSpy).toHaveBeenCalledTimes(1);
+		focusSpy.mockRestore();
+	});
+
+	it('"blur" on a klass element calls el.blur()', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const blurSpy = vi.spyOn(el, 'blur');
+
+		jQuery(el).trigger('blur');
+
+		expect(blurSpy).toHaveBeenCalledTimes(1);
+		blurSpy.mockRestore();
+	});
+
+	it('"submit" on a klass FORM calls form.submit() so the form actually submits', () => {
+		const form = makeEl('form');
+		makeKlassControl(form);
+		const submitSpy = vi.spyOn(form, 'submit').mockImplementation(() => {});
+		const submitHandler = vi.fn();
+		form.addEventListener('submit', submitHandler);
+
+		jQuery(form).trigger('submit');
+
+		// Both the submit event fires AND form.submit() is invoked.
+		expect(submitHandler).toHaveBeenCalledTimes(1);
+		expect(submitSpy).toHaveBeenCalledTimes(1);
+		submitSpy.mockRestore();
+	});
+
+	it('"submit" on a klass FORM respects preventDefault() (does NOT call submit())', () => {
+		const form = makeEl('form');
+		makeKlassControl(form);
+		const submitSpy = vi.spyOn(form, 'submit').mockImplementation(() => {});
+		form.addEventListener('submit', (e) => { e.preventDefault(); });
+
+		jQuery(form).trigger('submit');
+
+		expect(submitSpy).not.toHaveBeenCalled();
+		submitSpy.mockRestore();
+	});
+
+	it('"submit" on a non-FORM klass element does NOT call .submit() (no such method)', () => {
+		const div = makeEl('div');
+		makeKlassControl(div);
+		// Plain divs have no submit() — bridge must not throw.
+		expect(() => jQuery(div).trigger('submit')).not.toThrow();
+	});
+});
+
+describe('jQuery.fn.trigger bridge — CustomEvent payload', () => {
+	it('preserves a detail object passed as extraParameters', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		let received = null;
+		el.addEventListener('mything', (e) => { received = e.detail; });
+
+		jQuery(el).trigger('mything', { value: 7 });
+
+		expect(received).toEqual({ value: 7 });
+	});
+
+	it('uses CustomEvent (not plain Event) so detail is actually delivered', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		let received = null;
+		el.addEventListener('thing', (e) => { received = e; });
+
+		jQuery(el).trigger('thing', 'payload-string');
+
+		expect(received instanceof CustomEvent).toBe(true);
+		expect(received.detail).toBe('payload-string');
+	});
+});
+
+describe('jQuery.fn.trigger bridge — Event object passthrough', () => {
+	it('dispatches a real Event instance verbatim instead of wrapping it', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		let received = null;
+		el.addEventListener('keydown', (e) => { received = e; });
+
+		const realEvent = new Event('keydown', { bubbles: true, cancelable: true });
+		jQuery(el).trigger(realEvent);
+
+		expect(received).toBe(realEvent);
+	});
+
+	it('preserves a real Event instance over a CustomEvent wrap (no detail loss into CustomEvent)', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		let received = null;
+		el.addEventListener('keydown', (e) => { received = e; });
+
+		const realEvent = new Event('keydown', { bubbles: true });
+		jQuery(el).trigger(realEvent);
+
+		// Did NOT get re-wrapped into a CustomEvent.
+		expect(received instanceof CustomEvent).toBe(false);
+	});
+});
+
+describe('jQuery.fn.trigger bridge — chainability', () => {
+	it('returns the jQuery wrapper so .trigger() remains chainable', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const $el = jQuery(el);
+		const ret = $el.trigger('change');
+		expect(ret).toBe($el);
+	});
+
+	it('works on multiset selectors (each element processed independently)', () => {
+		const a = makeEl();
+		const b = makeEl();
+		makeKlassControl(a);
+		// b is intentionally NOT klass-registered.
+		const onA = vi.fn();
+		const onB = vi.fn();
+		a.addEventListener('change', onA);
+		b.addEventListener('change', onB); // jQuery installs an addEventListener for .on() too
+		jQuery(b).on('change', onB);
+
+		jQuery(a).add(b).trigger('change');
+
+		expect(onA).toHaveBeenCalledTimes(1); // bridge path
+		expect(onB).toHaveBeenCalled();        // original-trigger path (and also addEventListener)
+	});
+});
+
+// ─── 4b. Exactly-once dispatch across all overlap combinations ──────────────
+//
+// These are the "no double call" tests. The bridge MUST call dispatchEvent
+// without additionally invoking originalTrigger on the klass path — doing
+// both would fire jQuery-bound handlers twice (once via jQuery's internal
+// addEventListener registration, once via originalTrigger walking the same
+// handler list). These tests pin that contract.
+
+describe('jQuery.fn.trigger bridge — exactly-once dispatch (no overlap double-fire)', () => {
+	it('one addEventListener handler fires exactly once', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const fn = vi.fn();
+		el.addEventListener('change', fn);
+		jQuery(el).trigger('change');
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('one jQuery.on handler fires exactly once', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const fn = vi.fn();
+		jQuery(el).on('change', fn);
+		jQuery(el).trigger('change');
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('mixed: addEventListener + jQuery.on — each fires exactly once', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const native = vi.fn();
+		const jq = vi.fn();
+		el.addEventListener('change', native);
+		jQuery(el).on('change', jq);
+		jQuery(el).trigger('change');
+		expect(native).toHaveBeenCalledTimes(1);
+		expect(jq).toHaveBeenCalledTimes(1);
+	});
+
+	it('multiple addEventListener handlers (distinct functions) — each fires exactly once', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const a = vi.fn(), b = vi.fn(), c = vi.fn();
+		el.addEventListener('change', a);
+		el.addEventListener('change', b);
+		el.addEventListener('change', c);
+		jQuery(el).trigger('change');
+		expect(a).toHaveBeenCalledTimes(1);
+		expect(b).toHaveBeenCalledTimes(1);
+		expect(c).toHaveBeenCalledTimes(1);
+	});
+
+	it('multiple jQuery.on handlers (distinct functions) — each fires exactly once', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const a = vi.fn(), b = vi.fn(), c = vi.fn();
+		jQuery(el).on('change', a);
+		jQuery(el).on('change', b);
+		jQuery(el).on('change', c);
+		jQuery(el).trigger('change');
+		expect(a).toHaveBeenCalledTimes(1);
+		expect(b).toHaveBeenCalledTimes(1);
+		expect(c).toHaveBeenCalledTimes(1);
+	});
+
+	it('the matrix: 2 addEventListener + 2 jQuery.on — exactly 4 total calls, one per handler', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const n1 = vi.fn(), n2 = vi.fn(), j1 = vi.fn(), j2 = vi.fn();
+		el.addEventListener('change', n1);
+		el.addEventListener('change', n2);
+		jQuery(el).on('change', j1);
+		jQuery(el).on('change', j2);
+		jQuery(el).trigger('change');
+		expect(n1).toHaveBeenCalledTimes(1);
+		expect(n2).toHaveBeenCalledTimes(1);
+		expect(j1).toHaveBeenCalledTimes(1);
+		expect(j2).toHaveBeenCalledTimes(1);
+		// Total call budget — no spurious extra dispatch slipped in.
+		expect(n1.mock.calls.length + n2.mock.calls.length + j1.mock.calls.length + j2.mock.calls.length).toBe(4);
+	});
+
+	it('addEventListener dedupes when same fn registered twice (browser spec), still fires once', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const fn = vi.fn();
+		el.addEventListener('change', fn);
+		el.addEventListener('change', fn); // browser spec: this is a no-op
+		jQuery(el).trigger('change');
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('repeated jQuery.on with the same fn fires twice (jQuery behavior, not introduced by bridge)', () => {
+		// Documenting jQuery's behavior, NOT the bridge's. jQuery's handler
+		// list does not dedupe by default; the bridge must not paper over that.
+		const el = makeEl();
+		makeKlassControl(el);
+		const fn = vi.fn();
+		jQuery(el).on('change', fn);
+		jQuery(el).on('change', fn);
+		jQuery(el).trigger('change');
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
+	it('repeated trigger() calls fire each handler N times (no leftover state from prior triggers)', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const native = vi.fn();
+		const jq = vi.fn();
+		el.addEventListener('change', native);
+		jQuery(el).on('change', jq);
+		jQuery(el).trigger('change');
+		jQuery(el).trigger('change');
+		jQuery(el).trigger('change');
+		expect(native).toHaveBeenCalledTimes(3);
+		expect(jq).toHaveBeenCalledTimes(3);
+	});
+
+	it('two different event names do not bleed into each other', () => {
+		const el = makeEl();
+		makeKlassControl(el);
+		const onChange = vi.fn();
+		const onInput = vi.fn();
+		el.addEventListener('change', onChange);
+		jQuery(el).on('input', onInput);
+		jQuery(el).trigger('change');
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onInput).not.toHaveBeenCalled();
+	});
+
+	it('stopPropagation in a native handler stops jQuery-bound bubble handlers', () => {
+		// Confirms the native dispatch path obeys standard event-flow rules.
+		// If the bridge somehow ran the jQuery path independently, this
+		// assertion would fail.
+		const parent = makeEl('div');
+		const child = makeEl('input');
+		parent.appendChild(child);
+		makeKlassControl(child);
+		const childNative = vi.fn((e) => e.stopPropagation());
+		const parentJq = vi.fn();
+		child.addEventListener('change', childNative);
+		jQuery(parent).on('change', parentJq);
+		jQuery(child).trigger('change');
+		expect(childNative).toHaveBeenCalledTimes(1);
+		expect(parentJq).not.toHaveBeenCalled();
+	});
+});
+
+describe('jQuery.fn.trigger bridge — interplay with Prado.Class.prototype.trigger', () => {
+	// Verifies the recommended migration path: existing callers using
+	// jQuery .trigger() keep working; new code can switch to this.trigger()
+	// and reach the same handlers.
+
+	it('the same addEventListener handler fires whether dispatched via jQuery or via Prado.Class.trigger', () => {
+		const el = makeEl();
+		const inst = makeKlassControl(el);
+		const handler = vi.fn();
+		el.addEventListener('change', handler);
+
+		jQuery(el).trigger('change');  // pre-4.4 idiom
+		inst.trigger('change');         // 4.4+ idiom
+
+		expect(handler).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests/playwright/global-setup.js
+++ b/tests/playwright/global-setup.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { readdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Global setup: clear demo asset caches before every Playwright run.
+ *
+ * Prado's TAssetManager publishes framework JS/CSS into
+ * vendor/pradosoft/prado-demos/<demo>/assets/<hash>/ on first request. The
+ * published file is the minified output of the source at publish time —
+ * subsequent source edits do NOT invalidate that cache, so the browser
+ * keeps loading stale prado.min.js / controls.min.js / etc. Until those
+ * hashed directories are removed, the tests run against pre-edit code
+ * and report unrelated failures.
+ *
+ * This setup walks vendor/pradosoft/prado-demos/<demo>/assets/ and removes
+ * every <hash>/ subdirectory once per `npx playwright test` invocation.
+ * Prado re-publishes assets on the next page request, so there is no
+ * downside other than ~1s of first-page latency per demo.
+ */
+export default function globalSetup() {
+	const demosRoot = 'vendor/pradosoft/prado-demos';
+	let cleared = 0;
+	let demos;
+	try {
+		demos = readdirSync(demosRoot, { withFileTypes: true })
+			.filter((d) => d.isDirectory())
+			.map((d) => join(demosRoot, d.name, 'assets'));
+	} catch {
+		// prado-demos not installed — nothing to clear.
+		return;
+	}
+
+	for (const assetsDir of demos) {
+		let entries;
+		try {
+			entries = readdirSync(assetsDir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			const sub = join(assetsDir, entry.name);
+			try {
+				rmSync(sub, { recursive: true, force: true });
+				cleared++;
+			} catch {
+				/* ignore — best-effort */
+			}
+		}
+	}
+
+	if (cleared > 0) {
+		// eslint-disable-next-line no-console
+		console.log(`[global-setup] Cleared ${cleared} stale Prado asset cache dir(s).`);
+	}
+}

--- a/tests/playwright/issues/Issue1154TriggerBridgeTestCase.spec.js
+++ b/tests/playwright/issues/Issue1154TriggerBridgeTestCase.spec.js
@@ -1,0 +1,249 @@
+/**
+ * Functional coverage for the jQuery.fn.trigger → native dispatchEvent
+ * bridge installed in prado.js. Exercises every branch in a real browser
+ * (the unit suite at tests/js/prado/trigger-bridge.test.js covers jsdom).
+ *
+ * Bug context: PR #1154 changed Prado.WebUI.Control.observe from
+ * jQuery(el).bind(...) to addEventListener(...). jQuery.trigger() does
+ * not reach native addEventListener handlers for non-activation events
+ * (see jquery/jquery#2476), so every downstream control still calling
+ * jQuery(this.control).trigger('change') became a no-op. The bridge
+ * fixes this; these tests prove it across all three browsers.
+ *
+ * The harness page is tests/harness/issues/protected/pages/Issue1154TriggerBridge.{page,php}.
+ * It exposes a small window.__bridge API so each test can drive a single
+ * scenario via page.evaluate().
+ */
+import { test, expect } from '@playwright/test';
+import { genericHelper } from '../helpers.js';
+
+async function gotoBridge(page) {
+	const h = genericHelper(page);
+	await h.url('issues/index.php?page=Issue1154TriggerBridge');
+	// Wait for the setup script to finish registering klass instances.
+	await page.waitForFunction(() => typeof window.__bridge !== 'undefined');
+	return h;
+}
+
+// ─── 1. Factory marker (isPradoClass) ────────────────────────────────────────
+
+test('Issue1154 — every klass constructor carries the isPradoClass marker', async ({ page }) => {
+	await gotoBridge(page);
+	const ids = ['probeKlass', 'probeText', 'probeMulti1', 'probeFocus',
+		'probeButton', 'probeCustom', 'bridgeForm', 'probeSubmit'];
+	for (const id of ids) {
+		const marked = await page.evaluate((i) => window.__bridge.isPradoClassMarker(i), id);
+		expect(marked, `klass marker missing on registry[${id}]`).toBe(true);
+	}
+});
+
+// ─── 2. Prado.Class.prototype.trigger ────────────────────────────────────────
+
+test('Issue1154 — Prado.Class.prototype.trigger dispatches CustomEvent on this.element', async ({ page }) => {
+	await gotoBridge(page);
+	const got = await page.evaluate(() => window.__bridge.probeKlass_triggerHelper('change'));
+	expect(got).not.toBeNull();
+	expect(got.type).toBe('change');
+});
+
+test('Issue1154 — Prado.Class.prototype.trigger forwards detail payload', async ({ page }) => {
+	await gotoBridge(page);
+	const got = await page.evaluate(() => window.__bridge.probeKlass_triggerHelper('mything', { v: 42 }));
+	expect(got).toEqual({ type: 'mything', detail: { v: 42 } });
+});
+
+// ─── 3. The PR #1154 bug — the headline fix ──────────────────────────────────
+
+test('Issue1154 — FIXED: jQuery.trigger("change") on a klass element fires the addEventListener handler', async ({ page }) => {
+	await gotoBridge(page);
+	const fired = await page.evaluate(() => window.__bridge.klassChange_fires());
+	expect(fired).toBe(1);
+});
+
+test('Issue1154 — jQuery.on() handler also fires on a klass element when jQuery.trigger is used', async ({ page }) => {
+	await gotoBridge(page);
+	const fired = await page.evaluate(() => window.__bridge.klassChange_jq_on_fires());
+	expect(fired).toBe(1);
+});
+
+test('Issue1154 — mixed handlers (addEventListener + jQuery.on) each fire exactly once', async ({ page }) => {
+	await gotoBridge(page);
+	const out = await page.evaluate(() => window.__bridge.klassChange_mixed());
+	expect(out).toEqual({ native: 1, jq: 1 });
+});
+
+test('Issue1154 — handler dispatch order is native-then-jQuery for the same registration sequence', async ({ page }) => {
+	await gotoBridge(page);
+	// Both handlers go through addEventListener under the hood, so order
+	// reflects registration order. Spec exists so any future regression in
+	// dispatch order is caught immediately.
+	const order = await page.evaluate(() => window.__bridge.handlerOrder());
+	expect(order).toEqual(['native', 'jquery']);
+});
+
+// ─── 4. Non-klass passthrough ────────────────────────────────────────────────
+
+test('Issue1154 — non-klass element keeps the original jQuery.trigger pipeline', async ({ page }) => {
+	await gotoBridge(page);
+	const fired = await page.evaluate(() => window.__bridge.nonKlass_passthrough());
+	expect(fired).toBe(1);
+});
+
+test('Issue1154 — registry slot containing a non-klass object falls through to original trigger', async ({ page }) => {
+	await gotoBridge(page);
+	const fired = await page.evaluate(() => window.__bridge.registry_not_klass());
+	expect(fired).toBe(1);
+});
+
+// ─── 5. CustomEvent payload ──────────────────────────────────────────────────
+
+test('Issue1154 — extraParameters survive as event.detail', async ({ page }) => {
+	await gotoBridge(page);
+	const got = await page.evaluate(() => window.__bridge.customDetail({ a: 1, b: 'x' }));
+	expect(got).toEqual({ a: 1, b: 'x' });
+});
+
+test('Issue1154 — dispatched event is a CustomEvent (not a plain Event)', async ({ page }) => {
+	await gotoBridge(page);
+	const ok = await page.evaluate(() => window.__bridge.usesCustomEvent());
+	expect(ok).toBe(true);
+});
+
+test('Issue1154 — passing a real Event instance dispatches it verbatim', async ({ page }) => {
+	await gotoBridge(page);
+	const ok = await page.evaluate(() => window.__bridge.realEventPassthrough());
+	expect(ok).toBe(true);
+});
+
+// ─── 6. Chainability & multi-element ─────────────────────────────────────────
+
+test('Issue1154 — .trigger() returns the jQuery wrapper (chainable)', async ({ page }) => {
+	await gotoBridge(page);
+	const ok = await page.evaluate(() => window.__bridge.chainability());
+	expect(ok).toBe(true);
+});
+
+test('Issue1154 — multi-element selector processes klass + non-klass independently', async ({ page }) => {
+	await gotoBridge(page);
+	const out = await page.evaluate(() => window.__bridge.multiset());
+	expect(out).toEqual({ klassFired: 1, plainFired: 1 });
+});
+
+// ─── 7. Activation events (defaults must fire) ───────────────────────────────
+
+test('Issue1154 — jQuery.trigger("focus") actually focuses the element', async ({ page }) => {
+	await gotoBridge(page);
+	const focused = await page.evaluate(() => window.__bridge.focusActivation());
+	expect(focused).toBe(true);
+});
+
+test('Issue1154 — jQuery.trigger("blur") actually blurs the element', async ({ page }) => {
+	await gotoBridge(page);
+	const blurred = await page.evaluate(() => window.__bridge.blurActivation());
+	expect(blurred).toBe(true);
+});
+
+// jQuery.trigger('submit') on a klass form must invoke form.submit() — the
+// real-browser equivalent of "the form submits". We spy on form.submit()
+// rather than observe real navigation because Prado wraps the entire page
+// in its own outer form (nested forms are not honored by browsers).
+test('Issue1154 — jQuery.trigger("submit") on a klass form invokes form.submit()', async ({ page }) => {
+	await gotoBridge(page);
+	const calls = await page.evaluate(() => window.__bridge.submitInvoked());
+	expect(calls).toBe(1);
+});
+
+test('Issue1154 — the submit EVENT fires before form.submit() is invoked', async ({ page }) => {
+	await gotoBridge(page);
+	const order = await page.evaluate(() => window.__bridge.submitEventFires());
+	// Event handler must observe the event before form.submit() is called,
+	// so a handler can still preventDefault.
+	expect(order).toEqual(['event', 'submit']);
+});
+
+// preventDefault must stop the submit — important for any client-side
+// validation hooked into the submit event.
+test('Issue1154 — preventDefault on submit prevents the form.submit() call', async ({ page }) => {
+	await gotoBridge(page);
+	const calls = await page.evaluate(() => window.__bridge.submitPrevented());
+	expect(calls).toBe(0);
+});
+
+// jQuery.trigger('click') on a klass submit-button must invoke the native
+// el.click() so the browser runs the default activation (which would in
+// turn submit the owning form in real markup).
+test('Issue1154 — jQuery.trigger("click") on a klass submit button invokes el.click()', async ({ page }) => {
+	await gotoBridge(page);
+	const calls = await page.evaluate(() => window.__bridge.clickActivation());
+	expect(calls).toBe(1);
+});
+
+// ─── 8. Exactly-once dispatch: no overlap double-fire ────────────────────────
+//
+// These tests prove the bridge does NOT call originalTrigger after
+// dispatchEvent on the klass path. If it did, every jQuery-bound handler
+// would fire twice — once via jQuery's internal addEventListener
+// registration that dispatchEvent reaches, once via originalTrigger
+// walking the same handler list.
+
+test('Issue1154 — one native handler fires exactly once', async ({ page }) => {
+	await gotoBridge(page);
+	expect(await page.evaluate(() => window.__bridge.exactlyOnce_native())).toBe(1);
+});
+
+test('Issue1154 — one jQuery.on handler fires exactly once', async ({ page }) => {
+	await gotoBridge(page);
+	expect(await page.evaluate(() => window.__bridge.exactlyOnce_jq())).toBe(1);
+});
+
+test('Issue1154 — three native handlers each fire exactly once', async ({ page }) => {
+	await gotoBridge(page);
+	expect(await page.evaluate(() => window.__bridge.exactlyOnce_threeNative())).toEqual([1, 1, 1]);
+});
+
+test('Issue1154 — three jQuery.on handlers each fire exactly once', async ({ page }) => {
+	await gotoBridge(page);
+	expect(await page.evaluate(() => window.__bridge.exactlyOnce_threeJq())).toEqual([1, 1, 1]);
+});
+
+test('Issue1154 — matrix: 2 native + 2 jQuery handlers → exactly 4 total calls', async ({ page }) => {
+	await gotoBridge(page);
+	const out = await page.evaluate(() => window.__bridge.exactlyOnce_matrix());
+	expect(out).toEqual({ n1: 1, n2: 1, j1: 1, j2: 1, total: 4 });
+});
+
+test('Issue1154 — addEventListener deduplicates same-fn double registration (browser spec)', async ({ page }) => {
+	await gotoBridge(page);
+	expect(await page.evaluate(() => window.__bridge.exactlyOnce_addEventListenerDedupe())).toBe(1);
+});
+
+test('Issue1154 — jQuery.on same-fn double registration fires twice (jQuery behavior, NOT introduced by bridge)', async ({ page }) => {
+	await gotoBridge(page);
+	expect(await page.evaluate(() => window.__bridge.exactlyOnce_jqDoesNotDedupe())).toBe(2);
+});
+
+test('Issue1154 — three sequential trigger() calls fire each handler exactly three times (no leftover state)', async ({ page }) => {
+	await gotoBridge(page);
+	const out = await page.evaluate(() => window.__bridge.exactlyOnce_threeTriggers());
+	expect(out).toEqual({ native: 3, jq: 3 });
+});
+
+test('Issue1154 — distinct event names do not bleed: triggering "change" does not call "input" handlers', async ({ page }) => {
+	await gotoBridge(page);
+	const out = await page.evaluate(() => window.__bridge.exactlyOnce_distinctEventNames());
+	expect(out).toEqual({ change: 1, input: 0 });
+});
+
+test('Issue1154 — stopPropagation in a native handler stops jQuery-bound bubble handlers (proves single event flow path)', async ({ page }) => {
+	await gotoBridge(page);
+	const out = await page.evaluate(() => window.__bridge.exactlyOnce_stopPropagation());
+	expect(out).toEqual({ child: 1, parent: 0 });
+});
+
+// ─── 9. Edge cases ───────────────────────────────────────────────────────────
+
+test('Issue1154 — empty / undefined event name is a no-op (no throw, no handler fired)', async ({ page }) => {
+	await gotoBridge(page);
+	const fired = await page.evaluate(() => window.__bridge.emptyEventName());
+	expect(fired).toBe(0);
+});


### PR DESCRIPTION
This replaced jQuery with standard Javascript. Javascript has come a long way since jQuery started. jQuery was to help with the weak points of JS, except those holes are filled in over the last two decades.

There are still some places where jQuery is needed but much less so with this PR.

The conversion of jQuery to something more modern is the reason for the JS eslint, vitest, and playwright introduction.  And it was instrumental in terms of "the goal" to pass all the tests in the conversion.

#1098