### PR TITLE
TComponent - Behaviors’ methods caching

### DIFF
--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -27,6 +27,7 @@ use Prado\Util\IBehavior;
 use Prado\Util\TCallChain;
 use Prado\Util\IClassBehavior;
 use Prado\Util\IDynamicMethods;
+use Prado\Util\IOwnerVisibleMethods;
 use Prado\Util\TClassBehaviorEventParameter;
 use Prado\Web\Javascripts\TJavaScriptLiteral;
 use Prado\Web\Javascripts\TJavaScriptString;
@@ -403,12 +404,32 @@ class TComponent
 	protected $_m;
 
 	/**
+	 * `_bm` is the Behavior Methods cache for the `dy` event chain.
+	 * Populated by {@see getBehaviorsWithMethod}; cleared by {@see flushBehaviorMethodCache}.
 	 * @var array<string, IBaseBehavior[]> behaviors responding to a method, keyed by
-	 *   lowercased method name and in priority order.  Populated by
-	 *   {@see getBehaviorsWithMethod} and cleared when a behavior is attached or detached.
+	 *   lowercased method name and in priority order.
 	 * @since 4.4.0
 	 */
 	private array $_bm = [];
+
+	/**
+	 * `_cm` is the Callable Methods cache for owner method calls.
+	 * Populated by {@see getOwnerCallableBehaviors}; cleared by {@see flushBehaviorMethodCache}.
+	 * Depends on {@see $_bv} for the owner-visibility filter.
+	 * @var array<string, IBaseBehavior[]> behaviors exposing a method to the owner, keyed by
+	 *   lowercased method name and in priority order.
+	 * @since 4.4.0
+	 */
+	private array $_cm = [];
+
+	/**
+	 * `_bv` is the Behavior (owner-)Visible methods cache.
+	 * Populated by {@see getBehaviorOwnerVisibleMethods}; cleared by {@see flushBehaviorMethodCache}.
+	 * @var array<int, null|array<string, bool>> owner-visible method sets, keyed by behavior
+	 *   {@see spl_object_id}; `null` for no restriction, else lowercased visible method names as keys.
+	 * @since 4.4.0
+	 */
+	private array $_bv = [];
 
 	/**
 	 * @var array static global class behaviors, these behaviors are added upon instantiation of a class
@@ -788,7 +809,7 @@ class TComponent
 				$class = $behavior::class;
 				$lclass = strtolower($class);
 				if (!isset($checkedClasses[$lclass])) {
-					if ($behavior->getEnabled() && method_exists($class, $method)) {
+					if ($behavior->getEnabled() && method_exists($class, $method) && self::isStaticBehaviorOwnerVisibleMethod($behavior, $method)) {
 						return forward_static_call_array([$class, $method], $args);
 					}
 					$checkedClasses[$lclass] = true;
@@ -807,7 +828,7 @@ class TComponent
 
 				$lclass = strtolower($class);
 				if (!isset($checkedClasses[$lclass])) {
-					if ((!($behavior instanceof IBaseBehavior) || $behavior->getEnabled()) && method_exists($class, $method)) {
+					if ((!($behavior instanceof IBaseBehavior) || $behavior->getEnabled()) && method_exists($class, $method) && self::isStaticBehaviorOwnerVisibleMethod($behavior, $method)) {
 						return forward_static_call_array([$class, $method], $args);
 					}
 					$checkedClasses[$lclass] = true;
@@ -1140,8 +1161,8 @@ class TComponent
 					return true;
 				}
 			} else {
-				foreach ($this->_m->toArray() as $behavior) {
-					if ($behavior->getEnabled() && Prado::method_visible($behavior, $method)) {
+				foreach ($this->getOwnerCallableBehaviors($method) as $behavior) {
+					if ($behavior->getEnabled()) {
 						if ($behavior instanceof IClassBehavior) {
 							array_unshift($args, $this);
 						}
@@ -1194,13 +1215,18 @@ class TComponent
 	}
 
 	/**
-	 * Returns the behaviors responding to a method, in priority order.  A behavior responds
-	 * when the method is visible on it or it implements {@see \Prado\Util\IDynamicMethods}.
-	 * Enabled state is excluded, so callers filter on
-	 * {@see \Prado\Util\IBaseBehavior::getEnabled}.  Results are memoized in {@see $_bm}.
-	 * @param string $method the method name resolved against the behaviors.
-	 * @return IBaseBehavior[] the responding behaviors, possibly empty.
+	 * Resolves the behaviors for a `dy` event chain, in priority order, memoized in
+	 * {@see $_bm} keyed by lowercased method name.  A behavior is included when:
+	 *  - the method is visible on it ({@see \Prado\Prado::method_visible}); or
+	 *  - it implements {@see \Prado\Util\IDynamicMethods}, so it receives the event even
+	 *    without defining the method.
+	 * Enabled state is not applied here; {@see getCallChain} skips disabled behaviors.
+	 * Contrast {@see getOwnerCallableBehaviors}, which resolves owner method calls.
+	 * @param string $method the `dy` event method name.
+	 * @return IBaseBehavior[] the chain behaviors in priority order, possibly empty.
 	 * @since 4.4.0
+	 * @see getCallChain for use
+	 * @note _bm is Behavior Methods
 	 */
 	protected function getBehaviorsWithMethod(string $method): array
 	{
@@ -1220,13 +1246,124 @@ class TComponent
 	}
 
 	/**
-	 * Flushes the behavior method-resolution cache held in {@see $_bm}.  Called when the
-	 * set of attached behaviors changes so {@see getBehaviorsWithMethod} re-resolves.
+	 * Clears the three behavior-resolution caches: the `dy` event chain {@see $_bm}, the
+	 * owner method-call set {@see $_cm}, and the owner-visible method sets {@see $_bv}.
+	 * Called when a behavior is attached or detached, the only change that invalidates them.
 	 * @since 4.4.0
 	 */
 	protected function flushBehaviorMethodCache(): void
 	{
 		$this->_bm = [];
+		$this->_cm = [];
+		$this->_bv = [];
+	}
+
+	/**
+	 * Resolves the behaviors that expose a method to the owner, in priority order, memoized
+	 * in {@see $_cm} keyed by lowercased method name.  A behavior is included when both:
+	 *  - the method is visible on it ({@see \Prado\Prado::method_visible}); and
+	 *  - the method is visible to the owner ({@see isBehaviorOwnerVisibleMethod}).
+	 * {@see \Prado\Util\IDynamicMethods} behaviors that lack the method are excluded.  Both
+	 * conditions change only on behavior attach/detach, so the cached list lets dispatch
+	 * skip the reflection and re-check only the volatile {@see \Prado\Util\IBaseBehavior::getEnabled}
+	 * state.  Contrast {@see getBehaviorsWithMethod}, which resolves the `dy` event chain.
+	 * @param string $method the owner-called method name.
+	 * @return IBaseBehavior[] the exposing behaviors in priority order, possibly empty.
+	 * @since 4.4.0
+	 * @see callBehaviorsMethod for use
+	 * @see hasMethod for use
+	 * @note _cm is (Owner) Callable Methods
+	 */
+	protected function getOwnerCallableBehaviors(string $method): array
+	{
+		if ($this->_m === null) {
+			return [];
+		}
+		$key = strtolower($method);
+		if (isset($this->_cm[$key])) {
+			return $this->_cm[$key];
+		}
+		$behaviors = [];
+		foreach ($this->_m->toArray() as $behavior) {
+			if (Prado::method_visible($behavior, $method) && $this->isBehaviorOwnerVisibleMethod($behavior, $method)) {
+				$behaviors[] = $behavior;
+			}
+		}
+		return $this->_cm[$key] = $behaviors;
+	}
+
+	/**
+	 * Tests whether a behavior method is visible to the owner, using the memoized set from
+	 * {@see getBehaviorOwnerVisibleMethods}.  True when the behavior places no restriction
+	 * or names the method.  `dy` and `fx` events bypass this restriction and are handled by
+	 * callers before this check.
+	 * @param IBaseBehavior $behavior the behavior providing the method.
+	 * @param string $method the method name resolved against the behavior.
+	 * @return bool whether the method is visible to the owner.
+	 * @since 4.4.0
+	 */
+	protected function isBehaviorOwnerVisibleMethod(IBaseBehavior $behavior, string $method): bool
+	{
+		$set = $this->getBehaviorOwnerVisibleMethods($behavior);
+		return $set === null || isset($set[strtolower($method)]);
+	}
+
+	/**
+	 * Caches a behavior's {@see \Prado\Util\IOwnerVisibleMethods::getOwnerVisibleMethods}
+	 * result in {@see $_bv}, keyed by behavior {@see spl_object_id} and normalized to a
+	 * lowercased-name lookup set.  `null` means no restriction.
+	 * @param IBaseBehavior $behavior the behavior whose visible methods are resolved.
+	 * @return null|array<string, bool> `null` for no restriction, else the lowercased visible
+	 *   method names as keys.
+	 * @since 4.4.0
+	 * @note _bv is Behavior Visible
+	 */
+	protected function getBehaviorOwnerVisibleMethods(IBaseBehavior $behavior): ?array
+	{
+		$oid = spl_object_id($behavior);
+		if (array_key_exists($oid, $this->_bv)) {
+			return $this->_bv[$oid];
+		}
+		$set = null;
+		if ($behavior instanceof IOwnerVisibleMethods) {
+			$methods = $behavior->getOwnerVisibleMethods();
+			if ($methods !== null) {
+				$set = [];
+				foreach ((array) $methods as $methodName) {
+					$set[strtolower((string) $methodName)] = true;
+				}
+			}
+		}
+		return $this->_bv[$oid] = $set;
+	}
+
+	/**
+	 * Determines whether a behavior method is visible to its owner in a static context.
+	 * Used by {@see __callStatic} where only the behavior is available.  A behavior that
+	 * does not implement {@see \Prado\Util\IOwnerVisibleMethods} or returns `null` places
+	 * no restriction.  Non-object behaviors (class-wide configuration entries) are treated
+	 * as unrestricted.
+	 * @param mixed $behavior the behavior, configuration array, or class name.
+	 * @param string $method the method name resolved against the behavior.
+	 * @return bool whether the method is visible to the owner.
+	 * @since 4.4.0
+	 */
+	protected static function isStaticBehaviorOwnerVisibleMethod($behavior, string $method): bool
+	{
+		if (!($behavior instanceof IOwnerVisibleMethods)) {
+			return true;
+		}
+		$methods = $behavior->getOwnerVisibleMethods();
+		if ($methods === null) {
+			return true;
+		}
+		$lmethod = strtolower($method);
+		foreach ((array) $methods as $methodName) {
+			if (strtolower((string) $methodName) === $lmethod) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -1244,9 +1381,8 @@ class TComponent
 		if (Prado::method_visible($this, $name) || strncasecmp($name, 'dy', 2) === 0) {
 			return true;
 		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
-			foreach ($this->_m->toArray() as $behavior) {
-				//Prado::method_visible($behavior, $name) rather than $behavior->hasMethod($name) b/c only one layer is supported, @4.2.2
-				if ($behavior->getEnabled() && Prado::method_visible($behavior, $name)) {
+			foreach ($this->getOwnerCallableBehaviors($name) as $behavior) {
+				if ($behavior->getEnabled()) {
 					return true;
 				}
 			}
@@ -2274,6 +2410,8 @@ class TComponent
 		}
 		$exprops[] = "\0*\0_e";
 		$exprops[] = "\0" . __CLASS__ . "\0_bm";
+		$exprops[] = "\0" . __CLASS__ . "\0_cm";
+		$exprops[] = "\0" . __CLASS__ . "\0_bv";
 		if ($this->_m === null) {
 			$exprops[] = "\0*\0_m";
 		}

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -403,6 +403,14 @@ class TComponent
 	protected $_m;
 
 	/**
+	 * @var array<string, IBaseBehavior[]> behaviors responding to a method, keyed by
+	 *   lowercased method name and in priority order.  Populated by
+	 *   {@see getBehaviorsWithMethod} and cleared when a behavior is attached or detached.
+	 * @since 4.4.0
+	 */
+	private array $_bm = [];
+
+	/**
 	 * @var array static global class behaviors, these behaviors are added upon instantiation of a class
 	 */
 	private static $_um = [];
@@ -557,7 +565,7 @@ class TComponent
 	public function __destruct()
 	{
 		$this->clearBehaviors();
-		if ($this->_listeningenabled) {
+		if ($this->getListeningToGlobalEvents()) {
 			$this->unlisten();
 		}
 	}
@@ -637,7 +645,7 @@ class TComponent
 	 */
 	public function listen()
 	{
-		if ($this->_listeningenabled) {
+		if ($this->getListeningToGlobalEvents()) {
 			return;
 		}
 
@@ -676,7 +684,7 @@ class TComponent
 	 */
 	public function unlisten()
 	{
-		if (!$this->_listeningenabled) {
+		if (!$this->getListeningToGlobalEvents()) {
 			return;
 		}
 
@@ -858,12 +866,12 @@ class TComponent
 				self::$_ue[$name] = new TWeakCallableCollection();
 			}
 			return self::$_ue[$name];
-		} elseif ($this->getBehaviorsEnabled()) {
+		} elseif ($this->_m !== null && $this->getBehaviorsEnabled()) {
 			// getting a behavior property/event (handler list)
 			$name = strtolower($name);
 			if (isset($this->_m[$name])) {
 				return $this->_m[$name];
-			} elseif ($this->_m !== null) {
+			} else {
 				foreach ($this->_m->toArray() as $behavior) {
 					if ($behavior->getEnabled() && (property_exists($behavior, $name) || $behavior->canGetProperty($name) || $behavior->hasEvent($name))) {
 						return $behavior->$name;
@@ -1169,19 +1177,56 @@ class TComponent
 			return null;
 		}
 		$classArgs = $callchain = null;
-		foreach ($this->_m->toArray() as $behavior) {
-			if ($behavior->getEnabled() && (Prado::method_visible($behavior, $method) || ($behavior instanceof IDynamicMethods))) {
-				if ($classArgs === null) {
-					$classArgs = $args;
-					array_unshift($classArgs, $this);
-				}
-				if (!$callchain) {
-					$callchain = new TCallChain($method);
-				}
-				$callchain->addCall([$behavior, $method], ($behavior instanceof IClassBehavior) ? $classArgs : $args);
+		foreach ($this->getBehaviorsWithMethod($method) as $behavior) {
+			if (!$behavior->getEnabled()) {
+				continue;
 			}
+			if ($classArgs === null) {
+				$classArgs = $args;
+				array_unshift($classArgs, $this);
+			}
+			if (!$callchain) {
+				$callchain = new TCallChain($method);
+			}
+			$callchain->addCall([$behavior, $method], ($behavior instanceof IClassBehavior) ? $classArgs : $args);
 		}
 		return $callchain;
+	}
+
+	/**
+	 * Returns the behaviors responding to a method, in priority order.  A behavior responds
+	 * when the method is visible on it or it implements {@see \Prado\Util\IDynamicMethods}.
+	 * Enabled state is excluded, so callers filter on
+	 * {@see \Prado\Util\IBaseBehavior::getEnabled}.  Results are memoized in {@see $_bm}.
+	 * @param string $method the method name resolved against the behaviors.
+	 * @return IBaseBehavior[] the responding behaviors, possibly empty.
+	 * @since 4.4.0
+	 */
+	protected function getBehaviorsWithMethod(string $method): array
+	{
+		$key = strtolower($method);
+		if (isset($this->_bm[$key])) {
+			return $this->_bm[$key];
+		}
+		$behaviors = [];
+		if ($this->_m !== null) {
+			foreach ($this->_m->toArray() as $behavior) {
+				if (Prado::method_visible($behavior, $method) || ($behavior instanceof IDynamicMethods)) {
+					$behaviors[] = $behavior;
+				}
+			}
+		}
+		return $this->_bm[$key] = $behaviors;
+	}
+
+	/**
+	 * Flushes the behavior method-resolution cache held in {@see $_bm}.  Called when the
+	 * set of attached behaviors changes so {@see getBehaviorsWithMethod} re-resolves.
+	 * @since 4.4.0
+	 */
+	protected function flushBehaviorMethodCache(): void
+	{
+		$this->_bm = [];
 	}
 
 	/**
@@ -2036,6 +2081,7 @@ class TComponent
 			$name = $this->_m->getNextIntegerKey();
 		}
 		$this->_m->add($name, $behavior, $priority);
+		$this->flushBehaviorMethodCache();
 		$behavior->setName($name);
 		$behavior->attach($this);
 		$this->callBehaviorsMethod('dyAttachBehavior', $return, $name, $behavior);
@@ -2068,6 +2114,7 @@ class TComponent
 			$this->callBehaviorsMethod('dyDetachBehavior', $return, $name, $behavior);
 			$behavior->detach($this);
 			$this->_m->remove($name, $priority);
+			$this->flushBehaviorMethodCache();
 			return $behavior;
 		}
 		return null;
@@ -2089,7 +2136,7 @@ class TComponent
 	 */
 	public function enableBehaviors()
 	{
-		if (!$this->_behaviorsenabled) {
+		if (!$this->getBehaviorsEnabled()) {
 			$this->_behaviorsenabled = true;
 			$this->callBehaviorsMethod('dyEnableBehaviors', $return);
 		}
@@ -2111,7 +2158,7 @@ class TComponent
 	 */
 	public function disableBehaviors()
 	{
-		if ($this->_behaviorsenabled) {
+		if ($this->getBehaviorsEnabled()) {
 			$callchain = $this->getCallChain('dyDisableBehaviors');
 			$this->_behaviorsenabled = false;
 			if ($callchain) { // normal dynamic events won't work because behaviors are disabled.
@@ -2219,13 +2266,14 @@ class TComponent
 	 */
 	protected function _getZappableSleepProps(&$exprops)
 	{
-		if ($this->_listeningenabled === false) {
+		if ($this->getListeningToGlobalEvents() === false) {
 			$exprops[] = "\0*\0_listeningenabled";
 		}
-		if ($this->_behaviorsenabled === true) {
+		if ($this->getBehaviorsEnabled() === true) {
 			$exprops[] = "\0*\0_behaviorsenabled";
 		}
 		$exprops[] = "\0*\0_e";
+		$exprops[] = "\0" . __CLASS__ . "\0_bm";
 		if ($this->_m === null) {
 			$exprops[] = "\0*\0_m";
 		}

--- a/framework/Util/IBaseBehavior.php
+++ b/framework/Util/IBaseBehavior.php
@@ -67,7 +67,7 @@ interface IBaseBehavior extends IPriorityProperty
 
 	/**
 	 * Handles behavior configurations from TBehaviorsModule and TBehaviorParameterLoader.
-	 * @param mixed $config The configuration data.
+	 * @param null|array|\Prado\Xml\TXmlElement $config The configuration data.
 	 * @since 4.2.2
 	 */
 	public function init($config);

--- a/framework/Util/IOwnerVisibleMethods.php
+++ b/framework/Util/IOwnerVisibleMethods.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * IOwnerVisibleMethods interface file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util;
+
+/**
+ * IOwnerVisibleMethods interface.
+ *
+ * A behavior implements this interface to declare which of its methods remain
+ * visible to its owner. The name aligns with the gate predicate
+ * {@see \Prado\Prado::method_visible()}: after a behavior method passes the PHP
+ * visibility check, this interface decides whether it stays visible to the owner
+ * that called it.
+ *
+ * The owner consults {@see getOwnerVisibleMethods()} when resolving a method it
+ * does not implement itself. The return value is cast to an array by the caller
+ * (`null|string|array`), so implementations may return any of the following:
+ *
+ * | Return | Meaning |
+ * |--------|---------|
+ * | `null` | no restriction — every public method is visible to the owner |
+ * | `[]` | no method is visible to the owner unless explicitly declared |
+ * | `['doThing', 'doOther']` | only these methods are visible to the owner |
+ * | `'doThing'` | single-name shorthand, cast to `['doThing']` |
+ *
+ * Method names are matched case-insensitively. `dy` dynamic events and `fx` global
+ * events form the behavior-to-owner protocol and are never subject to this
+ * restriction.
+ *
+ * The declaration is overridable by subclasses through normal method overriding,
+ * so a child behavior may compose its visible methods with the parent's:
+ * ```php
+ * public function getOwnerVisibleMethods(): null|string|array
+ * {
+ *     return array_merge(parent::getOwnerVisibleMethods() ?? [], ['doMore']);
+ * }
+ * ```
+ *
+ * {@see \Prado\Util\TBaseBehavior} implements this interface and returns `null` by
+ * default, so standard behaviors expose every public method until they declare a
+ * restriction.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+interface IOwnerVisibleMethods
+{
+	/**
+	 * Returns the names of the behavior methods that remain visible to the owner.
+	 *
+	 * The return value is cast to an array by the caller, so a single string method
+	 * name may be returned as a convenience. Supported forms:
+	 *   - `null` — no restriction; every public method is visible to the owner
+	 *   - `[]` — no method is visible to the owner
+	 *   - `'doThing'` — single visible method
+	 *   - `['doThing', 'doOther']` — multiple visible methods
+	 *
+	 * Method names are matched case-insensitively.
+	 *
+	 * @return null|array|string the behavior method names visible to the owner.
+	 */
+	public function getOwnerVisibleMethods(): null|string|array;
+}

--- a/framework/Util/TBaseBehavior.php
+++ b/framework/Util/TBaseBehavior.php
@@ -47,7 +47,7 @@ use Prado\TPropertyValue;
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 4.3.0
  */
-abstract class TBaseBehavior extends TApplicationComponent implements IBaseBehavior
+abstract class TBaseBehavior extends TApplicationComponent implements IBaseBehavior, IOwnerVisibleMethods
 {
 	use TPriorityPropertyTrait;
 
@@ -119,6 +119,18 @@ abstract class TBaseBehavior extends TApplicationComponent implements IBaseBehav
 	public function events()
 	{
 		return [];
+	}
+
+	/**
+	 * Declares which behavior methods are visible to the owner.  The base behavior
+	 * returns `null` for no restriction; see {@see \Prado\Util\IOwnerVisibleMethods}
+	 * for the supported return forms.
+	 * @return null|array|string the visible method names, or `null` for no restriction.
+	 * @since 4.4.0
+	 */
+	public function getOwnerVisibleMethods(): null|string|array
+	{
+		return null;
 	}
 
 	/**

--- a/framework/Util/TBaseBehavior.php
+++ b/framework/Util/TBaseBehavior.php
@@ -88,7 +88,7 @@ abstract class TBaseBehavior extends TApplicationComponent implements IBaseBehav
 	/**
 	 * This processes behavior configuration elements.  This is usually called before
 	 * attach. This is only needed for complex behavior configurations.
-	 * @param array|\Prado\Xml\TXmlElement $config The innards to the behavior
+	 * @param null|array|\Prado\Xml\TXmlElement $config The innards to the behavior
 	 *   configuration.
 	 */
 	public function init($config)

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -366,6 +366,7 @@ return [
 'IDynamicMethods' => 'Prado\Util\IDynamicMethods',
 'IInstanceCheck' => 'Prado\Util\IInstanceCheck',
 'IOutputLogRoute' => 'Prado\Util\IOutputLogRoute',
+'IOwnerVisibleMethods' => 'Prado\Util\IOwnerVisibleMethods',
 'IPluginModule' => 'Prado\Util\IPluginModule',
 'TRational' => 'Prado\Util\Math\TRational',
 'TURational' => 'Prado\Util\Math\TURational',

--- a/tests/unit/TComponentBehaviorTest.php
+++ b/tests/unit/TComponentBehaviorTest.php
@@ -987,4 +987,216 @@ class TComponentBehaviorTest extends TComponentTestBase
 
 		$this->component->detachBehavior('fooUnknownB');
 	}
+
+	/**
+	 * A behavior implementing IOwnerVisibleMethods restricts which of its methods
+	 * the owner may call.  Declared methods are reachable; undeclared ones are not.
+	 */
+	public function testOwnerVisibleMethods_restrictsInstanceBehavior(): void
+	{
+		$this->component->attachBehavior('ownerVisible', new OwnerVisibleMethodsBehavior());
+
+		$this->assertTrue($this->component->hasMethod('visibleMethod'));
+		$this->assertFalse($this->component->hasMethod('hiddenMethod'));
+		$this->assertEquals('visible', $this->component->visibleMethod());
+
+		try {
+			$this->component->hiddenMethod();
+			$this->fail('TUnknownMethodException not raised for an owner-hidden behavior method');
+		} catch (TUnknownMethodException $e) {
+		}
+
+		$this->component->detachBehavior('ownerVisible');
+	}
+
+	/**
+	 * IOwnerVisibleMethods also restricts class behaviors, and accepts the single
+	 * string shorthand for the visible method name.
+	 */
+	public function testOwnerVisibleMethods_restrictsClassBehavior(): void
+	{
+		$this->component->attachBehavior('ownerVisibleClass', new OwnerVisibleMethodsClassBehavior());
+
+		$this->assertTrue($this->component->hasMethod('visibleClassMethod'));
+		$this->assertFalse($this->component->hasMethod('hiddenClassMethod'));
+		$this->assertEquals('visibleClass', $this->component->visibleClassMethod());
+
+		try {
+			$this->component->hiddenClassMethod();
+			$this->fail('TUnknownMethodException not raised for an owner-hidden class behavior method');
+		} catch (TUnknownMethodException $e) {
+		}
+
+		$this->component->detachBehavior('ownerVisibleClass');
+	}
+
+	/**
+	 * The behavior-method resolution caches ($_cm, $_bv) hold live behavior object
+	 * references and spl_object_id keys, so they must be excluded from serialization.
+	 * After a populate-then-round-trip the caches reset and the owner restriction
+	 * still holds against the reattached behavior, not a stale serialized copy.
+	 */
+	public function testOwnerVisibleMethods_cachesExcludedFromSerialization(): void
+	{
+		$this->component->attachBehavior('ownerVisibleSerial', new OwnerVisibleMethodsBehavior());
+
+		// Populate both caches: $_cm (method resolution) and $_bv (owner-visible set).
+		$this->assertEquals('visible', $this->component->visibleMethod());
+		$this->assertFalse($this->component->hasMethod('hiddenMethod'));
+		$this->assertNotEmpty(PradoUnit::getProp($this->component, '_cm'));
+		$this->assertNotEmpty(PradoUnit::getProp($this->component, '_bv'));
+
+		$restored = unserialize(serialize($this->component));
+
+		// The caches are rebuilt lazily, never carried across serialization.
+		$this->assertSame([], PradoUnit::getProp($restored, '_cm'));
+		$this->assertSame([], PradoUnit::getProp($restored, '_bv'));
+
+		// The restriction still applies through the reattached behavior.
+		$this->assertTrue($restored->hasMethod('visibleMethod'));
+		$this->assertFalse($restored->hasMethod('hiddenMethod'));
+		$this->assertEquals('visible', $restored->visibleMethod());
+
+		try {
+			$restored->hiddenMethod();
+			$this->fail('TUnknownMethodException not raised for an owner-hidden behavior method after unserialize');
+		} catch (TUnknownMethodException $e) {
+		}
+
+		$this->component->detachBehavior('ownerVisibleSerial');
+	}
+
+	/**
+	 * The default TBaseBehavior returns null from getOwnerVisibleMethods, placing
+	 * no restriction so every public behavior method remains visible to the owner.
+	 */
+	public function testOwnerVisibleMethods_nullPlacesNoRestriction(): void
+	{
+		$foo = new FooBehavior();
+		$this->assertNull($foo->getOwnerVisibleMethods());
+
+		$this->component->attachBehavior('fooNoRestriction', $foo);
+		$this->assertTrue($this->component->hasMethod('faaEverMore'));
+		$this->assertTrue($this->component->faaEverMore(true, true));
+
+		$this->component->detachBehavior('fooNoRestriction');
+	}
+
+	/**
+	 * An empty array from getOwnerVisibleMethods hides every behavior method from the
+	 * owner.  This is the 5.0 opt-in default expressed explicitly.
+	 */
+	public function testOwnerVisibleMethods_emptyArrayHidesAllMethods(): void
+	{
+		$this->component->attachBehavior('hiddenAll', new OwnerHiddenAllBehavior());
+
+		$this->assertFalse($this->component->hasMethod('visibleMethod'));
+
+		try {
+			$this->component->visibleMethod();
+			$this->fail('TUnknownMethodException not raised when all behavior methods are hidden');
+		} catch (TUnknownMethodException $e) {
+		}
+
+		$this->component->detachBehavior('hiddenAll');
+	}
+
+	/**
+	 * dy dynamic events are the behavior-to-owner protocol and bypass owner-method
+	 * visibility.  A behavior hiding all methods still receives its dy events.
+	 */
+	public function testOwnerVisibleMethods_dyEventBypassesRestriction(): void
+	{
+		$behavior = new OwnerHiddenAllBehavior();
+		$this->component->attachBehavior('hiddenAllDy', $behavior);
+
+		// The normal method is hidden ...
+		$this->assertFalse($this->component->hasMethod('visibleMethod'));
+		// ... but the dy event still reaches the behavior.
+		$this->assertEquals('bbb', $this->component->dyTextFilter('aaa'));
+		$this->assertTrue($behavior->isDyCalled());
+
+		$this->component->detachBehavior('hiddenAllDy');
+	}
+
+	/**
+	 * Enabled state is excluded from the $_cm cache and re-checked on each dispatch.
+	 * Disabling an attached behavior hides its visible method without flushing the
+	 * cache; re-enabling restores it.  This guards the cache design where only the
+	 * structural resolution is memoized.
+	 */
+	public function testOwnerVisibleMethods_enabledCheckedLiveNotCached(): void
+	{
+		$this->component->attachBehavior('ownerVisibleLive', new OwnerVisibleMethodsBehavior());
+
+		// Populate the $_cm cache for visibleMethod.
+		$this->assertEquals('visible', $this->component->visibleMethod());
+		$this->assertNotEmpty(PradoUnit::getProp($this->component, '_cm'));
+
+		$this->component->disableBehavior('ownerVisibleLive');
+
+		// The cache still holds the candidate (disable does not flush) ...
+		$this->assertNotEmpty(PradoUnit::getProp($this->component, '_cm'));
+		// ... but the live getEnabled() check hides the method.
+		$this->assertFalse($this->component->hasMethod('visibleMethod'));
+		try {
+			$this->component->visibleMethod();
+			$this->fail('TUnknownMethodException not raised for a disabled behavior method');
+		} catch (TUnknownMethodException $e) {
+		}
+
+		$this->component->enableBehavior('ownerVisibleLive');
+		$this->assertTrue($this->component->hasMethod('visibleMethod'));
+		$this->assertEquals('visible', $this->component->visibleMethod());
+
+		$this->component->detachBehavior('ownerVisibleLive');
+	}
+
+	/**
+	 * Detaching a behavior flushes $_cm so a previously resolved owner method no
+	 * longer resolves.
+	 */
+	public function testOwnerVisibleMethods_cacheFlushedOnDetach(): void
+	{
+		$this->component->attachBehavior('ownerVisibleFlush', new OwnerVisibleMethodsBehavior());
+
+		$this->assertEquals('visible', $this->component->visibleMethod());
+		$this->assertNotEmpty(PradoUnit::getProp($this->component, '_cm'));
+
+		$this->component->detachBehavior('ownerVisibleFlush');
+
+		$this->assertSame([], PradoUnit::getProp($this->component, '_cm'));
+		$this->assertFalse($this->component->hasMethod('visibleMethod'));
+	}
+
+	/**
+	 * Declared visible method names match case-insensitively, the names being
+	 * normalized to a lowercased lookup set.
+	 */
+	public function testOwnerVisibleMethods_matchingIsCaseInsensitive(): void
+	{
+		$this->component->attachBehavior('ownerVisibleCase', new OwnerVisibleMethodsBehavior());
+
+		$this->assertTrue($this->component->hasMethod('VISIBLEMETHOD'));
+		$this->assertEquals('visible', $this->component->VisibleMethod());
+
+		$this->component->detachBehavior('ownerVisibleCase');
+	}
+
+	/**
+	 * A subclass composes its visible methods with the parent result via parent::,
+	 * so both the inherited and the added methods are visible to the owner.
+	 */
+	public function testOwnerVisibleMethods_overrideComposesWithParent(): void
+	{
+		$this->component->attachBehavior('ownerVisibleComposed', new OwnerVisibleComposedBehavior());
+
+		$this->assertTrue($this->component->hasMethod('visibleMethod'));
+		$this->assertTrue($this->component->hasMethod('anotherVisibleMethod'));
+		$this->assertFalse($this->component->hasMethod('hiddenMethod'));
+		$this->assertEquals('visible', $this->component->visibleMethod());
+		$this->assertEquals('another', $this->component->anotherVisibleMethod());
+
+		$this->component->detachBehavior('ownerVisibleComposed');
+	}
 }

--- a/tests/unit/TComponentCallTest.php
+++ b/tests/unit/TComponentCallTest.php
@@ -166,4 +166,34 @@ class TComponentCallTest extends TComponentTestBase
 
 		unset($this->tearDownScripts[$behaviorName]);
 	}
+
+	/**
+	 * IOwnerVisibleMethods restricts the __callStatic class-behavior path.  A class
+	 * behavior attached as an instance that hides its methods makes its static method
+	 * unreachable through the owner class, while an unrestricted one resolves normally.
+	 */
+	public function testCallStatic_classBehaviorOwnerVisibility()
+	{
+		$behaviorName = 'aHiddenStaticMethodBehavior';
+		NewComponent::attachClassBehavior($behaviorName, new NewComponentStaticHiddenClassBehavior());
+		$this->tearDownScripts[$behaviorName] = function () use ($behaviorName) { NewComponent::detachClassBehavior($behaviorName); };
+
+		try {
+			NewComponent::aStaticMethod(3);
+			self::fail("failed to raise TUnknownMethodException for an owner-hidden static class-behavior method.");
+		} catch (TUnknownMethodException $e) {
+		}
+
+		NewComponent::detachClassBehavior($behaviorName);
+		unset($this->tearDownScripts[$behaviorName]);
+
+		// An unrestricted class behavior still resolves its static method.
+		NewComponent::attachClassBehavior($behaviorName, new NewComponentStaticClassBehavior());
+		$this->tearDownScripts[$behaviorName] = function () use ($behaviorName) { NewComponent::detachClassBehavior($behaviorName); };
+
+		self::assertEquals(9, NewComponent::aStaticMethod(3));
+
+		NewComponent::detachClassBehavior($behaviorName);
+		unset($this->tearDownScripts[$behaviorName]);
+	}
 }

--- a/tests/unit/TComponentTestFixtures.php
+++ b/tests/unit/TComponentTestFixtures.php
@@ -155,6 +155,18 @@ class NewComponentStaticClassBehavior extends TClassBehavior
 	}
 }
 
+class NewComponentStaticHiddenClassBehavior extends TClassBehavior
+{
+	public static function aStaticMethod(int $value)
+	{
+		return $value * $value;
+	}
+	public function getOwnerVisibleMethods(): null|string|array
+	{
+		return [];
+	}
+}
+
 class NewComponentNoListen extends NewComponent
 {
 	// this object does _not_ auto install global listeners during construction
@@ -311,6 +323,68 @@ class FooFooBehavior extends FooBehavior
 	public function faafaaEverMore($laa, $sol)
 	{
 		return sqrt($laa * $laa + $sol * $sol);
+	}
+}
+class OwnerVisibleMethodsBehavior extends TBehavior
+{
+	public function visibleMethod()
+	{
+		return 'visible';
+	}
+	public function hiddenMethod()
+	{
+		return 'hidden';
+	}
+	public function getOwnerVisibleMethods(): null|string|array
+	{
+		return ['visibleMethod'];
+	}
+}
+class OwnerVisibleMethodsClassBehavior extends TClassBehavior
+{
+	public function visibleClassMethod($obj)
+	{
+		return 'visibleClass';
+	}
+	public function hiddenClassMethod($obj)
+	{
+		return 'hiddenClass';
+	}
+	public function getOwnerVisibleMethods(): null|string|array
+	{
+		return 'visibleClassMethod';
+	}
+}
+class OwnerHiddenAllBehavior extends TBehavior
+{
+	protected $_dyCalled = false;
+	public function visibleMethod()
+	{
+		return 'visible';
+	}
+	public function dyTextFilter($text, $callchain)
+	{
+		$this->_dyCalled = true;
+		return str_replace('a', 'b', $callchain->dyTextFilter($text));
+	}
+	public function isDyCalled()
+	{
+		return $this->_dyCalled;
+	}
+	public function getOwnerVisibleMethods(): null|string|array
+	{
+		return [];
+	}
+}
+class OwnerVisibleComposedBehavior extends OwnerVisibleMethodsBehavior
+{
+	public function anotherVisibleMethod()
+	{
+		return 'another';
+	}
+	public function getOwnerVisibleMethods(): null|string|array
+	{
+		return array_merge((array) parent::getOwnerVisibleMethods(), ['anotherVisibleMethod']);
 	}
 }
 class FooBehaviorWithEvents extends FooBehavior


### PR DESCRIPTION
Caches for:
- `_bm` - Behavior Methods - caching for `dy` behavior-methods.
- `_cm` - (Owner) Callable Methods of Behaviors - caching for behaviors' owner callable methods.
- `_bv` - Behavior (owner-)Visible methods - Cache of IOwnerVisibleMethods