### PR TITLE
General Caching Refactor (Big)

### DIFF
--- a/framework/Caching/ICache.php
+++ b/framework/Caching/ICache.php
@@ -11,7 +11,7 @@
 namespace Prado\Caching;
 
 /**
- * ICache interface.
+ * ICache interface
  *
  * This interface must be implemented by cache managers.
  *
@@ -21,11 +21,17 @@ namespace Prado\Caching;
 interface ICache
 {
 	/**
+	 * Returns whether this cache backend's prerequisites are met.
+	 * @since 4.4.0
+	 */
+	public static function getIsAvailable(): bool;
+
+	/**
 	 * Retrieves a value from cache with a specified key.
 	 * @param string $id a key identifying the cached value
 	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get($id);
+	public function get(string $id): mixed;
 
 	/**
 	 * Stores a value identified by a key into cache.
@@ -35,10 +41,10 @@ interface ICache
 	 * @param string $id the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
-	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
+	 * @param ?ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function set($id, $value, $expire = 0, $dependency = null);
+	public function set(string $id, mixed $value, int $expire = 0, ?ICacheDependency $dependency = null): bool;
 
 	/**
 	 * Stores a value identified by a key into cache if the cache does not contain this key.
@@ -46,27 +52,21 @@ interface ICache
 	 * @param string $id the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
-	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
+	 * @param ?ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function add($id, $value, $expire = 0, $dependency = null);
+	public function add(string $id, mixed $value, int $expire = 0, ?ICacheDependency $dependency = null): bool;
 
 	/**
 	 * Deletes a value with the specified key from cache
 	 * @param string $id the key of the value to be deleted
 	 * @return bool if no error happens during deletion
 	 */
-	public function delete($id);
+	public function delete(string $id): bool;
 
 	/**
 	 * Deletes all values from cache.
 	 * Be careful of performing this operation if the cache is shared by multiple applications.
 	 */
-	public function flush();
-
-	/**
-	 * Returns whether this cache backend's prerequisites are met.
-	 * @since 4.4.0
-	 */
-	//public static function getIsAvailable(): bool;
+	public function flush(): void;
 }

--- a/framework/Caching/ICache.php
+++ b/framework/Caching/ICache.php
@@ -26,6 +26,7 @@ interface ICache
 	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
 	public function get($id);
+
 	/**
 	 * Stores a value identified by a key into cache.
 	 * If the cache already contains such a key, the existing value and
@@ -34,29 +35,38 @@ interface ICache
 	 * @param string $id the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
-	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labelled invalid.
+	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
 	public function set($id, $value, $expire = 0, $dependency = null);
+
 	/**
 	 * Stores a value identified by a key into cache if the cache does not contain this key.
 	 * Nothing will be done if the cache already contains the key.
 	 * @param string $id the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
-	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labelled invalid.
+	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
 	public function add($id, $value, $expire = 0, $dependency = null);
+
 	/**
 	 * Deletes a value with the specified key from cache
 	 * @param string $id the key of the value to be deleted
 	 * @return bool if no error happens during deletion
 	 */
 	public function delete($id);
+
 	/**
 	 * Deletes all values from cache.
 	 * Be careful of performing this operation if the cache is shared by multiple applications.
 	 */
 	public function flush();
+
+	/**
+	 * Returns whether this cache backend's prerequisites are met.
+	 * @since 4.4.0
+	 */
+	//public static function getIsAvailable(): bool;
 }

--- a/framework/Caching/ICache.php
+++ b/framework/Caching/ICache.php
@@ -31,7 +31,7 @@ interface ICache
 	 * @param string $id a key identifying the cached value
 	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get(string $id): mixed;
+	public function get($id);
 
 	/**
 	 * Stores a value identified by a key into cache.
@@ -44,7 +44,7 @@ interface ICache
 	 * @param ?ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function set(string $id, mixed $value, int $expire = 0, ?ICacheDependency $dependency = null): bool;
+	public function set($id, $value, $expire = 0, $dependency = null);
 
 	/**
 	 * Stores a value identified by a key into cache if the cache does not contain this key.
@@ -55,18 +55,18 @@ interface ICache
 	 * @param ?ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function add(string $id, mixed $value, int $expire = 0, ?ICacheDependency $dependency = null): bool;
+	public function add($id, $value, $expire = 0, $dependency = null);
 
 	/**
 	 * Deletes a value with the specified key from cache
 	 * @param string $id the key of the value to be deleted
 	 * @return bool if no error happens during deletion
 	 */
-	public function delete(string $id): bool;
+	public function delete($id);
 
 	/**
 	 * Deletes all values from cache.
 	 * Be careful of performing this operation if the cache is shared by multiple applications.
 	 */
-	public function flush(): void;
+	public function flush();
 }

--- a/framework/Caching/ICacheDependency.php
+++ b/framework/Caching/ICacheDependency.php
@@ -11,12 +11,13 @@
 namespace Prado\Caching;
 
 /**
- * ICacheDependency interface.
+ * ICacheDependency interface
  *
- * This interface must be implemented by classes meant to be used as
- * cache dependencies.
+ * Implemented by all cache dependency classes. A dependency determines whether
+ * a cached item has become stale since it was stored.
  *
- * Classes implementing this interface must support serialization and unserialization.
+ * Implementations must support serialization so that dependency state can persist
+ * across requests.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.0
@@ -24,7 +25,7 @@ namespace Prado\Caching;
 interface ICacheDependency
 {
 	/**
-	 * @return bool whether the dependency has changed. Defaults to false.
+	 * @return bool whether the cached item's dependency has changed since it was stored.
 	 */
-	public function getHasChanged();
+	public function getHasChanged(): bool;
 }

--- a/framework/Caching/ICacheSize.php
+++ b/framework/Caching/ICacheSize.php
@@ -46,7 +46,7 @@ interface ICacheSize
 	 *
 	 * @param int|string $value the maximum total size; 0 means unlimited
 	 */
-	public function setMaximumSize(int|string $value): void;
+	public function setMaximumSize($value);
 
 	/**
 	 * Returns the current total byte size of all cached entries.

--- a/framework/Caching/TAPCCache.php
+++ b/framework/Caching/TAPCCache.php
@@ -131,9 +131,7 @@ class TAPCCache extends TCache
 	}
 
 	/**
-	 * Deletes all values from cache.
-	 * Be careful of performing this operation if the cache is shared by multiple applications.
-	 * @return bool if no error happens during flush
+	 * @return bool true if no error happens during flush
 	 */
 	public function flush()
 	{

--- a/framework/Caching/TAPCCache.php
+++ b/framework/Caching/TAPCCache.php
@@ -96,7 +96,7 @@ class TAPCCache extends TCache
 	 * @param string $key a unique key identifying the cached value
 	 * @return mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue(string $key): mixed
+	protected function getValue($key)
 	{
 		return apcu_fetch($key);
 	}
@@ -107,7 +107,7 @@ class TAPCCache extends TCache
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue(string $key, mixed $value, int $expire): bool
+	protected function setValue($key, $value, $expire)
 	{
 		return apcu_store($key, $value, $expire);
 	}
@@ -118,7 +118,7 @@ class TAPCCache extends TCache
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue(string $key, mixed $value, int $expire): bool
+	protected function addValue($key, $value, $expire)
 	{
 		return apcu_add($key, $value, $expire);
 	}
@@ -127,7 +127,7 @@ class TAPCCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue(string $key): bool
+	protected function deleteValue($key)
 	{
 		return apcu_delete($key);
 	}
@@ -135,8 +135,8 @@ class TAPCCache extends TCache
 	/**
 	 * Deletes all values from cache.
 	 */
-	public function flush(): void
+	public function flush()
 	{
-		apcu_clear_cache();
+		return apcu_clear_cache();
 	}
 }

--- a/framework/Caching/TAPCCache.php
+++ b/framework/Caching/TAPCCache.php
@@ -18,7 +18,7 @@ use Prado\Exceptions\TConfigurationException;
  * TAPCCache implements a cache application module based on {@see http://www.php.net/apcu APCu}.
  *
  * By definition, cache does not ensure the existence of a value
- * even if it never expires. Cache is not meant to be an persistent storage.
+ * even if it never expires. Cache is not meant to be a persistent storage.
  *
  * To use this module, the APCu PHP extension must be loaded and set in the php.ini file.
  *
@@ -33,10 +33,10 @@ use Prado\Exceptions\TConfigurationException;
  * If loaded, TAPCCache will register itself with {@see \Prado\TApplication} as the
  * cache module. It can be accessed via {@see \Prado\TApplication::getCache()}.
  *
- * TAPCCache may be configured in application configuration file as follows
+ * XML configuration style:
  * ```xml
  * <modules>
- *     <module id="cache" class="Prado\Caching\TAPCCache" />
+ *   <module id="cache" class="Prado\Caching\TAPCCache" />
  * </modules>
  * ```
  *
@@ -44,7 +44,9 @@ use Prado\Exceptions\TConfigurationException;
  * ```php
  * return [
  *     'modules' => [
- *         'cache' => ['class' => 'Prado\Caching\TAPCCache'],
+ *         'cache' => [
+ *             'class' => 'Prado\Caching\TAPCCache',
+ *         ],
  *     ],
  * ];
  * ```
@@ -56,10 +58,20 @@ use Prado\Exceptions\TConfigurationException;
 class TAPCCache extends TCache
 {
 	/**
+	 * @return bool whether APCu is loaded, enabled, and (for CLI) `apc.enable_cli` is on.
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return extension_loaded('apcu')
+			&& ini_get('apc.enabled')
+			&& !(substr(php_sapi_name(), 0, 3) === 'cli' && !ini_get('apc.enable_cli'));
+	}
+
+	/**
 	 * Initializes this module.
 	 * This method is required by the IModule interface.
 	 * @param \Prado\Xml\TXmlElement $config configuration for this module, can be null
-	 * @throws TConfigurationException if apc extension is not installed or not started, check your php.ini
+	 * @throws TConfigurationException if the APCu extension is not installed, not enabled, or not enabled for CLI
 	 */
 	public function init($config)
 	{
@@ -79,8 +91,6 @@ class TAPCCache extends TCache
 	}
 
 	/**
-	 * Retrieves a value from cache with a specified key.
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
 	 */
@@ -90,9 +100,6 @@ class TAPCCache extends TCache
 	}
 
 	/**
-	 * Stores a value identified by a key in cache.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -104,9 +111,6 @@ class TAPCCache extends TCache
 	}
 
 	/**
-	 * Stores a value identified by a key into cache if the cache does not contain this key.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -118,10 +122,8 @@ class TAPCCache extends TCache
 	}
 
 	/**
-	 * Deletes a value with the specified key from cache
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key the key of the value to be deleted
-	 * @return bool if no error happens during deletion
+	 * @return bool true if no error happens during deletion
 	 */
 	protected function deleteValue($key)
 	{

--- a/framework/Caching/TAPCCache.php
+++ b/framework/Caching/TAPCCache.php
@@ -59,6 +59,7 @@ class TAPCCache extends TCache
 {
 	/**
 	 * @return bool whether APCu is loaded, enabled, and (for CLI) `apc.enable_cli` is on.
+	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{

--- a/framework/Caching/TAPCCache.php
+++ b/framework/Caching/TAPCCache.php
@@ -75,16 +75,18 @@ class TAPCCache extends TCache
 	 */
 	public function init($config)
 	{
-		if (!extension_loaded('apcu')) {
-			throw new TConfigurationException('apccache_extension_required');
-		}
+		if (!static::getIsAvailable()) {
+			if (!extension_loaded('apcu')) {
+				throw new TConfigurationException('apccache_extension_required');
+			}
 
-		if (ini_get('apc.enabled') == false) {
-			throw new TConfigurationException('apccache_extension_not_enabled');
-		}
+			if (ini_get('apc.enabled') == false) {
+				throw new TConfigurationException('apccache_extension_not_enabled');
+			}
 
-		if (substr(php_sapi_name(), 0, 3) === 'cli' && ini_get('apc.enable_cli') == false) {
-			throw new TConfigurationException('apccache_extension_not_enabled_cli');
+			if (substr(php_sapi_name(), 0, 3) === 'cli' && ini_get('apc.enable_cli') == false) {
+				throw new TConfigurationException('apccache_extension_not_enabled_cli');
+			}
 		}
 
 		parent::init($config);
@@ -92,31 +94,31 @@ class TAPCCache extends TCache
 
 	/**
 	 * @param string $key a unique key identifying the cached value
-	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
+	 * @return mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue($key)
+	protected function getValue(string $key): mixed
 	{
 		return apcu_fetch($key);
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function setValue(string $key, mixed $value, int $expire): bool
 	{
 		return apcu_store($key, $value, $expire);
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addValue(string $key, mixed $value, int $expire): bool
 	{
 		return apcu_add($key, $value, $expire);
 	}
@@ -125,16 +127,16 @@ class TAPCCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue($key)
+	protected function deleteValue(string $key): bool
 	{
 		return apcu_delete($key);
 	}
 
 	/**
-	 * @return bool true if no error happens during flush
+	 * Deletes all values from cache.
 	 */
-	public function flush()
+	public function flush(): void
 	{
-		return apcu_clear_cache();
+		apcu_clear_cache();
 	}
 }

--- a/framework/Caching/TAPCCache.php
+++ b/framework/Caching/TAPCCache.php
@@ -71,7 +71,7 @@ class TAPCCache extends TCache
 	/**
 	 * Initializes this module.
 	 * This method is required by the IModule interface.
-	 * @param \Prado\Xml\TXmlElement $config configuration for this module, can be null
+	 * @param null|array|\Prado\Xml\TXmlElement $config configuration for this module, can be null
 	 * @throws TConfigurationException if the APCu extension is not installed, not enabled, or not enabled for CLI
 	 */
 	public function init($config)

--- a/framework/Caching/TApplicationStateCacheDependency.php
+++ b/framework/Caching/TApplicationStateCacheDependency.php
@@ -10,20 +10,18 @@
 
 namespace Prado\Caching;
 
-use Prado\Prado;
 use Prado\TApplicationMode;
 
 /**
- * TApplicationStateCacheDependency class.
+ * TApplicationStateCacheDependency class
  *
- * TApplicationStateCacheDependency performs dependency checking based on
- * the mode of the currently running PRADO application.
- * The dependency is reported as unchanged if and only if the application
- * is running in performance mode.
+ * TApplicationStateCacheDependency reports a cache-dependency change whenever
+ * the application is not running in {@see \Prado\TApplicationMode::Performance} mode.
+ * In performance mode the dependency is reported as unchanged, allowing cached
+ * items to be reused without further staleness checks.
  *
- * You may chain this dependency together with other dependencies
- * so that only when the application is not in performance mode the other dependencies
- * will be checked.
+ * Combine this dependency with others via {@see \Prado\Caching\TChainedCacheDependency}
+ * to gate the remaining checks behind the performance-mode bypass.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
@@ -31,10 +29,11 @@ use Prado\TApplicationMode;
 class TApplicationStateCacheDependency extends TCacheDependency
 {
 	/**
-	 * @return bool true if the application is not running in performance mode.
+	 * @return bool `false` when the application is in performance mode (dependency
+	 *   has not changed); `true` for all other modes (dependency has changed).
 	 */
-	public function getHasChanged()
+	public function getHasChanged(): bool
 	{
-		return Prado::getApplication()->getMode() !== TApplicationMode::Performance;
+		return $this->getApplication()->getMode() !== TApplicationMode::Performance;
 	}
 }

--- a/framework/Caching/TApplicationStateCacheDependency.php
+++ b/framework/Caching/TApplicationStateCacheDependency.php
@@ -18,7 +18,7 @@ use Prado\TApplicationMode;
  *
  * TApplicationStateCacheDependency performs dependency checking based on
  * the mode of the currently running PRADO application.
- * The dependency is reportedly as unchanged if and only if the application
+ * The dependency is reported as unchanged if and only if the application
  * is running in performance mode.
  *
  * You may chain this dependency together with other dependencies
@@ -31,9 +31,7 @@ use Prado\TApplicationMode;
 class TApplicationStateCacheDependency extends TCacheDependency
 {
 	/**
-	 * Performs the actual dependency checking.
-	 * This method returns true if the currently running application is not in performance mode.
-	 * @return bool whether the dependency is changed or not.
+	 * @return bool true if the application is not running in performance mode.
 	 */
 	public function getHasChanged()
 	{

--- a/framework/Caching/TCache.php
+++ b/framework/Caching/TCache.php
@@ -220,6 +220,31 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 		return sha1($token);
 	}
 
+	/**
+	 * Returns the current Unix timestamp. Wraps the global {@see \time()} as a single
+	 * overridable seam so that subclasses and test doubles can control clock behavior
+	 * without modifying real system time.
+	 * @return int the current Unix timestamp in seconds
+	 * @since 4.4.0
+	 */
+	protected function time(): int
+	{
+		return \time();
+	}
+
+	/**
+	 * Returns the current Unix timestamp with microsecond resolution. Wraps the global
+	 * {@see \microtime()} as a single overridable seam so that subclasses and test
+	 * doubles can control sub-second clock behavior (e.g. for ordering
+	 * least-recently-used entries) without modifying real system time.
+	 * @return float the current Unix timestamp in seconds, with a fractional part
+	 * @since 4.4.0
+	 */
+	protected function microtime(): float
+	{
+		return \microtime(true);
+	}
+
 	// =========================================================================
 	// ICache implementation
 	// =========================================================================

--- a/framework/Caching/TCache.php
+++ b/framework/Caching/TCache.php
@@ -95,6 +95,10 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	// Lifecycle
 	// =========================================================================
 
+	/**
+	 * Seeds the cache key prefix with {@see DEFAULT_PREFIX} before construction completes.
+	 * @since 4.4.0
+	 */
 	public function __construct()
 	{
 		$this->setKeyPrefix(static::DEFAULT_PREFIX);

--- a/framework/Caching/TCache.php
+++ b/framework/Caching/TCache.php
@@ -27,11 +27,11 @@ use Prado\TPropertyValue;
  * - {@see flush()} : delete all values from cache
  *
  * Each value is associated with an expiration time. The {@see get()} operation
- * ensures that any expired value will not be returned. The expiration time by
- * the number of seconds. A expiration time 0 represents never expire.
+ * ensures that any expired value will not be returned. The expiration time is
+ * specified by the number of seconds. An expiration time of 0 means never expire.
  *
  * By definition, cache does not ensure the existence of a value
- * even if it never expires. Cache is not meant to be an persistent storage.
+ * even if it never expires. Cache is not meant to be a persistent storage.
  *
  * Child classes must implement the following methods:
  * - {@see getValue()}
@@ -39,10 +39,44 @@ use Prado\TPropertyValue;
  * - {@see addValue()}
  * - {@see deleteValue()}
  *
- * and optionally {@see flush()}
+ * and optionally {@see flush()}.
  *
  * Since version 3.1.2, TCache implements the \ArrayAccess interface such that
  * the cache acts as an array.
+ *
+ * When loaded as a module, a TCache subclass registers itself with
+ * {@see \Prado\TApplication} as the application cache (accessible via
+ * {@see \Prado\TApplication::getCache()}) unless {@see setPrimaryCache PrimaryCache}
+ * is set to `false`. Only one primary cache module may be loaded at a time.
+ *
+ * The {@see setKeyPrefix KeyPrefix} property may be used to namespace cache keys,
+ * which is useful when multiple applications share the same cache backend.
+ * By default it is set to {@see \Prado\TApplication::getUniqueID()}.
+ *
+ * XML configuration style, using {@see \Prado\Caching\TAPCCache} as a representative example:
+ * ```xml
+ * <modules>
+ *   <module id="cache" class="Prado\Caching\TMemCache"
+ *       PrimaryCache="true" KeyPrefix="myapp-" />
+ * </modules>
+ * ```
+ * where {@see getPrimaryCache PrimaryCache} and {@see getKeyPrefix KeyPrefix} are
+ * configurable properties inherited by all TCache subclasses.
+ *
+ * PHP configuration style:
+ * ```php
+ * return [
+ *     'modules' => [
+ *         'cache' => [
+ *             'class' => 'Prado\Caching\TMemCache',
+ *             'properties' => [
+ *                 'PrimaryCache' => 'true',
+ *                 'KeyPrefix' => 'myapp-',
+ *             ],
+ *         ],
+ *     ],
+ * ];
+ * ```
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.0
@@ -60,15 +94,14 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 */
 	public function init($config)
 	{
-		if ($this->_prefix === null) {
-			$this->_prefix = $this->getApplication()->getUniqueID();
+		if ($this->getKeyPrefix() === null) {
+			$this->setKeyPrefix($this->getApplication()?->getUniqueID() ?? '');
 		}
-		if ($this->_primary) {
-			if ($this->getApplication()->getCache() === null) {
-				$this->setAppCache();
-			} else {
-				throw new TConfigurationException('cache_primary_duplicated', $this::class);
+		if ($this->getPrimaryCache()) {
+			if ($this->getApplication()?->getCache() !== null) {
+				throw new TConfigurationException('cache_primary_duplicated', static::class);
 			}
+			$this->setAppCache();
 		}
 		parent::init($config);
 	}
@@ -76,7 +109,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	/**
 	 * Registers this module as the application cache when an application is available.
 	 * Called during {@see init()}; may also be called by behaviors or subclasses.
-	 * @since 4.4.0
+	 * @since 4.3.3
 	 */
 	protected function setAppCache()
 	{
@@ -94,7 +127,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	}
 
 	/**
-	 * @param bool $value whether this cache module is used as primary/system cache. Defaults to false.
+	 * @param bool $value whether this cache module is used as primary/system cache. Defaults to true.
 	 * @see getPrimaryCache
 	 */
 	public function setPrimaryCache($value)
@@ -125,7 +158,20 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 */
 	protected function generateUniqueKey($key)
 	{
-		return md5($this->_prefix . $key);
+		return $this->hashToken($this->getKeyPrefix() . $key);
+	}
+
+	/**
+	 * Hashes a token string for use as a cache key.
+	 * Override in a subclass to substitute a different hashing algorithm.
+	 * @param string $token the raw token to hash
+	 * @return string the hashed token
+	 * @since 4.3.3
+	 * @todo 4.4: change to sha1 for security
+	 */
+	protected function hashToken($token)
+	{
+		return md5($token);
 	}
 
 	/**
@@ -199,7 +245,6 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	/**
 	 * Deletes all values from cache.
 	 * Be careful of performing this operation if the cache is shared by multiple applications.
-	 * Child classes may implement this method to realize the flush operation.
 	 * @throws TNotSupportedException if this method is not overridden by child classes
 	 */
 	public function flush()
@@ -207,12 +252,15 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 		throw new TNotSupportedException('cache_flush_unsupported');
 	}
 
+	/*
+	 * Returns whether this cache backend's prerequisites (extensions, services) are met.
+	 * @since 4.4.0
+	 */
+	//abstract public static function getIsAvailable(): bool;
+
 	/**
 	 * Retrieves a value from cache with a specified key.
-	 * This method should be implemented by child classes to store the data
-	 * in specific cache storage. The uniqueness and dependency are handled
-	 * in {@see \Prado\Caching\TCache::get()} already. So only the implementation of data retrieval
-	 * is needed.
+	 * Uniqueness and dependency are handled by {@see get()}; implement storage retrieval only.
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
 	 */
@@ -220,11 +268,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 
 	/**
 	 * Stores a value identified by a key in cache.
-	 * This method should be implemented by child classes to store the data
-	 * in specific cache storage. The uniqueness and dependency are handled
-	 * in {@see \Prado\Caching\TCache::set()} already. So only the implementation of data storage
-	 * is needed.
-	 *
+	 * Uniqueness and dependency are handled by {@see set()}; implement storage write only.
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -234,11 +278,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 
 	/**
 	 * Stores a value identified by a key into cache if the cache does not contain this key.
-	 * This method should be implemented by child classes to store the data
-	 * in specific cache storage. The uniqueness and dependency are handled
-	 * in {@see \Prado\Caching\TCache::add()} already. So only the implementation of data storage
-	 * is needed.
-	 *
+	 * Uniqueness and dependency are handled by {@see add()}; implement storage write only.
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -247,10 +287,9 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	abstract protected function addValue($key, $value, $expire);
 
 	/**
-	 * Deletes a value with the specified key from cache
-	 * This method should be implemented by child classes to delete the data from actual cache storage.
+	 * Deletes a value with the specified key from cache.
 	 * @param string $key the key of the value to be deleted
-	 * @return bool if no error happens during deletion
+	 * @return bool true if no error happens during deletion
 	 */
 	abstract protected function deleteValue($key);
 

--- a/framework/Caching/TCache.php
+++ b/framework/Caching/TCache.php
@@ -109,7 +109,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * Initializes the cache module.
 	 * This method initializes the cache key prefix and registers the cache module
 	 * with the application if the cache is primary.
-	 * @param \Prado\Xml\TXmlElement $config the module configuration
+	 * @param null|array|\Prado\Xml\TXmlElement $config the module configuration
 	 */
 	public function init($config)
 	{

--- a/framework/Caching/TCache.php
+++ b/framework/Caching/TCache.php
@@ -12,6 +12,7 @@ namespace Prado\Caching;
 
 use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TNotSupportedException;
+use Prado\TModule;
 use Prado\TPropertyValue;
 
 /**
@@ -81,10 +82,24 @@ use Prado\TPropertyValue;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.0
  */
-abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
+abstract class TCache extends TModule implements ICache, \ArrayAccess
 {
-	private $_prefix;
-	private $_primary = true;
+	public const DEFAULT_PREFIX = '';
+
+	/** @var ?string unique key prefix for cached values, or null before initialization */
+	private ?string $_prefix = null;
+	/** @var bool whether this module is used as the primary application cache */
+	private bool $_primary = true;
+
+	// =========================================================================
+	// Lifecycle
+	// =========================================================================
+
+	public function __construct()
+	{
+		$this->setKeyPrefix(static::DEFAULT_PREFIX);
+		parent::__construct();
+	}
 
 	/**
 	 * Initializes the cache module.
@@ -94,7 +109,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 */
 	public function init($config)
 	{
-		if ($this->getKeyPrefix() === null) {
+		if ($this->getKeyPrefixDirect() === null) {
 			$this->setKeyPrefix($this->getApplication()?->getUniqueID() ?? '');
 		}
 		if ($this->getPrimaryCache()) {
@@ -109,28 +124,31 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	/**
 	 * Registers this module as the application cache when an application is available.
 	 * Called during {@see init()}; may also be called by behaviors or subclasses.
-	 * @since 4.3.3
+	 * @since 4.4.0
 	 */
-	protected function setAppCache()
+	protected function setAppCache(): void
 	{
 		$this->getApplication()?->setCache($this);
 	}
+
+	// =========================================================================
+	// Property Getters/Setters
+	// =========================================================================
 
 	/**
 	 * @return bool whether this cache module is used as primary/system cache.
 	 * A primary cache is used by PRADO core framework to cache data such as
 	 * parsed templates, themes, etc.
 	 */
-	public function getPrimaryCache()
+	public function getPrimaryCache(): bool
 	{
 		return $this->_primary;
 	}
 
 	/**
 	 * @param bool $value whether this cache module is used as primary/system cache. Defaults to true.
-	 * @see getPrimaryCache
 	 */
-	public function setPrimaryCache($value)
+	public function setPrimaryCache(bool $value): void
 	{
 		$this->_primary = TPropertyValue::ensureBoolean($value);
 	}
@@ -139,15 +157,34 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * @return string a unique prefix for the keys of cached values.
 	 * If it is not explicitly set, it will take the value of {@see \Prado\TApplication::getUniqueID}.
 	 */
-	public function getKeyPrefix()
+	public function getKeyPrefix(): string
+	{
+		return $this->getKeyPrefixDirect() ?? '';
+	}
+
+	/**
+	 * @param string $value a unique prefix for the keys of cached values
+	 */
+	public function setKeyPrefix(string $value): void
+	{
+		$this->setKeyPrefixDirect($value);
+	}
+
+	/**
+	 * @return string a unique prefix for the keys of cached values.
+	 * If it is not explicitly set, it will take the value of {@see \Prado\TApplication::getUniqueID}.
+	 * @since 4.4.0
+	 */
+	protected function getKeyPrefixDirect(): ?string
 	{
 		return $this->_prefix;
 	}
 
 	/**
 	 * @param string $value a unique prefix for the keys of cached values
+	 * @since 4.4.0
 	 */
-	public function setKeyPrefix($value)
+	protected function setKeyPrefixDirect(string $value): void
 	{
 		$this->_prefix = $value;
 	}
@@ -156,9 +193,19 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * @param string $key a key identifying a value to be cached
 	 * @return string a key generated from the provided key which ensures the uniqueness across applications
 	 */
-	protected function generateUniqueKey($key)
+	protected function generateUniqueKey(string $key): string
 	{
-		return $this->hashToken($this->getKeyPrefix() . $key);
+		return $this->hashToken($this->generateToken($key));
+	}
+
+	/**
+	 * @param string $key a key identifying a value to be cached
+	 * @return string a key generated from the provided key which ensures the uniqueness across applications
+	 * @since 4.4.0
+	 */
+	protected function generateToken(string $key): string
+	{
+		return $this->getKeyPrefix() . $key;
 	}
 
 	/**
@@ -166,20 +213,23 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * Override in a subclass to substitute a different hashing algorithm.
 	 * @param string $token the raw token to hash
 	 * @return string the hashed token
-	 * @since 4.3.3
-	 * @todo 4.4: change to sha1 for security
+	 * @since 4.4.0
 	 */
-	protected function hashToken($token)
+	protected function hashToken(string $token): string
 	{
-		return md5($token);
+		return sha1($token);
 	}
+
+	// =========================================================================
+	// ICache implementation
+	// =========================================================================
 
 	/**
 	 * Retrieves a value from cache with a specified key.
 	 * @param string $id a key identifying the cached value
-	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
+	 * @return mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get($id)
+	public function get(string $id): mixed
 	{
 		if (($data = $this->getValue($this->generateUniqueKey($id))) !== false) {
 			if (!is_array($data)) {
@@ -201,10 +251,10 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * @param string $id the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
-	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
+	 * @param ?ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function set($id, $value, $expire = 0, $dependency = null)
+	public function set(string $id, mixed $value, int $expire = 0, ?ICacheDependency $dependency = null): bool
 	{
 		if (empty($value) && $expire === 0) {
 			return $this->delete($id);
@@ -223,7 +273,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function add($id, $value, $expire = 0, $dependency = null)
+	public function add(string $id, mixed $value, int $expire = 0, $dependency = null): bool
 	{
 		if (empty($value) && $expire === 0) {
 			return false;
@@ -237,7 +287,7 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * @param string $id the key of the value to be deleted
 	 * @return bool if no error happens during deletion
 	 */
-	public function delete($id)
+	public function delete(string $id): bool
 	{
 		return $this->deleteValue($this->generateUniqueKey($id));
 	}
@@ -247,51 +297,65 @@ abstract class TCache extends \Prado\TModule implements ICache, \ArrayAccess
 	 * Be careful of performing this operation if the cache is shared by multiple applications.
 	 * @throws TNotSupportedException if this method is not overridden by child classes
 	 */
-	public function flush()
+	public function flush(): void
 	{
 		throw new TNotSupportedException('cache_flush_unsupported');
 	}
+
+	// =========================================================================
+	// Subclass Provider Methods
+	// =========================================================================
 
 	/*
 	 * Returns whether this cache backend's prerequisites (extensions, services) are met.
 	 * @since 4.4.0
 	 */
-	//abstract public static function getIsAvailable(): bool;
+	abstract public static function getIsAvailable(): bool;
 
 	/**
 	 * Retrieves a value from cache with a specified key.
 	 * Uniqueness and dependency are handled by {@see get()}; implement storage retrieval only.
+	 * Returns `false` on a cache miss; returns the stored mixed value (an array of
+	 * `[$value, $dependency]`) on a hit.
 	 * @param string $key a unique key identifying the cached value
-	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
+	 * @return false|mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	abstract protected function getValue($key);
+	abstract protected function getValue(string $key): mixed;
 
 	/**
 	 * Stores a value identified by a key in cache.
 	 * Uniqueness and dependency are handled by {@see set()}; implement storage write only.
+	 * The `$value` parameter receives a `[$value, $dependency]` array; backends are
+	 * responsible for any serialization required by their storage layer.
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached (a two-element array of value + dependency)
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	abstract protected function setValue($key, $value, $expire);
+	abstract protected function setValue(string $key, mixed $value, int $expire): bool;
 
 	/**
 	 * Stores a value identified by a key into cache if the cache does not contain this key.
 	 * Uniqueness and dependency are handled by {@see add()}; implement storage write only.
+	 * The `$value` parameter receives a `[$value, $dependency]` array; backends are
+	 * responsible for any serialization required by their storage layer.
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached (a two-element array of value + dependency)
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	abstract protected function addValue($key, $value, $expire);
+	abstract protected function addValue(string $key, mixed $value, int $expire): bool;
 
 	/**
 	 * Deletes a value with the specified key from cache.
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	abstract protected function deleteValue($key);
+	abstract protected function deleteValue(string $key): bool;
+
+	// =========================================================================
+	// \ArrayAccess
+	// =========================================================================
 
 	/**
 	 * Returns whether there is a cache entry with a specified key.

--- a/framework/Caching/TCache.php
+++ b/framework/Caching/TCache.php
@@ -126,7 +126,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * Called during {@see init()}; may also be called by behaviors or subclasses.
 	 * @since 4.4.0
 	 */
-	protected function setAppCache(): void
+	protected function setAppCache()
 	{
 		$this->getApplication()?->setCache($this);
 	}
@@ -140,7 +140,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * A primary cache is used by PRADO core framework to cache data such as
 	 * parsed templates, themes, etc.
 	 */
-	public function getPrimaryCache(): bool
+	public function getPrimaryCache()
 	{
 		return $this->_primary;
 	}
@@ -148,7 +148,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	/**
 	 * @param bool $value whether this cache module is used as primary/system cache. Defaults to true.
 	 */
-	public function setPrimaryCache(bool $value): void
+	public function setPrimaryCache($value)
 	{
 		$this->_primary = TPropertyValue::ensureBoolean($value);
 	}
@@ -157,7 +157,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @return string a unique prefix for the keys of cached values.
 	 * If it is not explicitly set, it will take the value of {@see \Prado\TApplication::getUniqueID}.
 	 */
-	public function getKeyPrefix(): string
+	public function getKeyPrefix()
 	{
 		return $this->getKeyPrefixDirect() ?? '';
 	}
@@ -165,7 +165,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	/**
 	 * @param string $value a unique prefix for the keys of cached values
 	 */
-	public function setKeyPrefix(string $value): void
+	public function setKeyPrefix($value)
 	{
 		$this->setKeyPrefixDirect($value);
 	}
@@ -193,7 +193,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param string $key a key identifying a value to be cached
 	 * @return string a key generated from the provided key which ensures the uniqueness across applications
 	 */
-	protected function generateUniqueKey(string $key): string
+	protected function generateUniqueKey($key)
 	{
 		return $this->hashToken($this->generateToken($key));
 	}
@@ -229,7 +229,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param string $id a key identifying the cached value
 	 * @return mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get(string $id): mixed
+	public function get($id)
 	{
 		if (($data = $this->getValue($this->generateUniqueKey($id))) !== false) {
 			if (!is_array($data)) {
@@ -254,7 +254,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param ?ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function set(string $id, mixed $value, int $expire = 0, ?ICacheDependency $dependency = null): bool
+	public function set($id, $value, $expire = 0, $dependency = null)
 	{
 		if (empty($value) && $expire === 0) {
 			return $this->delete($id);
@@ -273,7 +273,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function add(string $id, mixed $value, int $expire = 0, $dependency = null): bool
+	public function add($id, $value, $expire = 0, $dependency = null)
 	{
 		if (empty($value) && $expire === 0) {
 			return false;
@@ -287,7 +287,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param string $id the key of the value to be deleted
 	 * @return bool if no error happens during deletion
 	 */
-	public function delete(string $id): bool
+	public function delete($id)
 	{
 		return $this->deleteValue($this->generateUniqueKey($id));
 	}
@@ -297,7 +297,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * Be careful of performing this operation if the cache is shared by multiple applications.
 	 * @throws TNotSupportedException if this method is not overridden by child classes
 	 */
-	public function flush(): void
+	public function flush()
 	{
 		throw new TNotSupportedException('cache_flush_unsupported');
 	}
@@ -320,7 +320,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	abstract protected function getValue(string $key): mixed;
+	abstract protected function getValue($key);
 
 	/**
 	 * Stores a value identified by a key in cache.
@@ -332,7 +332,7 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	abstract protected function setValue(string $key, mixed $value, int $expire): bool;
+	abstract protected function setValue($key, $value, $expire);
 
 	/**
 	 * Stores a value identified by a key into cache if the cache does not contain this key.
@@ -344,14 +344,14 @@ abstract class TCache extends TModule implements ICache, \ArrayAccess
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	abstract protected function addValue(string $key, mixed $value, int $expire): bool;
+	abstract protected function addValue($key, $value, $expire);
 
 	/**
 	 * Deletes a value with the specified key from cache.
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	abstract protected function deleteValue(string $key): bool;
+	abstract protected function deleteValue($key);
 
 	// =========================================================================
 	// \ArrayAccess

--- a/framework/Caching/TCacheDependency.php
+++ b/framework/Caching/TCacheDependency.php
@@ -10,33 +10,29 @@
 
 namespace Prado\Caching;
 
+use Prado\TApplicationComponent;
+
 /**
- * TCacheDependency class.
+ * TCacheDependency class
  *
- * TCacheDependency is the base class implementing {@see \Prado\Caching\ICacheDependency} interface.
- * Descendant classes must implement {@see \Prado\Caching\ICacheDependency::getHasChanged()} to provide
- * actual dependency checking logic.
+ * TCacheDependency is the abstract base class for all cache dependency implementations.
+ * Subclasses must implement {@see \Prado\Caching\ICacheDependency::getHasChanged()} to provide
+ * the actual staleness-detection logic.
  *
- * The property value of {@see \Prado\Caching\ICacheDependency::getHasChanged() HasChanged} tells whether
- * the dependency is changed or not.
+ * Because dependency objects are often serialized so that they can persist across
+ * requests, subclasses that hold resource handles (database connections, file handles,
+ * and so on) must implement `__sleep()` and `__wakeup()` accordingly.
  *
- * You may disable the dependency checking by setting {@see setEnabled() Enabled}
- * to false.
- *
- * Note, since the dependency objects often need to be serialized so that
- * they can persist across requests, you may need to implement __sleep() and
- * __wakeup() if the dependency objects contain resource handles which are
- * not serializable.
- *
- * Currently, the following dependency classes are provided in the PRADO release:
- * - {@see \Prado\Caching\TFileCacheDependency}: checks whether a file is changed or not
- * - {@see \Prado\Caching\TDirectoryCacheDependency}: checks whether a directory is changed or not
- * - {@see \Prado\Caching\TGlobalStateCacheDependency}: checks whether a global state is changed or not
- * - {@see \Prado\Caching\TChainedCacheDependency}: checks whether any of a list of dependencies is changed or not
+ * The following dependency classes are included in PRADO:
+ * - {@see \Prado\Caching\TFileCacheDependency}: reports a change when a file's mtime changes.
+ * - {@see \Prado\Caching\TDirectoryCacheDependency}: reports a change when any file in a directory changes.
+ * - {@see \Prado\Caching\TGlobalStateCacheDependency}: reports a change when a global application state changes.
+ * - {@see \Prado\Caching\TApplicationStateCacheDependency}: reports a change when the application is not in performance mode.
+ * - {@see \Prado\Caching\TChainedCacheDependency}: reports a change when any dependency in a list has changed.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
  */
-abstract class TCacheDependency extends \Prado\TComponent implements ICacheDependency
+abstract class TCacheDependency extends TApplicationComponent implements ICacheDependency
 {
 }

--- a/framework/Caching/TCacheDependencyList.php
+++ b/framework/Caching/TCacheDependencyList.php
@@ -14,13 +14,14 @@ use Prado\Collections\TList;
 use Prado\Exceptions\TInvalidDataTypeException;
 
 /**
- * TCacheDependencyList class.
+ * TCacheDependencyList class
  *
- * TCacheDependencyList represents a list of cache dependency objects.
- * Only objects implementing {@see \Prado\Caching\ICacheDependency} can be added into this list.
+ * TCacheDependencyList is a typed list that only accepts objects implementing
+ * {@see \Prado\Caching\ICacheDependency}. It is used by
+ * {@see \Prado\Caching\TChainedCacheDependency} to hold a chain of dependencies.
  *
- * TCacheDependencyList can be used like an array. See {@see \Prado\Collections\TList}
- * for more details.
+ * The list supports all standard {@see \Prado\Collections\TList} operations
+ * (add, remove, count, iterate, array-access).
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
@@ -29,11 +30,11 @@ class TCacheDependencyList extends TList
 {
 	/**
 	 * Inserts an item at the specified position.
-	 * This overrides the parent implementation by performing additional type checking
-	 * for each newly added item.
-	 * @param int $index the specified position.
-	 * @param mixed $item new item
-	 * @throws TInvalidDataTypeException if the item to be inserted is not a dependency instance
+	 * Overrides the parent to enforce that every item implements
+	 * {@see \Prado\Caching\ICacheDependency}.
+	 * @param int $index the zero-based position at which to insert.
+	 * @param mixed $item the dependency to insert.
+	 * @throws TInvalidDataTypeException if `$item` does not implement {@see \Prado\Caching\ICacheDependency}.
 	 */
 	public function insertAt($index, $item)
 	{

--- a/framework/Caching/TCacheFileTrait.php
+++ b/framework/Caching/TCacheFileTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * TCacheFileTrait class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Caching;
+
+/**
+ * TCacheFileTrait trait
+ *
+ * Provides the shared filesystem read/write helpers used by the file-persisting
+ * cache modules ({@see TFileCache} and {@see TMemoryCache}). Each method is a thin,
+ * overridable seam so that subclasses and test doubles can intercept file I/O.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+trait TCacheFileTrait
+{
+	/**
+	 * Reads and returns the entire contents of a file.
+	 * Returns false when the file cannot be read.
+	 *
+	 * @param string $filePath the path of the file to read
+	 * @return false|string the file contents, or false on failure
+	 */
+	protected function getContents(string $filePath): string|false
+	{
+		return @file_get_contents($filePath);
+	}
+
+	/**
+	 * Writes data to a file, replacing its current contents.
+	 *
+	 * @param string $filePath the path of the file to write
+	 * @param string $data the data to write
+	 * @param bool $exclusive when true, the write acquires an exclusive lock (`LOCK_EX`);
+	 *   when false (default), no lock is used — atomicity is expected to be provided by
+	 *   the caller (e.g. a `tempnam()` + `rename()` pattern)
+	 * @return false|int the number of bytes written, or false on failure
+	 */
+	protected function putContents(string $filePath, string $data, bool $exclusive = false): int|false
+	{
+		return @file_put_contents($filePath, $data, $exclusive ? LOCK_EX : 0);
+	}
+}

--- a/framework/Caching/TCacheSizeTrait.php
+++ b/framework/Caching/TCacheSizeTrait.php
@@ -11,7 +11,11 @@
 namespace Prado\Caching;
 
 /**
- * TCacheSizeTrait provides a byte-cap and **Least Recently Used** eviction for cache modules.
+ * TCacheSizeTrait trait
+ *
+ * TCacheSizeTrait provides a byte-cap with size-driven eviction for cache modules. The
+ * eviction order is chosen by the implementing class in {@see evictToFitMaximumSize()}
+ * (for example least-recently-used or soonest-to-expire).
  *
  * Implementing classes must also implement {@see ICacheSize}, which defines the public
  * size-management contract and the {@see ICacheSize::SIZE_NOT_COMPUTED} sentinel constant.

--- a/framework/Caching/TCacheSizeTrait.php
+++ b/framework/Caching/TCacheSizeTrait.php
@@ -10,6 +10,8 @@
 
 namespace Prado\Caching;
 
+use Prado\TPropertyValue;
+
 /**
  * TCacheSizeTrait trait
  *
@@ -289,8 +291,9 @@ trait TCacheSizeTrait
 	 *
 	 * @param int|string $value the maximum total size; 0 means unlimited
 	 */
-	public function setMaximumSize(int|string $value): void
+	public function setMaximumSize($value)
 	{
+		$value = is_int($value) ? $value : TPropertyValue::ensureString($value);
 		$this->setMaximumSizeDirect(max(0, static::parseSizeString($value)));
 		$this->enforceMaximumSize();
 	}
@@ -315,8 +318,8 @@ trait TCacheSizeTrait
 	 */
 	protected static function parseSizeString(int|string $value): int
 	{
-		if (is_int($value)) {
-			return $value;
+		if (is_numeric($value)) {
+			return (int) $value;
 		}
 		$value = trim($value);
 		if (!preg_match('/^(\d+)\s*([KMGTP]?)B?$/i', $value, $m)) {

--- a/framework/Caching/TChainedCacheDependency.php
+++ b/framework/Caching/TChainedCacheDependency.php
@@ -11,42 +11,75 @@
 namespace Prado\Caching;
 
 /**
- * TChainedCacheDependency class.
+ * TChainedCacheDependency class
  *
- * TChainedCacheDependency represents a list of cache dependency objects
- * and performs the dependency checking based on the checking results of
- * these objects. If any of them reports a dependency change, TChainedCacheDependency
- * will return true for the checking.
+ * TChainedCacheDependency represents a list of {@see \Prado\Caching\ICacheDependency}
+ * objects and reports a dependency change when any one of them has changed.
  *
- * To add dependencies to TChainedCacheDependency, use {@see \Prado\Caching\TChainedCacheDependency::getDependencies() Dependencies }
- * which gives a {@see \Prado\Caching\TCacheDependencyList} instance and can be used like an array
- * (see {@see \Prado\Collections\TList} for more details).
+ * Dependencies are added via {@see getDependencies()}, which returns a
+ * {@see \Prado\Caching\TCacheDependencyList} that can be used like an array
+ * (see {@see \Prado\Collections\TList} for details). The list is created lazily
+ * on first access.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
  */
 class TChainedCacheDependency extends TCacheDependency
 {
-	private $_dependencies;
+	/** @var ?TCacheDependencyList lazily created list of chained dependencies */
+	private ?TCacheDependencyList $_dependencies = null;
 
 	/**
-	 * @return TCacheDependencyList list of dependency objects
+	 * Creates a new {@see \Prado\Caching\TCacheDependencyList} instance.
+	 * Override in a subclass to return a custom list type.
+	 * @return TCacheDependencyList a new dependency list.
+	 * @since 4.4.0
 	 */
-	public function getDependencies()
+	protected function newCacheDependencyList(): TCacheDependencyList
 	{
-		if ($this->_dependencies === null) {
-			$this->_dependencies = new TCacheDependencyList();
-		}
+		return new TCacheDependencyList();
+	}
+
+	/**
+	 * Returns the stored dependency list without lazy initialization.
+	 * @return ?TCacheDependencyList the stored list, or `null` if not yet created.
+	 * @since 4.4.0
+	 */
+	protected function getDependenciesDirect(): ?TCacheDependencyList
+	{
 		return $this->_dependencies;
 	}
 
 	/**
-	 * @return bool true if any dependency in the chain has changed.
+	 * Stores the dependency list directly without side effects.
+	 * @param ?TCacheDependencyList $value the list to store.
+	 * @since 4.4.0
 	 */
-	public function getHasChanged()
+	protected function setDependenciesDirect(?TCacheDependencyList $value): void
 	{
-		if ($this->_dependencies !== null) {
-			foreach ($this->_dependencies as $dependency) {
+		$this->_dependencies = $value;
+	}
+
+	/**
+	 * Returns the list of dependency objects, creating it on first access.
+	 * @return TCacheDependencyList the dependency list.
+	 */
+	public function getDependencies(): TCacheDependencyList
+	{
+		if ($this->getDependenciesDirect() === null) {
+			$this->setDependenciesDirect($this->newCacheDependencyList());
+		}
+		return $this->getDependenciesDirect();
+	}
+
+	/**
+	 * @return bool whether any dependency in the chain has reported a change.
+	 */
+	public function getHasChanged(): bool
+	{
+		$dependencies = $this->getDependenciesDirect();
+		if ($dependencies !== null) {
+			foreach ($dependencies as $dependency) {
 				if ($dependency->getHasChanged()) {
 					return true;
 				}

--- a/framework/Caching/TChainedCacheDependency.php
+++ b/framework/Caching/TChainedCacheDependency.php
@@ -10,6 +10,8 @@
 
 namespace Prado\Caching;
 
+use Prado\Prado;
+
 /**
  * TChainedCacheDependency class
  *
@@ -37,7 +39,7 @@ class TChainedCacheDependency extends TCacheDependency
 	 */
 	protected function newCacheDependencyList(): TCacheDependencyList
 	{
-		return new TCacheDependencyList();
+		return Prado::createComponent(TCacheDependencyList::class);
 	}
 
 	/**

--- a/framework/Caching/TChainedCacheDependency.php
+++ b/framework/Caching/TChainedCacheDependency.php
@@ -41,10 +41,7 @@ class TChainedCacheDependency extends TCacheDependency
 	}
 
 	/**
-	 * Performs the actual dependency checking.
-	 * This method returns true if any of the dependency objects
-	 * reports a dependency change.
-	 * @return bool whether the dependency is changed or not.
+	 * @return bool true if any dependency in the chain has changed.
 	 */
 	public function getHasChanged()
 	{

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -18,6 +18,7 @@ use Prado\Data\TDbPropertiesTrait;
 use Prado\Exceptions\TConfigurationException;
 use Prado\TPropertyValue;
 use Prado\Util\Cron\TCronTaskInfo;
+use Prado\Util\IDbModule;
 
 /**
  * TDbCache class
@@ -111,7 +112,7 @@ use Prado\Util\Cron\TCronTaskInfo;
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
  */
-class TDbCache extends TCache implements \Prado\Util\IDbModule
+class TDbCache extends TSerializingCache implements IDbModule
 {
 	use TDbPropertiesTrait {
 		getDbConnection as getTraitDbConnection;
@@ -126,19 +127,22 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 */
 	private $_flushInterval = 60;
 	/**
-	 * @var bool
+	 * @var bool whether the cache table has been verified or created for this request
 	 */
 	private $_cacheInitialized = false;
 	/**
-	 * @var bool
+	 * @var bool whether the cache table existence has already been confirmed in this request
 	 */
 	private $_createCheck = false;
 	/**
 	 * @var bool whether the cache DB table should be created automatically
 	 */
 	private $_autoCreate = true;
+	/** @var string username for establishing the DB connection */
 	private $_username = '';
+	/** @var string password for establishing the DB connection */
 	private $_password = '';
+	/** @var string DSN connection string for the DB connection */
 	private $_connectionString = '';
 
 	/**
@@ -213,7 +217,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @throws TConfigurationException if any error happens during creating database or cache table.
 	 * @since 3.1.5
 	 */
-	protected function initializeCache($force = false)
+	protected function initializeCache(bool $force = false)
 	{
 		if ($this->getIsCacheInitialized() && !$force) {
 			return;
@@ -271,7 +275,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @param bool $force override {@see \Prado\Caching\TDbCache::setFlushInterval() FlushInterval} and force deletion of expired items
 	 * @since 3.1.5
 	 */
-	public function flushCacheExpired($force = false)
+	public function flushCacheExpired(bool $force = false)
 	{
 		$interval = $this->getFlushInterval();
 		if (!$force && $interval === 0) {
@@ -307,7 +311,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @return int Interval in sec expired items will be removed from cache. Default to 60
 	 * @since 3.1.5
 	 */
-	public function getFlushInterval()
+	public function getFlushInterval(): int
 	{
 		return $this->_flushInterval;
 	}
@@ -321,9 +325,9 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @param int $value Interval in sec
 	 * @since 3.1.5
 	 */
-	public function setFlushInterval($value)
+	public function setFlushInterval(int $value)
 	{
-		$this->_flushInterval = (int) $value;
+		$this->_flushInterval = $value;
 	}
 
 	/**
@@ -364,7 +368,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @return string the SQLite database filename within the PRADO runtime path.
 	 * @since 4.3.3
 	 */
-	protected function getSqliteDatabaseName()
+	protected function getSqliteDatabaseName(): string
 	{
 		return 'sqlite3.cache';
 	}
@@ -372,7 +376,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	/**
 	 * @return string The Data Source Name, or DSN, contains the information required to connect to the database.
 	 */
-	public function getConnectionString()
+	public function getConnectionString(): string
 	{
 		return $this->_connectionString;
 	}
@@ -381,7 +385,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @param string $value The Data Source Name, or DSN, contains the information required to connect to the database.
 	 * @see http://www.php.net/manual/en/function.pdo-construct.php
 	 */
-	public function setConnectionString($value)
+	public function setConnectionString(string $value)
 	{
 		$this->_connectionString = $value;
 	}
@@ -389,7 +393,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	/**
 	 * @return string the username for establishing DB connection. Defaults to empty string.
 	 */
-	public function getUsername()
+	public function getUsername(): string
 	{
 		return $this->_username;
 	}
@@ -397,7 +401,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	/**
 	 * @param string $value the username for establishing DB connection
 	 */
-	public function setUsername($value)
+	public function setUsername(string $value)
 	{
 		$this->_username = $value;
 	}
@@ -413,7 +417,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	/**
 	 * @param string $value the password for establishing DB connection
 	 */
-	public function setPassword(#[\SensitiveParameter] $value)
+	public function setPassword(#[\SensitiveParameter] string $value)
 	{
 		$this->_password = $value;
 	}
@@ -446,7 +450,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @param string $value the name of the DB table to store cache content
 	 * @see setAutoCreateCacheTable
 	 */
-	public function setCacheTableName($value)
+	public function setCacheTableName(string $value)
 	{
 		$this->_cacheTable = $value;
 	}
@@ -464,16 +468,16 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @param bool $value whether the cache DB table should be automatically created if not exists.
 	 * @see setCacheTableName
 	 */
-	public function setAutoCreateCacheTable($value)
+	public function setAutoCreateCacheTable(bool $value)
 	{
 		$this->_autoCreate = TPropertyValue::ensureBoolean($value);
 	}
 
 	/**
 	 * @param string $key a unique key identifying the cached value
-	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
+	 * @return false|string the serialized value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue($key)
+	protected function getSerializedValue(string $key): false|string
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -482,20 +486,20 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 		$sql = 'SELECT value FROM ' . $this->getCacheTableName() . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>=' . time() . ') ORDER BY expire DESC';
 		$command = $this->getDbConnection()->createCommand($sql);
 		try {
-			return unserialize($command->queryScalar());
+			return $command->queryScalar();
 		} catch (\Exception $e) {
 			$this->initializeCache(true);
-			return unserialize($command->queryScalar());
+			return $command->queryScalar();
 		}
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function setSerializedValue(string $key, string $value, int $expire): bool
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -522,7 +526,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			}
 			$command = $db->createCommand($sql);
 			$command->bindValue(':key', $key, \PDO::PARAM_STR);
-			$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);
+			$command->bindValue(':value', $value, \PDO::PARAM_LOB);
 
 			try {
 				$command->execute();
@@ -541,7 +545,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			$transaction = $this->getDbConnection()->getCurrentTransaction() ?? $this->getDbConnection()->beginTransaction();
 
 			$this->deleteValue($key);
-			$return = $this->addValue($key, $value, $expire);
+			$return = $this->addSerializedValue($key, $value, $expire);
 
 			if (!$isCurrentTransaction) {
 				$transaction->commit();
@@ -553,11 +557,11 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addSerializedValue(string $key, string $value, int $expire): bool
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -566,7 +570,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 		$sql = "INSERT INTO {$this->getCacheTableName()} (itemkey,value,expire) VALUES(:key,:value,$expire)";
 		$command = $this->getDbConnection()->createCommand($sql);
 		$command->bindValue(':key', $key, \PDO::PARAM_STR);
-		$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);
+		$command->bindValue(':value', $value, \PDO::PARAM_LOB);
 
 		try {
 			$command->execute();
@@ -586,7 +590,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue($key)
+	protected function deleteValue(string $key): bool
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -605,9 +609,9 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	}
 
 	/**
-	 * @return bool true if no error happens during flush
+	 * Deletes all values from cache.
 	 */
-	public function flush()
+	public function flush(): void
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -619,11 +623,8 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			try {
 				$this->initializeCache(true);
 				$command->execute();
-				return true;
 			} catch (\Exception $e) {
-				return false;
 			}
 		}
-		return true;
 	}
 }

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -239,7 +239,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 				$db->createCommand($sql)->queryScalar();
 
 				$this->_createCheck = true;
-				$this->getApplication()->setGlobalState($key, time());
+				$this->getApplication()->setGlobalState($key, $this->time());
 			}
 		} catch (\Exception $e) {
 			// DB table not exists
@@ -262,7 +262,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 				$db->createCommand($sql)->execute();
 
 				$this->_createCheck = true;
-				$this->getApplication()->setGlobalState($key, time());
+				$this->getApplication()->setGlobalState($key, $this->time());
 			} else {
 				throw new TConfigurationException('db_cachetable_inexistent', $cacheTable);
 			}
@@ -283,7 +283,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 		}
 		$cacheTable = $this->getCacheTableName();
 		$key = 'TDbCache:' . $cacheTable . ':flushed';
-		$now = time();
+		$now = $this->time();
 		$next = $interval + (int) $this->getApplication()->getGlobalState($key, 0);
 
 		if ($force || $next <= $now) {
@@ -304,7 +304,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 */
 	public function fxGetCronTaskInfos($sender, $param)
 	{
-		return new TCronTaskInfo('dbcacheflushexpired', $this->getId() . '->flushCacheExpired(true)', $this, Prado::localize('DbCache Flush Expired Keys'), Prado::localize('This manually clears out the expired keys of TDbCache.'));
+		return Prado::createComponent(TCronTaskInfo::class, 'dbcacheflushexpired', $this->getId() . '->flushCacheExpired(true)', $this, Prado::localize('DbCache Flush Expired Keys'), Prado::localize('This manually clears out the expired keys of TDbCache.'));
 	}
 
 	/**
@@ -351,7 +351,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 		if (empty($connectionString)) {
 			return null;
 		}
-		$db = new TDbConnection();
+		$db = Prado::createComponent(TDbConnection::class);
 		$db->setConnectionString($connectionString);
 		$username = $this->getUsername();
 		if ($username !== '') {
@@ -483,7 +483,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 			$this->initializeCache();
 		}
 
-		$sql = 'SELECT value FROM ' . $this->getCacheTableName() . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>=' . time() . ') ORDER BY expire DESC';
+		$sql = 'SELECT value FROM ' . $this->getCacheTableName() . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>=' . $this->time() . ') ORDER BY expire DESC';
 		$command = $this->getDbConnection()->createCommand($sql);
 		try {
 			return $command->queryScalar();
@@ -507,7 +507,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 		$db = $this->getDbConnection();
 		$driver = $db->getDriverName();
 		if (in_array($driver, [TDbDriver::DRIVER_MYSQL, TDbDriver::EXTENSION_MYSQLI, TDbDriver::DRIVER_SQLITE, TDbDriver::DRIVER_IBM, TDbDriver::DRIVER_OCI, TDbDriver::DRIVER_SQLSRV, TDbDriver::EXTENSION_MSSQL, TDbDriver::DRIVER_DBLIB, TDbDriver::DRIVER_PGSQL])) {
-			$expire = ($expire <= 0) ? 0 : time() + $expire;
+			$expire = ($expire <= 0) ? 0 : $this->time() + $expire;
 			$cacheTable = $this->getCacheTableName();
 			if (in_array($driver, [TDbDriver::DRIVER_MYSQL, TDbDriver::EXTENSION_MYSQLI, TDbDriver::DRIVER_SQLITE])) {
 				$sql = "REPLACE INTO {$cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
@@ -566,7 +566,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
 		}
-		$expire = ($expire <= 0) ? 0 : time() + $expire;
+		$expire = ($expire <= 0) ? 0 : $this->time() + $expire;
 		$sql = "INSERT INTO {$this->getCacheTableName()} (itemkey,value,expire) VALUES(:key,:value,$expire)";
 		$command = $this->getDbConnection()->createCommand($sql);
 		$command->bindValue(':key', $key, \PDO::PARAM_STR);

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -217,7 +217,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @throws TConfigurationException if any error happens during creating database or cache table.
 	 * @since 3.1.5
 	 */
-	protected function initializeCache(bool $force = false)
+	protected function initializeCache($force = false)
 	{
 		if ($this->getIsCacheInitialized() && !$force) {
 			return;
@@ -275,7 +275,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param bool $force override {@see \Prado\Caching\TDbCache::setFlushInterval() FlushInterval} and force deletion of expired items
 	 * @since 3.1.5
 	 */
-	public function flushCacheExpired(bool $force = false)
+	public function flushCacheExpired($force = false)
 	{
 		$interval = $this->getFlushInterval();
 		if (!$force && $interval === 0) {
@@ -311,7 +311,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @return int Interval in sec expired items will be removed from cache. Default to 60
 	 * @since 3.1.5
 	 */
-	public function getFlushInterval(): int
+	public function getFlushInterval()
 	{
 		return $this->_flushInterval;
 	}
@@ -325,7 +325,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param int $value Interval in sec
 	 * @since 3.1.5
 	 */
-	public function setFlushInterval(int $value)
+	public function setFlushInterval($value)
 	{
 		$this->_flushInterval = $value;
 	}
@@ -368,7 +368,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @return string the SQLite database filename within the PRADO runtime path.
 	 * @since 4.3.3
 	 */
-	protected function getSqliteDatabaseName(): string
+	protected function getSqliteDatabaseName()
 	{
 		return 'sqlite3.cache';
 	}
@@ -376,7 +376,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	/**
 	 * @return string The Data Source Name, or DSN, contains the information required to connect to the database.
 	 */
-	public function getConnectionString(): string
+	public function getConnectionString()
 	{
 		return $this->_connectionString;
 	}
@@ -385,7 +385,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param string $value The Data Source Name, or DSN, contains the information required to connect to the database.
 	 * @see http://www.php.net/manual/en/function.pdo-construct.php
 	 */
-	public function setConnectionString(string $value)
+	public function setConnectionString($value)
 	{
 		$this->_connectionString = $value;
 	}
@@ -393,7 +393,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	/**
 	 * @return string the username for establishing DB connection. Defaults to empty string.
 	 */
-	public function getUsername(): string
+	public function getUsername()
 	{
 		return $this->_username;
 	}
@@ -401,7 +401,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	/**
 	 * @param string $value the username for establishing DB connection
 	 */
-	public function setUsername(string $value)
+	public function setUsername($value)
 	{
 		$this->_username = $value;
 	}
@@ -417,7 +417,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	/**
 	 * @param string $value the password for establishing DB connection
 	 */
-	public function setPassword(#[\SensitiveParameter] string $value)
+	public function setPassword(#[\SensitiveParameter] $value)
 	{
 		$this->_password = $value;
 	}
@@ -450,7 +450,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param string $value the name of the DB table to store cache content
 	 * @see setAutoCreateCacheTable
 	 */
-	public function setCacheTableName(string $value)
+	public function setCacheTableName($value)
 	{
 		$this->_cacheTable = $value;
 	}
@@ -468,7 +468,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param bool $value whether the cache DB table should be automatically created if not exists.
 	 * @see setCacheTableName
 	 */
-	public function setAutoCreateCacheTable(bool $value)
+	public function setAutoCreateCacheTable($value)
 	{
 		$this->_autoCreate = TPropertyValue::ensureBoolean($value);
 	}
@@ -590,7 +590,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue(string $key): bool
+	protected function deleteValue($key)
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -611,7 +611,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	/**
 	 * Deletes all values from cache.
 	 */
-	public function flush(): void
+	public function flush()
 	{
 		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
@@ -623,8 +623,11 @@ class TDbCache extends TSerializingCache implements IDbModule
 			try {
 				$this->initializeCache(true);
 				$command->execute();
+				return true;
 			} catch (\Exception $e) {
+				return false;
 			}
 		}
+		return true;
 	}
 }

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -605,9 +605,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	}
 
 	/**
-	 * Deletes all values from cache.
-	 * Be careful of performing this operation if the cache is shared by multiple applications.
-	 * @return bool if no error happens during flush
+	 * @return bool true if no error happens during flush
 	 */
 	public function flush()
 	{

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -50,7 +50,7 @@ use Prado\Util\Cron\TCronTaskInfo;
  * Important: Make sure that the indices are non-unique!
  *
  * If you want to change the cache table name, or if you want to create the table by yourself,
- * you may set {@see \Prado\Caching\TDbCache::setCacheTableName() CacheTableName} and {@see \Prado\Caching\TDbCache::setAutoCreateCacheTable() AutoCreateCacheTableName} properties.
+ * you may set {@see \Prado\Caching\TDbCache::setCacheTableName() CacheTableName} and {@see \Prado\Caching\TDbCache::setAutoCreateCacheTable() AutoCreateCacheTable} properties.
  *
  * {@see \Prado\Caching\TDbCache::setFlushInterval() FlushInterval} control how often expired items will be removed from cache.
  * If you prefer to remove expired items manualy e.g. via cronjob you can disable automatic deletion by setting FlushInterval to '0'.
@@ -67,7 +67,7 @@ use Prado\Util\Cron\TCronTaskInfo;
  * the number of seconds. A expiration time 0 represents never expire.
  *
  * By definition, cache does not ensure the existence of a value
- * even if it never expires. Cache is not meant to be an persistent storage.
+ * even if it never expires. Cache is not meant to be a persistent storage.
  *
  * Do not use the same database file for multiple applications using TDbCache.
  * Also note, cache is shared by all user sessions of an application.
@@ -83,10 +83,12 @@ use Prado\Util\Cron\TCronTaskInfo;
  * If loaded, TDbCache will register itself with {@see \Prado\TApplication} as the
  * cache module. It can be accessed via {@see \Prado\TApplication::getCache()}.
  *
- * TDbCache may be configured in application configuration file as follows
+ * XML configuration style:
  * ```xml
  * <modules>
- *     <module id="cache" class="Prado\Caching\TDbCache" ConnectionID="db" />
+ *   <module id="cache" class="Prado\Caching\TDbCache"
+ *       ConnectionString="sqlite:protected/runtime/cache.db"
+ *       CacheTableName="pradocache" AutoCreateCacheTable="true" />
  * </modules>
  * ```
  *
@@ -96,7 +98,11 @@ use Prado\Util\Cron\TCronTaskInfo;
  *     'modules' => [
  *         'cache' => [
  *             'class' => 'Prado\Caching\TDbCache',
- *             'properties' => ['ConnectionID' => 'db'],
+ *             'properties' => [
+ *                 'ConnectionString' => 'sqlite:protected/runtime/cache.db',
+ *                 'CacheTableName' => 'pradocache',
+ *                 'AutoCreateCacheTable' => 'true',
+ *             ],
  *         ],
  *     ],
  * ];
@@ -136,6 +142,30 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	private $_connectionString = '';
 
 	/**
+	 * @return bool whether the PDO extension is loaded.
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return extension_loaded('pdo');
+	}
+
+	/**
+	 * @return bool whether the cache table has been verified or created for this request.
+	 */
+	protected function getIsCacheInitialized(): bool
+	{
+		return $this->_cacheInitialized;
+	}
+
+	/**
+	 * @param bool $value whether the cache table has been verified or created for this request.
+	 */
+	protected function setIsCacheInitialized(bool $value): void
+	{
+		$this->_cacheInitialized = $value;
+	}
+
+	/**
 	 * Initializes this module.
 	 * This method is required by the IModule interface.
 	 * attach {@see \Prado\Caching\TDbCache::doInitializeCache()} to TApplication.OnLoadStateComplete event
@@ -144,6 +174,9 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 */
 	public function init($config)
 	{
+		if (!static::getIsAvailable()) {
+			throw new TConfigurationException('dbcache_unavailable');
+		}
 		$this->getApplication()->attachEventHandler('OnLoadStateComplete', [$this, 'doInitializeCache']);
 		$this->getApplication()->attachEventHandler('OnSaveState', [$this, 'doFlushCacheExpired']);
 		parent::init($config);
@@ -173,7 +206,7 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	/**
 	 * Initialize TDbCache
 	 *
-	 * If {@see \Prado\Caching\TDbCache::setAutoCreateCacheTable() AutoCreateCacheTableName} is 'true' check existence of cache table
+	 * If {@see \Prado\Caching\TDbCache::setAutoCreateCacheTable() AutoCreateCacheTable} is 'true', checks the existence of the cache table
 	 * and create table if does not exist.
 	 *
 	 * @param bool $force Force override global state check
@@ -182,22 +215,23 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 */
 	protected function initializeCache($force = false)
 	{
-		if ($this->_cacheInitialized && !$force) {
+		if ($this->getIsCacheInitialized() && !$force) {
 			return;
 		}
 		$db = $this->getDbConnection();
+		$cacheTable = $this->getCacheTableName();
 		try {
-			$key = 'TDbCache:' . $this->_cacheTable . ':created';
+			$key = 'TDbCache:' . $cacheTable . ':created';
 			if ($force) {
 				$this->_createCheck = false;
 			} else {
 				$this->_createCheck = $this->getApplication()->getGlobalState($key, 0);
 			}
 
-			if ($this->_autoCreate && !$this->_createCheck) {
-				Prado::trace(($force ? 'Force initializing: ' : 'Initializing: ') . $this->getConnectionID() . ', ' . $this->_cacheTable, TDbCache::class);
+			if ($this->getAutoCreateCacheTable() && !$this->_createCheck) {
+				Prado::trace(($force ? 'Force initializing: ' : 'Initializing: ') . $this->getConnectionID() . ', ' . $cacheTable, TDbCache::class);
 
-				$sql = 'SELECT 1 FROM ' . $this->_cacheTable . ' WHERE 0=1';
+				$sql = 'SELECT 1 FROM ' . $cacheTable . ' WHERE 0=1';
 				$db->createCommand($sql)->queryScalar();
 
 				$this->_createCheck = true;
@@ -205,8 +239,8 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 			}
 		} catch (\Exception $e) {
 			// DB table not exists
-			if ($this->_autoCreate) {
-				Prado::trace('Autocreate: ' . $this->_cacheTable, TDbCache::class);
+			if ($this->getAutoCreateCacheTable()) {
+				Prado::trace('Autocreate: ' . $cacheTable, TDbCache::class);
 
 				$driver = $db->getDriverName();
 				if ($driver === TDbDriver::DRIVER_MYSQL) {
@@ -217,19 +251,19 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 					$blob = 'BLOB';
 				}
 
-				$sql = 'CREATE TABLE ' . $this->_cacheTable . " (itemkey CHAR(128) PRIMARY KEY, value $blob, expire INTEGER)";
+				$sql = 'CREATE TABLE ' . $cacheTable . " (itemkey CHAR(128) PRIMARY KEY, value $blob, expire INTEGER)";
 				$db->createCommand($sql)->execute();
 
-				$sql = 'CREATE INDEX IX_expire ON ' . $this->_cacheTable . ' (expire)';
+				$sql = 'CREATE INDEX IX_expire ON ' . $cacheTable . ' (expire)';
 				$db->createCommand($sql)->execute();
 
 				$this->_createCheck = true;
 				$this->getApplication()->setGlobalState($key, time());
 			} else {
-				throw new TConfigurationException('db_cachetable_inexistent', $this->_cacheTable);
+				throw new TConfigurationException('db_cachetable_inexistent', $cacheTable);
 			}
 		}
-		$this->_cacheInitialized = true;
+		$this->setIsCacheInitialized(true);
 	}
 
 	/**
@@ -243,17 +277,17 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 		if (!$force && $interval === 0) {
 			return;
 		}
-
-		$key = 'TDbCache:' . $this->_cacheTable . ':flushed';
+		$cacheTable = $this->getCacheTableName();
+		$key = 'TDbCache:' . $cacheTable . ':flushed';
 		$now = time();
 		$next = $interval + (int) $this->getApplication()->getGlobalState($key, 0);
 
 		if ($force || $next <= $now) {
-			if (!$this->_cacheInitialized) {
+			if (!$this->getIsCacheInitialized()) {
 				$this->initializeCache();
 			}
-			Prado::trace(($force ? 'Force flush of expired items: ' : 'Flush expired items: ') . $this->getConnectionID() . ', ' . $this->_cacheTable, TDbCache::class);
-			$sql = 'DELETE FROM ' . $this->_cacheTable . ' WHERE expire<>0 AND expire<' . $now;
+			Prado::trace(($force ? 'Force flush of expired items: ' : 'Flush expired items: ') . $this->getConnectionID() . ', ' . $cacheTable, TDbCache::class);
+			$sql = 'DELETE FROM ' . $cacheTable . ' WHERE expire<>0 AND expire<' . $now;
 			$this->getDbConnection()->createCommand($sql)->execute();
 			$this->getApplication()->setGlobalState($key, $now);
 		}
@@ -315,11 +349,13 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 		}
 		$db = new TDbConnection();
 		$db->setConnectionString($connectionString);
-		if ($this->_username !== '') {
-			$db->setUsername($this->getUsername());
+		$username = $this->getUsername();
+		if ($username !== '') {
+			$db->setUsername($username);
 		}
-		if ($this->_password !== '') {
-			$db->setPassword($this->_password);
+		$password = $this->getPassword();
+		if ($password !== '') {
+			$db->setPassword($password);
 		}
 		return $db;
 	}
@@ -434,18 +470,16 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	}
 
 	/**
-	 * Retrieves a value from cache with a specified key.
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
 	 */
 	protected function getValue($key)
 	{
-		if (!$this->_cacheInitialized) {
+		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
 		}
 
-		$sql = 'SELECT value FROM ' . $this->_cacheTable . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>=' . time() . ') ORDER BY expire DESC';
+		$sql = 'SELECT value FROM ' . $this->getCacheTableName() . ' WHERE itemkey=\'' . $key . '\' AND (expire=0 OR expire>=' . time() . ') ORDER BY expire DESC';
 		$command = $this->getDbConnection()->createCommand($sql);
 		try {
 			return unserialize($command->queryScalar());
@@ -456,9 +490,6 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	}
 
 	/**
-	 * Stores a value identified by a key in cache.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -466,20 +497,21 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 */
 	protected function setValue($key, $value, $expire)
 	{
-		if (!$this->_cacheInitialized) {
+		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
 		}
 		$db = $this->getDbConnection();
 		$driver = $db->getDriverName();
 		if (in_array($driver, [TDbDriver::DRIVER_MYSQL, TDbDriver::EXTENSION_MYSQLI, TDbDriver::DRIVER_SQLITE, TDbDriver::DRIVER_IBM, TDbDriver::DRIVER_OCI, TDbDriver::DRIVER_SQLSRV, TDbDriver::EXTENSION_MSSQL, TDbDriver::DRIVER_DBLIB, TDbDriver::DRIVER_PGSQL])) {
 			$expire = ($expire <= 0) ? 0 : time() + $expire;
+			$cacheTable = $this->getCacheTableName();
 			if (in_array($driver, [TDbDriver::DRIVER_MYSQL, TDbDriver::EXTENSION_MYSQLI, TDbDriver::DRIVER_SQLITE])) {
-				$sql = "REPLACE INTO {$this->_cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
+				$sql = "REPLACE INTO {$cacheTable} (itemkey,value,expire) VALUES (:key,:value,$expire)";
 			} elseif ($driver === TDbDriver::DRIVER_PGSQL) {
-				$sql = "INSERT INTO {$this->_cacheTable} (itemkey, value, expire) VALUES (:key, :value, :expire) " .
+				$sql = "INSERT INTO {$cacheTable} (itemkey, value, expire) VALUES (:key, :value, :expire) " .
 					"ON CONFLICT (itemkey) DO UPDATE SET value = EXCLUDED.value, expire = EXCLUDED.expire";
 			} else {
-				$sql = "MERGE INTO {$this->_cacheTable} AS c " .
+				$sql = "MERGE INTO {$cacheTable} AS c " .
 				"USING (SELECT :key AS itemkey, :value AS value, $expire AS expire) AS data " .
 				"ON c.itemkey = data.itemkey " .
 				"WHEN MATCHED THEN " .
@@ -520,9 +552,6 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	}
 
 	/**
-	 * Stores a value identified by a key into cache if the cache does not contain this key.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -530,11 +559,11 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 */
 	protected function addValue($key, $value, $expire)
 	{
-		if (!$this->_cacheInitialized) {
+		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
 		}
 		$expire = ($expire <= 0) ? 0 : time() + $expire;
-		$sql = "INSERT INTO {$this->_cacheTable} (itemkey,value,expire) VALUES(:key,:value,$expire)";
+		$sql = "INSERT INTO {$this->getCacheTableName()} (itemkey,value,expire) VALUES(:key,:value,$expire)";
 		$command = $this->getDbConnection()->createCommand($sql);
 		$command->bindValue(':key', $key, \PDO::PARAM_STR);
 		$command->bindValue(':value', serialize($value), \PDO::PARAM_LOB);
@@ -554,18 +583,16 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	}
 
 	/**
-	 * Deletes a value with the specified key from cache
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key the key of the value to be deleted
-	 * @return bool if no error happens during deletion
+	 * @return bool true if no error happens during deletion
 	 */
 	protected function deleteValue($key)
 	{
-		if (!$this->_cacheInitialized) {
+		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
 		}
 
-		$command = $this->getDbConnection()->createCommand("DELETE FROM {$this->_cacheTable} WHERE itemkey=:key");
+		$command = $this->getDbConnection()->createCommand("DELETE FROM {$this->getCacheTableName()} WHERE itemkey=:key");
 		$command->bindValue(':key', $key, \PDO::PARAM_STR);
 		try {
 			$command->execute();
@@ -584,10 +611,10 @@ class TDbCache extends TCache implements \Prado\Util\IDbModule
 	 */
 	public function flush()
 	{
-		if (!$this->_cacheInitialized) {
+		if (!$this->getIsCacheInitialized()) {
 			$this->initializeCache();
 		}
-		$command = $this->getDbConnection()->createCommand("DELETE FROM {$this->_cacheTable}");
+		$command = $this->getDbConnection()->createCommand("DELETE FROM {$this->getCacheTableName()}");
 		try {
 			$command->execute();
 		} catch (\Exception $e) {

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -147,6 +147,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 
 	/**
 	 * @return bool whether the PDO extension is loaded.
+	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{
@@ -155,6 +156,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 
 	/**
 	 * @return bool whether the cache table has been verified or created for this request.
+	 * @since 4.4.0
 	 */
 	protected function getIsCacheInitialized(): bool
 	{
@@ -163,6 +165,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 
 	/**
 	 * @param bool $value whether the cache table has been verified or created for this request.
+	 * @since 4.4.0
 	 */
 	protected function setIsCacheInitialized(bool $value): void
 	{
@@ -481,6 +484,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	/**
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the serialized value on a hit, or `false` on a miss or expiry.
+	 * @since 4.4.0
 	 */
 	protected function getSerializedValue(string $key): false|string
 	{
@@ -503,6 +507,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
+	 * @since 4.4.0
 	 */
 	protected function setSerializedValue(string $key, string $value, int $expire): bool
 	{
@@ -565,6 +570,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
+	 * @since 4.4.0
 	 */
 	protected function addSerializedValue(string $key, string $value, int $expire): bool
 	{

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -387,6 +387,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 */
 	public function setConnectionString($value)
 	{
+		$this->assertUninitialized('ConnectionString');
 		$this->_connectionString = $value;
 	}
 
@@ -403,6 +404,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 */
 	public function setUsername($value)
 	{
+		$this->assertUninitialized('Username');
 		$this->_username = $value;
 	}
 
@@ -419,6 +421,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 */
 	public function setPassword(#[\SensitiveParameter] $value)
 	{
+		$this->assertUninitialized('Password');
 		$this->_password = $value;
 	}
 
@@ -452,6 +455,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 */
 	public function setCacheTableName($value)
 	{
+		$this->assertUninitialized('CacheTableName');
 		$this->_cacheTable = $value;
 	}
 
@@ -470,6 +474,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 */
 	public function setAutoCreateCacheTable($value)
 	{
+		$this->assertUninitialized('AutoCreateCacheTable');
 		$this->_autoCreate = TPropertyValue::ensureBoolean($value);
 	}
 

--- a/framework/Caching/TDbCache.php
+++ b/framework/Caching/TDbCache.php
@@ -177,7 +177,7 @@ class TDbCache extends TSerializingCache implements IDbModule
 	 * This method is required by the IModule interface.
 	 * attach {@see \Prado\Caching\TDbCache::doInitializeCache()} to TApplication.OnLoadStateComplete event
 	 * attach {@see \Prado\Caching\TDbCache::doFlushCacheExpired()} to TApplication.OnSaveState event
-	 * @param \Prado\Xml\TXmlElement $config configuration for this module, can be null
+	 * @param null|array|\Prado\Xml\TXmlElement $config configuration for this module, can be null
 	 */
 	public function init($config)
 	{

--- a/framework/Caching/TDirectoryCacheDependency.php
+++ b/framework/Caching/TDirectoryCacheDependency.php
@@ -108,7 +108,7 @@ class TDirectoryCacheDependency extends TCacheDependency
 	/**
 	 * @param bool $value whether subdirectories are included in the dependency check.
 	 */
-	public function setRecursiveCheck(bool $value): void
+	public function setRecursiveCheck($value): void
 	{
 		$this->_recursiveCheck = TPropertyValue::ensureBoolean($value);
 		if ($this->getDirectoryDirect() !== null) {
@@ -133,7 +133,7 @@ class TDirectoryCacheDependency extends TCacheDependency
 	 * under the tracked directory.
 	 * @param int $value the depth limit.
 	 */
-	public function setRecursiveLevel(int $value): void
+	public function setRecursiveLevel($value): void
 	{
 		$this->_recursiveLevel = TPropertyValue::ensureInteger($value);
 		if ($this->getDirectoryDirect() !== null) {

--- a/framework/Caching/TDirectoryCacheDependency.php
+++ b/framework/Caching/TDirectoryCacheDependency.php
@@ -109,9 +109,7 @@ class TDirectoryCacheDependency extends TCacheDependency
 	}
 
 	/**
-	 * Performs the actual dependency checking.
-	 * This method returns true if the directory is changed.
-	 * @return bool whether the dependency is changed or not.
+	 * @return bool true if any file's modification time or the file count has changed.
 	 */
 	public function getHasChanged()
 	{

--- a/framework/Caching/TDirectoryCacheDependency.php
+++ b/framework/Caching/TDirectoryCacheDependency.php
@@ -87,8 +87,9 @@ class TDirectoryCacheDependency extends TCacheDependency
 	 * @param string $directory path to the directory.
 	 * @throws TInvalidDataValueException if the path does not exist or is not a directory.
 	 */
-	public function setDirectory(string $directory): void
+	public function setDirectory($directory)
 	{
+		$directory = TPropertyValue::ensureString($directory);
 		if (($path = realpath($directory)) === false || !is_dir($path)) {
 			throw new TInvalidDataValueException('directorycachedependency_directory_invalid', $directory);
 		}
@@ -108,7 +109,7 @@ class TDirectoryCacheDependency extends TCacheDependency
 	/**
 	 * @param bool $value whether subdirectories are included in the dependency check.
 	 */
-	public function setRecursiveCheck($value): void
+	public function setRecursiveCheck($value)
 	{
 		$this->_recursiveCheck = TPropertyValue::ensureBoolean($value);
 		if ($this->getDirectoryDirect() !== null) {
@@ -133,7 +134,7 @@ class TDirectoryCacheDependency extends TCacheDependency
 	 * under the tracked directory.
 	 * @param int $value the depth limit.
 	 */
-	public function setRecursiveLevel($value): void
+	public function setRecursiveLevel($value)
 	{
 		$this->_recursiveLevel = TPropertyValue::ensureInteger($value);
 		if ($this->getDirectoryDirect() !== null) {

--- a/framework/Caching/TDirectoryCacheDependency.php
+++ b/framework/Caching/TDirectoryCacheDependency.php
@@ -15,153 +15,187 @@ use Prado\Exceptions\TIOException;
 use Prado\TPropertyValue;
 
 /**
- * TDirectoryCacheDependency class.
+ * TDirectoryCacheDependency class
  *
- * TDirectoryCacheDependency performs dependency checking based on the
- * modification time of the files contained in the specified directory.
- * The directory being checked is specified via {@see setDirectory Directory}.
+ * TDirectoryCacheDependency reports a cache-dependency change when the
+ * modification time of any file under the directory specified via
+ * {@see setDirectory Directory} differs from the snapshot taken when the
+ * dependency was created, or when the number of files in the directory has
+ * changed.
  *
- * By default, all files under the specified directory and subdirectories
- * will be checked. If the last modification time of any of them is changed
- * or if different number of files are contained in a directory, the dependency
- * is reported as changed. By specifying {@see setRecursiveCheck RecursiveCheck}
- * and {@see setRecursiveLevel RecursiveLevel}, one can limit the checking
- * to a certain depth of the subdirectories.
+ * By default all files under the specified directory and its subdirectories
+ * are checked. Set {@see setRecursiveCheck RecursiveCheck} to `false` to
+ * limit checking to the top level, or set {@see setRecursiveLevel RecursiveLevel}
+ * to cap the depth of subdirectory traversal.
+ *
+ * Override {@see validateFile()} or {@see validateDirectory()} in a subclass
+ * to restrict which files or subdirectories are included in the check.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
  */
 class TDirectoryCacheDependency extends TCacheDependency
 {
-	private $_recursiveCheck = true;
-	private $_recursiveLevel = -1;
-	private $_timestamps;
-	private $_directory;
+	/** @var ?string resolved absolute path of the tracked directory */
+	private ?string $_directory = null;
+	/** @var array<string,int> map of absolute file path to last recorded mtime */
+	private array $_timestamps = [];
+	/** @var bool whether subdirectories are included in the dependency check */
+	private bool $_recursiveCheck = true;
+	/** @var int maximum subdirectory depth to traverse; -1 means unlimited */
+	private int $_recursiveLevel = -1;
 
 	/**
-	 * Constructor.
-	 * @param string $directory the directory to be checked
+	 * @param string $directory path to the directory to be tracked.
 	 */
-	public function __construct($directory)
+	public function __construct(string $directory)
 	{
 		$this->setDirectory($directory);
 		parent::__construct();
 	}
 
 	/**
-	 * @return string the directory to be checked
+	 * Returns the stored directory path without validation.
+	 * @return ?string the resolved directory path, or `null` before initialization.
+	 * @since 4.4.0
 	 */
-	public function getDirectory()
+	protected function getDirectoryDirect(): ?string
 	{
 		return $this->_directory;
 	}
 
 	/**
-	 * @param string $directory the directory to be checked
-	 * @throws TInvalidDataValueException if the directory does not exist
+	 * Stores the resolved directory path without re-scanning.
+	 * @param ?string $value the resolved directory path.
+	 * @since 4.4.0
 	 */
-	public function setDirectory($directory)
+	protected function setDirectoryDirect(?string $value): void
+	{
+		$this->_directory = $value;
+	}
+
+	/**
+	 * @return string the resolved absolute path of the tracked directory.
+	 */
+	public function getDirectory(): string
+	{
+		return $this->_directory ?? '';
+	}
+
+	/**
+	 * Sets the directory to track and records a fresh snapshot of file mtimes.
+	 * @param string $directory path to the directory.
+	 * @throws TInvalidDataValueException if the path does not exist or is not a directory.
+	 */
+	public function setDirectory(string $directory): void
 	{
 		if (($path = realpath($directory)) === false || !is_dir($path)) {
 			throw new TInvalidDataValueException('directorycachedependency_directory_invalid', $directory);
 		}
-		$this->_directory = $path;
+		$this->setDirectoryDirect($path);
 		$this->_timestamps = $this->generateTimestamps($path);
 	}
 
 	/**
-	 * @return bool whether the subdirectories of the directory will also be checked.
-	 * It defaults to true.
+	 * @return bool whether subdirectories are included in the dependency check.
+	 *   Defaults to `true`.
 	 */
-	public function getRecursiveCheck()
+	public function getRecursiveCheck(): bool
 	{
 		return $this->_recursiveCheck;
 	}
 
 	/**
-	 * @param bool $value whether the subdirectories of the directory will also be checked.
+	 * @param bool $value whether subdirectories are included in the dependency check.
 	 */
-	public function setRecursiveCheck($value)
+	public function setRecursiveCheck(bool $value): void
 	{
 		$this->_recursiveCheck = TPropertyValue::ensureBoolean($value);
+		if ($this->getDirectoryDirect() !== null) {
+			$this->_timestamps = $this->generateTimestamps($this->getDirectoryDirect());
+		}
 	}
 
 	/**
-	 * @return int the depth of the subdirectories to be checked.
-	 * It defaults to -1, meaning unlimited depth.
+	 * @return int the maximum subdirectory depth to traverse.
+	 *   `-1` means unlimited depth; `0` means only the top-level directory.
+	 *   Defaults to `-1`.
 	 */
-	public function getRecursiveLevel()
+	public function getRecursiveLevel(): int
 	{
 		return $this->_recursiveLevel;
 	}
 
 	/**
-	 * Sets a value indicating the depth of the subdirectories to be checked.
-	 * This is meaningful only when {@see getRecursiveCheck RecursiveCheck}
-	 * is true.
-	 * @param int $value the depth of the subdirectories to be checked.
-	 * If the value is less than 0, it means unlimited depth.
-	 * If the value is 0, it means checking the files directly under the specified directory.
+	 * Sets the maximum subdirectory depth to traverse when
+	 * {@see getRecursiveCheck RecursiveCheck} is `true`.
+	 * Values less than `0` mean unlimited depth; `0` checks only files directly
+	 * under the tracked directory.
+	 * @param int $value the depth limit.
 	 */
-	public function setRecursiveLevel($value)
+	public function setRecursiveLevel(int $value): void
 	{
 		$this->_recursiveLevel = TPropertyValue::ensureInteger($value);
+		if ($this->getDirectoryDirect() !== null) {
+			$this->_timestamps = $this->generateTimestamps($this->getDirectoryDirect());
+		}
 	}
 
 	/**
-	 * @return bool true if any file's modification time or the file count has changed.
+	 * @return bool whether any tracked file's mtime or the file count has changed.
 	 */
-	public function getHasChanged()
+	public function getHasChanged(): bool
 	{
-		return $this->generateTimestamps($this->_directory) != $this->_timestamps;
+		return $this->generateTimestamps($this->getDirectoryDirect()) !== $this->_timestamps;
 	}
 
 	/**
-	 * Checks to see if the file should be checked for dependency.
-	 * This method is invoked when dependency of the whole directory is being checked.
-	 * By default, it always returns true, meaning the file should be checked.
-	 * You may override this method to check only certain files.
-	 * @param string $fileName the name of the file that may be checked for dependency.
-	 * @return bool whether this file should be checked.
+	 * Returns whether the given file should be included in the dependency check.
+	 * Called for each file encountered during the directory scan. Override in a
+	 * subclass to restrict which files are tracked.
+	 * @param string $fileName absolute path to the file.
+	 * @return bool `true` to include the file; `false` to skip it.
 	 */
-	protected function validateFile($fileName)
-	{
-		return true;
-	}
-
-	/**
-	 * Checks to see if the specified subdirectory should be checked for dependency.
-	 * This method is invoked when dependency of the whole directory is being checked.
-	 * By default, it always returns true, meaning the subdirectory should be checked.
-	 * You may override this method to check only certain subdirectories.
-	 * @param string $directory the name of the subdirectory that may be checked for dependency.
-	 * @return bool whether this subdirectory should be checked.
-	 */
-	protected function validateDirectory($directory)
+	protected function validateFile(string $fileName): bool
 	{
 		return true;
 	}
 
 	/**
-	 * Determines the last modification time for files under the directory.
-	 * This method may go recursively into subdirectories if
-	 * {@see setRecursiveCheck RecursiveCheck} is set true.
-	 * @param string $directory the directory name
-	 * @param int $level level of the recursion
-	 * @return array list of file modification time indexed by the file path
+	 * Returns whether the given subdirectory should be descended into.
+	 * Called for each subdirectory encountered during the scan. Override in a
+	 * subclass to restrict which subdirectories are traversed.
+	 * @param string $directory absolute path to the subdirectory.
+	 * @return bool `true` to traverse the subdirectory; `false` to skip it.
 	 */
-	protected function generateTimestamps($directory, $level = 0)
+	protected function validateDirectory(string $directory): bool
+	{
+		return true;
+	}
+
+	/**
+	 * Builds a map of absolute file paths to their modification times for all
+	 * tracked files under `$directory`.
+	 * Recurses into subdirectories when {@see getRecursiveCheck RecursiveCheck}
+	 * is `true` and the current depth is within {@see getRecursiveLevel RecursiveLevel}.
+	 * @param string $directory the directory to scan.
+	 * @param int $level the current recursion depth (0 = top level).
+	 * @throws TIOException if the directory cannot be opened.
+	 * @return array<string, int> map of file path to mtime.
+	 */
+	protected function generateTimestamps(string $directory, int $level = 0): array
 	{
 		if (($dir = opendir($directory)) === false) {
 			throw new TIOException('directorycachedependency_directory_invalid', $directory);
 		}
+		$recursiveLevel = $this->getRecursiveLevel();
 		$timestamps = [];
 		while (($file = readdir($dir)) !== false) {
 			$path = $directory . DIRECTORY_SEPARATOR . $file;
 			if ($file === '.' || $file === '..') {
 				continue;
 			} elseif (is_dir($path)) {
-				if (($this->_recursiveLevel < 0 || $level < $this->_recursiveLevel) && $this->validateDirectory($path)) {
+				if ($this->getRecursiveCheck() && ($recursiveLevel < 0 || $level < $recursiveLevel) && $this->validateDirectory($path)) {
 					$timestamps = array_merge($timestamps, $this->generateTimestamps($path, $level + 1));
 				}
 			} elseif ($this->validateFile($path)) {

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -123,6 +123,7 @@ class TEtcdCache extends TSerializingCache
 	 */
 	public function setHost($value)
 	{
+		$this->assertUninitialized('Host');
 		$this->_host = TPropertyValue::ensureString($value);
 	}
 
@@ -141,6 +142,7 @@ class TEtcdCache extends TSerializingCache
 	 */
 	public function setPort($value)
 	{
+		$this->assertUninitialized('Port');
 		$this->_port = TPropertyValue::ensureInteger($value);
 	}
 
@@ -157,6 +159,7 @@ class TEtcdCache extends TSerializingCache
 	 */
 	public function setDir($value)
 	{
+		$this->assertUninitialized('Dir');
 		$this->_dir = TPropertyValue::ensureString($value);
 	}
 

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -69,7 +69,7 @@ use Prado\Exceptions\TConfigurationException;
  * @author LANDWEHR Computer und Software GmbH <programmierung@landwehr-software.de>
  * @since 4.0
  */
-class TEtcdCache extends TCache
+class TEtcdCache extends TSerializingCache
 {
 	/**
 	 * @var string the etcd host
@@ -162,43 +162,43 @@ class TEtcdCache extends TCache
 
 	/**
 	 * @param string $key a unique key identifying the cached value
-	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
+	 * @return false|string the serialized value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue($key)
+	protected function getSerializedValue(string $key): false|string
 	{
 		$result = $this->request('GET', $this->getDir() . '/' . $key);
-		return property_exists($result, 'errorCode') ? false : unserialize($result->node->value);
+		return property_exists($result, 'errorCode') ? false : $result->node->value;
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function setSerializedValue(string $key, string $value, int $expire): bool
 	{
-		$value = ['value' => serialize($value)];
+		$params = ['value' => $value];
 		if ($expire > 0) {
-			$value['ttl'] = $expire;
+			$params['ttl'] = $expire;
 		}
-		$result = $this->request('PUT', $this->getDir() . '/' . $key, $value);
+		$result = $this->request('PUT', $this->getDir() . '/' . $key, $params);
 		return !property_exists($result, 'errorCode');
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addSerializedValue(string $key, string $value, int $expire): bool
 	{
-		$value = ['value' => serialize($value), 'prevExist' => 'false'];
+		$params = ['value' => $value, 'prevExist' => 'false'];
 		if ($expire > 0) {
-			$value['ttl'] = $expire;
+			$params['ttl'] = $expire;
 		}
-		$result = $this->request('PUT', $this->getDir() . '/' . $key, $value);
+		$result = $this->request('PUT', $this->getDir() . '/' . $key, $params);
 		return !property_exists($result, 'errorCode');
 	}
 
@@ -206,19 +206,18 @@ class TEtcdCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue($key)
+	protected function deleteValue(string $key): bool
 	{
 		$this->request('DELETE', $this->getDir() . '/' . $key);
 		return true;
 	}
 
 	/**
-	 * @return bool true if no error happens during flush
+	 * Deletes all values from cache.
 	 */
-	public function flush()
+	public function flush(): void
 	{
 		$this->request('DELETE', $this->getDir() . '?recursive=true');
-		return true;
 	}
 
 	/**

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -88,6 +88,7 @@ class TEtcdCache extends TSerializingCache
 
 	/**
 	 * @return bool whether the cURL extension is loaded.
+	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{
@@ -166,6 +167,7 @@ class TEtcdCache extends TSerializingCache
 	/**
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the serialized value on a hit, or `false` on a miss or expiry.
+	 * @since 4.4.0
 	 */
 	protected function getSerializedValue(string $key): false|string
 	{
@@ -178,6 +180,7 @@ class TEtcdCache extends TSerializingCache
 	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
+	 * @since 4.4.0
 	 */
 	protected function setSerializedValue(string $key, string $value, int $expire): bool
 	{
@@ -194,6 +197,7 @@ class TEtcdCache extends TSerializingCache
 	 * @param string $value the serialized value to store
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
+	 * @since 4.4.0
 	 */
 	protected function addSerializedValue(string $key, string $value, int $expire): bool
 	{

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -206,7 +206,7 @@ class TEtcdCache extends TSerializingCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue(string $key): bool
+	protected function deleteValue($key)
 	{
 		$this->request('DELETE', $this->getDir() . '/' . $key);
 		return true;
@@ -215,9 +215,10 @@ class TEtcdCache extends TSerializingCache
 	/**
 	 * Deletes all values from cache.
 	 */
-	public function flush(): void
+	public function flush()
 	{
 		$this->request('DELETE', $this->getDir() . '?recursive=true');
+		return true;
 	}
 
 	/**

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -98,7 +98,7 @@ class TEtcdCache extends TSerializingCache
 	/**
 	 * Initializes this module.
 	 * This method is required by the IModule interface.
-	 * @param \Prado\Xml\TXmlElement $config configuration for this module, can be null
+	 * @param null|array|\Prado\Xml\TXmlElement $config configuration for this module, can be null
 	 * @throws TConfigurationException if cURL extension is not installed
 	 */
 	public function init($config)

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -213,9 +213,7 @@ class TEtcdCache extends TCache
 	}
 
 	/**
-	 * Deletes all values from cache.
-	 * Be careful of performing this operation if the cache is shared by multiple applications.
-	 * @return bool if no error happens during flush
+	 * @return bool true if no error happens during flush
 	 */
 	public function flush()
 	{

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -43,10 +43,10 @@ use Prado\Exceptions\TConfigurationException;
  * If loaded, TEtcdCache will register itself with {@see \Prado\TApplication} as the
  * cache module. It can be accessed via {@see \Prado\TApplication::getCache()}.
  *
- * TEtcdCache may be configured in application configuration file as follows
+ * XML configuration style:
  * ```xml
  * <modules>
- *     <module id="cache" class="Prado\Caching\TEtcdCache" Host="localhost" Port="2379" Dir="pradocache" />
+ *   <module id="cache" class="Prado\Caching\TEtcdCache" Host="localhost" Port="2379" Dir="pradocache" />
  * </modules>
  * ```
  *
@@ -56,7 +56,11 @@ use Prado\Exceptions\TConfigurationException;
  *     'modules' => [
  *         'cache' => [
  *             'class' => 'Prado\Caching\TEtcdCache',
- *             'properties' => ['Host' => 'localhost', 'Port' => '2379', 'Dir' => 'pradocache'],
+ *             'properties' => [
+ *                 'Host' => 'localhost',
+ *                 'Port' => '2379',
+ *                 'Dir' => 'pradocache',
+ *             ],
  *         ],
  *     ],
  * ];
@@ -70,17 +74,25 @@ class TEtcdCache extends TCache
 	/**
 	 * @var string the etcd host
 	 */
-	protected $_host = 'localhost';
+	private $_host = 'localhost';
 
 	/**
 	 * @var int the etcd port
 	 */
-	protected $_port = 2379;
+	private $_port = 2379;
 
 	/**
 	 * @var string the directory to store values in
 	 */
-	protected $_dir = 'pradocache';
+	private $_dir = 'pradocache';
+
+	/**
+	 * @return bool whether the cURL extension is loaded.
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return function_exists('curl_version');
+	}
 
 	/**
 	 * Initializes this module.
@@ -90,7 +102,7 @@ class TEtcdCache extends TCache
 	 */
 	public function init($config)
 	{
-		if (!function_exists('curl_version')) {
+		if (!static::getIsAvailable()) {
 			throw new TConfigurationException('curl_extension_required');
 		}
 		parent::init($config);
@@ -133,8 +145,7 @@ class TEtcdCache extends TCache
 	}
 
 	/**
-	 * Sets the directory to store values in, defaults to 'pradocache'.
-	 * @return string the directory to store values in
+	 * @return string the directory to store values in. Defaults to 'pradocache'.
 	 */
 	public function getDir()
 	{
@@ -142,7 +153,6 @@ class TEtcdCache extends TCache
 	}
 
 	/**
-	 * Gets the directory to store values in.
 	 * @param string $value the directory to store values in
 	 */
 	public function setDir($value)
@@ -151,21 +161,16 @@ class TEtcdCache extends TCache
 	}
 
 	/**
-	 * Retrieves a value from cache with a specified key.
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
 	 */
 	protected function getValue($key)
 	{
-		$result = $this->request('GET', $this->_dir . '/' . $key);
+		$result = $this->request('GET', $this->getDir() . '/' . $key);
 		return property_exists($result, 'errorCode') ? false : unserialize($result->node->value);
 	}
 
 	/**
-	 * Stores a value identified by a key in cache.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -177,14 +182,11 @@ class TEtcdCache extends TCache
 		if ($expire > 0) {
 			$value['ttl'] = $expire;
 		}
-		$result = $this->request('PUT', $this->_dir . '/' . $key, $value);
+		$result = $this->request('PUT', $this->getDir() . '/' . $key, $value);
 		return !property_exists($result, 'errorCode');
 	}
 
 	/**
-	 * Stores a value identified by a key into cache if the cache does not contain this key.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -196,19 +198,17 @@ class TEtcdCache extends TCache
 		if ($expire > 0) {
 			$value['ttl'] = $expire;
 		}
-		$result = $this->request('PUT', $this->_dir . '/' . $key, $value);
+		$result = $this->request('PUT', $this->getDir() . '/' . $key, $value);
 		return !property_exists($result, 'errorCode');
 	}
 
 	/**
-	 * Deletes a value with the specified key from cache
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key the key of the value to be deleted
-	 * @return bool if no error happens during deletion
+	 * @return bool true if no error happens during deletion
 	 */
 	protected function deleteValue($key)
 	{
-		$this->request('DELETE', $this->_dir . '/' . $key);
+		$this->request('DELETE', $this->getDir() . '/' . $key);
 		return true;
 	}
 
@@ -219,7 +219,7 @@ class TEtcdCache extends TCache
 	 */
 	public function flush()
 	{
-		$this->request('DELETE', $this->_dir . '?recursive=true');
+		$this->request('DELETE', $this->getDir() . '?recursive=true');
 		return true;
 	}
 
@@ -235,7 +235,7 @@ class TEtcdCache extends TCache
 	 */
 	protected function request($method, $key, $value = [])
 	{
-		$curl = curl_init("http://{$this->_host}:{$this->_port}/v2/keys/{$key}");
+		$curl = curl_init("http://{$this->getHost()}:{$this->getPort()}/v2/keys/{$key}");
 		curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 		curl_setopt($curl, CURLOPT_HEADER, false);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);

--- a/framework/Caching/TEtcdCache.php
+++ b/framework/Caching/TEtcdCache.php
@@ -22,7 +22,7 @@ use Prado\Exceptions\TConfigurationException;
  * consensus algorithm to manage a highly-available replicated log.
  *
  * By definition, cache does not ensure the existence of a value
- * even if it never expires. Cache is not meant to be an persistent storage.
+ * even if it never expires. Cache is not meant to be a persistent storage.
  *
  * To use this module, an etcd instance must be running and reachable on the host
  * specified by {@see setHost} and the port specified by {@see setPort} which

--- a/framework/Caching/TFileCache.php
+++ b/framework/Caching/TFileCache.php
@@ -109,6 +109,9 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	/** Sentinel `mtime` marking a never-expiring entry; non-zero and `>= 2` to avoid stray `0`/`1` mtimes. */
 	public const NEVER_EXPIRES_MTIME = 3;
 
+	/** Default interval in seconds between automatic expired-file sweeps. */
+	public const DEFAULT_FLUSH_INTERVAL = 60;
+
 	/** @var string Absolute path to the cache directory; empty until configured. */
 	private string $_dir = '';
 
@@ -119,7 +122,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	private string $_tempFilePrefix = '';
 
 	/** @var int Interval in seconds between automatic expired-file sweeps; 0 disables them. */
-	private int $_flushInterval = 60;
+	private int $_flushInterval = self::DEFAULT_FLUSH_INTERVAL;
 
 	// ---------------------------------------------------------------- lifecycle
 
@@ -140,6 +143,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 		}
 		$this->setDefaultTtl($defaultTtl);
 		$this->setTempFilePrefix(static::CACHE_FILE_PREFIX);
+		$this->setFlushInterval(static::DEFAULT_FLUSH_INTERVAL);
 	}
 
 	/**
@@ -815,7 +819,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 		if ($this->getTempFilePrefixDirect() === static::CACHE_FILE_PREFIX) {
 			$exprops[] = "\0" . __CLASS__ . "\0_tempFilePrefix";
 		}
-		if ($this->getFlushIntervalDirect() === 60) {
+		if ($this->getFlushIntervalDirect() === static::DEFAULT_FLUSH_INTERVAL) {
 			$exprops[] = "\0" . __CLASS__ . "\0_flushInterval";
 		}
 	}

--- a/framework/Caching/TFileCache.php
+++ b/framework/Caching/TFileCache.php
@@ -308,10 +308,9 @@ class TFileCache extends TSerializingCache implements ICacheSize
 
 
 	/**
-	 * Retrieves the stored serialized payload for a unique key. When
-	 * {@see getMaximumSize MaximumSize} is active, a successful read calls
-	 * {@see touch()} on the cache file to update its `mtime`, which is used by
-	 * {@see evictToFitMaximumSize()} to order files for LRU eviction.
+	 * Retrieves the stored serialized payload for a unique key, using the file's
+	 * first-line expiry header as the authoritative liveness check; an expired entry is
+	 * deleted and reported as a miss.
 	 *
 	 * @param string $key the unique key
 	 * @return false|string the stored serialized payload, or false if the entry is
@@ -622,11 +621,11 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	}
 
 	/**
-	 * Evicts the least recently used cache files — determined by file `mtime`,
-	 * which is updated on every successful {@see getValue} via {@see touch()} — one
-	 * at a time until the total on-disk size is at or below
-	 * {@see getMaximumSize MaximumSize}. After all evictions the running size total
-	 * and fingerprint are updated.
+	 * Evicts cache files in soonest-to-expire order, read from each file's `mtime`
+	 * (which mirrors the absolute expiry), one at a time until the total on-disk size is
+	 * at or below {@see getMaximumSize MaximumSize}. Never-expiring entries
+	 * ({@see NEVER_EXPIRES_MTIME}) sort last and are evicted only when nothing else
+	 * remains. After all evictions the running size total and fingerprint are updated.
 	 */
 	protected function evictToFitMaximumSize(): void
 	{

--- a/framework/Caching/TFileCache.php
+++ b/framework/Caching/TFileCache.php
@@ -205,7 +205,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	/**
 	 * @return string the absolute path to the cache directory
 	 */
-	public function getDirectory(): string
+	public function getDirectory()
 	{
 		return $this->getDirectoryDirect();
 	}
@@ -219,7 +219,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	 * @throws TConfigurationException when the value is empty, or when the
 	 *   directory does not exist and cannot be created
 	 */
-	public function setDirectory($value): void
+	public function setDirectory($value)
 	{
 		$this->assertUninitialized('Directory');
 		$value = TPropertyValue::ensureString($value);
@@ -255,7 +255,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	/**
 	 * @return int the default TTL in seconds; 0 means entries never expire
 	 */
-	public function getDefaultTtl(): int
+	public function getDefaultTtl()
 	{
 		return $this->getDefaultTtlDirect();
 	}
@@ -263,7 +263,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	/**
 	 * @param int $value the default TTL in seconds; values below zero are clamped to 0
 	 */
-	public function setDefaultTtl($value): void
+	public function setDefaultTtl($value)
 	{
 		$this->setDefaultTtlDirect(max(0, TPropertyValue::ensureInteger($value)));
 	}
@@ -287,7 +287,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	/**
 	 * @return string the filename prefix used when creating atomic temporary write files
 	 */
-	public function getTempFilePrefix(): string
+	public function getTempFilePrefix()
 	{
 		return $this->getTempFilePrefixDirect();
 	}
@@ -299,7 +299,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	 *
 	 * @param string $value the filename prefix (e.g. `.my-cache-`)
 	 */
-	public function setTempFilePrefix($value): void
+	public function setTempFilePrefix($value)
 	{
 		$this->setTempFilePrefixDirect(TPropertyValue::ensureString($value));
 	}
@@ -472,7 +472,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	 * @return int interval in seconds between automatic expired-file sweeps. `0` disables
 	 *   the automatic sweep (e.g. when flushing externally via the cron task). Defaults to 60.
 	 */
-	public function getFlushInterval(): int
+	public function getFlushInterval()
 	{
 		return $this->getFlushIntervalDirect();
 	}
@@ -482,7 +482,7 @@ class TFileCache extends TSerializingCache implements ICacheSize
 	 * automatic sweep and rely on the {@see fxGetCronTaskInfos cron task} instead.
 	 * @param int $value the interval in seconds; values below zero are clamped to 0.
 	 */
-	public function setFlushInterval($value): void
+	public function setFlushInterval($value)
 	{
 		$this->setFlushIntervalDirect(max(0, TPropertyValue::ensureInteger($value)));
 	}

--- a/framework/Caching/TFileCache.php
+++ b/framework/Caching/TFileCache.php
@@ -129,6 +129,15 @@ class TFileCache extends TCache implements ICacheSize
 	}
 
 	/**
+	 * @return bool always true; file-based caching has no external dependency.
+	 * @since 4.4.0
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
+	/**
 	 * Initializes the cache module. When no {@see getDirectory Directory} has been
 	 * set, a `filecache/` subdirectory under the application runtime path is used
 	 * and created if necessary. Throws when the directory is not writable.

--- a/framework/Caching/TFileCache.php
+++ b/framework/Caching/TFileCache.php
@@ -13,15 +13,17 @@ namespace Prado\Caching;
 use Prado\Exceptions\TConfigurationException;
 use Prado\Prado;
 use Prado\TPropertyValue;
+use Prado\Util\Cron\TCronTaskInfo;
 
 /**
  * TFileCache class.
  *
- * TFileCache implements a file-based {@see TCache} application module. Each cache
- * entry is stored as a single file under the configured
+ * TFileCache implements a file-based {@see TSerializingCache} application module.
+ * Each cache entry is stored as a single file under the configured
  * {@see getDirectory Directory}, named by a SHA-1 hash of the internal key. The
- * file contains a serialized array with the absolute expiry timestamp and the
- * serialized payload.
+ * file contains the absolute expiry timestamp on the first line followed by the
+ * serialized payload produced by {@see TSerializingCache} (which may also be
+ * {@see getEncrypt encrypted} and {@see getEncoding encoded}).
  *
  * TFileCache requires no external extensions — it works on any PHP host with a
  * writable filesystem. For high-throughput deployments, prefer a shared-memory
@@ -42,10 +44,21 @@ use Prado\TPropertyValue;
  * **Maximum size**: when {@see getMaximumSize MaximumSize} is greater than `0`, the
  * module enforces a total on-disk byte limit measured by `filesize()` across all
  * `.cache` files in the directory. After every write the total is checked and the
- * least recently used files (by `mtime`, updated on each {@see TCache::get}) are
- * deleted one at a time until the directory fits within the limit, following the
- * algorithm used by Apple Foundation's `NSCache`. A value of `0` (the default)
- * means no size limit is enforced.
+ * files closest to expiry are deleted one at a time until the directory fits within the
+ * limit (never-expiring entries are evicted last). A value of `0` (the default) means no
+ * size limit is enforced.
+ *
+ * **Expiry in metadata**: each file's modification time (`mtime`) mirrors the entry's
+ * absolute expiry (never-expiring entries use the {@see NEVER_EXPIRES_MTIME} sentinel), so
+ * {@see flushCacheExpired()} and the size eviction read the expiry from `filemtime()`
+ * without opening any file. The file content still carries the expiry on its first line as
+ * the authoritative source for {@see TCache::get}.
+ *
+ * **Expired-file sweeps**: on every application `OnSaveState`, {@see flushCacheExpired()}
+ * deletes files whose TTL has passed, at most once per {@see getFlushInterval FlushInterval}
+ * seconds (default 60; set to `0` to disable the automatic sweep). The module also
+ * registers a cron task (`filecacheflush`) via the global `fxGetCronTaskInfos`
+ * event so the sweep can be scheduled externally — mirroring {@see \Prado\Caching\TDbCache}.
  *
  * If loaded, TFileCache will register itself with {@see \Prado\TApplication} as the
  * cache module. It can be accessed via {@see \Prado\TApplication::getCache()}.
@@ -85,18 +98,16 @@ use Prado\TPropertyValue;
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 4.4.0
  */
-class TFileCache extends TCache implements ICacheSize
+class TFileCache extends TSerializingCache implements ICacheSize
 {
 	use TCacheSizeTrait;
+	use TCacheFileTrait;
 
 	/** Default filename prefix for the atomic temporary write files. */
 	public const CACHE_FILE_PREFIX = '.prado-cache-';
 
-	/** Payload array key for the cached value. */
-	protected const CACHE_VALUE = 'value';
-
-	/** Payload array key for the absolute expiry timestamp (Unix seconds; 0 = never expires). */
-	protected const CACHE_EXPIRED = 'expired';
+	/** Sentinel `mtime` marking a never-expiring entry; non-zero and `>= 2` to avoid stray `0`/`1` mtimes. */
+	public const NEVER_EXPIRES_MTIME = 3;
 
 	/** @var string Absolute path to the cache directory; empty until configured. */
 	private string $_dir = '';
@@ -106,6 +117,9 @@ class TFileCache extends TCache implements ICacheSize
 
 	/** @var string Filename prefix used when creating atomic temporary write files. */
 	private string $_tempFilePrefix = '';
+
+	/** @var int Interval in seconds between automatic expired-file sweeps; 0 disables them. */
+	private int $_flushInterval = 60;
 
 	// ---------------------------------------------------------------- lifecycle
 
@@ -130,7 +144,6 @@ class TFileCache extends TCache implements ICacheSize
 
 	/**
 	 * @return bool always true; file-based caching has no external dependency.
-	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{
@@ -142,7 +155,7 @@ class TFileCache extends TCache implements ICacheSize
 	 * set, a `filecache/` subdirectory under the application runtime path is used
 	 * and created if necessary. Throws when the directory is not writable.
 	 *
-	 * @param null|\Prado\Xml\TXmlElement $config module configuration
+	 * @param null|array|\Prado\Xml\TXmlElement $config module configuration
 	 * @throws TConfigurationException when the directory cannot be created or is
 	 *   not writable, or when the {@see hashToken} implementation does not properly
 	 *   hash its input (returns the token unchanged, or returns an unsafe value
@@ -167,6 +180,7 @@ class TFileCache extends TCache implements ICacheSize
 		if (strpbrk($hash, '/\\') !== false) {
 			throw new TConfigurationException('filecache_hash_token_path_separator');
 		}
+		$this->getApplication()?->attachEventHandler('OnSaveState', [$this, 'doFlushCacheExpired']);
 		parent::init($config);
 	}
 
@@ -207,6 +221,7 @@ class TFileCache extends TCache implements ICacheSize
 	 */
 	public function setDirectory($value): void
 	{
+		$this->assertUninitialized('Directory');
 		$value = TPropertyValue::ensureString($value);
 		if ($value === '') {
 			throw new TConfigurationException('filecache_directory_required');
@@ -293,16 +308,16 @@ class TFileCache extends TCache implements ICacheSize
 
 
 	/**
-	 * Retrieves a stored entry by its TCache-generated unique key. When
+	 * Retrieves the stored serialized payload for a unique key. When
 	 * {@see getMaximumSize MaximumSize} is active, a successful read calls
 	 * {@see touch()} on the cache file to update its `mtime`, which is used by
 	 * {@see evictToFitMaximumSize()} to order files for LRU eviction.
 	 *
 	 * @param string $key the unique key
-	 * @return false|mixed the stored value, or false if the entry is missing,
-	 *   malformed, or expired
+	 * @return false|string the stored serialized payload, or false if the entry is
+	 *   missing, malformed, or expired
 	 */
-	protected function getValue($key)
+	protected function getSerializedValue(string $key): false|string
 	{
 		$file = $this->pathFor($key);
 		if (!$this->isFile($file)) {
@@ -312,50 +327,47 @@ class TFileCache extends TCache implements ICacheSize
 		if ($raw === false || $raw === '') {
 			return false;
 		}
-		$decoded = $this->unserialize($raw);
-		if (!is_array($decoded) || !array_key_exists(static::CACHE_EXPIRED, $decoded) || !array_key_exists(static::CACHE_VALUE, $decoded)) {
+		$pos = strpos($raw, "\n");
+		if ($pos === false) {
 			return false;
 		}
-		$expire = (int) $decoded[static::CACHE_EXPIRED];
-		if ($expire > 0 && $expire <= $this->now()) {
+		$expire = (int) substr($raw, 0, $pos);
+		if ($expire > 0 && $expire <= $this->time()) {
 			$this->unlink($file);
 			return false;
 		}
-		if ($this->getMaximumSizeDirect() > 0) {
-			$this->touch($file);
-		}
-		return $decoded[static::CACHE_VALUE];
+		return substr($raw, $pos + 1);
 	}
 
 	/**
-	 * Stores a value under the given unique key, overwriting any existing entry.
+	 * Stores a serialized payload under the given unique key, overwriting any existing entry.
 	 *
 	 * @param string $key the unique key
-	 * @param mixed $value the value to store
+	 * @param string $value the serialized payload to store
 	 * @param int $expire TTL in seconds; 0 falls back to {@see getDefaultTtl}
 	 * @return bool true on success
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function setSerializedValue(string $key, string $value, int $expire): bool
 	{
-		return $this->writeEntry($key, $value, (int) $expire, false);
+		return $this->writeEntry($key, $value, $expire, false);
 	}
 
 	/**
-	 * Stores a value only when no live entry already exists under the key.
+	 * Stores a serialized payload only when no live entry already exists under the key.
 	 *
 	 * @param string $key the unique key
-	 * @param mixed $value the value to store
+	 * @param string $value the serialized payload to store
 	 * @param int $expire TTL in seconds; 0 falls back to {@see getDefaultTtl}
 	 * @return bool true when the entry was stored; false when a live entry
 	 *   already existed
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addSerializedValue(string $key, string $value, int $expire): bool
 	{
 		$file = $this->pathFor($key);
-		if ($this->isFile($file) && $this->getValue($key) !== false) {
+		if ($this->isFile($file) && $this->getSerializedValue($key) !== false) {
 			return false;
 		}
-		return $this->writeEntry($key, $value, (int) $expire, true);
+		return $this->writeEntry($key, $value, $expire, true);
 	}
 
 	/**
@@ -411,22 +423,19 @@ class TFileCache extends TCache implements ICacheSize
 	 * overwrites of existing files whose size may have changed.
 	 *
 	 * @param string $key the unique key
-	 * @param mixed $value the value to store
+	 * @param string $value the serialized payload to store
 	 * @param int $expire TTL in seconds; 0 falls back to {@see getDefaultTtl}
 	 * @param bool $exclusive when true, aborts if the final file already exists
-	 *   (used by {@see addValue} to prevent overwriting a live entry)
+	 *   (used by {@see addSerializedValue} to prevent overwriting a live entry)
 	 * @throws \Prado\Exceptions\TInvalidDataValueException when MaximumSize is active
-	 *   and the serialized entry exceeds it
+	 *   and the entry exceeds it
 	 * @return bool true on success
 	 */
-	protected function writeEntry(string $key, mixed $value, int $expire, bool $exclusive): bool
+	protected function writeEntry(string $key, string $value, int $expire, bool $exclusive): bool
 	{
 		$ttl = $expire > 0 ? $expire : $this->getDefaultTtl();
-		$entry = [
-			static::CACHE_VALUE => $value,
-			static::CACHE_EXPIRED => $ttl > 0 ? $this->now() + $ttl : 0,
-		];
-		$serialized = $this->serialize($entry);
+		$expireAt = $ttl > 0 ? $this->time() + $ttl : 0;
+		$serialized = $expireAt . "\n" . $value;
 		$this->assertItemFitsMaximumSize(strlen($serialized));
 		$file = $this->pathFor($key);
 		$tmpFile = $this->tempnam($this->getDirectory(), $this->getTempFilePrefix());
@@ -446,12 +455,125 @@ class TFileCache extends TCache implements ICacheSize
 			$this->unlink($tmpFile);
 			return false;
 		}
+		// Mirror the expiry into the file's mtime so the sweep and eviction can read it from
+		// filemtime() without opening the file. Never-expiring entries (header expiry 0) use
+		// the NEVER_EXPIRES_MTIME sentinel instead.
+		$this->touch($file, $expireAt > 0 ? $expireAt : static::NEVER_EXPIRES_MTIME);
 		if ($this->getMaximumSizeDirect() > 0) {
 			// Invalidate fingerprint so validateSizeCache() triggers a full recompute.
 			$this->setSizeFingerprintDirect('');
 			$this->enforceMaximumSize();
 		}
 		return true;
+	}
+
+	// ------------------------------------------------------------------ expired-file flushing
+
+	/**
+	 * @return int interval in seconds between automatic expired-file sweeps. `0` disables
+	 *   the automatic sweep (e.g. when flushing externally via the cron task). Defaults to 60.
+	 */
+	public function getFlushInterval(): int
+	{
+		return $this->getFlushIntervalDirect();
+	}
+
+	/**
+	 * Sets the interval between automatic expired-file sweeps. Set to `0` to disable the
+	 * automatic sweep and rely on the {@see fxGetCronTaskInfos cron task} instead.
+	 * @param int $value the interval in seconds; values below zero are clamped to 0.
+	 */
+	public function setFlushInterval($value): void
+	{
+		$this->setFlushIntervalDirect(max(0, TPropertyValue::ensureInteger($value)));
+	}
+
+	/**
+	 * @return int the raw FlushInterval field value
+	 */
+	protected function getFlushIntervalDirect(): int
+	{
+		return $this->_flushInterval;
+	}
+
+	/**
+	 * @param int $value the interval in seconds to store directly
+	 */
+	protected function setFlushIntervalDirect(int $value): void
+	{
+		$this->_flushInterval = $value;
+	}
+
+	/**
+	 * Event listener for the application `OnSaveState` event; sweeps expired files subject
+	 * to {@see getFlushInterval FlushInterval}.
+	 */
+	public function doFlushCacheExpired(): void
+	{
+		$this->flushCacheExpired(false);
+	}
+
+	/**
+	 * Deletes expired cache files from the directory. When {@see getFlushInterval
+	 * FlushInterval} is `0` and `$force` is false, the sweep is skipped; otherwise it runs
+	 * at most once per interval, tracked through application global state.
+	 * @param bool $force when true, ignores the interval and sweeps immediately (the cron
+	 *   task uses this).
+	 */
+	public function flushCacheExpired($force = false): void
+	{
+		$interval = $this->getFlushInterval();
+		if (!$force && $interval === 0) {
+			return;
+		}
+		$key = 'TFileCache:' . $this->getDirectory() . ':flushed';
+		$now = $this->time();
+		$next = $interval + (int) $this->getApplication()->getGlobalState($key, 0);
+		if ($force || $next <= $now) {
+			Prado::trace(($force ? 'Force flush of expired files: ' : 'Flush expired files: ') . $this->getDirectory(), TFileCache::class);
+			$this->deleteExpiredFiles($now);
+			$this->getApplication()->setGlobalState($key, $now);
+		}
+	}
+
+	/**
+	 * Scans the cache directory and deletes every `.cache` file whose stored expiry has
+	 * passed. When {@see getMaximumSize MaximumSize} is active, the size fingerprint is
+	 * invalidated so the running total is recomputed on the next access.
+	 * @param int $now the reference timestamp for expiry comparison.
+	 */
+	protected function deleteExpiredFiles(int $now): void
+	{
+		$dir = $this->getDirectory();
+		if ($dir === '' || !is_dir($dir)) {
+			return;
+		}
+		clearstatcache();
+		$deleted = false;
+		foreach (glob($dir . DIRECTORY_SEPARATOR . '*.cache') ?: [] as $file) {
+			// The mtime mirrors the entry's absolute expiry, so the sweep reads it from
+			// filesystem metadata without opening the file. The NEVER_EXPIRES_MTIME sentinel
+			// is skipped; any other past mtime (including stray 0/1) is swept.
+			$expire = @filemtime($file);
+			if ($expire !== false && $expire !== static::NEVER_EXPIRES_MTIME && $expire <= $now && $this->unlink($file)) {
+				$deleted = true;
+			}
+		}
+		if ($deleted && $this->getMaximumSizeDirect() > 0) {
+			// Invalidate the fingerprint so the running size total recomputes on next use.
+			$this->setSizeFingerprintDirect('');
+		}
+	}
+
+	/**
+	 * Provides the cron task that clears out expired cache files, raised via the global
+	 * `fxGetCronTaskInfos` event.
+	 * @param object $sender the object raising fxGetCronTaskInfos.
+	 * @param mixed $param the parameter.
+	 */
+	public function fxGetCronTaskInfos($sender, $param)
+	{
+		return Prado::createComponent(TCronTaskInfo::class, 'filecacheflush', $this->getId() . '->flushCacheExpired(true)', $this, Prado::localize('FileCache Flush Expired Files'), Prado::localize('This manually clears out the expired files of TFileCache.'));
 	}
 
 	// ------------------------------------------------------------------ TCacheSizeTrait impl
@@ -518,11 +640,12 @@ class TFileCache extends TCache implements ICacheSize
 			$mtime = @filemtime($f);
 			$fsize = @filesize($f);
 			if ($mtime !== false && $fsize !== false) {
-				$files[$f] = ['mtime' => $mtime, 'size' => $fsize];
+				// mtime mirrors the absolute expiry; the never-expire sentinel sorts last.
+				$files[$f] = ['expire' => $mtime === static::NEVER_EXPIRES_MTIME ? PHP_INT_MAX : $mtime, 'size' => $fsize];
 			}
 		}
-		// Sort by mtime ascending so that the least recently accessed file comes first.
-		uasort($files, static fn ($a, $b): int => $a['mtime'] <=> $b['mtime']);
+		// Sort by expiry ascending so the soonest-to-expire file is evicted first.
+		uasort($files, static fn ($a, $b): int => $a['expire'] <=> $b['expire']);
 		$current = $this->getCurrentSizeDirect();
 		foreach ($files as $f => $info) {
 			if ($current <= $max) {
@@ -590,17 +713,6 @@ class TFileCache extends TCache implements ICacheSize
 	}
 
 	/**
-	 * Returns the current Unix timestamp. Extracted to allow subclasses and
-	 * test doubles to control clock behavior without modifying real system time.
-	 *
-	 * @return int the current Unix timestamp in seconds
-	 */
-	protected function now(): int
-	{
-		return time();
-	}
-
-	/**
 	 * Returns whether the given path refers to an existing regular file.
 	 * Extracted to allow subclasses and test doubles to intercept filesystem
 	 * existence checks.
@@ -624,58 +736,6 @@ class TFileCache extends TCache implements ICacheSize
 	protected function tempnam(string $dir, string $prefix): string|false
 	{
 		return @tempnam($dir, $prefix);
-	}
-
-	/**
-	 * Serializes a value to a string for storage in a cache file.
-	 *
-	 * @param mixed $value the value to serialize
-	 * @return string the serialized representation
-	 */
-	protected function serialize(mixed $value): string
-	{
-		return serialize($value);
-	}
-
-	/**
-	 * Unserializes a string produced by {@see serialize}.
-	 * Returns false when the string is not valid serialized data.
-	 *
-	 * @param string $value the serialized string to decode
-	 * @return mixed the unserialized value, or false on failure
-	 */
-	protected function unserialize(string $value): mixed
-	{
-		return @unserialize($value);
-	}
-
-	/**
-	 * Reads and returns the entire contents of a file.
-	 * Returns false when the file cannot be read.
-	 *
-	 * @param string $filePath the path of the file to read
-	 * @return false|string the file contents, or false on failure
-	 */
-	protected function getContents(string $filePath): string|false
-	{
-		return @file_get_contents($filePath);
-	}
-
-	/**
-	 * Writes data to a file, replacing its current contents.
-	 * Returns false when the file cannot be written.
-	 *
-	 * Note: this method does **not** use `LOCK_EX`. Write atomicity is instead
-	 * guaranteed by the `tempnam()` + `rename()` pattern in {@see writeEntry()},
-	 * so no exclusive lock is needed here.
-	 *
-	 * @param string $filePath the path of the file to write
-	 * @param string $data the data to write
-	 * @return false|int the number of bytes written, or false on failure
-	 */
-	protected function putContents(string $filePath, string $data): int|false
-	{
-		return @file_put_contents($filePath, $data);
 	}
 
 	/**
@@ -714,16 +774,21 @@ class TFileCache extends TCache implements ICacheSize
 	}
 
 	/**
-	 * Updates the access and modification time of a file to the current time.
-	 * Used by {@see getValue()} to refresh the `mtime` of cache files on every
-	 * read so that {@see evictToFitMaximumSize()} can order files by recency.
+	 * Sets a file's modification time. {@see writeEntry()} sets it to the entry's absolute
+	 * expiry (`0` for never-expire) so that {@see deleteExpiredFiles()} and
+	 * {@see evictToFitMaximumSize()} can read the expiry from `filemtime()` without opening
+	 * the file. The PHP stat cache for the path is cleared so the new mtime is seen
+	 * immediately within the same request.
 	 *
 	 * @param string $filePath the path of the file to touch
+	 * @param ?int $mtime the modification time to set; `null` uses the current time
 	 * @return bool true on success, false on failure
 	 */
-	protected function touch(string $filePath): bool
+	protected function touch(string $filePath, ?int $mtime = null): bool
 	{
-		return @touch($filePath);
+		$ok = $mtime === null ? @touch($filePath) : @touch($filePath, $mtime);
+		clearstatcache(true, $filePath);
+		return $ok;
 	}
 
 	// --------------------------------------- serialization / cloning
@@ -750,6 +815,9 @@ class TFileCache extends TCache implements ICacheSize
 		}
 		if ($this->getTempFilePrefixDirect() === static::CACHE_FILE_PREFIX) {
 			$exprops[] = "\0" . __CLASS__ . "\0_tempFilePrefix";
+		}
+		if ($this->getFlushIntervalDirect() === 60) {
+			$exprops[] = "\0" . __CLASS__ . "\0_flushInterval";
 		}
 	}
 }

--- a/framework/Caching/TFileCacheDependency.php
+++ b/framework/Caching/TFileCacheDependency.php
@@ -62,9 +62,7 @@ class TFileCacheDependency extends TCacheDependency
 	}
 
 	/**
-	 * Performs the actual dependency checking.
-	 * This method returns true if the last modification time of the file is changed.
-	 * @return bool whether the dependency is changed or not.
+	 * @return bool true if the file's last modification time has changed.
 	 */
 	public function getHasChanged()
 	{

--- a/framework/Caching/TFileCacheDependency.php
+++ b/framework/Caching/TFileCacheDependency.php
@@ -11,7 +11,7 @@
 namespace Prado\Caching;
 
 /**
- * TFileCacheDependency class.
+ * TFileCacheDependency class
  *
  * TFileCacheDependency performs dependency checking based on the
  * last modification time of the file specified via {@see setFileName FileName}.
@@ -23,7 +23,9 @@ namespace Prado\Caching;
  */
 class TFileCacheDependency extends TCacheDependency
 {
+	/** @var string absolute path to the tracked file */
 	private $_fileName;
+	/** @var false|int last recorded modification time of the file */
 	private $_timestamp;
 
 	/**
@@ -46,11 +48,29 @@ class TFileCacheDependency extends TCacheDependency
 
 	/**
 	 * @param string $value the name of the file whose change is to be checked
+	 * @since 4.4.0
+	 */
+	protected function setFileNameDirect($value)
+	{
+		$this->_fileName = $value;
+	}
+
+	/**
+	 * @param string $value the name of the file whose change is to be checked
 	 */
 	public function setFileName($value)
 	{
-		$this->_fileName = $value;
-		$this->_timestamp = @filemtime($value);
+		$this->setFileNameDirect($value);
+		$this->updateTimestamp();
+	}
+
+	/**
+	 * @todo
+	 * @since 4.4.0
+	 */
+	public function updateTimestamp()
+	{
+		$this->setTimestamp(@filemtime($this->getFileName()));
 	}
 
 	/**
@@ -62,10 +82,19 @@ class TFileCacheDependency extends TCacheDependency
 	}
 
 	/**
+	 * @since 4.4.0
+	 * @param mixed $value
+	 */
+	protected function setTimestamp($value): void
+	{
+		$this->_timestamp = $value;
+	}
+
+	/**
 	 * @return bool true if the file's last modification time has changed.
 	 */
-	public function getHasChanged()
+	public function getHasChanged(): bool
 	{
-		return @filemtime($this->_fileName) !== $this->_timestamp;
+		return @filemtime($this->getFileName()) !== $this->getTimestamp();
 	}
 }

--- a/framework/Caching/TFileCacheDependency.php
+++ b/framework/Caching/TFileCacheDependency.php
@@ -65,7 +65,9 @@ class TFileCacheDependency extends TCacheDependency
 	}
 
 	/**
-	 * @todo
+	 * Re-captures the tracked file's current modification time as the baseline. Call this
+	 * after intentionally modifying the file so the next {@see getHasChanged()} compares
+	 * against the refreshed timestamp.
 	 * @since 4.4.0
 	 */
 	public function updateTimestamp()

--- a/framework/Caching/TGlobalStateCacheDependency.php
+++ b/framework/Caching/TGlobalStateCacheDependency.php
@@ -57,9 +57,7 @@ class TGlobalStateCacheDependency extends TCacheDependency
 	}
 
 	/**
-	 * Performs the actual dependency checking.
-	 * This method returns true if the specified global state is changed.
-	 * @return bool whether the dependency is changed or not.
+	 * @return bool true if the specified global state has changed.
 	 */
 	public function getHasChanged()
 	{

--- a/framework/Caching/TGlobalStateCacheDependency.php
+++ b/framework/Caching/TGlobalStateCacheDependency.php
@@ -11,6 +11,7 @@
 namespace Prado\Caching;
 
 use Prado\Prado;
+use Prado\TPropertyValue;
 
 /**
  * TGlobalStateCacheDependency class
@@ -71,9 +72,9 @@ class TGlobalStateCacheDependency extends TCacheDependency
 	 * @param string $value the name of the global state to track.
 	 * @see \Prado\TApplication::setGlobalState()
 	 */
-	public function setStateName(string $value): void
+	public function setStateName($value)
 	{
-		$this->setStateNameDirect($value);
+		$this->setStateNameDirect(TPropertyValue::ensureString($value));
 		$this->updateStateValue();
 	}
 

--- a/framework/Caching/TGlobalStateCacheDependency.php
+++ b/framework/Caching/TGlobalStateCacheDependency.php
@@ -13,54 +13,87 @@ namespace Prado\Caching;
 use Prado\Prado;
 
 /**
- * TGlobalStateCacheDependency class.
+ * TGlobalStateCacheDependency class
  *
- * TGlobalStateCacheDependency checks if a global state is changed or not.
- * If the global state is changed, the dependency is reported as changed.
- * To specify which global state this dependency should check with,
- * set {@see setStateName StateName} to the name of the global state.
+ * TGlobalStateCacheDependency reports a cache-dependency change when the
+ * value of the global application state named by {@see setStateName StateName}
+ * differs from the value captured when the dependency was created.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 3.1.0
  */
 class TGlobalStateCacheDependency extends TCacheDependency
 {
-	private $_stateName;
-	private $_stateValue;
+	/** @var string name of the global application state being tracked */
+	private string $_stateName;
+	/** @var mixed value of the global state captured at construction time */
+	private mixed $_stateValue;
 
 	/**
-	 * Constructor.
-	 * @param string $name the name of the global state
+	 * @param string $name the name of the global state to track.
 	 */
-	public function __construct($name)
+	public function __construct(string $name)
 	{
 		$this->setStateName($name);
 		parent::__construct();
 	}
 
 	/**
-	 * @return string the name of the global state
+	 * Returns the stored state name without side effects.
+	 * @return string the tracked global state name.
+	 * @since 4.4.0
 	 */
-	public function getStateName()
+	protected function getStateNameDirect(): string
 	{
 		return $this->_stateName;
 	}
 
 	/**
-	 * @param string $value the name of the global state
-	 * @see TApplication::setGlobalState
+	 * Stores the state name directly without re-capturing the state value.
+	 * @param string $value the global state name.
+	 * @since 4.4.0
 	 */
-	public function setStateName($value)
+	protected function setStateNameDirect(string $value): void
 	{
 		$this->_stateName = $value;
-		$this->_stateValue = Prado::getApplication()->getGlobalState($value);
 	}
 
 	/**
-	 * @return bool true if the specified global state has changed.
+	 * @return string the name of the tracked global state.
 	 */
-	public function getHasChanged()
+	public function getStateName(): string
 	{
-		return $this->_stateValue !== Prado::getApplication()->getGlobalState($this->_stateName);
+		return $this->getStateNameDirect();
+	}
+
+	/**
+	 * Sets the global state name and re-captures its current value.
+	 * @param string $value the name of the global state to track.
+	 * @see \Prado\TApplication::setGlobalState()
+	 */
+	public function setStateName(string $value): void
+	{
+		$this->setStateNameDirect($value);
+		$this->updateStateValue();
+	}
+
+	/**
+	 * Re-captures the current value of the tracked global state.
+	 * Call this after the state has been intentionally updated so that the next
+	 * `getHasChanged()` check uses the refreshed baseline.
+	 * @since 4.4.0
+	 */
+	public function updateStateValue(): void
+	{
+		$this->_stateValue = Prado::getApplication()->getGlobalState($this->getStateName());
+	}
+
+	/**
+	 * @return bool whether the tracked global state's current value differs from
+	 *   the value captured at construction time (or the last {@see updateStateValue()} call).
+	 */
+	public function getHasChanged(): bool
+	{
+		return $this->_stateValue !== Prado::getApplication()->getGlobalState($this->getStateName());
 	}
 }

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -167,7 +167,7 @@ class TMemCache extends TCache
 	 * This method is required by the IModule interface. It makes sure that
 	 * UniquePrefix has been set, creates a Memcache instance and connects
 	 * to the memcache server.
-	 * @param \Prado\Xml\TXmlElement $config configuration for this module, can be null
+	 * @param null|array|\Prado\Xml\TXmlElement $config configuration for this module, can be null
 	 * @throws TConfigurationException if memcache extension is not installed or memcache sever connection fails
 	 */
 	public function init($config)

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -136,7 +136,7 @@ class TMemCache extends TCache
 	 */
 	private $_servers = [];
 	/**
-	 * @var null|string persistent id for the instance of the memcache server
+	 * @var ?string persistent id for the instance of the memcache server
 	 */
 	private $_persistentid;
 
@@ -263,7 +263,7 @@ class TMemCache extends TCache
 	/**
 	 * Creates the Memcached instance.
 	 * Override in a subclass to substitute a mock or alternative implementation.
-	 * @param null|string $persistentId the persistent ID; null creates a non-persistent instance
+	 * @param ?string $persistentId the persistent ID; null creates a non-persistent instance
 	 * @return \Memcached the new Memcached instance
 	 * @since 4.3.3
 	 */
@@ -369,31 +369,31 @@ class TMemCache extends TCache
 
 	/**
 	 * @param string $key a unique key identifying the cached value
-	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
+	 * @return mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue($key)
+	protected function getValue(string $key): mixed
 	{
 		return $this->getCacheDirect()->get($key);
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function setValue(string $key, mixed $value, int $expire): bool
 	{
 		return $this->getCacheDirect()->set($key, $value, $expire);
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addValue(string $key, mixed $value, int $expire): bool
 	{
 		return $this->getCacheDirect()->add($key, $value, $expire);
 	}
@@ -402,16 +402,16 @@ class TMemCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue($key)
+	protected function deleteValue(string $key): bool
 	{
 		return $this->getCacheDirect()->delete($key);
 	}
 
 	/**
-	 * @return bool true if no error happens during flush
+	 * Deletes all values from cache.
 	 */
-	public function flush()
+	public function flush(): void
 	{
-		return $this->getCacheDirect()->flush();
+		$this->getCacheDirect()->flush();
 	}
 }

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -333,7 +333,7 @@ class TMemCache extends TCache
 	 */
 	public function setOptions($value)
 	{
-		$this->assertUninitialized('Options');
+		// Applies to the live Memcached instance, so it is a post-init runtime operation.
 		if (!$this->getIsInitialized()) {
 			throw new TInvalidOperationException('memcache_not_initialized');
 		}
@@ -364,7 +364,6 @@ class TMemCache extends TCache
 	 */
 	public function setUseMemcached($value)
 	{
-		$this->assertUninitialized('UseMemcached');
 		if ($this->getIsInitialized() || TPropertyValue::ensureBoolean($value) === false) {
 			throw new TInvalidOperationException('initialized_property_unchangeable', 'UseMemcached');
 		}

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -56,39 +56,52 @@ use Prado\Xml\TXmlElement;
  * $object2=$cache->get('object');
  * ```
  *
- * You can configure TMemCache two different ways. If you only need one memcache server
- * you may use the method as follows.
- * ```php
- * <module id="cache" class="Prado\Caching\TMemCache" Host="localhost" Port="11211" />
- * ```
- *
- * If you want a more complex configuration, you may use the method as follows.
- * ```php
- * <module id="cache" class="Prado\Caching\TMemCache">
- *     <server Host="localhost" Port="11211" Weight="1" />
- *     <server Host="anotherhost" Port="11211" Weight="1" />
- * </module>
- * ```
- *
  * If loaded, TMemCache will register itself with {@see \Prado\TApplication} as the
  * cache module. It can be accessed via {@see \Prado\TApplication::getCache()}.
  *
- * TMemCache may be configured in application configuration file as follows
+ * XML configuration style, single server:
  * ```xml
  * <modules>
- *     <module id="cache" class="Prado\Caching\TMemCache" Host="localhost" Port="11211" />
+ *   <module id="cache" class="Prado\Caching\TMemCache" Host="localhost" Port="11211" />
  * </modules>
  * ```
- * where {@see getHost Host} and {@see getPort Port} are configurable properties
- * of TMemCache.
+ * where {@see getHost Host} and {@see getPort Port} are configurable properties of TMemCache.
  *
- * PHP configuration style:
+ * PHP configuration style, single server:
  * ```php
  * return [
  *     'modules' => [
  *         'cache' => [
  *             'class' => 'Prado\Caching\TMemCache',
- *             'properties' => ['Host' => 'localhost', 'Port' => '11211'],
+ *             'properties' => [
+ *                 'Host' => 'localhost',
+ *                 'Port' => '11211',
+ *             ],
+ *         ],
+ *     ],
+ * ];
+ * ```
+ *
+ * XML configuration style, multi-server:
+ * ```xml
+ * <modules>
+ *   <module id="cache" class="Prado\Caching\TMemCache">
+ *     <server Host="localhost" Port="11211" Weight="1" />
+ *     <server Host="anotherhost" Port="11211" Weight="1" />
+ *   </module>
+ * </modules>
+ * ```
+ *
+ * PHP configuration style, multi-server:
+ * ```php
+ * return [
+ *     'modules' => [
+ *         'cache' => [
+ *             'class' => 'Prado\Caching\TMemCache',
+ *             'servers' => [
+ *                 ['Host' => 'localhost', 'Port' => '11211', 'Weight' => '1'],
+ *                 ['Host' => 'anotherhost', 'Port' => '11211', 'Weight' => '1'],
+ *             ],
  *         ],
  *     ],
  * ];
@@ -107,7 +120,7 @@ class TMemCache extends TCache
 	use TInitializedTrait;
 
 	/**
-	 * @var \Memcached the Memcached instance
+	 * @var \Memcached The Memcached instance.
 	 */
 	private $_cache;
 	/**
@@ -128,14 +141,22 @@ class TMemCache extends TCache
 	private $_persistentid;
 
 	/**
+	 * @todo
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return function_exists('memcached');
+	}
+
+	/**
 	 * Destructor.
 	 * Disconnect the memcache server.
 	 */
 	public function __destruct()
 	{
-		if ($this->_cache !== null) {
+		if ($this->getCacheDirect() !== null) {
 			// Quit() is available only for memcached >= 2
-			// $this->_cache->quit();
+			// $this->getCacheDirect()->quit();
 		}
 		parent::__destruct();
 	}
@@ -150,19 +171,22 @@ class TMemCache extends TCache
 	 */
 	public function init($config)
 	{
-		if (!extension_loaded('memcached')) {
+		if (!static::getIsAvailable()) {
 			throw new TConfigurationException('memcached_extension_required');
 		}
 
 		$this->loadConfig($config);
-		$this->_cache = new \Memcached($this->_persistentid);
-		if ($this->_persistentid !== null && count($this->_cache->getServerList()) > 0) {
-			Prado::trace('Skipping re-adding servers for persistent id ' . $this->_persistentid, TMemCache::class);
+
+		$persistentId = $this->getPersistentID();
+		$this->setCacheDirect(new \Memcached($persistentId));
+		$memCache = $this->getCacheDirect();
+		if ($persistentId !== null && count($memCache->getServerList()) > 0) {
+			Prado::trace('Skipping re-adding servers for persistent id ' . $persistentId, TMemCache::class);
 		} else {
 			if (count($this->_servers)) {
 				foreach ($this->_servers as $server) {
 					Prado::trace('Adding server ' . $server['Host'] . ' from serverlist', TMemCache::class);
-					if ($this->_cache->addServer(
+					if ($memCache->addServer(
 						$server['Host'],
 						$server['Port'],
 						$server['Weight']
@@ -171,9 +195,9 @@ class TMemCache extends TCache
 					}
 				}
 			} else {
-				Prado::trace('Adding server ' . $this->_host, TMemCache::class);
-				if ($this->_cache->addServer($this->_host, $this->_port) === false) {
-					throw new TConfigurationException('memcache_connection_failed', $this->_host, $this->_port);
+				Prado::trace('Adding server ' . $this->getHost(), TMemCache::class);
+				if ($memCache->addServer($this->getHost(), $this->getPort()) === false) {
+					throw new TConfigurationException('memcache_connection_failed', $this->getHost(), $this->getPort());
 				}
 			}
 		}
@@ -182,14 +206,14 @@ class TMemCache extends TCache
 	}
 
 	/**
-	 * Loads configuration from an XML element
-	 * @param \Prado\Xml\TXmlElement $xml configuration node
-	 * @throws TConfigurationException if log route class or type is not specified
+	 * Loads configuration from an XML element or PHP array.
+	 * @param array|\Prado\Xml\TXmlElement $config configuration node
+	 * @throws TConfigurationException if a server Host or Port is missing or invalid
 	 */
-	private function loadConfig($xml)
+	private function loadConfig($config)
 	{
-		if ($xml instanceof TXmlElement) {
-			foreach ($xml->getElementsByTagName('server') as $serverConfig) {
+		if ($config instanceof TXmlElement) {
+			foreach ($config->getElementsByTagName('server') as $serverConfig) {
 				$properties = $serverConfig->getAttributes();
 				if (($host = $properties->remove('Host')) === null) {
 					throw new TConfigurationException('memcache_serverhost_required');
@@ -214,7 +238,45 @@ class TMemCache extends TCache
 				}
 				$this->_servers[] = $server;
 			}
+		} elseif (is_array($config) && isset($config['servers']) && is_array($config['servers'])) {
+			foreach ($config['servers'] as $serverConfig) {
+				if (!isset($serverConfig['Host'])) {
+					throw new TConfigurationException('memcache_serverhost_required');
+				}
+				if (!isset($serverConfig['Port'])) {
+					throw new TConfigurationException('memcache_serverport_required');
+				}
+				if (!is_numeric($serverConfig['Port'])) {
+					throw new TConfigurationException('memcache_serverport_invalid');
+				}
+				$server = ['Host' => $serverConfig['Host'], 'Port' => $serverConfig['Port'], 'Weight' => 1];
+				if (isset($serverConfig['Weight'])) {
+					if (!is_numeric($serverConfig['Weight'])) {
+						throw new TConfigurationException('memcache_serverweight_invalid');
+					}
+					$server['Weight'] = $serverConfig['Weight'];
+				}
+				$this->_servers[] = $server;
+			}
 		}
+	}
+
+	/**
+	 * @return \Memcached the underlying Memcached instance
+	 * @since 4.3.3
+	 */
+	protected function getCacheDirect(): object
+	{
+		return $this->_cache;
+	}
+
+	/**
+	 * @param \Memcached $value the underlying Memcached instance
+	 * @since 4.3.3
+	 */
+	protected function setCacheDirect($value): void
+	{
+		$this->_cache = $value;
 	}
 
 	/**
@@ -263,7 +325,7 @@ class TMemCache extends TCache
 		if (!$this->getIsInitialized()) {
 			throw new TInvalidOperationException('memcache_not_initialized');
 		}
-		$this->_cache->setOptions(TPropertyValue::ensureArray($value));
+		$this->getCacheDirect()->setOptions(TPropertyValue::ensureArray($value));
 	}
 
 	/**
@@ -295,20 +357,15 @@ class TMemCache extends TCache
 	}
 
 	/**
-	 * Retrieves a value from cache with a specified key.
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
 	 */
 	protected function getValue($key)
 	{
-		return $this->_cache->get($key);
+		return $this->getCacheDirect()->get($key);
 	}
 
 	/**
-	 * Stores a value identified by a key in cache.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -316,13 +373,10 @@ class TMemCache extends TCache
 	 */
 	protected function setValue($key, $value, $expire)
 	{
-		return $this->_cache->set($key, $value, $expire);
+		return $this->getCacheDirect()->set($key, $value, $expire);
 	}
 
 	/**
-	 * Stores a value identified by a key into cache if the cache does not contain this key.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -330,18 +384,16 @@ class TMemCache extends TCache
 	 */
 	protected function addValue($key, $value, $expire)
 	{
-		return $this->_cache->add($key, $value, $expire);
+		return $this->getCacheDirect()->add($key, $value, $expire);
 	}
 
 	/**
-	 * Deletes a value with the specified key from cache
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key the key of the value to be deleted
-	 * @return bool if no error happens during deletion
+	 * @return bool true if no error happens during deletion
 	 */
 	protected function deleteValue($key)
 	{
-		return $this->_cache->delete($key);
+		return $this->getCacheDirect()->delete($key);
 	}
 
 	/**
@@ -351,6 +403,6 @@ class TMemCache extends TCache
 	 */
 	public function flush()
 	{
-		return $this->_cache->flush();
+		return $this->getCacheDirect()->flush();
 	}
 }

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -41,7 +41,7 @@ use Prado\Xml\TXmlElement;
  * or a UNIX timestamp. A expiration time 0 represents never expire.
  *
  * By definition, cache does not ensure the existence of a value
- * even if it never expires. Cache is not meant to be an persistent storage.
+ * even if it never expires. Cache is not meant to be a persistent storage.
  *
  * Also note, there is no security measure to protected data in memcache.
  * All data in memcache can be accessed by any process running in the system.
@@ -141,7 +141,7 @@ class TMemCache extends TCache
 	private $_persistentid;
 
 	/**
-	 * @todo
+	 * @return bool whether the `memcached` extension is loaded.
 	 */
 	public static function getIsAvailable(): bool
 	{

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -176,9 +176,8 @@ class TMemCache extends TCache
 		}
 
 		$this->loadConfig($config);
-
 		$persistentId = $this->getPersistentID();
-		$this->setCacheDirect(new \Memcached($persistentId));
+		$this->setCacheDirect($this->newMemcached($persistentId));
 		$memCache = $this->getCacheDirect();
 		if ($persistentId !== null && count($memCache->getServerList()) > 0) {
 			Prado::trace('Skipping re-adding servers for persistent id ' . $persistentId, TMemCache::class);
@@ -262,16 +261,28 @@ class TMemCache extends TCache
 	}
 
 	/**
-	 * @return \Memcached the underlying Memcached instance
+	 * Creates the Memcached instance.
+	 * Override in a subclass to substitute a mock or alternative implementation.
+	 * @param null|string $persistentId the persistent ID; null creates a non-persistent instance
+	 * @return \Memcached the new Memcached instance
 	 * @since 4.3.3
 	 */
-	protected function getCacheDirect(): object
+	protected function newMemcached($persistentId): object
+	{
+		return new \Memcached($persistentId);
+	}
+
+	/**
+	 * @return ?\Memcached the underlying Memcached instance, or null before initialization
+	 * @since 4.3.3
+	 */
+	protected function getCacheDirect(): ?object
 	{
 		return $this->_cache;
 	}
 
 	/**
-	 * @param \Memcached $value the underlying Memcached instance
+	 * @param ?\Memcached $value the underlying Memcached instance
 	 * @since 4.3.3
 	 */
 	protected function setCacheDirect($value): void

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -371,7 +371,7 @@ class TMemCache extends TCache
 	 * @param string $key a unique key identifying the cached value
 	 * @return mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue(string $key): mixed
+	protected function getValue($key)
 	{
 		return $this->getCacheDirect()->get($key);
 	}
@@ -382,7 +382,7 @@ class TMemCache extends TCache
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue(string $key, mixed $value, int $expire): bool
+	protected function setValue($key, $value, $expire)
 	{
 		return $this->getCacheDirect()->set($key, $value, $expire);
 	}
@@ -393,7 +393,7 @@ class TMemCache extends TCache
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue(string $key, mixed $value, int $expire): bool
+	protected function addValue($key, $value, $expire)
 	{
 		return $this->getCacheDirect()->add($key, $value, $expire);
 	}
@@ -402,7 +402,7 @@ class TMemCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue(string $key): bool
+	protected function deleteValue($key)
 	{
 		return $this->getCacheDirect()->delete($key);
 	}
@@ -410,8 +410,8 @@ class TMemCache extends TCache
 	/**
 	 * Deletes all values from cache.
 	 */
-	public function flush(): void
+	public function flush()
 	{
-		$this->getCacheDirect()->flush();
+		return $this->getCacheDirect()->flush();
 	}
 }

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -397,9 +397,7 @@ class TMemCache extends TCache
 	}
 
 	/**
-	 * Deletes all values from cache.
-	 * Be careful of performing this operation if the cache is shared by multiple applications.
-	 * @return bool if no error happens during flush
+	 * @return bool true if no error happens during flush
 	 */
 	public function flush()
 	{

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -142,6 +142,7 @@ class TMemCache extends TCache
 
 	/**
 	 * @return bool whether the `memcached` extension is loaded.
+	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -145,7 +145,7 @@ class TMemCache extends TCache
 	 */
 	public static function getIsAvailable(): bool
 	{
-		return function_exists('memcached');
+		return extension_loaded('memcached');
 	}
 
 	/**

--- a/framework/Caching/TMemCache.php
+++ b/framework/Caching/TMemCache.php
@@ -333,6 +333,7 @@ class TMemCache extends TCache
 	 */
 	public function setOptions($value)
 	{
+		$this->assertUninitialized('Options');
 		if (!$this->getIsInitialized()) {
 			throw new TInvalidOperationException('memcache_not_initialized');
 		}
@@ -352,6 +353,7 @@ class TMemCache extends TCache
 	 */
 	public function setPersistentID($value)
 	{
+		$this->assertUninitialized('PersistentID');
 		$this->_persistentid = TPropertyValue::ensureString($value);
 	}
 
@@ -362,6 +364,7 @@ class TMemCache extends TCache
 	 */
 	public function setUseMemcached($value)
 	{
+		$this->assertUninitialized('UseMemcached');
 		if ($this->getIsInitialized() || TPropertyValue::ensureBoolean($value) === false) {
 			throw new TInvalidOperationException('initialized_property_unchangeable', 'UseMemcached');
 		}

--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -884,7 +884,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	/**
 	 * @return string the module ID of the backing cache; empty when not configured
 	 */
-	public function getBackingCacheId(): string
+	public function getBackingCacheId()
 	{
 		return $this->getBackingCacheIdDirect();
 	}
@@ -897,7 +897,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *
 	 * @param string $value the module ID of a registered {@see TCache} module
 	 */
-	public function setBackingCacheId($value): void
+	public function setBackingCacheId($value)
 	{
 		$this->assertUninitialized('BackingCacheId');
 		$this->setBackingCacheIdDirect(TPropertyValue::ensureString($value));
@@ -922,7 +922,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	/**
 	 * @return string the absolute path of the backing file; empty when not configured
 	 */
-	public function getBackingFile(): string
+	public function getBackingFile()
 	{
 		return $this->getBackingFileDirect();
 	}
@@ -937,7 +937,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 * @param string $value the file path for the backing store
 	 * @throws TConfigurationException when the parent directory does not exist
 	 */
-	public function setBackingFile($value): void
+	public function setBackingFile($value)
 	{
 		$this->assertUninitialized('BackingFile');
 		$value = TPropertyValue::ensureString($value);
@@ -978,7 +978,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *
 	 * @return string the backing cache key
 	 */
-	public function getBackingCacheKey(): string
+	public function getBackingCacheKey()
 	{
 		return $this->getBackingCacheKeyDirect();
 	}
@@ -990,7 +990,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *
 	 * @param string $value the cache key string
 	 */
-	public function setBackingCacheKey($value): void
+	public function setBackingCacheKey($value)
 	{
 		$this->assertUninitialized('BackingCacheKey');
 		$this->setBackingCacheKeyDirect(TPropertyValue::ensureString($value));
@@ -1016,7 +1016,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 * @return string the active merge policy; one of {@see MERGE} or {@see REPLACE}.
 	 *   Defaults to {@see DEFAULT_MERGE_POLICY}.
 	 */
-	public function getMergePolicy(): string
+	public function getMergePolicy()
 	{
 		return $this->getMergePolicyDirect();
 	}
@@ -1032,7 +1032,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 * @param string $value one of {@see MERGE} (`'Merge'`) or {@see REPLACE} (`'Replace'`)
 	 * @throws \Prado\Exceptions\TInvalidDataValueException when the value is not a valid policy name
 	 */
-	public function setMergePolicy($value): void
+	public function setMergePolicy($value)
 	{
 		$this->assertUninitialized('MergePolicy');
 		$this->setMergePolicyDirect(TPropertyValue::ensureEnum($value, [self::MERGE, self::REPLACE]));
@@ -1066,7 +1066,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *
 	 * @return ?bool the current HashKeys setting
 	 */
-	public function getHashKeys(): ?bool
+	public function getHashKeys()
 	{
 		return $this->getHashKeysDirect();
 	}
@@ -1079,7 +1079,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *
 	 * @param mixed $value `true`, `false`, or `null` (also accepts string equivalents)
 	 */
-	public function setHashKeys($value): void
+	public function setHashKeys($value)
 	{
 		$this->assertUninitialized('HashKeys');
 		if (is_string($value)) {
@@ -1116,7 +1116,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 * @return bool whether each value is serialized before being stored in memory.
 	 *   Defaults to `false`. See {@see $_serializeValues} for the trade-offs.
 	 */
-	public function getSerializeValues(): bool
+	public function getSerializeValues()
 	{
 		return $this->getSerializeValuesDirect();
 	}
@@ -1129,7 +1129,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 * before any entries are stored.
 	 * @param mixed $value whether to serialize stored values.
 	 */
-	public function setSerializeValues($value): void
+	public function setSerializeValues($value)
 	{
 		$this->assertUninitialized('SerializeValues');
 		$this->setSerializeValuesDirect(TPropertyValue::ensureBoolean($value));
@@ -1159,7 +1159,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *   with the backing store. {@see save()} skips the backing write when this
 	 *   returns false.
 	 */
-	public function getChanged(): bool
+	public function getChanged()
 	{
 		return $this->getChangedDirect();
 	}

--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -280,6 +280,15 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	}
 
 	/**
+	 * @return bool always true; the in-memory store has no external dependency.
+	 * @since 4.4.0
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
+	/**
 	 * Initializes the module. Refines the {@see getBackingCacheKey BackingCacheKey}
 	 * set by {@see __construct()} by appending `'.<moduleId>'` when the key is still
 	 * at its {@see DEFAULT_BACKING_CACHE_KEY default} and a module ID is available,

--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -654,8 +654,9 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	// ------------------------- shared store access (both modes) -------------------------
 
 	/**
-	 * Reads the stored payload for a key, enforcing TTL and refreshing the LRU access
-	 * time. The payload is opaque: it is the live value in non-serializing mode and the
+	 * Reads the stored payload for a key, enforcing TTL and, when
+	 * {@see getMaximumSize MaximumSize} is active, refreshing the LRU access time.
+	 * The payload is opaque: it is the live value in non-serializing mode and the
 	 * serialized string in serializing mode. Expired entries are removed on access; when
 	 * {@see getMaximumSize MaximumSize} is active the running size total is decremented.
 	 * @param string $key the unique key

--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -72,17 +72,18 @@ use Prado\TPropertyValue;
  *
  * ## Value isolation ({@see getSerializeValues SerializeValues})
  *
- * By default ({@see getSerializeValues SerializeValues}`= false`) the live value is
- * stored by reference. This is the fastest option and is the only Prado cache that can
- * hold non-serializable values (closures, resources). The trade-off is that a stored
- * object is shared with the caller: mutating it after {@see set()}, or mutating the
- * object returned by {@see get()}, also changes the cached entry. Set
- * `SerializeValues="true"` to store each entry through the {@see TSerializingCache}
- * pipeline — serialized on {@see set()} and deserialized on {@see get()} — so that each
- * entry is an independent copy, matching every other {@see TCache} backend. In that mode
+ * By default ({@see getSerializeValues SerializeValues}`= false`) each value is stored
+ * as-is, without serialization. Objects, closures, and resources are kept as the same
+ * instance and shared with the caller: mutating a stored object after {@see set()}, or
+ * mutating the object returned by {@see get()}, also changes the cached entry. Scalars
+ * and arrays follow PHP copy-on-write semantics and behave as independent copies. This
+ * is the fastest mode and the only Prado cache that can hold non-serializable values.
+ * Set `SerializeValues="true"` to store each entry through the {@see TSerializingCache}
+ * pipeline, serialized on {@see set()} and deserialized on {@see get()}, so that every
+ * entry is an independent copy matching every other {@see TCache} backend. In that mode
  * the inherited {@see getSerializationType SerializationType}, {@see getEncrypt Encrypt},
- * and {@see getEncoding Encoding} settings apply; in reference mode they are ignored.
- * Both modes share the same in-memory store via {@see readStore()} / {@see writeStore()}.
+ * and {@see getEncoding Encoding} settings apply; they are ignored when values are stored
+ * as-is. Both modes share the same in-memory store via {@see readStore()} / {@see writeStore()}.
  *
  * ## Key hashing
  *

--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -247,14 +247,9 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	private ?bool $_hashKeys = null;
 
 	/**
-	 * @var bool Whether each value is serialized before it is stored in memory.
-	 *   When `false` *(default)* the live value is stored by reference: this is fast
-	 *   and can hold non-serializable values (closures, resources), but a stored
-	 *   object is shared with the caller — mutating it after {@see set()}, or mutating
-	 *   the result of {@see get()}, changes the cached entry. When `true` the value is
-	 *   serialized on {@see set()} and unserialized on {@see get()}, so each entry is an
-	 *   independent copy (matching every other {@see TCache} backend). Set this at
-	 *   configuration time, before any entries are stored.
+	 * @var bool Whether each value is serialized before being stored. `false` *(default)*
+	 *   stores the live value by reference; `true` stores an independent serialized copy.
+	 *   See the "Value isolation" section in the class docblock.
 	 */
 	private bool $_serializeValues = false;
 

--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -20,7 +20,7 @@ use Prado\TPropertyValue;
 /**
  * TMemoryCache class.
  *
- * TMemoryCache is an in-process, in-memory {@see TCache} application module.
+ * TMemoryCache is an in-process, in-memory {@see TSerializingCache} application module.
  * All cache entries are held in a plain PHP array for the lifetime of the current
  * process. Data is never shared across processes or requests unless it is
  * explicitly persisted through a backing store.
@@ -69,6 +69,20 @@ use Prado\TPropertyValue;
  *
  * {@see ICacheDependency} objects are supported and serialized together with
  * each value, consistent with the behavior of every other {@see TCache} subclass.
+ *
+ * ## Value isolation ({@see getSerializeValues SerializeValues})
+ *
+ * By default ({@see getSerializeValues SerializeValues}`= false`) the live value is
+ * stored by reference. This is the fastest option and is the only Prado cache that can
+ * hold non-serializable values (closures, resources). The trade-off is that a stored
+ * object is shared with the caller: mutating it after {@see set()}, or mutating the
+ * object returned by {@see get()}, also changes the cached entry. Set
+ * `SerializeValues="true"` to store each entry through the {@see TSerializingCache}
+ * pipeline — serialized on {@see set()} and deserialized on {@see get()} — so that each
+ * entry is an independent copy, matching every other {@see TCache} backend. In that mode
+ * the inherited {@see getSerializationType SerializationType}, {@see getEncrypt Encrypt},
+ * and {@see getEncoding Encoding} settings apply; in reference mode they are ignored.
+ * Both modes share the same in-memory store via {@see readStore()} / {@see writeStore()}.
  *
  * ## Key hashing
  *
@@ -153,9 +167,10 @@ use Prado\TPropertyValue;
  * @author Brad Anderson <belisoful@icloud.com>
  * @since 4.4.0
  */
-class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
+class TMemoryCache extends TSerializingCache implements IModuleDependency, ICacheSize
 {
 	use TCacheSizeTrait;
+	use TCacheFileTrait;
 
 	/** Merge policy: backing fills in only the keys absent from memory. */
 	public const MERGE = 'Merge';
@@ -232,6 +247,18 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	private ?bool $_hashKeys = null;
 
 	/**
+	 * @var bool Whether each value is serialized before it is stored in memory.
+	 *   When `false` *(default)* the live value is stored by reference: this is fast
+	 *   and can hold non-serializable values (closures, resources), but a stored
+	 *   object is shared with the caller — mutating it after {@see set()}, or mutating
+	 *   the result of {@see get()}, changes the cached entry. When `true` the value is
+	 *   serialized on {@see set()} and unserialized on {@see get()}, so each entry is an
+	 *   independent copy (matching every other {@see TCache} backend). Set this at
+	 *   configuration time, before any entries are stored.
+	 */
+	private bool $_serializeValues = false;
+
+	/**
 	 * @var array<string, int> Per-key byte size of the serialized STORE_DATA payload,
 	 *   maintained incrementally by {@see setValue()} and {@see deleteValue()}.
 	 *   Rebuilt from scratch by {@see computeCurrentSize()} on a fingerprint mismatch.
@@ -239,7 +266,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	private array $_entrySizes = [];
 
 	/**
-	 * @var array<string, float> Per-key last-access timestamp from `microtime(true)`,
+	 * @var array<string, float> Per-key last-access timestamp from `$this->microtime()`,
 	 *   used to determine eviction order in {@see evictToFitMaximumSize()}.
 	 *   Entries loaded without an explicit access record are assigned `0.0` (oldest
 	 *   possible) by {@see computeCurrentSize()} so they are evicted first.
@@ -281,7 +308,6 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 
 	/**
 	 * @return bool always true; the in-memory store has no external dependency.
-	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{
@@ -296,7 +322,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	 * {@see handleSaveState()} as a handler for the application's `OnSaveState`
 	 * event so that the store is persisted automatically at the end of each request.
 	 *
-	 * @param null|\Prado\Xml\TXmlElement $config module configuration
+	 * @param null|array|\Prado\Xml\TXmlElement $config module configuration
 	 */
 	public function init($config)
 	{
@@ -514,7 +540,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 		}
 		$file = $this->getBackingFileDirect();
 		if ($file !== '') {
-			return $this->putContents($file, $this->serialize($store)) !== false;
+			return $this->putContents($file, $this->serialize($store), true) !== false;
 		}
 		return false;
 	}
@@ -543,22 +569,111 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	// --------------------------------------------------------------- ICache impl
 
 	/**
-	 * Retrieves a value from the in-memory store by its unique key. Expired entries
-	 * are removed from the store on access; when {@see getMaximumSize MaximumSize}
-	 * is active the running size total is decremented accordingly. Access time is
-	 * updated on every live hit so that LRU eviction remains accurate.
+	 * Retrieves a value by its unique key. In serializing mode
+	 * ({@see getSerializeValues SerializeValues}`= true`) the value is read and
+	 * deserialized through {@see TSerializingCache::getValue()}; otherwise the live
+	 * value is read directly from the store via {@see readStore()}.
 	 *
 	 * @param string $key the unique key produced by {@see \Prado\Caching\TCache::generateUniqueKey()}
-	 * @return false|mixed the stored payload, or false when the key is absent or expired
+	 * @return false|mixed the stored value, or false when the key is absent or expired
 	 */
 	protected function getValue($key)
+	{
+		return $this->getSerializeValues() ? parent::getValue($key) : $this->readStore($key);
+	}
+
+	/**
+	 * Stores a value under the given unique key, overwriting any existing entry. In
+	 * serializing mode the value is serialized through {@see TSerializingCache::setValue()};
+	 * otherwise the live value is written directly via {@see writeStore()}.
+	 *
+	 * @param string $key the unique key
+	 * @param mixed $value the value to store
+	 * @param int $expire TTL in seconds; 0 means never expire
+	 * @return bool true on success
+	 */
+	protected function setValue($key, $value, $expire)
+	{
+		return $this->getSerializeValues()
+			? parent::setValue($key, $value, $expire)
+			: $this->writeStore($key, $value, (int) $expire);
+	}
+
+	/**
+	 * Stores a value only when no live entry already exists under the key. In serializing
+	 * mode the value is serialized through {@see TSerializingCache::addValue()}; otherwise
+	 * the live value is written directly via {@see addStore()}.
+	 *
+	 * @param string $key the unique key
+	 * @param mixed $value the value to store
+	 * @param int $expire TTL in seconds; 0 means never expire
+	 * @return bool true when the entry was stored; false when a live entry already existed
+	 */
+	protected function addValue($key, $value, $expire)
+	{
+		return $this->getSerializeValues()
+			? parent::addValue($key, $value, $expire)
+			: $this->addStore($key, $value, (int) $expire);
+	}
+
+	// ------------------------- TSerializingCache contract (serializing mode) -------------------------
+
+	/**
+	 * Reads the raw serialized payload for a key. Used by {@see TSerializingCache} in
+	 * serializing mode; delegates to the shared {@see readStore()}.
+	 * @param string $key the unique key
+	 * @return false|string the serialized payload, or false when absent or expired
+	 */
+	protected function getSerializedValue(string $key): false|string
+	{
+		$raw = $this->readStore($key);
+		return $raw === false ? false : (string) $raw;
+	}
+
+	/**
+	 * Writes a serialized payload. Used by {@see TSerializingCache} in serializing mode;
+	 * delegates to the shared {@see writeStore()}.
+	 * @param string $key the unique key
+	 * @param string $value the serialized payload
+	 * @param int $expire TTL in seconds; 0 means never expire
+	 * @return bool true on success
+	 */
+	protected function setSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->writeStore($key, $value, $expire);
+	}
+
+	/**
+	 * Writes a serialized payload only when the key is absent. Used by {@see TSerializingCache}
+	 * in serializing mode; delegates to the shared {@see addStore()}.
+	 * @param string $key the unique key
+	 * @param string $value the serialized payload
+	 * @param int $expire TTL in seconds; 0 means never expire
+	 * @return bool true when stored; false when the key already existed
+	 */
+	protected function addSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->addStore($key, $value, $expire);
+	}
+
+	// ------------------------- shared store access (both modes) -------------------------
+
+	/**
+	 * Reads the stored payload for a key, enforcing TTL and refreshing the LRU access
+	 * time. The payload is opaque: it is the live value in non-serializing mode and the
+	 * serialized string in serializing mode. Expired entries are removed on access; when
+	 * {@see getMaximumSize MaximumSize} is active the running size total is decremented.
+	 * @param string $key the unique key
+	 * @return false|mixed the stored payload, or false when the key is absent or expired
+	 */
+	protected function readStore(string $key): mixed
 	{
 		if (!$this->hasStoreEntry($key)) {
 			return false;
 		}
 		$entry = $this->getStoreEntry($key);
 		$expire = (int) $entry[static::STORE_EXPIRE];
-		if ($expire > 0 && $expire <= $this->now()) {
+		if ($expire > 0 && $expire <= $this->time()) {
 			if ($this->getMaximumSizeDirect() > 0) {
 				$size = $this->_entrySizes[$key] ?? 0;
 				$current = $this->getCurrentSizeDirect();
@@ -574,41 +689,44 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 			return false;
 		}
 		if ($this->getMaximumSizeDirect() > 0) {
-			$this->_accessTimes[$key] = microtime(true);
+			$this->_accessTimes[$key] = $this->microtime();
 		}
 		return $entry[static::STORE_DATA];
 	}
 
 	/**
-	 * Stores a value under the given unique key, overwriting any existing entry.
-	 * When {@see getMaximumSize MaximumSize} is active, the serialized size of the
-	 * entry is checked before the write — an oversized item is rejected rather than
-	 * written and immediately evicted. After the write the running size total is
-	 * updated incrementally and {@see enforceMaximumSize()} is called to evict LRU
-	 * entries when the cache has exceeded its limit.
-	 *
+	 * Writes a payload to the store with the given TTL, overwriting any existing entry.
+	 * The payload is opaque (the live value or a serialized string). When
+	 * {@see getMaximumSize MaximumSize} is active the payload size is checked before the
+	 * write — an oversized item is rejected rather than written and immediately evicted —
+	 * then the running size total is updated and {@see enforceMaximumSize()} evicts LRU
+	 * entries as needed.
 	 * @param string $key the unique key
-	 * @param mixed $value the payload to store (contains the value and its dependency)
+	 * @param mixed $payload the payload to store
 	 * @param int $expire TTL in seconds; 0 means never expire
-	 * @throws \Prado\Exceptions\TInvalidDataValueException when MaximumSize is active
-	 *   and the serialized entry exceeds it
-	 * @return true
+	 * @throws \Prado\Exceptions\TInvalidDataValueException when MaximumSize is active and
+	 *   the payload exceeds it
+	 * @return bool true on success
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function writeStore(string $key, mixed $payload, int $expire): bool
 	{
-		$newSize = strlen(is_string($value) ? $value : serialize($value));
-		$this->assertItemFitsMaximumSize($newSize);
-		$oldSize = $this->_entrySizes[$key] ?? 0;
-		$this->_entrySizes[$key] = $newSize;
+		$oldSize = 0;
+		$newSize = 0;
+		if ($this->getMaximumSizeDirect() > 0) {
+			$newSize = strlen(is_string($payload) ? $payload : serialize($payload));
+			$this->assertItemFitsMaximumSize($newSize);
+			$oldSize = $this->_entrySizes[$key] ?? 0;
+			$this->_entrySizes[$key] = $newSize;
+		}
 
 		$this->setStoreEntry($key, [
-			static::STORE_DATA => $value,
-			static::STORE_EXPIRE => (int) $expire > 0 ? $this->now() + (int) $expire : 0,
+			static::STORE_DATA => $payload,
+			static::STORE_EXPIRE => $expire > 0 ? $this->time() + $expire : 0,
 		]);
 		$this->setChangedDirect(true);
 
 		if ($this->getMaximumSizeDirect() > 0) {
-			$this->_accessTimes[$key] = microtime(true);
+			$this->_accessTimes[$key] = $this->microtime();
 			$current = $this->getCurrentSizeDirect();
 			if ($current >= 0) {
 				$this->setCurrentSizeDirect($current - $oldSize + $newSize);
@@ -621,19 +739,18 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	}
 
 	/**
-	 * Stores a value only when no live entry already exists under the given key.
-	 *
+	 * Writes a payload to the store only when the key is absent.
 	 * @param string $key the unique key
-	 * @param mixed $value the payload to store
+	 * @param mixed $payload the payload to store
 	 * @param int $expire TTL in seconds; 0 means never expire
-	 * @return bool true when the entry was stored; false when a live entry already existed
+	 * @return bool true when stored; false when an entry already existed
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addStore(string $key, mixed $payload, int $expire): bool
 	{
-		if ($this->getValue($key) !== false) {
+		if ($this->readStore($key) !== false) {
 			return false;
 		}
-		return $this->setValue($key, $value, $expire);
+		return $this->writeStore($key, $payload, $expire);
 	}
 
 	/**
@@ -786,6 +903,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	 */
 	public function setBackingCacheId($value): void
 	{
+		$this->assertUninitialized('BackingCacheId');
 		$this->setBackingCacheIdDirect(TPropertyValue::ensureString($value));
 	}
 
@@ -825,6 +943,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	 */
 	public function setBackingFile($value): void
 	{
+		$this->assertUninitialized('BackingFile');
 		$value = TPropertyValue::ensureString($value);
 		if ($value === '') {
 			$this->setBackingFileDirect('');
@@ -877,6 +996,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	 */
 	public function setBackingCacheKey($value): void
 	{
+		$this->assertUninitialized('BackingCacheKey');
 		$this->setBackingCacheKeyDirect(TPropertyValue::ensureString($value));
 	}
 
@@ -918,6 +1038,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	 */
 	public function setMergePolicy($value): void
 	{
+		$this->assertUninitialized('MergePolicy');
 		$this->setMergePolicyDirect(TPropertyValue::ensureEnum($value, [self::MERGE, self::REPLACE]));
 	}
 
@@ -964,6 +1085,7 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	 */
 	public function setHashKeys($value): void
 	{
+		$this->assertUninitialized('HashKeys');
 		if (is_string($value)) {
 			if ($value === '' || strcasecmp($value, 'null') === 0) {
 				$value = null;
@@ -974,6 +1096,47 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 			$value = (bool) $value;
 		}
 		$this->setHashKeysDirect($value);
+	}
+
+	// --------------------------------------------------------------- accessors (SerializeValues)
+
+	/**
+	 * @return bool the raw SerializeValues field value
+	 */
+	protected function getSerializeValuesDirect(): bool
+	{
+		return $this->_serializeValues;
+	}
+
+	/**
+	 * @param bool $value the SerializeValues flag to store directly
+	 */
+	protected function setSerializeValuesDirect(bool $value): void
+	{
+		$this->_serializeValues = $value;
+	}
+
+	/**
+	 * @return bool whether each value is serialized before being stored in memory.
+	 *   Defaults to `false`. See {@see $_serializeValues} for the trade-offs.
+	 */
+	public function getSerializeValues(): bool
+	{
+		return $this->getSerializeValuesDirect();
+	}
+
+	/**
+	 * Sets whether each value is serialized before being stored in memory. Enabling this
+	 * gives each entry independent-copy semantics (a stored or retrieved object can no
+	 * longer be mutated through a shared reference); disabling it stores the live value
+	 * by reference, which is faster and can hold non-serializable values. Configure this
+	 * before any entries are stored.
+	 * @param mixed $value whether to serialize stored values.
+	 */
+	public function setSerializeValues($value): void
+	{
+		$this->assertUninitialized('SerializeValues');
+		$this->setSerializeValuesDirect(TPropertyValue::ensureBoolean($value));
 	}
 
 	// --------------------------------------------------------------- accessors (Changed)
@@ -1008,17 +1171,6 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	// --------------------------------------------------------------- helpers
 
 	/**
-	 * Returns the current Unix timestamp. Extracted to allow subclasses and
-	 * test doubles to control clock behavior without modifying real system time.
-	 *
-	 * @return int the current Unix timestamp in seconds
-	 */
-	protected function now(): int
-	{
-		return time();
-	}
-
-	/**
 	 * Serializes a store snapshot to a string for file-based persistence.
 	 * Override to substitute a different serialization format.
 	 *
@@ -1040,31 +1192,6 @@ class TMemoryCache extends TCache implements IModuleDependency, ICacheSize
 	protected function unserialize(string $data): mixed
 	{
 		return @unserialize($data);
-	}
-
-	/**
-	 * Reads and returns the entire contents of a file.
-	 * Returns false when the file cannot be read.
-	 *
-	 * @param string $filePath the path of the file to read
-	 * @return false|string the file contents, or false on failure
-	 */
-	protected function getContents(string $filePath): string|false
-	{
-		return @file_get_contents($filePath);
-	}
-
-	/**
-	 * Writes data to a file with exclusive locking, replacing its current contents.
-	 * Returns false when the file cannot be written.
-	 *
-	 * @param string $filePath the path of the file to write
-	 * @param string $data the data to write
-	 * @return false|int the number of bytes written, or false on failure
-	 */
-	protected function putContents(string $filePath, string $data): int|false
-	{
-		return @file_put_contents($filePath, $data, LOCK_EX);
 	}
 
 	// --------------------------------------- serialization / cloning

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -144,7 +144,7 @@ class TRedisCache extends TCache
 	 */
 	private $_port = 6379;
 	/**
-	 * @var string the unix socket of the redis cache server.
+	 * @var ?string the unix socket of the redis cache server, or null to use TCP.
 	 */
 	private $_socket;
 	/**
@@ -221,7 +221,7 @@ class TRedisCache extends TCache
 	 * @param ?\Redis $value the underlying Redis instance
 	 * @since 4.3.3
 	 */
-	protected function setCacheDirect($value): void
+	protected function setCacheDirect(?object $value): void
 	{
 		$this->_cache = $value;
 	}
@@ -229,7 +229,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return string the host name of the redis cache server
 	 */
-	public function getHost()
+	public function getHost(): string
 	{
 		return $this->_host;
 	}
@@ -238,7 +238,7 @@ class TRedisCache extends TCache
 	 * @param string $value the host name of the redis cache server
 	 * @throws TInvalidOperationException if the module is already initialized
 	 */
-	public function setHost($value)
+	public function setHost(string $value)
 	{
 		$this->assertUninitialized('Host');
 		$this->_host = $value;
@@ -247,7 +247,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return int the port number of the redis cache server
 	 */
-	public function getPort()
+	public function getPort(): int
 	{
 		return $this->_port;
 	}
@@ -265,7 +265,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return string the unix socket of the redis cache server
 	 */
-	public function getSocket()
+	public function getSocket(): string
 	{
 		return $this->_socket;
 	}
@@ -283,7 +283,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return int the database index to use. Defaults to 0.
 	 */
-	public function getIndex()
+	public function getIndex(): int
 	{
 		return $this->_index;
 	}
@@ -300,20 +300,20 @@ class TRedisCache extends TCache
 
 	/**
 	 * @param string $key a unique key identifying the cached value
-	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
+	 * @return mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue($key)
+	protected function getValue(string $key): mixed
 	{
 		return $this->getCacheDirect()->get($key);
 	}
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue($key, $value, $expire)
+	protected function setValue(string $key, mixed $value, int $expire): bool
 	{
 		$options = $expire === 0 ? [] : ['ex' => $expire];
 		return $this->getCacheDirect()->set($key, $value, $options);
@@ -321,11 +321,11 @@ class TRedisCache extends TCache
 
 	/**
 	 * @param string $key the key identifying the value to be cached
-	 * @param string $value the value to be cached
+	 * @param mixed $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue($key, $value, $expire)
+	protected function addValue(string $key, mixed $value, int $expire): bool
 	{
 		$options = $expire === 0 ? ['nx'] : ['nx', 'ex' => $expire];
 		return $this->getCacheDirect()->set($key, $value, $options);
@@ -335,7 +335,7 @@ class TRedisCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue($key)
+	protected function deleteValue(string $key): bool
 	{
 		$this->getCacheDirect()->delete($key);
 		return true;
@@ -343,10 +343,9 @@ class TRedisCache extends TCache
 
 	/**
 	 * Flushes the currently selected Redis database only.
-	 * @return bool true if no error happens during flush
 	 */
-	public function flush()
+	public function flush(): void
 	{
-		return $this->getCacheDirect()->flushDB();
+		$this->getCacheDirect()->flushDB();
 	}
 }

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -47,7 +47,7 @@ use Prado\Xml\TXmlElement;
  * be specified by the number of seconds. A expiration time 0 represents never expire.
  *
  * By definition, cache does not ensure the existence of a value
- * even if it never expires. Cache is not meant to be an persistent storage.
+ * even if it never expires. Cache is not meant to be a persistent storage.
  *
  * Also note, there is no security measure to protected data in redis cache.
  * All data in redis cache can be accessed by any process running in the system.
@@ -56,7 +56,7 @@ use Prado\Xml\TXmlElement;
  *
  * Some usage examples of TRedisCache are as follows,
  * ```php
- * $cache=new TRedisCache;  // TRedisache may also be loaded as a Prado application module
+ * $cache=new TRedisCache;  // TRedisCache may also be loaded as a Prado application module
  * $cache->init(null);
  * $cache->add('object',$object);
  * $object2=$cache->get('object');
@@ -153,7 +153,7 @@ class TRedisCache extends TCache
 	private $_index = 0;
 
 	/**
-	 * @todo
+	 * @return bool whether the `redis` extension is loaded and the `\Redis` class exists.
 	 */
 	public static function getIsAvailable(): bool
 	{

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -132,7 +132,7 @@ class TRedisCache extends TCache
 	use TInitializedTrait;
 
 	/**
-	 * @var \Redis the Redis instance
+	 * @var ?\Redis the Redis instance
 	 */
 	private $_cache;
 	/**
@@ -184,7 +184,7 @@ class TRedisCache extends TCache
 		if (!static::getIsAvailable()) {
 			throw new TConfigurationException('rediscache_extension_required');
 		}
-		$this->setCacheDirect(new \Redis());
+		$this->setCacheDirect($this->newRedis());
 		$cacheObject = $this->getCacheDirect();
 		if ($this->_socket !== null) {
 			$cacheObject->connect($this->getSocket());
@@ -198,16 +198,27 @@ class TRedisCache extends TCache
 	}
 
 	/**
-	 * @return \Redis the underlying Redis instance
+	 * Creates the Redis instance.
+	 * Override in a subclass to substitute a mock or alternative implementation.
+	 * @return \Redis the new Redis instance
 	 * @since 4.3.3
 	 */
-	protected function getCacheDirect(): object
+	protected function newRedis(): object
+	{
+		return new \Redis();
+	}
+
+	/**
+	 * @return ?\Redis the underlying Redis instance, or null before initialization
+	 * @since 4.3.3
+	 */
+	protected function getCacheDirect(): ?object
 	{
 		return $this->_cache;
 	}
 
 	/**
-	 * @param \Redis $value the underlying Redis instance
+	 * @param ?\Redis $value the underlying Redis instance
 	 * @since 4.3.3
 	 */
 	protected function setCacheDirect($value): void

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -154,6 +154,7 @@ class TRedisCache extends TCache
 
 	/**
 	 * @return bool whether the `redis` extension is loaded and the `\Redis` class exists.
+	 * @since 4.4.0
 	 */
 	public static function getIsAvailable(): bool
 	{

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -229,7 +229,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return string the host name of the redis cache server
 	 */
-	public function getHost(): string
+	public function getHost()
 	{
 		return $this->_host;
 	}
@@ -238,7 +238,7 @@ class TRedisCache extends TCache
 	 * @param string $value the host name of the redis cache server
 	 * @throws TInvalidOperationException if the module is already initialized
 	 */
-	public function setHost(string $value)
+	public function setHost($value)
 	{
 		$this->assertUninitialized('Host');
 		$this->_host = $value;
@@ -247,7 +247,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return int the port number of the redis cache server
 	 */
-	public function getPort(): int
+	public function getPort()
 	{
 		return $this->_port;
 	}
@@ -265,7 +265,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return string the unix socket of the redis cache server
 	 */
-	public function getSocket(): string
+	public function getSocket()
 	{
 		return $this->_socket;
 	}
@@ -283,7 +283,7 @@ class TRedisCache extends TCache
 	/**
 	 * @return int the database index to use. Defaults to 0.
 	 */
-	public function getIndex(): int
+	public function getIndex()
 	{
 		return $this->_index;
 	}
@@ -302,7 +302,7 @@ class TRedisCache extends TCache
 	 * @param string $key a unique key identifying the cached value
 	 * @return mixed the stored value on a hit, or `false` on a miss or expiry.
 	 */
-	protected function getValue(string $key): mixed
+	protected function getValue($key)
 	{
 		return $this->getCacheDirect()->get($key);
 	}
@@ -313,7 +313,7 @@ class TRedisCache extends TCache
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function setValue(string $key, mixed $value, int $expire): bool
+	protected function setValue($key, $value, $expire)
 	{
 		$options = $expire === 0 ? [] : ['ex' => $expire];
 		return $this->getCacheDirect()->set($key, $value, $options);
@@ -325,7 +325,7 @@ class TRedisCache extends TCache
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
 	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	protected function addValue(string $key, mixed $value, int $expire): bool
+	protected function addValue($key, $value, $expire)
 	{
 		$options = $expire === 0 ? ['nx'] : ['nx', 'ex' => $expire];
 		return $this->getCacheDirect()->set($key, $value, $options);
@@ -335,7 +335,7 @@ class TRedisCache extends TCache
 	 * @param string $key the key of the value to be deleted
 	 * @return bool true if no error happens during deletion
 	 */
-	protected function deleteValue(string $key): bool
+	protected function deleteValue($key)
 	{
 		$this->getCacheDirect()->delete($key);
 		return true;
@@ -344,8 +344,8 @@ class TRedisCache extends TCache
 	/**
 	 * Flushes the currently selected Redis database only.
 	 */
-	public function flush(): void
+	public function flush()
 	{
-		$this->getCacheDirect()->flushDB();
+		return $this->getCacheDirect()->flushDB();
 	}
 }

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -65,20 +65,51 @@ use Prado\Xml\TXmlElement;
  * If loaded as module, TRedisCache will register itself with {@see \Prado\TApplication} as the
  * default cache module. It can be accessed via {@see \Prado\TApplication::getCache()}.
  *
- * TRedisCache may be configured in application configuration file as follows
+ * XML configuration style, TCP:
  * ```xml
  * <modules>
- *     <module id="cache" class="Prado\Caching\TRedisCache" Host="localhost" Port="6379" />
+ *   <module id="cache" class="Prado\Caching\TRedisCache" Host="localhost" Port="6379" />
  * </modules>
  * ```
- * or
+ *
+ * PHP configuration style, TCP:
+ * ```php
+ * return [
+ *     'modules' => [
+ *         'cache' => [
+ *             'class' => 'Prado\Caching\TRedisCache',
+ *             'properties' => [
+ *                 'Host' => 'localhost',
+ *                 'Port' => '6379',
+ *             ],
+ *         ],
+ *     ],
+ * ];
+ * ```
+ *
+ * XML configuration style, Unix socket:
  * ```xml
  * <modules>
- *     <module id="cache" class="Prado\Caching\TRedisCache" Socket="/var/run/redis/redis.sock" Index="2" />
+ *   <module id="cache" class="Prado\Caching\TRedisCache" Socket="/var/run/redis/redis.sock" Index="2" />
  * </modules>
  * ```
- * where {@see setHost Host} and {@see setPort Port} or {@see setSocket Socket} are configurable properties
- * of TRedisCache.
+ *
+ * PHP configuration style, Unix socket:
+ * ```php
+ * return [
+ *     'modules' => [
+ *         'cache' => [
+ *             'class' => 'Prado\Caching\TRedisCache',
+ *             'properties' => [
+ *                 'Socket' => '/var/run/redis/redis.sock',
+ *                 'Index' => '2',
+ *             ],
+ *         ],
+ *     ],
+ * ];
+ * ```
+ * where {@see setHost Host} and {@see setPort Port} or {@see setSocket Socket} are configurable
+ * properties of TRedisCache.
  *
  * PHP configuration style:
  * ```php
@@ -122,13 +153,22 @@ class TRedisCache extends TCache
 	private $_index = 0;
 
 	/**
+	 * @todo
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return extension_loaded('redis') && class_exists('\Redis', false);
+	}
+
+	/**
 	 * Destructor.
 	 * Disconnect the redis cache server.
 	 */
 	public function __destruct()
 	{
-		if ($this->_cache instanceof \Redis) {
-			$this->_cache->close();
+		$cacheObject = $this->getCacheDirect();
+		if ($cacheObject instanceof \Redis) {
+			$cacheObject->close();
 		}
 		parent::__destruct();
 	}
@@ -141,28 +181,38 @@ class TRedisCache extends TCache
 	 */
 	public function init($config)
 	{
-		if (!extension_loaded('redis') || !class_exists('\Redis', false)) {
+		if (!static::getIsAvailable()) {
 			throw new TConfigurationException('rediscache_extension_required');
 		}
-		$this->_cache = new \Redis();
+		$this->setCacheDirect(new \Redis());
+		$cacheObject = $this->getCacheDirect();
 		if ($this->_socket !== null) {
-			$this->_cache->connect($this->_socket);
+			$cacheObject->connect($this->getSocket());
 		} else {
-			$this->_cache->connect($this->_host, $this->_port);
+			$cacheObject->connect($this->getHost(), $this->getPort());
 		}
-		$this->_cache->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_PHP);
-		$this->_cache->select($this->_index);
+		$cacheObject->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_PHP);
+		$cacheObject->select($this->getIndex());
 		parent::init($config);
 		$this->markInitialized();
 	}
 
 	/**
-	 * @param mixed $key
-	 * @return bool always true
+	 * @return \Redis the underlying Redis instance
+	 * @since 4.3.3
 	 */
-	public function valid($key)
+	protected function getCacheDirect(): object
 	{
-		return true;
+		return $this->_cache;
+	}
+
+	/**
+	 * @param \Redis $value the underlying Redis instance
+	 * @since 4.3.3
+	 */
+	protected function setCacheDirect($value): void
+	{
+		$this->_cache = $value;
 	}
 
 	/**
@@ -238,20 +288,15 @@ class TRedisCache extends TCache
 	}
 
 	/**
-	 * Retrieves a value from cache with a specified key.
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key a unique key identifying the cached value
 	 * @return false|string the value stored in cache, false if the value is not in the cache or expired.
 	 */
 	protected function getValue($key)
 	{
-		return $this->_cache->get($key);
+		return $this->getCacheDirect()->get($key);
 	}
 
 	/**
-	 * Stores a value identified by a key in cache.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -260,13 +305,10 @@ class TRedisCache extends TCache
 	protected function setValue($key, $value, $expire)
 	{
 		$options = $expire === 0 ? [] : ['ex' => $expire];
-		return $this->_cache->set($key, $value, $options);
+		return $this->getCacheDirect()->set($key, $value, $options);
 	}
 
 	/**
-	 * Stores a value identified by a key into cache if the cache does not contain this key.
-	 * This is the implementation of the method declared in the parent class.
-	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param string $value the value to be cached
 	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
@@ -275,18 +317,16 @@ class TRedisCache extends TCache
 	protected function addValue($key, $value, $expire)
 	{
 		$options = $expire === 0 ? ['nx'] : ['nx', 'ex' => $expire];
-		return $this->_cache->set($key, $value, $options);
+		return $this->getCacheDirect()->set($key, $value, $options);
 	}
 
 	/**
-	 * Deletes a value with the specified key from cache
-	 * This is the implementation of the method declared in the parent class.
 	 * @param string $key the key of the value to be deleted
-	 * @return bool if no error happens during deletion
+	 * @return bool true if no error happens during deletion
 	 */
 	protected function deleteValue($key)
 	{
-		$this->_cache->delete($key);
+		$this->getCacheDirect()->delete($key);
 		return true;
 	}
 
@@ -296,6 +336,6 @@ class TRedisCache extends TCache
 	 */
 	public function flush()
 	{
-		return $this->_cache->flushDB();
+		return $this->getCacheDirect()->flushDB();
 	}
 }

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -177,7 +177,7 @@ class TRedisCache extends TCache
 	/**
 	 * Initializes this module.
 	 * This method is required by the IModule interface. It creates a Redis instance and connects to the redis server.
-	 * @param \Prado\Xml\TXmlElement $config configuration for this module, can be null
+	 * @param null|array|\Prado\Xml\TXmlElement $config configuration for this module, can be null
 	 * @throws TConfigurationException if php-redis extension is not installed or redis cache sever connection fails
 	 */
 	public function init($config)

--- a/framework/Caching/TRedisCache.php
+++ b/framework/Caching/TRedisCache.php
@@ -331,8 +331,8 @@ class TRedisCache extends TCache
 	}
 
 	/**
-	 * Deletes all values from cache, only clearing the currently selected database.
-	 * @return bool if no error happens during flush
+	 * Flushes the currently selected Redis database only.
+	 * @return bool true if no error happens during flush
 	 */
 	public function flush()
 	{

--- a/framework/Caching/TSerializingCache.php
+++ b/framework/Caching/TSerializingCache.php
@@ -156,7 +156,7 @@ abstract class TSerializingCache extends TCache
 	 * @param string $key a unique key identifying the cached value.
 	 * @return false|mixed the stored value, or `false` on a miss or expiry.
 	 */
-	final protected function getValue(string $key): mixed
+	final protected function getValue($key)
 	{
 		$raw = $this->getSerializedValue($key);
 		return $raw === false ? false : $this->unserializeValue($raw);
@@ -169,7 +169,7 @@ abstract class TSerializingCache extends TCache
 	 * @param int $expire the number of seconds until expiry; 0 means never expire.
 	 * @return bool `true` on success.
 	 */
-	final protected function setValue(string $key, mixed $value, int $expire): bool
+	final protected function setValue($key, $value, $expire)
 	{
 		return $this->setSerializedValue($key, $this->serializeValue($value), $expire);
 	}
@@ -181,7 +181,7 @@ abstract class TSerializingCache extends TCache
 	 * @param int $expire the number of seconds until expiry; 0 means never expire.
 	 * @return bool `true` on success.
 	 */
-	final protected function addValue(string $key, mixed $value, int $expire): bool
+	final protected function addValue($key, $value, $expire)
 	{
 		return $this->addSerializedValue($key, $this->serializeValue($value), $expire);
 	}

--- a/framework/Caching/TSerializingCache.php
+++ b/framework/Caching/TSerializingCache.php
@@ -130,7 +130,7 @@ abstract class TSerializingCache extends TCache
 	 * @param string $value one of `'PHP'` or `'JSON'`.
 	 * @throws TInvalidDataValueException if the value is not a recognized type.
 	 */
-	public function setSerializationType($value): void
+	public function setSerializationType($value)
 	{
 		$this->assertUninitialized('SerializationType');
 		$value = TPropertyValue::ensureString($value);
@@ -161,7 +161,7 @@ abstract class TSerializingCache extends TCache
 	/**
 	 * @param mixed $value whether to encrypt the serialized payload.
 	 */
-	public function setEncrypt($value): void
+	public function setEncrypt($value)
 	{
 		$this->assertUninitialized('Encrypt');
 		$this->setEncryptDirect(TPropertyValue::ensureBoolean($value));
@@ -190,7 +190,7 @@ abstract class TSerializingCache extends TCache
 	 * @param string $value one of `'None'`, `'Base64'`, or `'Hex'`.
 	 * @throws TInvalidDataValueException if the value is not a recognized encoding.
 	 */
-	public function setEncoding($value): void
+	public function setEncoding($value)
 	{
 		$this->assertUninitialized('Encoding');
 		$value = TPropertyValue::ensureString($value);
@@ -239,7 +239,7 @@ abstract class TSerializingCache extends TCache
 	 * @param string|TSecurityManager $value the security manager module id or instance.
 	 * @throws TConfigurationException if the value is neither a string nor a {@see TSecurityManager}.
 	 */
-	public function setSecurityManager($value): void
+	public function setSecurityManager($value)
 	{
 		$this->assertUninitialized('SecurityManager');
 		if (!is_string($value) && !($value instanceof TSecurityManager)) {

--- a/framework/Caching/TSerializingCache.php
+++ b/framework/Caching/TSerializingCache.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * TSerializingCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Caching;
+
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\TPropertyValue;
+
+/**
+ * TSerializingCache class
+ *
+ * TSerializingCache is an intermediate abstract base class that sits between
+ * {@see \Prado\Caching\TCache} and cache backends whose storage layer expects
+ * plain strings (e.g. database BLOBs, HTTP key-value APIs).
+ *
+ * It intercepts the mixed-typed `getValue`/`setValue`/`addValue` calls from
+ * {@see \Prado\Caching\TCache}, applies serialization or deserialization,
+ * then forwards a `string` to or from the three new abstract storage methods
+ * that child classes must implement:
+ * - {@see getSerializedValue()} — retrieve a raw serialized string.
+ * - {@see setSerializedValue()} — store a raw serialized string.
+ * - {@see addSerializedValue()} — conditionally store a raw serialized string.
+ *
+ * Attached behaviors take priority over the configured format: on every
+ * serialize/unserialize call, {@see dySerialize()} and {@see dyUnserialize()}
+ * are raised first. If a behavior returns a value that differs from the
+ * sentinel default, that result is used directly and the
+ * {@see setSerializationType SerializationType} setting is bypassed.
+ *
+ * The fallback serialization format is controlled by
+ * {@see setSerializationType SerializationType}:
+ * - `'PHP'` — PHP's native {@see serialize()} / {@see unserialize()} (default).
+ * - `'JSON'` — {@see json_encode()} / {@see json_decode()}.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ * @method string dySerialize(object $sentinel, mixed $value) Raised before serializing a value; return a string (different from `$sentinel`) to override the configured serialization type.
+ * @method mixed dyUnserialize(object $sentinel, string $data) Raised before unserializing data; return any non-sentinel value to override the configured serialization type.
+ */
+abstract class TSerializingCache extends TCache
+{
+	/** serialization type constant for PHP native serialize/unserialize */
+	public const SERIALIZATION_PHP = 'PHP';
+
+	/** serialization type constant for JSON encode/decode */
+	public const SERIALIZATION_JSON = 'JSON';
+
+	/** serialization type constant for JSON encode/decode */
+	public const DEFAULT_SERIALIZATION_TYPE = self::SERIALIZATION_PHP;
+
+	/** @var string the active serialization type */
+	private string $_serializationType = '';
+
+	// =========================================================================
+	// Lifecycle
+	// =========================================================================
+
+	public function __construct()
+	{
+		$this->setSerializationTypeDirect(static::DEFAULT_SERIALIZATION_TYPE);
+		parent::__construct();
+	}
+
+	// =========================================================================
+	// Property Getters/Setters
+	// =========================================================================
+
+	/**
+	 * @return string the serialization type. Defaults to `'PHP'`.
+	 */
+	public function getSerializationType(): string
+	{
+		return $this->_serializationType;
+	}
+
+	/**
+	 * Sets the serialization type used when no behavior handles {@see dySerialize()}.
+	 * @param string $value one of `'PHP'` or `'JSON'`.
+	 * @throws TInvalidDataValueException if the value is not a recognized type.
+	 */
+	public function setSerializationType(string $value): void
+	{
+		$value = TPropertyValue::ensureString($value);
+		if (!in_array($value, [self::SERIALIZATION_PHP, self::SERIALIZATION_JSON], true)) {
+			throw new TInvalidDataValueException('serializingcache_type_invalid', $value);
+		}
+		$this->setSerializationTypeDirect($value);
+	}
+
+	/**
+	 * Stores the serialization type without validation.
+	 * @param string $value the serialization type.
+	 */
+	protected function setSerializationTypeDirect(string $value): void
+	{
+		$this->_serializationType = $value;
+	}
+
+	// =========================================================================
+	// Serialization Helpers
+	// =========================================================================
+
+	/**
+	 * Serializes a mixed value to a string for storage.
+	 * {@see dySerialize()} is always raised first; if a behavior returns a value
+	 * that differs from the sentinel, that string is used. Otherwise the
+	 * configured {@see getSerializationType SerializationType} is applied.
+	 * @param mixed $value the value to serialize.
+	 * @return string the serialized string.
+	 */
+	protected function serializeValue(mixed $value): string
+	{
+		$newValue = $this->dySerialize($value);
+		if ($newValue !== $value) {
+			return (string) $newValue;
+		}
+		return $this->getSerializationType() === self::SERIALIZATION_JSON
+			? json_encode($value)
+			: serialize($value);
+	}
+
+	/**
+	 * Restores a mixed value from a serialized string.
+	 * {@see dyUnserialize()} is always raised first; if a behavior returns a value
+	 * that differs from the sentinel, that value is used. Otherwise the
+	 * configured {@see getSerializationType SerializationType} is applied.
+	 * @param string $data the serialized string to restore.
+	 * @return mixed the unserialized value.
+	 */
+	protected function unserializeValue(string $data): mixed
+	{
+		$newData = $this->dyUnserialize($data);
+		if ($newData !== $data) {
+			return $newData;
+		}
+		return $this->getSerializationType() === self::SERIALIZATION_JSON
+			? json_decode($data, true)
+			: unserialize($data);
+	}
+
+	// =========================================================================
+	// Implementation of the TCache abstract contract
+	// =========================================================================
+
+	/**
+	 * Retrieves and deserializes a value from cache.
+	 * Calls {@see getSerializedValue()} and passes the result through
+	 * {@see unserializeValue()}; returns `false` on a cache miss.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return false|mixed the stored value, or `false` on a miss or expiry.
+	 */
+	final protected function getValue(string $key): mixed
+	{
+		$raw = $this->getSerializedValue($key);
+		return $raw === false ? false : $this->unserializeValue($raw);
+	}
+
+	/**
+	 * Serializes a value and stores it via {@see setSerializedValue()}.
+	 * @param string $key the key identifying the value to be cached.
+	 * @param mixed $value the value to be cached.
+	 * @param int $expire the number of seconds until expiry; 0 means never expire.
+	 * @return bool `true` on success.
+	 */
+	final protected function setValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->setSerializedValue($key, $this->serializeValue($value), $expire);
+	}
+
+	/**
+	 * Serializes a value and conditionally stores it via {@see addSerializedValue()}.
+	 * @param string $key the key identifying the value to be cached.
+	 * @param mixed $value the value to be cached.
+	 * @param int $expire the number of seconds until expiry; 0 means never expire.
+	 * @return bool `true` on success.
+	 */
+	final protected function addValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->addSerializedValue($key, $this->serializeValue($value), $expire);
+	}
+
+	// =========================================================================
+	// Subclass Abstract Contract
+	// =========================================================================
+
+	/**
+	 * Retrieves the raw serialized string for the given key from the storage backend.
+	 * Uniqueness and dependency are handled by {@see getValue()}; implement storage retrieval only.
+	 * @param string $key a unique key identifying the cached value.
+	 * @return false|string the serialized string, or `false` if not in the cache or expired.
+	 */
+	abstract protected function getSerializedValue(string $key): false|string;
+
+	/**
+	 * Stores a serialized string in the storage backend; replaces any existing value for the key.
+	 * Uniqueness and dependency are handled by {@see setValue()}; implement storage write only.
+	 * @param string $key the key identifying the value to be cached.
+	 * @param string $value the serialized value to store.
+	 * @param int $expire the number of seconds until expiry; 0 means never expire.
+	 * @return bool `true` if successfully stored, `false` otherwise.
+	 */
+	abstract protected function setSerializedValue(string $key, string $value, int $expire): bool;
+
+	/**
+	 * Stores a serialized string only if the key does not already exist in the cache.
+	 * Nothing is written and `false` is returned if the key is already present.
+	 * Uniqueness and dependency are handled by {@see addValue()}; implement storage write only.
+	 * @param string $key the key identifying the value to be cached.
+	 * @param string $value the serialized value to store.
+	 * @param int $expire the number of seconds until expiry; 0 means never expire.
+	 * @return bool `true` if successfully stored, `false` if the key already existed or the write failed.
+	 */
+	abstract protected function addSerializedValue(string $key, string $value, int $expire): bool;
+}

--- a/framework/Caching/TSerializingCache.php
+++ b/framework/Caching/TSerializingCache.php
@@ -102,7 +102,7 @@ abstract class TSerializingCache extends TCache
 	 * format-defining properties ({@see setSerializationType SerializationType},
 	 * {@see setEncrypt Encrypt}, {@see setEncoding Encoding},
 	 * {@see setSecurityManager SecurityManager}) can no longer be changed.
-	 * @param mixed $config module configuration.
+	 * @param null|array|\Prado\Xml\TXmlElement $config module configuration.
 	 */
 	public function init($config)
 	{

--- a/framework/Caching/TSerializingCache.php
+++ b/framework/Caching/TSerializingCache.php
@@ -331,14 +331,11 @@ abstract class TSerializingCache extends TCache
 	 */
 	protected function decode(string $data): false|string
 	{
-		switch ($this->getEncoding()) {
-			case self::ENCODING_BASE64:
-				return base64_decode($data, true);
-			case self::ENCODING_HEX:
-				return (strlen($data) % 2 === 0 && ctype_xdigit($data)) ? hex2bin($data) : false;
-			default:
-				return $data;
-		}
+		return match ($this->getEncoding()) {
+			self::ENCODING_BASE64 => base64_decode($data, true),
+			self::ENCODING_HEX => (strlen($data) % 2 === 0 && ctype_xdigit($data)) ? hex2bin($data) : false,
+			default => $data,
+		};
 	}
 
 	// =========================================================================

--- a/framework/Caching/TSerializingCache.php
+++ b/framework/Caching/TSerializingCache.php
@@ -10,8 +10,11 @@
 
 namespace Prado\Caching;
 
+use Prado\Exceptions\TConfigurationException;
 use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Security\TSecurityManager;
 use Prado\TPropertyValue;
+use Prado\Util\Traits\TInitializedTrait;
 
 /**
  * TSerializingCache class
@@ -46,6 +49,8 @@ use Prado\TPropertyValue;
  */
 abstract class TSerializingCache extends TCache
 {
+	use TInitializedTrait;
+
 	/** serialization type constant for PHP native serialize/unserialize */
 	public const SERIALIZATION_PHP = 'PHP';
 
@@ -55,8 +60,29 @@ abstract class TSerializingCache extends TCache
 	/** serialization type constant for JSON encode/decode */
 	public const DEFAULT_SERIALIZATION_TYPE = self::SERIALIZATION_PHP;
 
+	/** encoding constant: store the payload verbatim (no encoding) */
+	public const ENCODING_NONE = 'None';
+
+	/** encoding constant: base64-encode the payload */
+	public const ENCODING_BASE64 = 'Base64';
+
+	/** encoding constant: hexadecimal-encode the payload */
+	public const ENCODING_HEX = 'Hex';
+
+	/** default payload encoding */
+	public const DEFAULT_ENCODING = self::ENCODING_NONE;
+
 	/** @var string the active serialization type */
 	private string $_serializationType = '';
+
+	/** @var bool whether the serialized payload is encrypted */
+	private bool $_encrypt = false;
+
+	/** @var string the active payload encoding */
+	private string $_encoding = '';
+
+	/** @var string|TSecurityManager security manager module id, or the instance; '' = application security manager */
+	private string|TSecurityManager $_securityManager = '';
 
 	// =========================================================================
 	// Lifecycle
@@ -65,7 +91,26 @@ abstract class TSerializingCache extends TCache
 	public function __construct()
 	{
 		$this->setSerializationTypeDirect(static::DEFAULT_SERIALIZATION_TYPE);
+		$this->setEncodingDirect(static::DEFAULT_ENCODING);
 		parent::__construct();
+	}
+
+	/**
+	 * Initializes the module. When {@see getEncrypt Encrypt} is enabled, the
+	 * {@see getSecurityManager SecurityManager} is resolved and validated up front so
+	 * that a misconfigured module id fails fast. After initialization the
+	 * format-defining properties ({@see setSerializationType SerializationType},
+	 * {@see setEncrypt Encrypt}, {@see setEncoding Encoding},
+	 * {@see setSecurityManager SecurityManager}) can no longer be changed.
+	 * @param mixed $config module configuration.
+	 */
+	public function init($config)
+	{
+		if ($this->getEncrypt()) {
+			$this->getSecurityManager();
+		}
+		parent::init($config);
+		$this->markInitialized();
 	}
 
 	// =========================================================================
@@ -85,8 +130,9 @@ abstract class TSerializingCache extends TCache
 	 * @param string $value one of `'PHP'` or `'JSON'`.
 	 * @throws TInvalidDataValueException if the value is not a recognized type.
 	 */
-	public function setSerializationType(string $value): void
+	public function setSerializationType($value): void
 	{
+		$this->assertUninitialized('SerializationType');
 		$value = TPropertyValue::ensureString($value);
 		if (!in_array($value, [self::SERIALIZATION_PHP, self::SERIALIZATION_JSON], true)) {
 			throw new TInvalidDataValueException('serializingcache_type_invalid', $value);
@@ -101,6 +147,105 @@ abstract class TSerializingCache extends TCache
 	protected function setSerializationTypeDirect(string $value): void
 	{
 		$this->_serializationType = $value;
+	}
+
+	/**
+	 * @return bool whether the serialized payload is encrypted with the
+	 *   {@see getSecurityManager SecurityManager}. Defaults to `false`.
+	 */
+	public function getEncrypt(): bool
+	{
+		return $this->_encrypt;
+	}
+
+	/**
+	 * @param mixed $value whether to encrypt the serialized payload.
+	 */
+	public function setEncrypt($value): void
+	{
+		$this->assertUninitialized('Encrypt');
+		$this->setEncryptDirect(TPropertyValue::ensureBoolean($value));
+	}
+
+	/**
+	 * Stores the encrypt flag without conversion.
+	 * @param bool $value whether to encrypt the serialized payload.
+	 */
+	protected function setEncryptDirect(bool $value): void
+	{
+		$this->_encrypt = $value;
+	}
+
+	/**
+	 * @return string the payload encoding, one of {@see ENCODING_NONE},
+	 *   {@see ENCODING_BASE64}, {@see ENCODING_HEX}. Defaults to `'None'`.
+	 */
+	public function getEncoding(): string
+	{
+		return $this->_encoding;
+	}
+
+	/**
+	 * Sets the encoding applied to the (possibly encrypted) payload before storage.
+	 * @param string $value one of `'None'`, `'Base64'`, or `'Hex'`.
+	 * @throws TInvalidDataValueException if the value is not a recognized encoding.
+	 */
+	public function setEncoding($value): void
+	{
+		$this->assertUninitialized('Encoding');
+		$value = TPropertyValue::ensureString($value);
+		if (!in_array($value, [self::ENCODING_NONE, self::ENCODING_BASE64, self::ENCODING_HEX], true)) {
+			throw new TInvalidDataValueException('serializingcache_encoding_invalid', $value);
+		}
+		$this->setEncodingDirect($value);
+	}
+
+	/**
+	 * Stores the encoding without validation.
+	 * @param string $value the encoding.
+	 */
+	protected function setEncodingDirect(string $value): void
+	{
+		$this->_encoding = $value;
+	}
+
+	/**
+	 * Returns the security manager used for {@see getEncrypt encryption}. When the
+	 * property is the empty string (the default), the application security manager is
+	 * returned. When it is a module id, that module is resolved and validated.
+	 * @return TSecurityManager the resolved security manager.
+	 * @throws TConfigurationException if the configured module id does not resolve to a {@see TSecurityManager}.
+	 */
+	public function getSecurityManager(): TSecurityManager
+	{
+		$sm = $this->_securityManager;
+		if ($sm === '') {
+			return $this->getApplication()->getSecurityManager();
+		}
+		if (is_string($sm)) {
+			$module = $this->getApplication()->getModule($sm);
+			if (!($module instanceof TSecurityManager)) {
+				throw new TConfigurationException('serializingcache_securitymanager_invalid', $sm);
+			}
+			$this->_securityManager = $module;
+			return $module;
+		}
+		return $sm;
+	}
+
+	/**
+	 * Sets the security manager used for encryption, as a module id or an instance.
+	 * The default empty string means the application security manager is used.
+	 * @param string|TSecurityManager $value the security manager module id or instance.
+	 * @throws TConfigurationException if the value is neither a string nor a {@see TSecurityManager}.
+	 */
+	public function setSecurityManager($value): void
+	{
+		$this->assertUninitialized('SecurityManager');
+		if (!is_string($value) && !($value instanceof TSecurityManager)) {
+			throw new TConfigurationException('serializingcache_securitymanager_invalid', $value);
+		}
+		$this->_securityManager = $value;
 	}
 
 	// =========================================================================
@@ -119,11 +264,19 @@ abstract class TSerializingCache extends TCache
 	{
 		$newValue = $this->dySerialize($value);
 		if ($newValue !== $value) {
-			return (string) $newValue;
+			$data = (string) $newValue;
+		} elseif ($this->getSerializationType() === self::SERIALIZATION_JSON) {
+			$data = json_encode($value);
+			if ($data === false) {
+				throw new TInvalidDataValueException('serializingcache_json_encode_failed', json_last_error_msg());
+			}
+		} else {
+			$data = serialize($value);
 		}
-		return $this->getSerializationType() === self::SERIALIZATION_JSON
-			? json_encode($value)
-			: serialize($value);
+		if ($this->getEncrypt()) {
+			$data = $this->getSecurityManager()->encrypt($data);
+		}
+		return $this->encode($data);
 	}
 
 	/**
@@ -136,6 +289,17 @@ abstract class TSerializingCache extends TCache
 	 */
 	protected function unserializeValue(string $data): mixed
 	{
+		$decoded = $this->decode($data);
+		if ($decoded === false) {
+			return false;
+		}
+		$data = $decoded;
+		if ($this->getEncrypt()) {
+			$data = $this->getSecurityManager()->decrypt($data);
+			if ($data === false) {
+				return false;
+			}
+		}
 		$newData = $this->dyUnserialize($data);
 		if ($newData !== $data) {
 			return $newData;
@@ -143,6 +307,38 @@ abstract class TSerializingCache extends TCache
 		return $this->getSerializationType() === self::SERIALIZATION_JSON
 			? json_decode($data, true)
 			: unserialize($data);
+	}
+
+	/**
+	 * Encodes a (possibly encrypted) payload into a text-safe string per
+	 * {@see getEncoding Encoding}.
+	 * @param string $data the raw payload.
+	 * @return string the encoded payload.
+	 */
+	protected function encode(string $data): string
+	{
+		return match ($this->getEncoding()) {
+			self::ENCODING_BASE64 => base64_encode($data),
+			self::ENCODING_HEX => bin2hex($data),
+			default => $data,
+		};
+	}
+
+	/**
+	 * Reverses {@see encode()}.
+	 * @param string $data the encoded payload.
+	 * @return false|string the decoded payload, or `false` if the input is not validly encoded.
+	 */
+	protected function decode(string $data): false|string
+	{
+		switch ($this->getEncoding()) {
+			case self::ENCODING_BASE64:
+				return base64_decode($data, true);
+			case self::ENCODING_HEX:
+				return (strlen($data) % 2 === 0 && ctype_xdigit($data)) ? hex2bin($data) : false;
+			default:
+				return $data;
+		}
 	}
 
 	// =========================================================================
@@ -156,9 +352,9 @@ abstract class TSerializingCache extends TCache
 	 * @param string $key a unique key identifying the cached value.
 	 * @return false|mixed the stored value, or `false` on a miss or expiry.
 	 */
-	final protected function getValue($key)
+	protected function getValue($key)
 	{
-		$raw = $this->getSerializedValue($key);
+		$raw = $this->getSerializedValue((string) $key);
 		return $raw === false ? false : $this->unserializeValue($raw);
 	}
 
@@ -169,9 +365,9 @@ abstract class TSerializingCache extends TCache
 	 * @param int $expire the number of seconds until expiry; 0 means never expire.
 	 * @return bool `true` on success.
 	 */
-	final protected function setValue($key, $value, $expire)
+	protected function setValue($key, $value, $expire)
 	{
-		return $this->setSerializedValue($key, $this->serializeValue($value), $expire);
+		return $this->setSerializedValue((string) $key, $this->serializeValue($value), (int) $expire);
 	}
 
 	/**
@@ -181,9 +377,9 @@ abstract class TSerializingCache extends TCache
 	 * @param int $expire the number of seconds until expiry; 0 means never expire.
 	 * @return bool `true` on success.
 	 */
-	final protected function addValue($key, $value, $expire)
+	protected function addValue($key, $value, $expire)
 	{
-		return $this->addSerializedValue($key, $this->serializeValue($value), $expire);
+		return $this->addSerializedValue((string) $key, $this->serializeValue($value), (int) $expire);
 	}
 
 	// =========================================================================

--- a/framework/Data/SqlMap/DataMapper/TSqlMapApplicationCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapApplicationCache.php
@@ -85,10 +85,11 @@ class TSqlMapApplicationCache implements ICache
 	}
 
 	/**
-	 * @param mixed $key
-	 * @return mixed Gets a cached object with the specified key.
+	 * Retrieves a value from cache with a specified key.
+	 * @param string $key a key identifying the cached value
+	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get($key): mixed
+	public function get($key)
 	{
 		$result = $this->getCache()->get($key);
 		if ($result === false) {
@@ -104,13 +105,16 @@ class TSqlMapApplicationCache implements ICache
 
 	/**
 	 * Stores a value identified by a key into cache.
+	 * If the cache already contains such a key, the existing value and
+	 * expiration time will be replaced with the new ones.
+	 *
 	 * @param string $key the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
-	 * @param mixed $expire
-	 * @param null|mixed $dependency
-	 * @return bool true if the value is successfully stored into cache, false otherwise.
+	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
+	 * @param ?\Prado\Caching\ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
+	 * @return bool true if the value is successfully stored into cache, false otherwise
 	 */
-	public function set($key, $value, $expire = 0, $dependency = null): bool
+	public function set($key, $value, $expire = 0, $dependency = null)
 	{
 		$this->getCache()->set($key, $value, $expire, $dependency);
 		$keyList = $this->getKeyList();
@@ -122,22 +126,25 @@ class TSqlMapApplicationCache implements ICache
 	}
 
 	/**
-	 * @param mixed $id
-	 * @param mixed $value
-	 * @param mixed $expire
-	 * @param null|mixed $dependency
+	 * Stores a value identified by a key into cache if the cache does not contain this key.
+	 * Nothing will be done if the cache already contains the key.
+	 * @param string $id the key identifying the value to be cached
+	 * @param mixed $value the value to be cached
+	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
+	 * @param ?\Prado\Caching\ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @throws TSqlMapException not implemented.
 	 */
-	public function add($id, $value, $expire = 0, $dependency = null): bool
+	public function add($id, $value, $expire = 0, $dependency = null)
 	{
 		throw new TSqlMapException('sqlmap_use_set_to_store_cache');
 	}
 
 	/**
-	 * @param string $key item to be deleted.
-	 * @return bool true if no error happens during deletion.
+	 * Deletes a value with the specified key from cache
+	 * @param string $key the key of the value to be deleted
+	 * @return bool if no error happens during deletion
 	 */
-	public function delete($key): bool
+	public function delete($key)
 	{
 		$keyList = $this->getKeyList();
 		$keyList->remove($key);
@@ -149,7 +156,7 @@ class TSqlMapApplicationCache implements ICache
 	/**
 	 * Deletes all items in the cache, only for data cached by sqlmap cachemodel
 	 */
-	public function flush(): void
+	public function flush()
 	{
 		$keyList = $this->getKeyList();
 		$cache = $this->getCache();

--- a/framework/Data/SqlMap/DataMapper/TSqlMapApplicationCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapApplicationCache.php
@@ -16,6 +16,8 @@ use Prado\Data\SqlMap\Configuration\TSqlMapCacheModel;
 use Prado\Prado;
 
 /**
+ * TSqlMapApplicationCache class
+ *
  * TSqlMapApplicationCache uses the default Prado application cache for
  * caching SqlMap results.
  *
@@ -33,6 +35,23 @@ class TSqlMapApplicationCache implements ICache
 	public function __construct($cacheModel = null)
 	{
 		$this->_cacheModel = $cacheModel;
+	}
+
+	/**
+	 * @return bool whether the application cache is available.
+	 * @since 4.4.0
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return Prado::getApplication()?->getCache() !== null;
+	}
+
+	/**
+	 * @return ICache Application cache instance.
+	 */
+	protected function getCache()
+	{
+		return Prado::getApplication()->getCache();
 	}
 
 	/**
@@ -66,36 +85,10 @@ class TSqlMapApplicationCache implements ICache
 	}
 
 	/**
-	 * @param string $key item to be deleted.
-	 */
-	public function delete($key)
-	{
-		$keyList = $this->getKeyList();
-		$keyList->remove($key);
-		$this->getCache()->delete($key);
-		$this->setKeyList($keyList);
-		return true;
-	}
-
-	/**
-	 * Deletes all items in the cache, only for data cached by sqlmap cachemodel
-	 */
-	public function flush()
-	{
-		$keyList = $this->getKeyList();
-		$cache = $this->getCache();
-		foreach ($keyList as $key) {
-			$cache->delete($key);
-		}
-		// Remove the old keylist
-		$cache->delete($this->getKeyListId());
-	}
-
-	/**
 	 * @param mixed $key
 	 * @return mixed Gets a cached object with the specified key.
 	 */
-	public function get($key)
+	public function get($key): mixed
 	{
 		$result = $this->getCache()->get($key);
 		if ($result === false) {
@@ -115,8 +108,9 @@ class TSqlMapApplicationCache implements ICache
 	 * @param mixed $value the value to be cached
 	 * @param mixed $expire
 	 * @param null|mixed $dependency
+	 * @return bool true if the value is successfully stored into cache, false otherwise.
 	 */
-	public function set($key, $value, $expire = 0, $dependency = null)
+	public function set($key, $value, $expire = 0, $dependency = null): bool
 	{
 		$this->getCache()->set($key, $value, $expire, $dependency);
 		$keyList = $this->getKeyList();
@@ -128,22 +122,41 @@ class TSqlMapApplicationCache implements ICache
 	}
 
 	/**
-	 * @return ICache Application cache instance.
-	 */
-	protected function getCache()
-	{
-		return Prado::getApplication()->getCache();
-	}
-
-	/**
 	 * @param mixed $id
 	 * @param mixed $value
 	 * @param mixed $expire
 	 * @param null|mixed $dependency
 	 * @throws TSqlMapException not implemented.
 	 */
-	public function add($id, $value, $expire = 0, $dependency = null)
+	public function add($id, $value, $expire = 0, $dependency = null): bool
 	{
 		throw new TSqlMapException('sqlmap_use_set_to_store_cache');
+	}
+
+	/**
+	 * @param string $key item to be deleted.
+	 * @return bool true if no error happens during deletion.
+	 */
+	public function delete($key): bool
+	{
+		$keyList = $this->getKeyList();
+		$keyList->remove($key);
+		$this->getCache()->delete($key);
+		$this->setKeyList($keyList);
+		return true;
+	}
+
+	/**
+	 * Deletes all items in the cache, only for data cached by sqlmap cachemodel
+	 */
+	public function flush(): void
+	{
+		$keyList = $this->getKeyList();
+		$cache = $this->getCache();
+		foreach ($keyList as $key) {
+			$cache->delete($key);
+		}
+		// Remove the old keylist
+		$cache->delete($this->getKeyListId());
 	}
 }

--- a/framework/Data/SqlMap/DataMapper/TSqlMapCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapCache.php
@@ -73,22 +73,25 @@ abstract class TSqlMapCache implements ICache
 	}
 
 	/**
-	 * @param mixed $id
-	 * @param mixed $value
-	 * @param mixed $expire
-	 * @param null|mixed $dependency
+	 * Stores a value identified by a key into cache if the cache does not contain this key.
+	 * Nothing will be done if the cache already contains the key.
+	 * @param string $id the key identifying the value to be cached
+	 * @param mixed $value the value to be cached
+	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
+	 * @param ?\Prado\Caching\ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 * @throws TSqlMapException not implemented.
 	 */
-	public function add($id, $value, $expire = 0, $dependency = null): bool
+	public function add($id, $value, $expire = 0, $dependency = null)
 	{
 		throw new TSqlMapException('sqlmap_use_set_to_store_cache');
 	}
 
 	/**
-	 * @param mixed $key
-	 * @return bool true if no error happens during deletion.
+	 * Deletes a value with the specified key from cache
+	 * @param string $key the key of the value to be deleted
+	 * @return bool if no error happens during deletion
 	 */
-	public function delete($key): bool
+	public function delete($key)
 	{
 		$this->_cache->remove($key);
 		$this->_keyList->remove($key);
@@ -98,7 +101,7 @@ abstract class TSqlMapCache implements ICache
 	/**
 	 * Clears the cache.
 	 */
-	public function flush(): void
+	public function flush()
 	{
 		$this->_keyList->clear();
 		$this->_cache->clear();

--- a/framework/Data/SqlMap/DataMapper/TSqlMapCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapCache.php
@@ -16,6 +16,8 @@ use Prado\Collections\TMap;
 use Prado\TPropertyValue;
 
 /**
+ * TSqlMapCache class
+ *
  * Allow different implementation of caching strategy. See <tt>TSqlMapFifoCache</tt>
  * for a first-in-first-out implementation. See <tt>TSqlMapLruCache</tt> for
  * a least-recently-used cache implementation.
@@ -31,6 +33,15 @@ abstract class TSqlMapCache implements ICache
 	protected $_cacheModel;
 
 	/**
+	 * @return bool whether this cache is always available (in-memory, no external dependencies).
+	 * @since 4.4.0
+	 */
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
+	/**
 	 * Create a new cache with limited cache size.
 	 * @param \Prado\Data\SqlMap\Configuration\TSqlMapCacheModel $cacheModel
 	 */
@@ -39,6 +50,14 @@ abstract class TSqlMapCache implements ICache
 		$this->_cache = new TMap();
 		$this->_keyList = new TList();
 		$this->_cacheModel = $cacheModel;
+	}
+
+	/**
+	 * @return int cache size.
+	 */
+	public function getCacheSize()
+	{
+		return $this->_cacheSize;
 	}
 
 	/**
@@ -54,43 +73,34 @@ abstract class TSqlMapCache implements ICache
 	}
 
 	/**
-	 * @return int cache size.
-	 */
-	public function getCacheSize()
-	{
-		return $this->_cacheSize;
-	}
-
-	/**
-	 * @param mixed $key
-	 * @return object the object removed if exists, null otherwise.
-	 */
-	public function delete($key)
-	{
-		$object = $this->get($key);
-		$this->_cache->remove($key);
-		$this->_keyList->remove($key);
-		return $object;
-	}
-
-	/**
-	 * Clears the cache.
-	 */
-	public function flush()
-	{
-		$this->_keyList->clear();
-		$this->_cache->clear();
-	}
-
-	/**
 	 * @param mixed $id
 	 * @param mixed $value
 	 * @param mixed $expire
 	 * @param null|mixed $dependency
 	 * @throws TSqlMapException not implemented.
 	 */
-	public function add($id, $value, $expire = 0, $dependency = null)
+	public function add($id, $value, $expire = 0, $dependency = null): bool
 	{
 		throw new TSqlMapException('sqlmap_use_set_to_store_cache');
+	}
+
+	/**
+	 * @param mixed $key
+	 * @return bool true if no error happens during deletion.
+	 */
+	public function delete($key): bool
+	{
+		$this->_cache->remove($key);
+		$this->_keyList->remove($key);
+		return true;
+	}
+
+	/**
+	 * Clears the cache.
+	 */
+	public function flush(): void
+	{
+		$this->_keyList->clear();
+		$this->_cache->clear();
 	}
 }

--- a/framework/Data/SqlMap/DataMapper/TSqlMapFifoCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapFifoCache.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Prado\Data\SqlMap\DataMapper;
-
 /**
  * TSqlMapCache class file contains FIFO, LRU, and GLOBAL cache implementations.
  *
@@ -10,7 +8,11 @@ namespace Prado\Data\SqlMap\DataMapper;
  * @license https://github.com/pradosoft/prado/blob/master/LICENSE
  */
 
+namespace Prado\Data\SqlMap\DataMapper;
+
 /**
+ * TSqlMapCache class
+ *
  * First-in-First-out cache implementation, removes
  * object that was first added when the cache is full.
  *
@@ -23,7 +25,7 @@ class TSqlMapFifoCache extends TSqlMapCache
 	 * @param mixed $key
 	 * @return mixed Gets a cached object with the specified key.
 	 */
-	public function get($key)
+	public function get($key): mixed
 	{
 		return $this->_cache->itemAt($key);
 	}
@@ -36,7 +38,7 @@ class TSqlMapFifoCache extends TSqlMapCache
 	 * @param mixed $expire
 	 * @param null|mixed $dependency
 	 */
-	public function set($key, $value, $expire = 0, $dependency = null)
+	public function set($key, $value, $expire = 0, $dependency = null): bool
 	{
 		$this->_cache->add($key, $value);
 		$this->_keyList->add($key);

--- a/framework/Data/SqlMap/DataMapper/TSqlMapFifoCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapFifoCache.php
@@ -22,10 +22,11 @@ namespace Prado\Data\SqlMap\DataMapper;
 class TSqlMapFifoCache extends TSqlMapCache
 {
 	/**
-	 * @param mixed $key
-	 * @return mixed Gets a cached object with the specified key.
+	 * Retrieves a value from cache with a specified key.
+	 * @param string $key a key identifying the cached value
+	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get($key): mixed
+	public function get($key)
 	{
 		return $this->_cache->itemAt($key);
 	}
@@ -33,12 +34,12 @@ class TSqlMapFifoCache extends TSqlMapCache
 	/**
 	 * Stores a value identified by a key into cache.
 	 * The expire and dependency parameters are ignored.
-	 * @param string $key cache key
-	 * @param mixed $value value to cache.
-	 * @param mixed $expire
-	 * @param null|mixed $dependency
+	 * @param string $key the key identifying the value to be cached
+	 * @param mixed $value the value to be cached
+	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
+	 * @param ?\Prado\Caching\ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 */
-	public function set($key, $value, $expire = 0, $dependency = null): bool
+	public function set($key, $value, $expire = 0, $dependency = null)
 	{
 		$this->_cache->add($key, $value);
 		$this->_keyList->add($key);

--- a/framework/Data/SqlMap/DataMapper/TSqlMapLruCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapLruCache.php
@@ -22,10 +22,11 @@ namespace Prado\Data\SqlMap\DataMapper;
 class TSqlMapLruCache extends TSqlMapCache
 {
 	/**
-	 * @param mixed $key
-	 * @return mixed Gets a cached object with the specified key.
+	 * Retrieves a value from cache with a specified key.
+	 * @param string $key a key identifying the cached value
+	 * @return false|mixed the value stored in cache, false if the value is not in the cache or expired.
 	 */
-	public function get($key): mixed
+	public function get($key)
 	{
 		if ($this->_keyList->contains($key)) {
 			$this->_keyList->remove($key);
@@ -40,10 +41,10 @@ class TSqlMapLruCache extends TSqlMapCache
 	 * The expire and dependency parameters are ignored.
 	 * @param string $key the key identifying the value to be cached
 	 * @param mixed $value the value to be cached
-	 * @param mixed $expire
-	 * @param null|mixed $dependency
+	 * @param int $expire the number of seconds in which the cached value will expire. 0 means never expire.
+	 * @param ?\Prado\Caching\ICacheDependency $dependency dependency of the cached item. If the dependency changes, the item is labeled invalid.
 	 */
-	public function set($key, $value, $expire = 0, $dependency = null): bool
+	public function set($key, $value, $expire = 0, $dependency = null)
 	{
 		$this->_cache->add($key, $value);
 		$this->_keyList->add($key);

--- a/framework/Data/SqlMap/DataMapper/TSqlMapLruCache.php
+++ b/framework/Data/SqlMap/DataMapper/TSqlMapLruCache.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Prado\Data\SqlMap\DataMapper;
-
 /**
  * TSqlMapCache class file contains FIFO, LRU, and GLOBAL cache implementations.
  *
@@ -10,7 +8,11 @@ namespace Prado\Data\SqlMap\DataMapper;
  * @license https://github.com/pradosoft/prado/blob/master/LICENSE
  */
 
+namespace Prado\Data\SqlMap\DataMapper;
+
 /**
+ * TSqlMapLruCache class
+ *
  * Least recently used cache implementation, removes
  * object that was accessed last when the cache is full.
  *
@@ -23,13 +25,14 @@ class TSqlMapLruCache extends TSqlMapCache
 	 * @param mixed $key
 	 * @return mixed Gets a cached object with the specified key.
 	 */
-	public function get($key)
+	public function get($key): mixed
 	{
 		if ($this->_keyList->contains($key)) {
 			$this->_keyList->remove($key);
 			$this->_keyList->add($key);
 			return $this->_cache->itemAt($key);
 		}
+		return null;
 	}
 
 	/**
@@ -40,7 +43,7 @@ class TSqlMapLruCache extends TSqlMapCache
 	 * @param mixed $expire
 	 * @param null|mixed $dependency
 	 */
-	public function set($key, $value, $expire = 0, $dependency = null)
+	public function set($key, $value, $expire = 0, $dependency = null): bool
 	{
 		$this->_cache->add($key, $value);
 		$this->_keyList->add($key);

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -544,6 +544,7 @@ dbtablegateway_mismatch_args_exception	= TTableGateway finder method '{0}' expec
 dbtablegateway_mismatch_column_name		= In dynamic __call() method '{0}', no matching columns were found, valid columns for table '{2}' are '{1}'.
 dbtablegateway_invalid_table_info		= Table must be a string or an instance of TDbTableInfo.
 
+serializingcache_type_invalid = TSerializingCache.SerializationType '{0}' is invalid. Valid values are 'PHP' and 'JSON'.
 directorycachedependency_directory_invalid = TDirectoryCacheDependency.Directory {0} does not refer to a valid directory.
 cachedependencylist_cachedependency_required = Only objects implementing ICacheDependency can be added into TCacheDependencyList.
 

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -162,6 +162,13 @@ filecache_hash_token_path_separator		= TFileCache.hashToken must not return a va
 
 memorycache_backing_file_directory_not_found	= TMemoryCache.BackingFile directory does not exist for path '{0}'.
 
+serializingcache_type_invalid = TSerializingCache.SerializationType '{0}' is invalid. Valid values are 'PHP' and 'JSON'.
+serializingcache_encoding_invalid = TSerializingCache.Encoding '{0}' is invalid. Valid values are 'None', 'Base64' and 'Hex'.
+serializingcache_securitymanager_invalid = TSerializingCache.SecurityManager '{0}' is invalid. It must be a TSecurityManager module id or a TSecurityManager instance.
+serializingcache_json_encode_failed = TSerializingCache failed to JSON-encode the value: {0}.
+directorycachedependency_directory_invalid = TDirectoryCacheDependency.Directory {0} does not refer to a valid directory.
+cachedependencylist_cachedependency_required = Only objects implementing ICacheDependency can be added into TCacheDependencyList.
+
 errorhandler_errortemplatepath_invalid	= TErrorHandler.ErrorTemplatePath '{0}' is invalid. Make sure it is in namespace form and points to a valid directory containing error template files.
 
 pageservice_page_unknown				= Page '{0}' Not Found
@@ -543,10 +550,6 @@ dbtablegateway_pk_value_count_mismatch	= Composite key value count mismatch in f
 dbtablegateway_mismatch_args_exception	= TTableGateway finder method '{0}' expects {1} parameters but found only {2} parameters instead.
 dbtablegateway_mismatch_column_name		= In dynamic __call() method '{0}', no matching columns were found, valid columns for table '{2}' are '{1}'.
 dbtablegateway_invalid_table_info		= Table must be a string or an instance of TDbTableInfo.
-
-serializingcache_type_invalid = TSerializingCache.SerializationType '{0}' is invalid. Valid values are 'PHP' and 'JSON'.
-directorycachedependency_directory_invalid = TDirectoryCacheDependency.Directory {0} does not refer to a valid directory.
-cachedependencylist_cachedependency_required = Only objects implementing ICacheDependency can be added into TCacheDependencyList.
 
 soapservice_configfile_invalid			= TSoapService.ConfigFile '{0}' does not exist. Note, it has to be specified in a namespace format and the file extension must be '.xml' or '.php'.
 soapservice_request_invalid				= SOAP server '{0}' not found.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -142,6 +142,8 @@ sqlitecache_table_creation_failed		= TSqliteCache failed to create cache databas
 sqlitecache_dbfile_unchangeable			= TSqliteCache.DbFile cannot be modified after the module is initialized.
 sqlitecache_dbfile_invalid				= TSqliteCache.DbFile is invalid. Make sure it is in a proper namespace format.
 
+dbcache_unavailable						= TDbCache requires the PDO PHP extension.
+
 memcache_extension_required				= TMemCache requires memcache PHP extension.
 memcache_connection_failed				= TMemCache failed to connect to memcache server {0}:{1}.
 memcache_not_initialized				= Options cannot be set on TMemCache before the module is initialized.

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -19,6 +19,7 @@ return [
 'TCache' => 'Prado\Caching\TCache',
 'TCacheDependency' => 'Prado\Caching\TCacheDependency',
 'TCacheDependencyList' => 'Prado\Caching\TCacheDependencyList',
+'TCacheFileTrait' => 'Prado\Caching\TCacheFileTrait',
 'TCacheSizeTrait' => 'Prado\Caching\TCacheSizeTrait',
 'TChainedCacheDependency' => 'Prado\Caching\TChainedCacheDependency',
 'TDbCache' => 'Prado\Caching\TDbCache',

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -30,6 +30,7 @@ return [
 'TMemCache' => 'Prado\Caching\TMemCache',
 'TMemoryCache' => 'Prado\Caching\TMemoryCache',
 'TRedisCache' => 'Prado\Caching\TRedisCache',
+'TSerializingCache' => 'Prado\Caching\TSerializingCache',
 'ICollectionFilter' => 'Prado\Collections\ICollectionFilter',
 'IPriorityCapture' => 'Prado\Collections\IPriorityCapture',
 'IPriorityCollection' => 'Prado\Collections\IPriorityCollection',

--- a/tests/unit/Caching/TAPCCacheTest.php
+++ b/tests/unit/Caching/TAPCCacheTest.php
@@ -2,7 +2,6 @@
 
 use Prado\Caching\TAPCCache;
 use Prado\Exceptions\TConfigurationException;
-use Prado\Exceptions\TNotSupportedException;
 use Prado\TApplication;
 
 class TAPCCacheTest extends PHPUnit\Framework\TestCase
@@ -18,7 +17,7 @@ class TAPCCacheTest extends PHPUnit\Framework\TestCase
 			$basePath = __DIR__ . '/mockapp';
 			$runtimePath = $basePath . '/runtime';
 			if (!is_writable($runtimePath)) {
-				self::markTestSkipped("'$runtimePath' is writable");
+				self::markTestSkipped("'$runtimePath' is not writable");
 			}
 			try {
 				$this->app = new TApplication($basePath);

--- a/tests/unit/Caching/TAPCCacheTest.php
+++ b/tests/unit/Caching/TAPCCacheTest.php
@@ -80,6 +80,6 @@ class TAPCCacheTest extends PHPUnit\Framework\TestCase
 	public function testFlush()
 	{
 		$this->testSetAndGet();
-		self::assertEquals(true, self::$cache->flush());
+		self::$cache->flush();
 	}
 }

--- a/tests/unit/Caching/TAPCCacheTest.php
+++ b/tests/unit/Caching/TAPCCacheTest.php
@@ -80,6 +80,6 @@ class TAPCCacheTest extends PHPUnit\Framework\TestCase
 	public function testFlush()
 	{
 		$this->testSetAndGet();
-		self::$cache->flush();
+		self::assertEquals(true, self::$cache->flush());
 	}
 }

--- a/tests/unit/Caching/TApplicationStateCacheDependencyTest.php
+++ b/tests/unit/Caching/TApplicationStateCacheDependencyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * TApplicationStateCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/../PradoUnitRequires.php';
+
+use Prado\Caching\TApplicationStateCacheDependency;
+use Prado\Prado;
+use Prado\TApplicationMode;
+
+/**
+ * TApplicationStateCacheDependencyTest class
+ *
+ * Unit tests for {@see \Prado\Caching\TApplicationStateCacheDependency}.
+ *
+ * The dependency reports `false` (unchanged) only in Performance mode; all
+ * other modes cause it to report `true` (changed).
+ *
+ * Each test saves the current application mode in setUp() and restores it in
+ * tearDown() so this suite does not affect other tests.
+ */
+class TApplicationStateCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	private string $_originalMode;
+
+	protected function setUp(): void
+	{
+		$this->_originalMode = Prado::getApplication()->getMode();
+	}
+
+	protected function tearDown(): void
+	{
+		Prado::getApplication()->setMode($this->_originalMode);
+	}
+
+	// -------------------------------------------------------------------------
+	// getHasChanged by mode
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedFalseInPerformanceMode(): void
+	{
+		Prado::getApplication()->setMode(TApplicationMode::Performance);
+		$dep = new TApplicationStateCacheDependency();
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueInNormalMode(): void
+	{
+		Prado::getApplication()->setMode(TApplicationMode::Normal);
+		$dep = new TApplicationStateCacheDependency();
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueInDebugMode(): void
+	{
+		Prado::getApplication()->setMode(TApplicationMode::Debug);
+		$dep = new TApplicationStateCacheDependency();
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueInOffMode(): void
+	{
+		Prado::getApplication()->setMode(TApplicationMode::Off);
+		$dep = new TApplicationStateCacheDependency();
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// Mode changes after construction
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedReflectsCurrentModeNotConstructionMode(): void
+	{
+		// Dependency is stateless — it always reads the live application mode.
+		Prado::getApplication()->setMode(TApplicationMode::Normal);
+		$dep = new TApplicationStateCacheDependency();
+		$this->assertTrue($dep->getHasChanged());
+
+		Prado::getApplication()->setMode(TApplicationMode::Performance);
+		$this->assertFalse($dep->getHasChanged());
+
+		Prado::getApplication()->setMode(TApplicationMode::Debug);
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// Serialization round-trip
+	// -------------------------------------------------------------------------
+
+	public function testSerializationAndDeserializationWork(): void
+	{
+		Prado::getApplication()->setMode(TApplicationMode::Performance);
+		$dep      = new TApplicationStateCacheDependency();
+		$restored = unserialize(serialize($dep));
+
+		$this->assertInstanceOf(TApplicationStateCacheDependency::class, $restored);
+		$this->assertFalse($restored->getHasChanged());
+	}
+
+	public function testGetHasChangedAfterSerializationReflectsCurrentMode(): void
+	{
+		Prado::getApplication()->setMode(TApplicationMode::Performance);
+		$dep        = new TApplicationStateCacheDependency();
+		$serialized = serialize($dep);
+
+		Prado::getApplication()->setMode(TApplicationMode::Normal);
+		$restored = unserialize($serialized);
+
+		$this->assertTrue($restored->getHasChanged());
+	}
+}

--- a/tests/unit/Caching/TCacheDependencyListTest.php
+++ b/tests/unit/Caching/TCacheDependencyListTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * TCacheDependencyListTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\ICacheDependency;
+use Prado\Caching\TCacheDependencyList;
+use Prado\Exceptions\TInvalidDataTypeException;
+
+/**
+ * Unit tests for {@see \Prado\Caching\TCacheDependencyList}.
+ */
+class TCacheDependencyListTest extends PHPUnit\Framework\TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private function dep(): ICacheDependency
+	{
+		return $this->createMock(ICacheDependency::class);
+	}
+
+	// -------------------------------------------------------------------------
+	// Type enforcement
+	// -------------------------------------------------------------------------
+
+	public function testInsertValidDependencySucceeds(): void
+	{
+		$list = new TCacheDependencyList();
+		$list->add($this->dep());
+		$this->assertSame(1, $list->getCount());
+	}
+
+	public function testInsertNullThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		$list = new TCacheDependencyList();
+		$list->add(null);
+	}
+
+	public function testInsertStringThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		$list = new TCacheDependencyList();
+		$list->add('not-a-dependency');
+	}
+
+	public function testInsertIntThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		$list = new TCacheDependencyList();
+		$list->add(42);
+	}
+
+	public function testInsertPlainObjectThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		$list = new TCacheDependencyList();
+		$list->add(new stdClass());
+	}
+
+	public function testInsertAtValidPositionSucceeds(): void
+	{
+		$list = new TCacheDependencyList();
+		$a = $this->dep();
+		$b = $this->dep();
+		$c = $this->dep();
+
+		$list->add($a);
+		$list->add($c);
+		$list->insertAt(1, $b); // insert b between a and c
+
+		$this->assertSame(3, $list->getCount());
+		$this->assertSame($a, $list->itemAt(0));
+		$this->assertSame($b, $list->itemAt(1));
+		$this->assertSame($c, $list->itemAt(2));
+	}
+
+	public function testInsertAtWithInvalidItemThrows(): void
+	{
+		$this->expectException(TInvalidDataTypeException::class);
+		$list = new TCacheDependencyList();
+		$list->insertAt(0, 'bad');
+	}
+
+	// -------------------------------------------------------------------------
+	// Count
+	// -------------------------------------------------------------------------
+
+	public function testCountStartsAtZero(): void
+	{
+		$list = new TCacheDependencyList();
+		$this->assertSame(0, $list->getCount());
+	}
+
+	public function testCountIncrementsOnAdd(): void
+	{
+		$list = new TCacheDependencyList();
+		$list->add($this->dep());
+		$list->add($this->dep());
+		$this->assertSame(2, $list->getCount());
+	}
+
+	// -------------------------------------------------------------------------
+	// Iteration and ordering
+	// -------------------------------------------------------------------------
+
+	public function testIterationPreservesFifoOrder(): void
+	{
+		$list = new TCacheDependencyList();
+		$a = $this->dep();
+		$b = $this->dep();
+		$c = $this->dep();
+
+		$list->add($a);
+		$list->add($b);
+		$list->add($c);
+
+		$items = [];
+		foreach ($list as $item) {
+			$items[] = $item;
+		}
+		$this->assertSame([$a, $b, $c], $items);
+	}
+
+	// -------------------------------------------------------------------------
+	// Remove / contains
+	// -------------------------------------------------------------------------
+
+	public function testContainsReturnsTrueForAddedItem(): void
+	{
+		$list = new TCacheDependencyList();
+		$dep  = $this->dep();
+		$list->add($dep);
+		$this->assertTrue($list->contains($dep));
+	}
+
+	public function testContainsReturnsFalseForUnaddedItem(): void
+	{
+		$list = new TCacheDependencyList();
+		$list->add($this->dep());
+		$this->assertFalse($list->contains($this->dep()));
+	}
+
+	public function testRemoveDecrementsCount(): void
+	{
+		$list = new TCacheDependencyList();
+		$dep  = $this->dep();
+		$list->add($dep);
+		$list->add($this->dep());
+		$list->remove($dep);
+		$this->assertSame(1, $list->getCount());
+	}
+
+	public function testRemoveExcludesItemFromContains(): void
+	{
+		$list = new TCacheDependencyList();
+		$dep  = $this->dep();
+		$list->add($dep);
+		$list->remove($dep);
+		$this->assertFalse($list->contains($dep));
+	}
+
+	// -------------------------------------------------------------------------
+	// Clear
+	// -------------------------------------------------------------------------
+
+	public function testClearEmptiesList(): void
+	{
+		$list = new TCacheDependencyList();
+		$list->add($this->dep());
+		$list->add($this->dep());
+		$list->clear();
+		$this->assertSame(0, $list->getCount());
+	}
+
+	// -------------------------------------------------------------------------
+	// Multiple valid dependencies
+	// -------------------------------------------------------------------------
+
+	public function testMultipleValidDependenciesAccepted(): void
+	{
+		$list = new TCacheDependencyList();
+		for ($i = 0; $i < 5; $i++) {
+			$list->add($this->dep());
+		}
+		$this->assertSame(5, $list->getCount());
+	}
+}

--- a/tests/unit/Caching/TCacheFileTraitTest.php
+++ b/tests/unit/Caching/TCacheFileTraitTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * TCacheFileTraitTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+/**
+ * Unit tests for {@see \Prado\Caching\TCacheFileTrait}, exercised through the
+ * {@see TTestFileCache} harness (which uses the trait). Covers the filesystem read/write
+ * seams, including the optional exclusive-lock write parameter.
+ */
+class TCacheFileTraitTest extends PHPUnit\Framework\TestCase
+{
+	private string $dir;
+	private TTestFileCache $cache;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_filetrait_' . getmypid();
+		@mkdir($this->dir, 0o755, true);
+		$this->cache = new TTestFileCache($this->dir);
+		$this->cache->setPrimaryCache(false);
+		$this->cache->init(null);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . DIRECTORY_SEPARATOR . '*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	public function testPutAndGetContentsRoundTrip(): void
+	{
+		$file = $this->dir . DIRECTORY_SEPARATOR . 'rt.bin';
+		$this->assertSame(5, $this->cache->pubPutContents($file, 'hello'));
+		$this->assertSame('hello', $this->cache->pubGetContents($file));
+	}
+
+	public function testPutContentsWithExclusiveLock(): void
+	{
+		$file = $this->dir . DIRECTORY_SEPARATOR . 'locked.bin';
+		$this->assertNotFalse($this->cache->pubPutContents($file, 'data', true));
+		$this->assertSame('data', $this->cache->pubGetContents($file));
+	}
+
+	public function testGetContentsReturnsFalseForMissingFile(): void
+	{
+		$missing = $this->dir . DIRECTORY_SEPARATOR . 'does_not_exist_' . uniqid() . '.bin';
+		$this->assertFalse($this->cache->pubGetContents($missing));
+	}
+}

--- a/tests/unit/Caching/TCacheSizeTraitTest.php
+++ b/tests/unit/Caching/TCacheSizeTraitTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * TCacheSizeTraitTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\ICacheSize;
+
+/**
+ * Unit tests for {@see \Prado\Caching\TCacheSizeTrait}, exercised through the
+ * {@see TTestFileCache} harness (which uses the trait). Covers size-string parsing,
+ * the MaximumSize property, over-capacity detection, and the running-size accessors.
+ */
+class TCacheSizeTraitTest extends PHPUnit\Framework\TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_sizetrait_' . getmypid();
+		@mkdir($this->dir, 0o755, true);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . DIRECTORY_SEPARATOR . '*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	private function newCache(): TTestFileCache
+	{
+		$cache = new TTestFileCache($this->dir);
+		$cache->setPrimaryCache(false);
+		$cache->init(null);
+		return $cache;
+	}
+
+	public function testMaximumSizeDefaultsToZero(): void
+	{
+		$this->assertSame(0, $this->newCache()->getMaximumSize());
+	}
+
+	/**
+	 * @dataProvider sizeStringProvider
+	 */
+	public function testSetMaximumSizeParsesSizeStrings(int|string $input, int $expected): void
+	{
+		$cache = $this->newCache();
+		$cache->setMaximumSize($input);
+		$this->assertSame($expected, $cache->getMaximumSize());
+	}
+
+	public static function sizeStringProvider(): array
+	{
+		return [
+			'plain int'       => [4_194_304, 4_194_304],
+			'plain digits'    => ['4194304', 4_194_304],
+			'K suffix'        => ['1K', 1_024],
+			'M suffix'        => ['2M', 2_097_152],
+			'G suffix'        => ['1G', 1_073_741_824],
+			'KB suffix'       => ['256KB', 262_144],
+			'plain B suffix'  => ['512B', 512],
+			'lowercase b'     => ['512b', 512],
+			'lowercase m'     => ['1m', 1_048_576],
+			'whitespace'      => [' 512 K ', 524_288],
+			'invalid → zero'  => ['not-a-size', 0],
+			'negative → zero' => [-5, 0],
+		];
+	}
+
+	public function testIsOverCapacity(): void
+	{
+		$cache = $this->newCache();
+		$cache->setMaximumSize(100);
+		$cache->pubSetCurrentSizeDirect(200);
+		$this->assertTrue($cache->isOverCapacity());
+		$cache->pubSetCurrentSizeDirect(50);
+		$this->assertFalse($cache->isOverCapacity());
+	}
+
+	public function testIsOverCapacityFalseWhenUnlimited(): void
+	{
+		$cache = $this->newCache(); // MaximumSize 0 (unlimited)
+		$cache->pubSetCurrentSizeDirect(1_000_000);
+		$this->assertFalse($cache->isOverCapacity(),
+			'An unlimited cache (MaximumSize=0) is never over capacity.');
+	}
+
+	public function testCurrentSizeReflectsStoredBytes(): void
+	{
+		$cache = $this->newCache();
+		$cache->setMaximumSize(1_000_000);
+		$this->assertSame(0, $cache->getCurrentSize());
+		$cache->set('k', str_repeat('x', 100));
+		$this->assertGreaterThan(0, $cache->getCurrentSize());
+	}
+
+	public function testSizeNotComputedConstant(): void
+	{
+		$this->assertSame(-1, ICacheSize::SIZE_NOT_COMPUTED);
+	}
+}

--- a/tests/unit/Caching/TCacheTest.php
+++ b/tests/unit/Caching/TCacheTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * TCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\ICache;
+use Prado\Caching\ICacheDependency;
+use Prado\Exceptions\TConfigurationException;
+use Prado\TApplication;
+
+/**
+ * Unit tests for the abstract {@see \Prado\Caching\TCache} base, exercised through the
+ * {@see TTestCache} harness (an array-backed concrete TCache). Covers the public ICache
+ * behavior (key prefixing/hashing, dependency wrapping, empty-value delete, ArrayAccess),
+ * primary-cache registration, and the time()/microtime() clock seams.
+ */
+class TCacheTest extends PHPUnit\Framework\TestCase
+{
+	private TApplication $app;
+
+	protected function setUp(): void
+	{
+		// A fresh application per test → getCache() starts null for primary-cache tests.
+		$this->app = new TApplication(__DIR__ . '/mockapp');
+	}
+
+	private function newCache(bool $primary = false): TTestCache
+	{
+		$cache = new TTestCache();
+		$cache->setPrimaryCache($primary);
+		$cache->init(null);
+		return $cache;
+	}
+
+	public function testIsAnICache(): void
+	{
+		$this->assertInstanceOf(ICache::class, $this->newCache());
+		$this->assertTrue(TTestCache::getIsAvailable());
+	}
+
+	public function testSetGetRoundTrip(): void
+	{
+		$cache = $this->newCache();
+		$this->assertTrue($cache->set('k', ['a' => 1]));
+		$this->assertSame(['a' => 1], $cache->get('k'));
+		$this->assertFalse($cache->get('missing'));
+	}
+
+	public function testUnchangedDependencyKeepsValueChangedDependencyMisses(): void
+	{
+		$cache = $this->newCache();
+		$unchanged = new class implements ICacheDependency {
+			public function getHasChanged(): bool
+			{
+				return false;
+			}
+		};
+		$cache->set('a', 'v', 0, $unchanged);
+		$this->assertSame('v', $cache->get('a'));
+
+		$changed = new class implements ICacheDependency {
+			public function getHasChanged(): bool
+			{
+				return true;
+			}
+		};
+		$cache->set('b', 'v', 0, $changed);
+		$this->assertFalse($cache->get('b'), 'A changed dependency must make get() a miss.');
+	}
+
+	public function testEmptyValueWithZeroExpireDeletes(): void
+	{
+		$cache = $this->newCache();
+		$cache->set('k', 'value');
+		$this->assertTrue($cache->set('k', '', 0)); // delegates to delete()
+		$this->assertFalse($cache->get('k'));
+	}
+
+	public function testEmptyValueWithNonZeroExpireIsStored(): void
+	{
+		$cache = $this->newCache();
+		$this->assertTrue($cache->set('k', '', 10));
+		$this->assertSame('', $cache->get('k'));
+	}
+
+	public function testAddOnlyStoresWhenAbsent(): void
+	{
+		$cache = $this->newCache();
+		$this->assertTrue($cache->add('k', 'first'));
+		$this->assertFalse($cache->add('k', 'second'));
+		$this->assertSame('first', $cache->get('k'));
+	}
+
+	public function testAddRejectsEmptyValueWithZeroExpire(): void
+	{
+		$cache = $this->newCache();
+		$this->assertFalse($cache->add('k', '', 0));
+		$this->assertFalse($cache->get('k'));
+	}
+
+	public function testDelete(): void
+	{
+		$cache = $this->newCache();
+		$cache->set('k', 'v');
+		$this->assertTrue($cache->delete('k'));
+		$this->assertFalse($cache->get('k'));
+	}
+
+	public function testArrayAccess(): void
+	{
+		$cache = $this->newCache();
+		$cache['k'] = 'v';
+		$this->assertTrue(isset($cache['k']));
+		$this->assertSame('v', $cache['k']);
+		unset($cache['k']);
+		$this->assertFalse(isset($cache['k']));
+		$this->assertFalse($cache['k']);
+	}
+
+	public function testKeyPrefixAndGeneration(): void
+	{
+		$cache = $this->newCache();
+		$cache->setKeyPrefix('pfx_');
+		$this->assertSame('pfx_', $cache->pubGetKeyPrefix());
+		$this->assertSame('pfx_my_key', $cache->pubGenerateToken('my_key'));
+		$this->assertSame(sha1('pfx_my_key'), $cache->pubHashToken('pfx_my_key'));
+		$this->assertSame(sha1('pfx_my_key'), $cache->pubGenerateUniqueKey('my_key'));
+	}
+
+	public function testTimeAndMicrotimeSeamsDriveExpiry(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 1_000_000;
+		$cache->set('k', 'v', 10);
+		$this->assertSame('v', $cache->get('k'));
+		$this->assertSame(1_000_000, $cache->pubTime());
+
+		$cache->fakeNow = 1_000_010; // exactly at expiry → expired (expire <= now)
+		$this->assertFalse($cache->get('k'));
+
+		$cache->fakeMicrotime = 5.5;
+		$this->assertSame(5.5, $cache->pubMicrotime());
+	}
+
+	public function testPrimaryCacheRegistersAndDuplicateThrows(): void
+	{
+		$first = $this->newCache(true);
+		$this->assertSame($first, $this->app->getCache());
+
+		$second = new TTestCache();
+		$second->setPrimaryCache(true);
+		$this->expectException(TConfigurationException::class);
+		$second->init(null); // app already has a primary cache → cache_primary_duplicated
+	}
+
+	public function testNonPrimaryCacheDoesNotRegister(): void
+	{
+		$this->newCache(false);
+		$this->assertNull($this->app->getCache());
+	}
+}

--- a/tests/unit/Caching/TChainedCacheDependencyTest.php
+++ b/tests/unit/Caching/TChainedCacheDependencyTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * TChainedCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\ICacheDependency;
+use Prado\Caching\TChainedCacheDependency;
+use Prado\Caching\TCacheDependencyList;
+
+/**
+ * Unit tests for {@see \Prado\Caching\TChainedCacheDependency}.
+ */
+class TChainedCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/** Returns a mock ICacheDependency that will report getHasChanged() = $changed. */
+	private function dep(bool $changed): ICacheDependency
+	{
+		$mock = $this->createMock(ICacheDependency::class);
+		$mock->method('getHasChanged')->willReturn($changed);
+		return $mock;
+	}
+
+	// -------------------------------------------------------------------------
+	// getDependencies — lazy initialization
+	// -------------------------------------------------------------------------
+
+	public function testGetDependenciesCreatesListOnFirstAccess(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$list  = $chain->getDependencies();
+		$this->assertInstanceOf(TCacheDependencyList::class, $list);
+	}
+
+	public function testGetDependenciesReturnsSameInstanceOnRepeatCalls(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$this->assertSame($chain->getDependencies(), $chain->getDependencies());
+	}
+
+	public function testGetDependenciesListStartsEmpty(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$this->assertSame(0, $chain->getDependencies()->getCount());
+	}
+
+	// -------------------------------------------------------------------------
+	// newCacheDependencyList override
+	// -------------------------------------------------------------------------
+
+	public function testNewCacheDependencyListCanBeOverridden(): void
+	{
+		$customList = new TCacheDependencyList();
+
+		$chain = new class($customList) extends TChainedCacheDependency {
+			private TCacheDependencyList $_custom;
+			public function __construct(TCacheDependencyList $list)
+			{
+				$this->_custom = $list;
+				parent::__construct();
+			}
+			protected function newCacheDependencyList(): TCacheDependencyList
+			{
+				return $this->_custom;
+			}
+		};
+
+		$this->assertSame($customList, $chain->getDependencies());
+	}
+
+	// -------------------------------------------------------------------------
+	// getHasChanged
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedFalseWhenChainIsEmpty(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$this->assertFalse($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedFalseWhenAllUnchanged(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add($this->dep(false));
+		$chain->getDependencies()->add($this->dep(false));
+		$chain->getDependencies()->add($this->dep(false));
+		$this->assertFalse($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenOneChanged(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add($this->dep(false));
+		$chain->getDependencies()->add($this->dep(true));
+		$chain->getDependencies()->add($this->dep(false));
+		$this->assertTrue($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenFirstChanged(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add($this->dep(true));
+		$chain->getDependencies()->add($this->dep(false));
+		$this->assertTrue($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenLastChanged(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add($this->dep(false));
+		$chain->getDependencies()->add($this->dep(true));
+		$this->assertTrue($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenAllChanged(): void
+	{
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add($this->dep(true));
+		$chain->getDependencies()->add($this->dep(true));
+		$this->assertTrue($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedShortCircuitsOnFirstChanged(): void
+	{
+		// The second dependency must not be evaluated once the first reports changed.
+		$first  = $this->createMock(ICacheDependency::class);
+		$second = $this->createMock(ICacheDependency::class);
+
+		$first->expects($this->once())->method('getHasChanged')->willReturn(true);
+		$second->expects($this->never())->method('getHasChanged');
+
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add($first);
+		$chain->getDependencies()->add($second);
+
+		$this->assertTrue($chain->getHasChanged());
+	}
+
+	public function testGetHasChangedBeforeListIsCreated(): void
+	{
+		// When the internal list is never created (getDependencies never called),
+		// getHasChanged must still return false gracefully.
+		$chain = new TChainedCacheDependency();
+		$this->assertFalse($chain->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// Serialization round-trip
+	// -------------------------------------------------------------------------
+
+	public function testSerializationPreservesDependencies(): void
+	{
+		// Use a concrete, serializable dependency for the round-trip.
+		$file = __DIR__ . '/temp/TChainedCacheDep_serial.txt';
+		file_put_contents($file, 'x');
+		clearstatcache();
+
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add(new \Prado\Caching\TFileCacheDependency($file));
+
+		$restored = unserialize(serialize($chain));
+
+		$this->assertSame(1, $restored->getDependencies()->getCount());
+		$this->assertFalse($restored->getHasChanged());
+
+		unlink($file);
+	}
+
+	public function testGetHasChangedAfterSerializationWhenDependencyChanged(): void
+	{
+		$file = __DIR__ . '/temp/TChainedCacheDep_changed.txt';
+		file_put_contents($file, 'x');
+		clearstatcache();
+
+		$chain = new TChainedCacheDependency();
+		$chain->getDependencies()->add(new \Prado\Caching\TFileCacheDependency($file));
+		$serialized = serialize($chain);
+
+		touch($file, filemtime($file) - 30);
+		clearstatcache();
+
+		$restored = unserialize($serialized);
+		$this->assertTrue($restored->getHasChanged());
+
+		unlink($file);
+	}
+}

--- a/tests/unit/Caching/TDbCacheTest.php
+++ b/tests/unit/Caching/TDbCacheTest.php
@@ -681,4 +681,25 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 		$result = $this->_cache->get($key);
 		$this->assertEquals('after_delete', $result);
 	}
+
+	/**
+	 * @dataProvider frozenSetterProvider
+	 */
+	public function testConfigPropertiesCannotChangeAfterInit($setter, $value)
+	{
+		$this->_cache->init(null);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$this->_cache->$setter($value);
+	}
+
+	public static function frozenSetterProvider(): array
+	{
+		return [
+			'ConnectionString'     => ['setConnectionString', 'sqlite::memory:'],
+			'Username'             => ['setUsername', 'user'],
+			'Password'             => ['setPassword', 'pw'],
+			'CacheTableName'       => ['setCacheTableName', 'othertable'],
+			'AutoCreateCacheTable' => ['setAutoCreateCacheTable', false],
+		];
+	}
 }

--- a/tests/unit/Caching/TDbCacheTest.php
+++ b/tests/unit/Caching/TDbCacheTest.php
@@ -259,8 +259,7 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 		$this->_cache->set('key2', 'value2');
 		$this->_cache->set('key3', 'value3');
 
-		$result = $this->_cache->flush();
-		$this->assertTrue($result);
+		$this->_cache->flush();
 
 		$this->assertFalse($this->_cache->get('key1'));
 		$this->assertFalse($this->_cache->get('key2'));

--- a/tests/unit/Caching/TDbCacheTest.php
+++ b/tests/unit/Caching/TDbCacheTest.php
@@ -259,7 +259,7 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 		$this->_cache->set('key2', 'value2');
 		$this->_cache->set('key3', 'value3');
 
-		$this->_cache->flush();
+		$this->assertTrue($this->_cache->flush());
 
 		$this->assertFalse($this->_cache->get('key1'));
 		$this->assertFalse($this->_cache->get('key2'));

--- a/tests/unit/Caching/TDirectoryCacheDependencyTest.php
+++ b/tests/unit/Caching/TDirectoryCacheDependencyTest.php
@@ -1,77 +1,378 @@
 <?php
 
+/**
+ * TDirectoryCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
 use Prado\Caching\TDirectoryCacheDependency;
+use Prado\Caching\TCacheDependency;
 use Prado\Exceptions\TInvalidDataValueException;
 
+/**
+ * Unit tests for {@see \Prado\Caching\TDirectoryCacheDependency}.
+ *
+ * Each test uses an isolated subdirectory under `temp/` so tests do not
+ * interfere with one another.  Directories and files created during a test
+ * are cleaned up in `tearDown()`.
+ */
 class TDirectoryCacheDependencyTest extends PHPUnit\Framework\TestCase
 {
+	private string $_tempBase;
+	private array $_createdPaths = [];
+
 	protected function setUp(): void
 	{
+		$this->_tempBase = __DIR__ . '/temp';
+		$this->_createdPaths = [];
 	}
 
 	protected function tearDown(): void
 	{
-	}
-
-	public function testDirectoryName()
-	{
-		$directory = realpath(__DIR__ . '/temp');
-		$dependency = new TDirectoryCacheDependency(__DIR__ . '/temp');
-		$this->assertEquals($dependency->getDirectory(), $directory);
-
-		try {
-			$dependency = new TDirectoryCacheDependency(__DIR__ . '/temp2');
-			$this->fail("Expected exception is not raised");
-		} catch (TInvalidDataValueException $e) {
+		// Remove in reverse so files are deleted before their parent directories.
+		foreach (array_reverse($this->_createdPaths) as $path) {
+			if (is_file($path)) {
+				@unlink($path);
+			} elseif (is_dir($path)) {
+				@rmdir($path);
+			}
 		}
 	}
 
-	public function testRecursiveCheck()
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private function makeDir(string $name): string
 	{
-		$directory = realpath(__DIR__ . '/temp');
-		$dependency = new TDirectoryCacheDependency(__DIR__ . '/temp');
-		$this->assertTrue($dependency->getRecursiveCheck());
-		$dependency->setRecursiveCheck(false);
-		$this->assertFalse($dependency->getRecursiveCheck());
+		$path = $this->_tempBase . '/' . $name;
+		if (!is_dir($path)) {
+			mkdir($path, 0777, true);
+		}
+		$this->_createdPaths[] = $path;
+		return $path;
 	}
 
-	public function testRecursiveLevel()
+	private function makeFile(string $dirPath, string $name, string $content = 'x'): string
 	{
-		$directory = realpath(__DIR__ . '/temp');
-		$dependency = new TDirectoryCacheDependency(__DIR__ . '/temp');
-		$this->assertEquals($dependency->getRecursiveLevel(), -1);
-		$dependency->setRecursiveLevel(5);
-		$this->assertEquals($dependency->getRecursiveLevel(), 5);
+		$path = $dirPath . '/' . $name;
+		file_put_contents($path, $content);
+		$this->_createdPaths[] = $path;
+		clearstatcache();
+		return $path;
 	}
 
-	public function testHasChanged()
+	// -------------------------------------------------------------------------
+	// Construction and directory resolution
+	// -------------------------------------------------------------------------
+
+	public function testConstructorResolvesRealPath(): void
 	{
-		$tempFile = __DIR__ . '/temp/foo.txt';
-		@unlink($tempFile);
-		$fw = fopen($tempFile, "w");
-		fwrite($fw, "test");
-		fclose($fw);
+		$dir = $this->makeDir('dir_resolve');
+		$dep = new TDirectoryCacheDependency($dir);
+		$this->assertSame(realpath($dir), $dep->getDirectory());
+	}
+
+	public function testConstructorWithInvalidDirectoryThrows(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		new TDirectoryCacheDependency($this->_tempBase . '/does_not_exist_xyz');
+	}
+
+	public function testConstructorWithFilePath(): void
+	{
+		$file = $this->makeFile($this->_tempBase, 'TDirCacheDep_not_a_dir.txt');
+		$this->expectException(TInvalidDataValueException::class);
+		new TDirectoryCacheDependency($file);
+	}
+
+	// -------------------------------------------------------------------------
+	// RecursiveCheck and RecursiveLevel
+	// -------------------------------------------------------------------------
+
+	public function testRecursiveCheckDefaultsToTrue(): void
+	{
+		$dir = $this->makeDir('dir_rc_default');
+		$dep = new TDirectoryCacheDependency($dir);
+		$this->assertTrue($dep->getRecursiveCheck());
+	}
+
+	public function testSetRecursiveCheckFalse(): void
+	{
+		$dir = $this->makeDir('dir_rc_false');
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveCheck(false);
+		$this->assertFalse($dep->getRecursiveCheck());
+	}
+
+	public function testSetRecursiveCheckTrue(): void
+	{
+		$dir = $this->makeDir('dir_rc_true');
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveCheck(false);
+		$dep->setRecursiveCheck(true);
+		$this->assertTrue($dep->getRecursiveCheck());
+	}
+
+	public function testRecursiveLevelDefaultsToMinusOne(): void
+	{
+		$dir = $this->makeDir('dir_rl_default');
+		$dep = new TDirectoryCacheDependency($dir);
+		$this->assertSame(-1, $dep->getRecursiveLevel());
+	}
+
+	public function testSetRecursiveLevel(): void
+	{
+		$dir = $this->makeDir('dir_rl_set');
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveLevel(3);
+		$this->assertSame(3, $dep->getRecursiveLevel());
+	}
+
+	public function testSetRecursiveLevelZero(): void
+	{
+		$dir = $this->makeDir('dir_rl_zero');
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveLevel(0);
+		$this->assertSame(0, $dep->getRecursiveLevel());
+	}
+
+	// -------------------------------------------------------------------------
+	// getHasChanged — basic
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedFalseWhenUnchanged(): void
+	{
+		$dir = $this->makeDir('dir_unchanged');
+		$this->makeFile($dir, 'a.txt');
+
+		$dep = new TDirectoryCacheDependency($dir);
+		clearstatcache();
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenFileMtimeChanges(): void
+	{
+		$dir = $this->makeDir('dir_mtime');
+		$file = $this->makeFile($dir, 'b.txt');
+		$originalMtime = filemtime($file);
+
+		$dep = new TDirectoryCacheDependency($dir);
+
+		touch($file, $originalMtime - 10);
 		clearstatcache();
 
-		$dependency = new TDirectoryCacheDependency(dirname($tempFile));
-		$str = serialize($dependency);
+		$this->assertTrue($dep->getHasChanged());
+	}
 
-		// test directory not changed
-		sleep(2);
-		$dependency = unserialize($str);
-		$this->assertFalse($dependency->getHasChanged());
+	public function testGetHasChangedTrueWhenFileAdded(): void
+	{
+		$dir = $this->makeDir('dir_add');
+		$this->makeFile($dir, 'existing.txt');
 
-		// change file
-		$fw = fopen($tempFile, "w");
-		fwrite($fw, "test again");
-		fclose($fw);
+		$dep = new TDirectoryCacheDependency($dir);
+
+		// Add a new file after dependency was created.
+		$newFile = $dir . '/new_file.txt';
+		file_put_contents($newFile, 'new');
+		$this->_createdPaths[] = $newFile;
 		clearstatcache();
 
-		// test file changed
-		sleep(2);
-		$dependency = unserialize($str);
-		$this->assertTrue($dependency->getHasChanged());
+		$this->assertTrue($dep->getHasChanged());
+	}
 
-		@unlink($tempFile);
+	public function testGetHasChangedTrueWhenFileRemoved(): void
+	{
+		$dir = $this->makeDir('dir_remove');
+		$file = $this->makeFile($dir, 'to_remove.txt');
+
+		$dep = new TDirectoryCacheDependency($dir);
+
+		unlink($file);
+		// Remove from cleanup list since it's gone.
+		$this->_createdPaths = array_filter($this->_createdPaths, fn($p) => $p !== $file);
+		clearstatcache();
+
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// getHasChanged — recursive behaviour
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedTrueForDeepFileWhenFullyRecursive(): void
+	{
+		$dir   = $this->makeDir('dir_deep');
+		$sub   = $this->makeDir('dir_deep/sub');
+		$file  = $this->makeFile($sub, 'deep.txt');
+		$mtime = filemtime($file);
+
+		$dep = new TDirectoryCacheDependency($dir);
+
+		touch($file, $mtime - 10);
+		clearstatcache();
+
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedFalseForSubdirFileWhenNotRecursive(): void
+	{
+		$dir  = $this->makeDir('dir_nonrecursive');
+		$sub  = $this->makeDir('dir_nonrecursive/sub');
+		$file = $this->makeFile($sub, 'hidden.txt');
+		$mtime = filemtime($file);
+
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveCheck(false);
+
+		touch($file, $mtime - 10);
+		clearstatcache();
+
+		// Subdirectory is excluded → dependency has not changed.
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testRecursiveLevelZeroIgnoresSubdirChanges(): void
+	{
+		$dir  = $this->makeDir('dir_level0');
+		$sub  = $this->makeDir('dir_level0/sub');
+		$file = $this->makeFile($sub, 'nested.txt');
+		$mtime = filemtime($file);
+
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveLevel(0);
+
+		touch($file, $mtime - 10);
+		clearstatcache();
+
+		// Level 0 → only top-level files are checked.
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testRecursiveLevelOneSeesFirstLevelOnly(): void
+	{
+		$dir   = $this->makeDir('dir_level1');
+		$sub1  = $this->makeDir('dir_level1/sub1');
+		$sub2  = $this->makeDir('dir_level1/sub1/sub2');
+		$fileL1 = $this->makeFile($sub1, 'level1.txt');
+		$fileL2 = $this->makeFile($sub2, 'level2.txt');
+
+		$dep = new TDirectoryCacheDependency($dir);
+		$dep->setRecursiveLevel(1);
+
+		// Snapshot taken with RecursiveLevel=1 only includes files up to depth 1.
+		clearstatcache();
+		$this->assertFalse($dep->getHasChanged());
+
+		// Changing a level-2 file should not be detected.
+		touch($fileL2, filemtime($fileL2) - 10);
+		clearstatcache();
+		$this->assertFalse($dep->getHasChanged());
+
+		// Changing a level-1 file should be detected.
+		touch($fileL1, filemtime($fileL1) - 10);
+		clearstatcache();
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// validateFile / validateDirectory overrides
+	// -------------------------------------------------------------------------
+
+	public function testValidateFileCanExcludeFiles(): void
+	{
+		$dir  = $this->makeDir('dir_validatefile');
+		$kept = $this->makeFile($dir, 'keep.txt');
+		$skip = $this->makeFile($dir, 'skip.log');
+
+		$dep = new class($dir) extends TDirectoryCacheDependency {
+			protected function validateFile(string $fileName): bool
+			{
+				return str_ends_with($fileName, '.txt');
+			}
+		};
+
+		// Change only the excluded file — dependency must stay false.
+		touch($skip, filemtime($skip) - 10);
+		clearstatcache();
+		$this->assertFalse($dep->getHasChanged());
+
+		// Change the included file — dependency must become true.
+		touch($kept, filemtime($kept) - 10);
+		clearstatcache();
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testValidateDirectoryCanExcludeSubdirs(): void
+	{
+		$dir     = $this->makeDir('dir_validatedir');
+		$included = $this->makeDir('dir_validatedir/included');
+		$excluded = $this->makeDir('dir_validatedir/excluded');
+		$fileIn  = $this->makeFile($included, 'a.txt');
+		$fileOut = $this->makeFile($excluded, 'b.txt');
+
+		$dep = new class($dir) extends TDirectoryCacheDependency {
+			protected function validateDirectory(string $directory): bool
+			{
+				return !str_ends_with($directory, 'excluded');
+			}
+		};
+
+		// Change only the excluded subdirectory's file — no change expected.
+		touch($fileOut, filemtime($fileOut) - 10);
+		clearstatcache();
+		$this->assertFalse($dep->getHasChanged());
+
+		// Change the included subdirectory's file — change expected.
+		touch($fileIn, filemtime($fileIn) - 10);
+		clearstatcache();
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// Serialization round-trip
+	// -------------------------------------------------------------------------
+
+	public function testSerializationPreservesState(): void
+	{
+		$dir  = $this->makeDir('dir_serial');
+		$this->makeFile($dir, 'serial.txt');
+
+		$dep      = new TDirectoryCacheDependency($dir);
+		$restored = unserialize(serialize($dep));
+
+		$this->assertSame($dep->getDirectory(), $restored->getDirectory());
+		$this->assertSame($dep->getRecursiveCheck(), $restored->getRecursiveCheck());
+		$this->assertSame($dep->getRecursiveLevel(), $restored->getRecursiveLevel());
+	}
+
+	public function testGetHasChangedAfterSerializationWhenUnchanged(): void
+	{
+		$dir = $this->makeDir('dir_serial_ok');
+		$this->makeFile($dir, 'stable.txt');
+
+		$dep = new TDirectoryCacheDependency($dir);
+		$restored = unserialize(serialize($dep));
+
+		clearstatcache();
+		$this->assertFalse($restored->getHasChanged());
+	}
+
+	public function testGetHasChangedAfterSerializationWhenChanged(): void
+	{
+		$dir  = $this->makeDir('dir_serial_changed');
+		$file = $this->makeFile($dir, 'will_change.txt');
+
+		$dep = new TDirectoryCacheDependency($dir);
+		$serialized = serialize($dep);
+
+		touch($file, filemtime($file) - 10);
+		clearstatcache();
+
+		$restored = unserialize($serialized);
+		$this->assertTrue($restored->getHasChanged());
 	}
 }

--- a/tests/unit/Caching/TEtcdCacheTest.php
+++ b/tests/unit/Caching/TEtcdCacheTest.php
@@ -64,4 +64,27 @@ class TEtcdCacheTest extends PHPUnit\Framework\TestCase
 		$cache->fakeNow = 4242;
 		$this->assertSame(4242, $cache->pubTime());
 	}
+
+	/**
+	 * @dataProvider frozenSetterProvider
+	 */
+	public function testConfigPropertiesCannotChangeAfterInit(string $setter, mixed $value): void
+	{
+		if (!TEtcdCache::getIsAvailable()) {
+			$this->markTestSkipped('cURL required to initialize TEtcdCache.');
+		}
+		$cache = $this->newCache();
+		$cache->init(null);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$cache->$setter($value);
+	}
+
+	public static function frozenSetterProvider(): array
+	{
+		return [
+			'Host' => ['setHost', 'other.host'],
+			'Port' => ['setPort', 9999],
+			'Dir'  => ['setDir', 'otherdir'],
+		];
+	}
 }

--- a/tests/unit/Caching/TEtcdCacheTest.php
+++ b/tests/unit/Caching/TEtcdCacheTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * TEtcdCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TEtcdCache;
+use Prado\Exceptions\TConfigurationException;
+
+/**
+ * Unit tests for {@see TEtcdCache}, via the {@see TTestEtcdCache} harness. Host/Port/Dir
+ * properties and availability are tested without a server; the HTTP request path and the
+ * serialized contract require a live etcd instance and are not exercised here.
+ */
+class TEtcdCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestEtcdCache
+	{
+		$cache = new TTestEtcdCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsAvailableReflectsCurl(): void
+	{
+		$this->assertSame(function_exists('curl_version'), TEtcdCache::getIsAvailable());
+	}
+
+	public function testPropertyDefaults(): void
+	{
+		$cache = $this->newCache();
+		$this->assertSame('localhost', $cache->getHost());
+		$this->assertSame(2379, $cache->getPort());
+		$this->assertSame('pradocache', $cache->getDir());
+	}
+
+	public function testPropertyRoundTrip(): void
+	{
+		$cache = $this->newCache();
+		$cache->setHost('etcd.example.test');
+		$cache->setPort(12379);
+		$cache->setDir('myapp');
+		$this->assertSame('etcd.example.test', $cache->getHost());
+		$this->assertSame(12379, $cache->getPort());
+		$this->assertSame('myapp', $cache->getDir());
+	}
+
+	public function testInitThrowsWhenCurlUnavailable(): void
+	{
+		if (TEtcdCache::getIsAvailable()) {
+			$this->markTestSkipped('cURL present; cannot exercise the unavailable path.');
+		}
+		$this->expectException(TConfigurationException::class);
+		$this->newCache()->init(null);
+	}
+
+	public function testFakeClockSeam(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 4242;
+		$this->assertSame(4242, $cache->pubTime());
+	}
+}

--- a/tests/unit/Caching/TFileCacheDependencyTest.php
+++ b/tests/unit/Caching/TFileCacheDependencyTest.php
@@ -1,55 +1,214 @@
 <?php
 
+/**
+ * TFileCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
 use Prado\Caching\TFileCacheDependency;
 
+/**
+ * Unit tests for {@see \Prado\Caching\TFileCacheDependency}.
+ *
+ * File-system stat results are cached by the OS/PHP. All tests that change a
+ * file's mtime call {@see clearstatcache()} immediately afterward so that
+ * subsequent {@see filemtime()} calls reflect the new value.
+ */
 class TFileCacheDependencyTest extends PHPUnit\Framework\TestCase
 {
+	private string $_tempFile;
+
 	protected function setUp(): void
 	{
+		$this->_tempFile = __DIR__ . '/temp/TFileCacheDependencyTest_file.txt';
+		file_put_contents($this->_tempFile, 'initial');
+		clearstatcache();
 	}
 
 	protected function tearDown(): void
 	{
+		if (file_exists($this->_tempFile)) {
+			unlink($this->_tempFile);
+		}
 	}
 
-	public function testFileName()
-	{
-		$dependency = new TFileCacheDependency(__FILE__);
-		$this->assertEquals($dependency->getFileName(), __FILE__);
-		$this->assertEquals($dependency->getTimestamp(), filemtime(__FILE__));
+	// -------------------------------------------------------------------------
+	// Construction and property access
+	// -------------------------------------------------------------------------
 
-		$dependency = new TFileCacheDependency(__DIR__ . '/foo.txt');
-		$this->assertFalse($dependency->getTimestamp());
+	public function testConstructorExistingFile(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$this->assertSame($this->_tempFile, $dep->getFileName());
+		$this->assertSame(filemtime($this->_tempFile), $dep->getTimestamp());
 	}
 
-	public function testHasChanged()
+	public function testConstructorNonExistentFile(): void
 	{
-		$tempFile = __DIR__ . '/temp/foo.txt';
-		@unlink($tempFile);
-		$fw = fopen($tempFile, "w");
-		fwrite($fw, "test");
-		fclose($fw);
+		$missing = __DIR__ . '/temp/does_not_exist_xyz.txt';
+		$dep = new TFileCacheDependency($missing);
+		$this->assertSame($missing, $dep->getFileName());
+		$this->assertFalse($dep->getTimestamp());
+	}
+
+	// -------------------------------------------------------------------------
+	// setFileName / setFileNameDirect
+	// -------------------------------------------------------------------------
+
+	public function testSetFileNameUpdatesTimestamp(): void
+	{
+		$dep = new TFileCacheDependency(__DIR__ . '/temp/does_not_exist_xyz.txt');
+		$this->assertFalse($dep->getTimestamp(), 'Timestamp must be false for a missing file.');
+
+		$dep->setFileName($this->_tempFile);
+		$this->assertSame($this->_tempFile, $dep->getFileName());
+		$this->assertSame(filemtime($this->_tempFile), $dep->getTimestamp());
+	}
+
+	public function testSetFileNameDirectDoesNotUpdateTimestamp(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$originalTimestamp = $dep->getTimestamp();
+
+		// Touch the file so its mtime changes.
+		touch($this->_tempFile, $originalTimestamp - 60);
 		clearstatcache();
 
-		$dependency = new TFileCacheDependency($tempFile);
-		$str = serialize($dependency);
+		// setFileNameDirect must not re-read the mtime — timestamp stays the same.
+		$this->callProtected($dep, 'setFileNameDirect', [$this->_tempFile]);
+		$this->assertSame($originalTimestamp, $dep->getTimestamp());
+	}
 
-		// test file not changed
-		sleep(2);
-		$dependency = unserialize($str);
-		$this->assertFalse($dependency->getHasChanged());
+	// -------------------------------------------------------------------------
+	// updateTimestamp
+	// -------------------------------------------------------------------------
 
-		// change file
-		$fw = fopen($tempFile, "w");
-		fwrite($fw, "test again");
-		fclose($fw);
+	public function testUpdateTimestampRefreshesStoredValue(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$originalTimestamp = $dep->getTimestamp();
+
+		// Set the file's mtime to a known past value.
+		touch($this->_tempFile, $originalTimestamp - 120);
 		clearstatcache();
 
-		// test file changed
-		sleep(2);
-		$dependency = unserialize($str);
-		$this->assertTrue($dependency->getHasChanged());
+		$dep->updateTimestamp();
+		$this->assertSame(filemtime($this->_tempFile), $dep->getTimestamp());
+		$this->assertNotSame($originalTimestamp, $dep->getTimestamp());
+	}
 
-		@unlink($tempFile);
+	public function testUpdateTimestampStoresFalseForMissingFile(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$this->assertIsInt($dep->getTimestamp());
+
+		unlink($this->_tempFile);
+		clearstatcache();
+
+		$dep->updateTimestamp();
+		$this->assertFalse($dep->getTimestamp());
+	}
+
+	// -------------------------------------------------------------------------
+	// getHasChanged
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedFalseWhenFileUnchanged(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		clearstatcache();
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenMtimeChanges(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$originalMtime = filemtime($this->_tempFile);
+
+		// Wind the mtime back so it differs from the stored snapshot.
+		touch($this->_tempFile, $originalMtime - 10);
+		clearstatcache();
+
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenFileDeleted(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		unlink($this->_tempFile);
+		clearstatcache();
+
+		// File gone → filemtime returns false, stored mtime is an int → changed.
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenMissingFileIsCreated(): void
+	{
+		$missing = __DIR__ . '/temp/TFileCacheDep_new_file.txt';
+		@unlink($missing);
+		clearstatcache();
+
+		// Dependency records false (file absent).
+		$dep = new TFileCacheDependency($missing);
+		$this->assertFalse($dep->getTimestamp());
+
+		// File is created.
+		file_put_contents($missing, 'created');
+		clearstatcache();
+
+		// false (stored) !== int (current) → changed.
+		$this->assertTrue($dep->getHasChanged());
+
+		unlink($missing);
+	}
+
+	// -------------------------------------------------------------------------
+	// Serialization round-trip
+	// -------------------------------------------------------------------------
+
+	public function testSerializationPreservesState(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$restored = unserialize(serialize($dep));
+
+		$this->assertSame($dep->getFileName(), $restored->getFileName());
+		$this->assertSame($dep->getTimestamp(), $restored->getTimestamp());
+	}
+
+	public function testGetHasChangedAfterSerializationWhenUnchanged(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$serialized = serialize($dep);
+
+		clearstatcache();
+		$restored = unserialize($serialized);
+		$this->assertFalse($restored->getHasChanged());
+	}
+
+	public function testGetHasChangedAfterSerializationWhenChanged(): void
+	{
+		$dep = new TFileCacheDependency($this->_tempFile);
+		$serialized = serialize($dep);
+
+		// Change the mtime after serializing.
+		touch($this->_tempFile, filemtime($this->_tempFile) - 30);
+		clearstatcache();
+
+		$restored = unserialize($serialized);
+		$this->assertTrue($restored->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// Helper
+	// -------------------------------------------------------------------------
+
+	private function callProtected(object $obj, string $method, array $args = []): mixed
+	{
+		$rm = new ReflectionMethod($obj, $method);
+		$rm->setAccessible(true);
+		return $rm->invokeArgs($obj, $args);
 	}
 }

--- a/tests/unit/Caching/TFileCacheTest.php
+++ b/tests/unit/Caching/TFileCacheTest.php
@@ -1297,6 +1297,29 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse($this->cache->pubIsFile($expFile));
 	}
 
+	public function testFlushCacheExpiredThrottlesWithinInterval(): void
+	{
+		$this->cache->setFlushInterval(60);
+		// First non-forced flush records the global-state timestamp.
+		$this->cache->fakeNow = 3_000_000;
+		$this->cache->flushCacheExpired(false);
+
+		// An entry expires shortly after; a second non-forced flush within the
+		// interval is throttled and must not sweep it.
+		$this->cache->set('exp', 'v', 10); // expires at 3_000_010
+		$expFile = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('exp'));
+		$this->cache->fakeNow = 3_000_030; // past expiry, < 60s since the recorded flush
+		$this->cache->flushCacheExpired(false);
+		$this->assertTrue($this->cache->pubIsFile($expFile),
+			'A non-forced flush within FlushInterval must be throttled.');
+
+		// Once the interval elapses, the next non-forced flush sweeps.
+		$this->cache->fakeNow = 3_000_061; // > 60s since the recorded flush
+		$this->cache->flushCacheExpired(false);
+		$this->assertFalse($this->cache->pubIsFile($expFile),
+			'After FlushInterval elapses, the expired file is swept.');
+	}
+
 	// ── Expiry mirrored into mtime ────────────────────────────────────────────
 
 	public function testWriteMirrorsExpiryIntoMtime(): void

--- a/tests/unit/Caching/TFileCacheTest.php
+++ b/tests/unit/Caching/TFileCacheTest.php
@@ -13,188 +13,8 @@ use Prado\Caching\TCache;
 use Prado\Caching\TFileCache;
 use Prado\Exceptions\TConfigurationException;
 use Prado\TApplication;
+use Prado\Util\Cron\TCronTaskInfo;
 
-// ── Helper class ───────────────────────────────────────────────────────────────
-
-/**
- * Exposes protected internals and overrides now() for clock-controlled TTL tests.
- * Using this subclass eliminates all sleep() calls from the test suite, making
- * expiry tests instant and deterministic.
- */
-class TFileCacheTestAccessor extends TFileCache
-{
-	/** @var int|null when set, now() returns this value instead of time() */
-	public ?int $fakeNow = null;
-
-	/**
-	 * @var callable|null when set, hashToken() delegates to this callable instead
-	 *   of the default sha1 implementation. Allows tests to inject a bad hashToken
-	 *   after init() has already succeeded with the normal implementation.
-	 */
-	public $hashTokenCallback = null;
-
-	protected function now(): int
-	{
-		return $this->fakeNow ?? parent::now();
-	}
-
-	protected function hashToken(string $token): string
-	{
-		return $this->hashTokenCallback !== null
-			? ($this->hashTokenCallback)($token)
-			: parent::hashToken($token);
-	}
-
-	public function pubNow(): int
-	{
-		return $this->now();
-	}
-
-	public function pubGenerateUniqueKey(string $key): string
-	{
-		return $this->generateUniqueKey($key);
-	}
-
-	public function pubHashToken(string $token): string
-	{
-		return $this->hashToken($token);
-	}
-
-	public function pubPathFor(string $key): string
-	{
-		return $this->pathFor($key);
-	}
-
-	public function pubSerialize(mixed $value): string
-	{
-		return $this->serialize($value);
-	}
-
-	public function pubUnserialize(string $value): mixed
-	{
-		return $this->unserialize($value);
-	}
-
-	public function pubGetContents(string $filePath): string|false
-	{
-		return $this->getContents($filePath);
-	}
-
-	public function pubPutContents(string $filePath, string $data): int|false
-	{
-		return $this->putContents($filePath, $data);
-	}
-
-	public function pubUnlink(string $filePath): bool
-	{
-		return $this->unlink($filePath);
-	}
-
-	public function pubRename(string $srcFilePath, string $destFilePath): bool
-	{
-		return $this->rename($srcFilePath, $destFilePath);
-	}
-
-	public function pubChmod(string $filePath, int $mode): bool
-	{
-		return $this->chmod($filePath, $mode);
-	}
-
-	public function pubTempnam(string $dir, string $prefix): string|false
-	{
-		return $this->tempnam($dir, $prefix);
-	}
-
-	public function pubGetTempFilePrefixDirect(): string
-	{
-		return $this->getTempFilePrefixDirect();
-	}
-
-	public function pubIsFile(string $path): bool
-	{
-		return $this->isFile($path);
-	}
-
-	public function pubTouch(string $filePath): bool
-	{
-		return $this->touch($filePath);
-	}
-
-	public function pubComputeSizeFingerprint(): string
-	{
-		return $this->computeSizeFingerprint();
-	}
-
-	public function pubComputeCurrentSize(): int
-	{
-		return $this->computeCurrentSize();
-	}
-
-	public function pubGetMaximumSizeDirect(): int
-	{
-		return $this->getMaximumSizeDirect();
-	}
-
-	public function pubGetCurrentSizeDirect(): int
-	{
-		return $this->getCurrentSizeDirect();
-	}
-
-	public function pubSetCurrentSizeDirect(int $value): void
-	{
-		$this->setCurrentSizeDirect($value);
-	}
-
-	public function pubGetSizeFingerprintDirect(): string
-	{
-		return $this->getSizeFingerprintDirect();
-	}
-
-	public function pubSetSizeFingerprintDirect(string $value): void
-	{
-		$this->setSizeFingerprintDirect($value);
-	}
-}
-
-// ── Fixture: identity hashToken subclass ───────────────────────────────────────
-
-/**
- * A TFileCache subclass whose hashToken() returns its input unchanged.
- * Used to verify that init() rejects an identity hashToken() implementation.
- */
-class TFileCacheIdentityHash extends TFileCache
-{
-	protected function hashToken(string $token): string
-	{
-		return $token;
-	}
-}
-
-/**
- * A TFileCache subclass whose hashToken() returns a value containing a
- * forward-slash path separator.
- * Used to verify that init() rejects unsafe hashToken() implementations.
- */
-class TFileCacheSlashHash extends TFileCache
-{
-	protected function hashToken(string $token): string
-	{
-		return 'sub/dir/' . sha1($token);
-	}
-}
-
-/**
- * A TFileCache subclass whose hashToken() returns a value containing a
- * backslash path separator.
- * Used to verify that init() rejects unsafe hashToken() implementations.
- */
-class TFileCacheBackslashHash extends TFileCache
-{
-	protected function hashToken(string $token): string
-	{
-		return 'sub\\dir\\' . sha1($token);
-	}
-}
 
 // ── Test class ─────────────────────────────────────────────────────────────────
 
@@ -214,8 +34,8 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 {
 	private static string $cacheDir;
 
-	/** @var TFileCacheTestAccessor */
-	private TFileCacheTestAccessor $cache;
+	/** @var TTestFileCache */
+	private TTestFileCache $cache;
 
 	private ?TApplication $app = null;
 
@@ -243,7 +63,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$basePath = __DIR__ . '/mockapp';
 		$this->app = new TApplication($basePath);
 
-		$this->cache = new TFileCacheTestAccessor(self::$cacheDir);
+		$this->cache = new TTestFileCache(self::$cacheDir);
 		$this->cache->setPrimaryCache(false);
 		$this->cache->init(null);
 	}
@@ -301,7 +121,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testConstructWithDefaultTtlSetsDefaultTtl(): void
 	{
-		$cache = new TFileCacheTestAccessor(self::$cacheDir, 300);
+		$cache = new TTestFileCache(self::$cacheDir, 300);
 		$this->assertSame(300, $cache->getDefaultTtl());
 	}
 
@@ -310,8 +130,9 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 	public function testGetSetDirectory(): void
 	{
 		$newDir = self::$cacheDir . DIRECTORY_SEPARATOR . 'subdir';
-		$this->cache->setDirectory($newDir);
-		$this->assertSame(realpath($newDir) ?: $newDir, $this->cache->getDirectory());
+		$cache = new TTestFileCache(); // un-initialized: Directory is still settable
+		$cache->setDirectory($newDir);
+		$this->assertSame(realpath($newDir) ?: $newDir, $cache->getDirectory());
 		// Directory should have been created.
 		$this->assertDirectoryExists($newDir);
 		@rmdir($newDir);
@@ -322,7 +143,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$newDir = self::$cacheDir . DIRECTORY_SEPARATOR . 'autocreated_' . uniqid();
 		$this->assertDirectoryDoesNotExist($newDir);
 
-		$this->cache->setDirectory($newDir);
+		(new TTestFileCache())->setDirectory($newDir);
 
 		$this->assertDirectoryExists($newDir);
 		@rmdir($newDir);
@@ -333,7 +154,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$newDir = self::$cacheDir . DIRECTORY_SEPARATOR . 'level1' . DIRECTORY_SEPARATOR . 'level2';
 		$this->assertDirectoryDoesNotExist($newDir);
 
-		$this->cache->setDirectory($newDir);
+		(new TTestFileCache())->setDirectory($newDir);
 
 		$this->assertDirectoryExists($newDir);
 		@rmdir($newDir);
@@ -343,7 +164,14 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 	public function testSetDirectoryThrowsOnEmptyString(): void
 	{
 		$this->expectException(TConfigurationException::class);
-		$this->cache->setDirectory('');
+		(new TTestFileCache())->setDirectory('');
+	}
+
+	public function testDirectoryCannotChangeAfterInit(): void
+	{
+		// The cache from setUp() is already initialized → Directory is frozen.
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$this->cache->setDirectory(self::$cacheDir . DIRECTORY_SEPARATOR . 'late');
 	}
 
 	// ── DefaultTtl property ───────────────────────────────────────────────────
@@ -370,14 +198,14 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testDefaultTempFilePrefixMatchesCacheFilePrefixConstant(): void
 	{
-		$cache = new TFileCacheTestAccessor();
+		$cache = new TTestFileCache();
 		// The constructor seeds TempFilePrefix from static::CACHE_FILE_PREFIX.
 		$this->assertSame(TFileCache::CACHE_FILE_PREFIX, $cache->getTempFilePrefix());
 	}
 
 	public function testDefaultTempFilePrefixIsSetViaDirectAccessor(): void
 	{
-		$cache = new TFileCacheTestAccessor();
+		$cache = new TTestFileCache();
 		$this->assertSame(TFileCache::CACHE_FILE_PREFIX, $cache->pubGetTempFilePrefixDirect());
 	}
 
@@ -404,7 +232,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$basePath = __DIR__ . '/mockapp';
 		$app = new TApplication($basePath);
 
-		$cache = new TFileCacheTestAccessor();
+		$cache = new TTestFileCache();
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 
@@ -429,7 +257,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		try {
 			// setDirectory succeeds because the directory already exists.
 			// init() must throw because the directory is not writable.
-			$cache = new TFileCacheTestAccessor($unwritable);
+			$cache = new TTestFileCache($unwritable);
 			$cache->setPrimaryCache(false);
 			$this->expectException(TConfigurationException::class);
 			$cache->init(null);
@@ -441,24 +269,27 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testInitThrowsWhenHashTokenReturnsInputUnchanged(): void
 	{
-		$cache = new TFileCacheIdentityHash(self::$cacheDir);
+		$cache = new TTestFileCache(self::$cacheDir);
 		$cache->setPrimaryCache(false);
+		$cache->hashTokenCallback = static fn (string $token): string => $token; // identity
 		$this->expectException(TConfigurationException::class);
 		$cache->init(null);
 	}
 
 	public function testInitThrowsWhenHashTokenContainsForwardSlash(): void
 	{
-		$cache = new TFileCacheSlashHash(self::$cacheDir);
+		$cache = new TTestFileCache(self::$cacheDir);
 		$cache->setPrimaryCache(false);
+		$cache->hashTokenCallback = static fn (string $token): string => 'sub/dir/' . sha1($token);
 		$this->expectException(TConfigurationException::class);
 		$cache->init(null);
 	}
 
 	public function testInitThrowsWhenHashTokenContainsBackslash(): void
 	{
-		$cache = new TFileCacheBackslashHash(self::$cacheDir);
+		$cache = new TTestFileCache(self::$cacheDir);
 		$cache->setPrimaryCache(false);
+		$cache->hashTokenCallback = static fn (string $token): string => 'sub\\dir\\' . sha1($token);
 		$this->expectException(TConfigurationException::class);
 		$cache->init(null);
 	}
@@ -644,7 +475,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$emptyDir = self::$cacheDir . DIRECTORY_SEPARATOR . 'empty_' . uniqid();
 		mkdir($emptyDir, 0o755, true);
 
-		$cache = new TFileCacheTestAccessor($emptyDir);
+		$cache = new TTestFileCache($emptyDir);
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 
@@ -659,7 +490,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$ghostDir = self::$cacheDir . DIRECTORY_SEPARATOR . 'ghost_' . uniqid();
 		mkdir($ghostDir, 0o755, true);
 
-		$cache = new TFileCacheTestAccessor($ghostDir);
+		$cache = new TTestFileCache($ghostDir);
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 
@@ -708,13 +539,13 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertFalse($this->cache->get($key));
 	}
 
-	public function testGetReturnsFalseWhenSerializedArrayMissingKeys(): void
+	public function testGetReturnsFalseWhenFileHasNoExpiryHeader(): void
 	{
 		$key = 'corrupt_keys';
 		$this->cache->set($key, 'val');
 
-		// Write a valid serialized array but without the required CACHE_VALUE
-		// and CACHE_EXPIRED keys.
+		// Write content with no expiry-header newline; getSerializedValue() treats
+		// it as malformed and returns a miss.
 		$filePath = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey($key));
 		file_put_contents($filePath, serialize(['x' => 1, 'y' => 2]));
 
@@ -854,7 +685,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 	public function testNowReturnsAnIntegerCloseToCurrentTime(): void
 	{
 		$before = time();
-		$result = $this->cache->pubNow();
+		$result = $this->cache->pubTime();
 		$after = time();
 
 		$this->assertGreaterThanOrEqual($before, $result);
@@ -864,7 +695,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 	public function testFakeNowOverridesNow(): void
 	{
 		$this->cache->fakeNow = 42;
-		$this->assertSame(42, $this->cache->pubNow());
+		$this->assertSame(42, $this->cache->pubTime());
 	}
 
 	// ── Protected helpers: isFile() ───────────────────────────────────────────
@@ -902,23 +733,6 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertStringStartsWith($this->cache->getDirectory(), $path);
 
 		@unlink($path);
-	}
-
-	// ── Protected helpers: serialize() / unserialize() ───────────────────────
-
-	public function testSerializeProducesStringUnserializableBackToOriginal(): void
-	{
-		$original = ['key' => 'value', 'nested' => [1, 2, 3]];
-		$serialized = $this->cache->pubSerialize($original);
-
-		$this->assertIsString($serialized);
-		$this->assertSame($original, $this->cache->pubUnserialize($serialized));
-	}
-
-	public function testUnserializeReturnsFalseOnInvalidInput(): void
-	{
-		$result = $this->cache->pubUnserialize('this is not serialized data');
-		$this->assertFalse($result);
 	}
 
 	// ── Protected helpers: getContents() / putContents() ─────────────────────
@@ -1028,7 +842,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		// init() runs with the default sha1 hashToken and succeeds.
 		// The callback is then swapped in so that generateUniqueKey() receives an
 		// identity function, exercising the per-call guard independently of init().
-		$cache = new TFileCacheTestAccessor(self::$cacheDir);
+		$cache = new TTestFileCache(self::$cacheDir);
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 
@@ -1043,7 +857,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		// init() runs with the default sha1 hashToken and succeeds.
 		// The callback is then swapped in to inject a "/" separator, exercising
 		// the per-call path-traversal guard independently of init().
-		$cache = new TFileCacheTestAccessor(self::$cacheDir);
+		$cache = new TTestFileCache(self::$cacheDir);
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 
@@ -1172,7 +986,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testFileCacheMaximumSizeDefaultsToZero(): void
 	{
-		$cache = new TFileCacheTestAccessor();
+		$cache = new TTestFileCache();
 		$this->assertSame(0, $cache->getMaximumSize(),
 			'MaximumSize must default to 0 (unlimited).');
 	}
@@ -1210,7 +1024,7 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 	{
 		// MaximumSize is 0 by default; size tracking is inactive, sentinel stays SIZE_NOT_COMPUTED.
 		// Access the raw field directly to confirm it has never been set.
-		$cache = new TFileCacheTestAccessor();
+		$cache = new TTestFileCache();
 		$this->assertSame(TFileCache::SIZE_NOT_COMPUTED, $cache->pubGetCurrentSizeDirect(),
 			'Initial _currentSize must be SIZE_NOT_COMPUTED when MaximumSize is 0.');
 	}
@@ -1325,45 +1139,42 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 			'isOverCapacity() must return false when the cache is well under the limit.');
 	}
 
-	public function testGetValueWithMaximumSizeActivePromotesEntryInLruOrder(): void
+	public function testEvictionRemovesSoonestToExpireFirst(): void
 	{
-		// Write entry A, then B.  Both are the same size so the LRU tiebreak is mtime.
+		// mtime mirrors the absolute expiry, so eviction orders by expiry.
 		$payload = str_repeat('g', 200);
-		$this->cache->set('a', $payload);
+		$this->cache->set('soon', $payload, 10);      // expires sooner
+		$this->cache->set('later', $payload, 100_000); // expires much later
 
-		// Backdate A's cache file so it appears older than B before any reads.
-		$keyA = $this->cache->pubGenerateUniqueKey('a');
-		$fileA = $this->cache->pubPathFor($keyA);
-		touch($fileA, time() - 20);
-		clearstatcache(true, $fileA);
+		$oneEntrySize = (int) @filesize(
+			$this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('soon'))
+		);
+		$this->assertGreaterThan(0, $oneEntrySize);
 
-		$this->cache->set('b', $payload);
-
-		// Backdate B too, so it also appears old.
-		$keyB = $this->cache->pubGenerateUniqueKey('b');
-		$fileB = $this->cache->pubPathFor($keyB);
-		touch($fileB, time() - 10);
-		clearstatcache(true, $fileB);
-
-		// READ entry A with MaximumSize active — getValue() must call touch() to
-		// refresh A's mtime, promoting it above B in the LRU order.
-		$this->cache->setMaximumSize(99999);
-		$this->assertSame($payload, $this->cache->get('a'),
-			'Entry A must still be present after enabling MaximumSize.');
-
-		// Now set a limit small enough to force one eviction.
-		$oneEntrySize = (int) @filesize($fileA);
-		if ($oneEntrySize <= 0) {
-			$this->markTestSkipped('Could not determine cache file size for LRU promotion test.');
-		}
+		// A limit fitting ~one entry forces eviction of the soonest-to-expire entry.
 		$this->cache->setMaximumSize($oneEntrySize + 50);
 
-		// B was not read after being backdated, so its mtime is older than A's (which
-		// was refreshed by the touch() in getValue()). B must be the eviction victim.
-		$this->assertFalse($this->cache->get('b'),
-			'Entry B must have been evicted: it has the oldest mtime after A was read.');
-		$this->assertSame($payload, $this->cache->get('a'),
-			'Entry A must survive: getValue() promoted it via touch().');
+		$this->assertFalse($this->cache->get('soon'),
+			'The soonest-to-expire entry must be evicted first.');
+		$this->assertSame($payload, $this->cache->get('later'),
+			'The later-expiring entry must survive.');
+	}
+
+	public function testNeverExpiringEntryIsEvictedLast(): void
+	{
+		$payload = str_repeat('g', 200);
+		$this->cache->set('forever', $payload);   // DefaultTtl 0 → never expires (mtime 0)
+		$this->cache->set('soon', $payload, 10);  // expires soon
+
+		$oneEntrySize = (int) @filesize(
+			$this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('soon'))
+		);
+		$this->cache->setMaximumSize($oneEntrySize + 50);
+
+		$this->assertFalse($this->cache->get('soon'),
+			'The expiring entry is evicted before the never-expiring one.');
+		$this->assertSame($payload, $this->cache->get('forever'),
+			'A never-expiring entry is evicted last.');
 	}
 
 	// ── TCacheSizeTrait — oversized item rejection ────────────────────────────────
@@ -1377,10 +1188,8 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSetValueDoesNotWriteFileWhenItemExceedsMaximumSize(): void
 	{
-		// TCache::set() passes [$value, $dependency] as a raw PHP array to writeEntry().
-		// writeEntry() wraps it in ['value' => $tcacheArray, 'expired' => 0] and serializes.
-		// serialize(['value' => ['ok', null], 'expired' => 0]) ≈ 61 bytes.
-		// serialize(['value' => [str_repeat('x',100), null], 'expired' => 0]) ≈ 161 bytes.
+		// The on-disk entry is "<expireAt>\n<serialized [$value,$dependency]>".
+		// For 'ok' that is well under 100 bytes; for a 100-char string it exceeds 100.
 		// MaximumSize=100 fits 'ok' but rejects the 100-char string.
 		$this->cache->setMaximumSize(100);
 		$this->cache->set('small', 'ok');
@@ -1397,16 +1206,15 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSetValueAllowsItemExactlyAtMaximumSize(): void
 	{
-		// assertItemFitsMaximumSize uses strict >, so an item whose serialized size
+		// assertItemFitsMaximumSize uses strict >, so an item whose on-disk size
 		// equals MaximumSize exactly must succeed (not throw).
-		// TCache::set() passes [$value, $dependency] as a raw PHP array to setValue(),
-		// which in turn passes it to writeEntry(). writeEntry() wraps that array in
-		// ['value' => $tcacheArray, 'expired' => $expiry] and serializes the whole
-		// structure. Reproduce that exact layout to compute the true on-disk size.
+		// TCache::set() passes [$value, $dependency] to TSerializingCache::setValue(),
+		// which serializes it and hands the string to TFileCache::setSerializedValue().
+		// The on-disk content is "<expireAt>\n<serialized payload>" (expireAt=0 when
+		// DefaultTtl=0). Reproduce that exact layout to compute the true on-disk size.
 		$value = 'x';
 		$tcacheArray = [$value, null]; // the [$value, $dependency] pair TCache builds
-		$entry = ['value' => $tcacheArray, 'expired' => 0]; // DefaultTtl=0 → expiry=0
-		$exactSize = strlen(serialize($entry));
+		$exactSize = strlen('0' . "\n" . serialize($tcacheArray));
 		$this->cache->setMaximumSize($exactSize);
 		$this->assertTrue($this->cache->set('exact', $value),
 			'set() must succeed when the serialized size equals MaximumSize exactly (strict > check).');
@@ -1420,5 +1228,151 @@ class TFileCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertSame(0, $this->cache->getMaximumSize());
 		$this->assertTrue($this->cache->set('large', str_repeat('x', 10_000)),
 			'set() must succeed for any payload when MaximumSize is 0 (unlimited).');
+	}
+
+	// ── Expired-file flushing / cron task ─────────────────────────────────────
+
+	public function testFlushIntervalDefaultsTo60(): void
+	{
+		$this->assertSame(60, $this->cache->getFlushInterval());
+	}
+
+	public function testSetFlushIntervalClampsNegativeToZero(): void
+	{
+		$this->cache->setFlushInterval(-5);
+		$this->assertSame(0, $this->cache->getFlushInterval());
+		$this->cache->setFlushInterval(120);
+		$this->assertSame(120, $this->cache->getFlushInterval());
+	}
+
+	public function testFlushCacheExpiredForceRemovesOnlyExpiredFiles(): void
+	{
+		$this->cache->fakeNow = 1_000_000;
+		$this->cache->set('live', 'v');       // DefaultTtl 0 → never expires
+		$this->cache->set('exp', 'v', 10);    // expires at 1_000_010
+
+		$liveFile = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('live'));
+		$expFile  = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('exp'));
+		$this->assertTrue($this->cache->pubIsFile($liveFile));
+		$this->assertTrue($this->cache->pubIsFile($expFile));
+
+		$this->cache->fakeNow = 1_000_011; // past the expiry
+		$this->cache->flushCacheExpired(true);
+
+		$this->assertFalse($this->cache->pubIsFile($expFile), 'Expired file must be swept.');
+		$this->assertTrue($this->cache->pubIsFile($liveFile), 'Never-expiring file must remain.');
+	}
+
+	public function testFlushCacheExpiredWithZeroIntervalSkipsWhenNotForced(): void
+	{
+		$this->cache->setFlushInterval(0);
+		$this->cache->fakeNow = 1_000_000;
+		$this->cache->set('exp', 'v', 10);
+		$expFile = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('exp'));
+
+		$this->cache->fakeNow = 1_000_011;
+		$this->cache->flushCacheExpired(false); // interval 0 + not forced → no sweep
+
+		$this->assertTrue($this->cache->pubIsFile($expFile),
+			'With FlushInterval=0 and no force, the expired file must not be swept.');
+	}
+
+	public function testFxGetCronTaskInfosReturnsFileCacheTask(): void
+	{
+		$info = $this->cache->fxGetCronTaskInfos(null, null);
+		$this->assertInstanceOf(TCronTaskInfo::class, $info);
+		$this->assertSame('filecacheflush', $info->getName());
+	}
+
+	public function testDoFlushCacheExpiredHonorsInterval(): void
+	{
+		// With the default 60s interval and no recorded prior flush, doFlushCacheExpired()
+		// performs the sweep on first call.
+		$this->cache->fakeNow = 2_000_000;
+		$this->cache->set('exp', 'v', 10);
+		$expFile = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('exp'));
+
+		$this->cache->fakeNow = 2_000_100; // past expiry and past the 60s interval
+		$this->cache->doFlushCacheExpired();
+		$this->assertFalse($this->cache->pubIsFile($expFile));
+	}
+
+	// ── Expiry mirrored into mtime ────────────────────────────────────────────
+
+	public function testWriteMirrorsExpiryIntoMtime(): void
+	{
+		$this->cache->fakeNow = 1_500_000;
+		$this->cache->set('exp', 'v', 30); // expires at 1_500_030
+		$file = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('exp'));
+		clearstatcache(true, $file);
+		$this->assertSame(1_500_030, filemtime($file), 'mtime mirrors the absolute expiry.');
+
+		$this->cache->set('forever', 'v'); // DefaultTtl 0 → never expires
+		$fileF = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('forever'));
+		clearstatcache(true, $fileF);
+		$this->assertSame(TFileCache::NEVER_EXPIRES_MTIME, filemtime($fileF),
+			'A never-expiring entry stamps the sentinel mtime, not 0.');
+	}
+
+	public function testFlushCacheExpiredUsesMtimeWithoutReadingContents(): void
+	{
+		// Store a never-expiring entry (its header says expire=0), then mark it expired
+		// via mtime only. The sweep deletes it from filesystem metadata alone.
+		$this->cache->set('k', 'v');
+		$file = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('k'));
+		touch($file, time() - 100); // past mtime
+		clearstatcache(true, $file);
+
+		$this->cache->flushCacheExpired(true);
+		$this->assertFalse($this->cache->pubIsFile($file),
+			'The sweep removes a file with a past mtime regardless of its stored header.');
+	}
+
+	public function testStrayEpochMtimeFileIsSweptButRealNeverExpireSurvives(): void
+	{
+		// A legitimately never-expiring entry uses the sentinel mtime and survives.
+		$this->cache->set('forever', 'v');
+		$foreverFile = $this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('forever'));
+
+		// A stray .cache file left at mtime 1 (e.g. a boolean-true modification time) is
+		// NOT mistaken for never-expiring — the sentinel is >= 2 specifically to avoid that.
+		$stray = $this->cache->getDirectory() . DIRECTORY_SEPARATOR . 'stray.cache';
+		file_put_contents($stray, "0\nx");
+		touch($stray, 1);
+		clearstatcache(true, $stray);
+
+		$this->cache->flushCacheExpired(true);
+
+		$this->assertFalse($this->cache->pubIsFile($stray),
+			'A stray epoch/bool-true mtime file must be swept.');
+		$this->assertTrue($this->cache->pubIsFile($foreverFile),
+			'A real never-expiring entry (sentinel mtime) must survive.');
+	}
+
+	// ── On-disk format ────────────────────────────────────────────────────────
+
+	public function testOnDiskFormatIsExpiryHeaderThenSerializedPayload(): void
+	{
+		$this->cache->fakeNow = 1_500_000;
+		$this->cache->set('fmt', 'the-value', 30); // expires at 1_500_030
+
+		$raw = $this->cache->pubGetContents(
+			$this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('fmt'))
+		);
+		$this->assertIsString($raw);
+		$pos = strpos($raw, "\n");
+		$this->assertNotFalse($pos, 'File must contain an expiry-header newline.');
+		$this->assertSame('1500030', substr($raw, 0, $pos), 'First line is the absolute expiry timestamp.');
+		// Remainder is the base-class serialized [value, dependency] payload.
+		$this->assertSame(serialize(['the-value', null]), substr($raw, $pos + 1));
+	}
+
+	public function testOnDiskFormatNeverExpiresStoresZeroHeader(): void
+	{
+		$this->cache->set('forever', 'v'); // DefaultTtl 0 → never expires
+		$raw = $this->cache->pubGetContents(
+			$this->cache->pubPathFor($this->cache->pubGenerateUniqueKey('forever'))
+		);
+		$this->assertStringStartsWith("0\n", $raw, 'A never-expiring entry stores a 0 expiry header.');
 	}
 }

--- a/tests/unit/Caching/TGlobalStateCacheDependencyTest.php
+++ b/tests/unit/Caching/TGlobalStateCacheDependencyTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * TGlobalStateCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/../PradoUnitRequires.php';
+
+use Prado\Caching\TGlobalStateCacheDependency;
+use Prado\Prado;
+
+/**
+ * Unit tests for {@see \Prado\Caching\TGlobalStateCacheDependency}.
+ *
+ * The test application started by the phpunit bootstrap provides
+ * `Prado::getApplication()`, which these tests use to read and write global state.
+ * All global state keys used here are prefixed with `TGlobalStateCacheDependencyTest_`
+ * to avoid collisions with other tests.
+ */
+class TGlobalStateCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	private static string $_prefix = 'TGlobalStateCacheDependencyTest_';
+
+	protected function setUp(): void
+	{
+		// Reset all state keys used by this suite.
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', null);
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key2', null);
+	}
+
+	protected function tearDown(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', null);
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key2', null);
+	}
+
+	// -------------------------------------------------------------------------
+	// Construction and property access
+	// -------------------------------------------------------------------------
+
+	public function testConstructorSetsStateName(): void
+	{
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$this->assertSame(self::$_prefix . 'key', $dep->getStateName());
+	}
+
+	public function testConstructorCapturesCurrentValue(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'initial');
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+
+		// Dependency should report unchanged immediately after construction.
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testConstructorCapturesNullForUnsetState(): void
+	{
+		// Key has not been set; state value is null.
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// setStateName
+	// -------------------------------------------------------------------------
+
+	public function testSetStateNameUpdatesNameAndRecapturesValue(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'v1');
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key2', 'v2');
+
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$dep->setStateName(self::$_prefix . 'key2');
+
+		$this->assertSame(self::$_prefix . 'key2', $dep->getStateName());
+		// Value for key2 has been captured; state is unchanged.
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// getHasChanged
+	// -------------------------------------------------------------------------
+
+	public function testGetHasChangedFalseWhenStateUnchanged(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'same');
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenStateValueChanges(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'before');
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'after');
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenStateSetToNull(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'has-value');
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', null);
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedTrueWhenStateSetFromNull(): void
+	{
+		// State starts as null (not set).
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'now-set');
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	public function testGetHasChangedDetectsTypeChange(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 1);
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+
+		// Strict comparison: 1 !== '1'
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', '1');
+		$this->assertTrue($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// updateStateValue
+	// -------------------------------------------------------------------------
+
+	public function testUpdateStateValueRefreshesBaseline(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'original');
+		$dep = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'changed');
+		$this->assertTrue($dep->getHasChanged());
+
+		// Re-capture the new value as the baseline.
+		$dep->updateStateValue();
+		$this->assertFalse($dep->getHasChanged());
+	}
+
+	// -------------------------------------------------------------------------
+	// Serialization round-trip
+	// -------------------------------------------------------------------------
+
+	public function testSerializationPreservesStateName(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'snap');
+		$dep      = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$restored = unserialize(serialize($dep));
+
+		$this->assertSame($dep->getStateName(), $restored->getStateName());
+	}
+
+	public function testGetHasChangedAfterSerializationWhenUnchanged(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'stable');
+		$dep      = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$restored = unserialize(serialize($dep));
+
+		$this->assertFalse($restored->getHasChanged());
+	}
+
+	public function testGetHasChangedAfterSerializationWhenChanged(): void
+	{
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'before');
+		$dep        = new TGlobalStateCacheDependency(self::$_prefix . 'key');
+		$serialized = serialize($dep);
+
+		Prado::getApplication()->setGlobalState(self::$_prefix . 'key', 'after');
+		$restored = unserialize($serialized);
+
+		$this->assertTrue($restored->getHasChanged());
+	}
+}

--- a/tests/unit/Caching/TMemCacheTest.php
+++ b/tests/unit/Caching/TMemCacheTest.php
@@ -70,7 +70,7 @@ class TMemCacheTest extends PHPUnit\Framework\TestCase
 	public function testFlush()
 	{
 		$this->testSetAndGet();
-		self::$cache->flush();
+		self::assertEquals(true, self::$cache->flush());
 	}
 
 	public function testSetOptions()

--- a/tests/unit/Caching/TMemCacheTest.php
+++ b/tests/unit/Caching/TMemCacheTest.php
@@ -70,7 +70,7 @@ class TMemCacheTest extends PHPUnit\Framework\TestCase
 	public function testFlush()
 	{
 		$this->testSetAndGet();
-		self::assertEquals(true, self::$cache->flush());
+		self::$cache->flush();
 	}
 
 	public function testSetOptions()

--- a/tests/unit/Caching/TMemCacheTest.php
+++ b/tests/unit/Caching/TMemCacheTest.php
@@ -104,4 +104,35 @@ class TMemCacheTest extends PHPUnit\Framework\TestCase
 		$cache2->init(null);
 		self::assertEquals('persistentvalue', $cache2->get('persistentkey'));
 	}
+
+	public function testHostCannotChangeAfterInit()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		self::$cache->setHost('other.host');
+	}
+
+	public function testPortCannotChangeAfterInit()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		self::$cache->setPort(11212);
+	}
+
+	public function testPersistentIdCannotChangeAfterInit()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		self::$cache->setPersistentID('other');
+	}
+
+	public function testSetUseMemcachedThrowsAfterInit()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		self::$cache->setUseMemcached(true);
+	}
+
+	public function testSetOptionsBeforeInitThrows()
+	{
+		$fresh = new TMemCache();
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$fresh->setOptions([Memcached::OPT_PREFIX_KEY => 'widgets']);
+	}
 }

--- a/tests/unit/Caching/TMemoryCacheTest.php
+++ b/tests/unit/Caching/TMemoryCacheTest.php
@@ -15,257 +15,6 @@ use Prado\Exceptions\TConfigurationException;
 use Prado\TApplication;
 use Prado\TApplicationMode;
 
-// ── Helpers ────────────────────────────────────────────────────────────────────
-
-/**
- * Exposes protected internals and overrides now() for clock-controlled TTL tests.
- */
-class TMemoryCacheTestAccessor extends TMemoryCache
-{
-	/** @var int|null when set, now() returns this value instead of time() */
-	public ?int $fakeNow = null;
-
-	protected function now(): int
-	{
-		return $this->fakeNow ?? parent::now();
-	}
-
-	public function pubNow(): int
-	{
-		return $this->now();
-	}
-
-	public function pubGetValue(string $key): mixed
-	{
-		return $this->getValue($key);
-	}
-
-	public function pubSetValue(string $key, mixed $value, int $expire): bool
-	{
-		return $this->setValue($key, $value, $expire);
-	}
-
-	public function pubAddValue(string $key, mixed $value, int $expire): bool
-	{
-		return $this->addValue($key, $value, $expire);
-	}
-
-	public function pubDeleteValue(string $key): bool
-	{
-		return $this->deleteValue($key);
-	}
-
-	public function pubLoad(): bool
-	{
-		return $this->load();
-	}
-
-	public function pubSave(): bool
-	{
-		return $this->save();
-	}
-
-	public function pubLoadFromBacking(): ?array
-	{
-		return $this->loadFromBacking();
-	}
-
-	public function pubSaveToBacking(array $store): bool
-	{
-		return $this->saveToBacking($store);
-	}
-
-	public function pubGenerateUniqueKey(string $key): string
-	{
-		return $this->generateUniqueKey($key);
-	}
-
-	public function pubGetStore(): array
-	{
-		return $this->getStoreDirect();
-	}
-
-	public function &pubGetStoreRef(): array
-	{
-		return $this->getStoreDirect();
-	}
-
-	public function pubComputeSizeFingerprint(): string
-	{
-		return $this->computeSizeFingerprint();
-	}
-
-	public function pubComputeCurrentSize(): int
-	{
-		return $this->computeCurrentSize();
-	}
-
-	public function pubEvictToFitMaximumSize(): void
-	{
-		$this->evictToFitMaximumSize();
-	}
-
-	public function pubValidateSizeCache(): void
-	{
-		$this->validateSizeCache();
-	}
-
-	public function pubGetMaximumSizeDirect(): int
-	{
-		return $this->getMaximumSizeDirect();
-	}
-
-	public function pubGetCurrentSizeDirect(): int
-	{
-		return $this->getCurrentSizeDirect();
-	}
-
-	public function pubSetCurrentSizeDirect(int $value): void
-	{
-		$this->setCurrentSizeDirect($value);
-	}
-
-	public function pubGetSizeFingerprintDirect(): string
-	{
-		return $this->getSizeFingerprintDirect();
-	}
-
-	public function pubSetSizeFingerprintDirect(string $value): void
-	{
-		$this->setSizeFingerprintDirect($value);
-	}
-
-	public function pubSetStore(array $value): void
-	{
-		$this->setStoreDirect($value);
-	}
-
-	public function pubGetStoreEntry(string $key): ?array
-	{
-		return $this->getStoreEntry($key);
-	}
-
-	public function pubHasStoreEntry(string $key): bool
-	{
-		return $this->hasStoreEntry($key);
-	}
-
-	public function pubSetStoreEntry(string $key, array $entry): void
-	{
-		$this->setStoreEntry($key, $entry);
-	}
-
-	public function pubClearStoreEntry(string $key): void
-	{
-		$this->clearStoreEntry($key);
-	}
-
-	public function pubGetChanged(): bool
-	{
-		return $this->getChanged();
-	}
-
-	public function pubGetHashKeys(): ?bool
-	{
-		return $this->getHashKeys();
-	}
-
-	public function pubSerialize(mixed $value): string
-	{
-		return $this->serialize($value);
-	}
-
-	public function pubUnserialize(string $data): mixed
-	{
-		return $this->unserialize($data);
-	}
-
-	public function pubGetContents(string $filePath): string|false
-	{
-		return $this->getContents($filePath);
-	}
-
-	public function pubPutContents(string $filePath, string $data): int|false
-	{
-		return $this->putContents($filePath, $data);
-	}
-}
-
-/**
- * A TMemoryCache subclass that overrides DEFAULT_BACKING_CACHE_KEY to verify
- * that the constructor seeds _backingCacheKey via late static binding.
- */
-class TMemoryCacheCustomKeyAccessor extends TMemoryCacheTestAccessor
-{
-	public const DEFAULT_BACKING_CACHE_KEY = 'custom.key';
-}
-
-/**
- * A TMemoryCache subclass that overrides DEFAULT_MERGE_POLICY to verify
- * that the constructor seeds _mergePolicy via late static binding.
- */
-class TMemoryCacheCustomMergePolicyAccessor extends TMemoryCacheTestAccessor
-{
-	public const DEFAULT_MERGE_POLICY = TMemoryCache::REPLACE;
-}
-
-/**
- * A minimal in-memory TCache stub used as a backing cache module in tests.
- * Stores data in a plain PHP array so tests do not depend on TFileCache or
- * any external service.
- */
-class StubBackingCache extends TCache
-{
-	private array $_data = [];
-
-	public static function getIsAvailable(): bool
-	{
-		return true;
-	}
-
-	public function init($config): void
-	{
-		parent::init($config);
-	}
-
-	protected function getValue($key)
-	{
-		return $this->_data[$key] ?? false;
-	}
-
-	protected function setValue($key, $value, $expire)
-	{
-		$this->_data[$key] = $value;
-		return true;
-	}
-
-	protected function addValue($key, $value, $expire)
-	{
-		if (array_key_exists($key, $this->_data)) {
-			return false;
-		}
-		$this->_data[$key] = $value;
-		return true;
-	}
-
-	protected function deleteValue($key)
-	{
-		unset($this->_data[$key]);
-		return true;
-	}
-
-	public function flush()
-	{
-		$this->_data = [];
-		return true;
-	}
-
-	/** Direct access for test assertions. */
-	public function getRawData(): array
-	{
-		return $this->_data;
-	}
-}
 
 // ── Test class ─────────────────────────────────────────────────────────────────
 
@@ -288,8 +37,8 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	private ?TApplication $app = null;
 
-	/** @var TMemoryCacheTestAccessor */
-	private TMemoryCacheTestAccessor $cache;
+	/** @var TTestMemoryCache */
+	private TTestMemoryCache $cache;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -314,7 +63,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$basePath = __DIR__ . '/mockapp';
 		$this->app = new TApplication($basePath);
 
-		$this->cache = new TMemoryCacheTestAccessor();
+		$this->cache = new TTestMemoryCache();
 		$this->cache->setPrimaryCache(false);
 		$this->cache->init(null);
 	}
@@ -328,12 +77,13 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	// ── helpers ─────────────────────────────────────────────────────────────────
 
 	/**
-	 * Creates and initializes a StubBackingCache, registers it with the
-	 * application as a non-primary module, and returns it.
+	 * Creates and initializes a {@see TTestCache} (an array-backed cache used here as the
+	 * backing module), registers it with the application as a non-primary module, and
+	 * returns it. Its public `$store` is inspected directly to assert backing contents.
 	 */
-	private function makeBackingCache(string $moduleId = 'backingCache'): StubBackingCache
+	private function makeBackingCache(string $moduleId = 'backingCache'): TTestCache
 	{
-		$backing = new StubBackingCache();
+		$backing = new TTestCache();
 		$backing->setID($moduleId);
 		$backing->setPrimaryCache(false);
 		$backing->init(null);
@@ -342,11 +92,11 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * Creates a TMemoryCacheTestAccessor wired to the given backing cache module.
+	 * Creates a TTestMemoryCache wired to the given backing cache module.
 	 */
-	private function makeCacheWithBacking(string $moduleId = 'backingCache'): TMemoryCacheTestAccessor
+	private function makeCacheWithBacking(string $moduleId = 'backingCache'): TTestMemoryCache
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setID('memcache');
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId($moduleId);
@@ -399,7 +149,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testGetModuleDependenciesReturnsIdWhenBackingCacheIdSet(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setBackingCacheId('fileCache');
 
 		self::assertModuleDependency('fileCache', $cache->getModuleDependencies());
@@ -407,7 +157,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testGetModuleDependenciesSameForBothPhases(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setBackingCacheId('someModule');
 
 		self::assertModuleDependency(
@@ -420,7 +170,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testInitSetsDefaultBackingCacheKeyFromModuleId(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setID('myCache');
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
@@ -430,7 +180,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testInitSetsDefaultBackingCacheKeyWhenNoId(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 
@@ -439,7 +189,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testExplicitBackingCacheKeyIsPreservedByInit(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheKey('my-custom-key');
 		$cache->init(null);
@@ -675,7 +425,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	public function testNowReturnsIntegerCloseToCurrentTime(): void
 	{
 		$before = time();
-		$result = $this->cache->pubNow();
+		$result = $this->cache->pubTime();
 		$after = time();
 
 		$this->assertGreaterThanOrEqual($before, $result);
@@ -685,14 +435,14 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	public function testFakeNowOverridesNow(): void
 	{
 		$this->cache->fakeNow = 42;
-		$this->assertSame(42, $this->cache->pubNow());
+		$this->assertSame(42, $this->cache->pubTime());
 	}
 
 	// ── BackingCacheId property ───────────────────────────────────────────────
 
 	public function testGetSetBackingCacheId(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setBackingCacheId('someModule');
 		$this->assertSame('someModule', $cache->getBackingCacheId());
 	}
@@ -707,8 +457,9 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	public function testGetSetBackingFile(): void
 	{
 		$file = self::$tempDir . DIRECTORY_SEPARATOR . 'test.cache';
-		$this->cache->setBackingFile($file);
-		$this->assertSame($file, $this->cache->getBackingFile());
+		$cache = new TTestMemoryCache();
+		$cache->setBackingFile($file);
+		$this->assertSame($file, $cache->getBackingFile());
 	}
 
 	public function testBackingFileDefaultsToEmpty(): void
@@ -719,23 +470,25 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	public function testSetBackingFileToEmptyStringClearsIt(): void
 	{
 		$file = self::$tempDir . DIRECTORY_SEPARATOR . 'test.cache';
-		$this->cache->setBackingFile($file);
-		$this->cache->setBackingFile('');
-		$this->assertSame('', $this->cache->getBackingFile());
+		$cache = new TTestMemoryCache();
+		$cache->setBackingFile($file);
+		$cache->setBackingFile('');
+		$this->assertSame('', $cache->getBackingFile());
 	}
 
 	public function testSetBackingFileThrowsWhenDirectoryDoesNotExist(): void
 	{
 		$this->expectException(TConfigurationException::class);
-		$this->cache->setBackingFile('/nonexistent/dir/cache.dat');
+		(new TTestMemoryCache())->setBackingFile('/nonexistent/dir/cache.dat');
 	}
 
 	// ── BackingCacheKey property ──────────────────────────────────────────────
 
 	public function testGetSetBackingCacheKey(): void
 	{
-		$this->cache->setBackingCacheKey('my-store-key');
-		$this->assertSame('my-store-key', $this->cache->getBackingCacheKey());
+		$cache = new TTestMemoryCache();
+		$cache->setBackingCacheKey('my-store-key');
+		$this->assertSame('my-store-key', $cache->getBackingCacheKey());
 	}
 
 	// ── MergePolicy property ──────────────────────────────────────────────────
@@ -747,20 +500,22 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSetMergePolicyAcceptsReplace(): void
 	{
-		$this->cache->setMergePolicy(TMemoryCache::REPLACE);
-		$this->assertSame(TMemoryCache::REPLACE, $this->cache->getMergePolicy());
+		$cache = new TTestMemoryCache();
+		$cache->setMergePolicy(TMemoryCache::REPLACE);
+		$this->assertSame(TMemoryCache::REPLACE, $cache->getMergePolicy());
 	}
 
 	public function testSetMergePolicyAcceptsMerge(): void
 	{
-		$this->cache->setMergePolicy(TMemoryCache::MERGE);
-		$this->assertSame(TMemoryCache::MERGE, $this->cache->getMergePolicy());
+		$cache = new TTestMemoryCache();
+		$cache->setMergePolicy(TMemoryCache::MERGE);
+		$this->assertSame(TMemoryCache::MERGE, $cache->getMergePolicy());
 	}
 
 	public function testSetMergePolicyThrowsOnInvalidValue(): void
 	{
 		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
-		$this->cache->setMergePolicy('invalid-policy');
+		(new TTestMemoryCache())->setMergePolicy('invalid-policy');
 	}
 
 	// ── Changed (dirty) flag ─────────────────────────────────────────────────
@@ -817,7 +572,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	public function testChangedRemainsWhenSaveFails(): void
 	{
 		// Back cache is not registered → saveToBacking returns false.
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId('nonexistent');
 		$cache->init(null);
@@ -844,7 +599,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		// Store is clean after init() load (nothing in backing, no data written).
 		$this->assertFalse($cache->pubGetChanged());
 		$cache->save(); // must be a no-op
-		$this->assertEmpty($backing->getRawData(),
+		$this->assertEmpty($backing->store,
 			'Backing cache must remain empty when save() is called with no changes.');
 	}
 
@@ -884,7 +639,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$backing = $this->makeBackingCache();
 
 		// Pre-seed the backing cache with a store snapshot.
-		$seed = new TMemoryCacheTestAccessor();
+		$seed = new TTestMemoryCache();
 		$seed->setID('memcache');
 		$seed->setPrimaryCache(false);
 		$seed->setBackingCacheId('backingCache');
@@ -893,7 +648,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$seed->save();
 
 		// Fresh instance must pick up the seeded data.
-		$fresh = new TMemoryCacheTestAccessor();
+		$fresh = new TTestMemoryCache();
 		$fresh->setID('memcache');
 		$fresh->setPrimaryCache(false);
 		$fresh->setBackingCacheId('backingCache');
@@ -905,7 +660,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	public function testLoadReturnsFalseWhenBackingCacheModuleHasNoData(): void
 	{
 		$this->makeBackingCache();
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setID('memcache');
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId('backingCache');
@@ -917,7 +672,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSaveReturnsFalseWhenBackingModuleNotFound(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId('nonexistent');
 		$cache->init(null);
@@ -931,7 +686,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	{
 		$file = self::$tempDir . DIRECTORY_SEPARATOR . 'roundtrip_' . uniqid() . '.dat';
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->setBackingFile($file);
 		$cache->init(null);
@@ -939,7 +694,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertTrue($cache->save());
 
 		// Second instance reads from file.
-		$cache2 = new TMemoryCacheTestAccessor();
+		$cache2 = new TTestMemoryCache();
 		$cache2->setPrimaryCache(false);
 		$cache2->setBackingFile($file);
 		$cache2->init(null);
@@ -950,7 +705,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testLoadReturnsFalseWhenBackingFileIsMissing(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->setBackingFile(self::$tempDir . DIRECTORY_SEPARATOR . 'no_such_file_' . uniqid() . '.dat');
 		$cache->init(null);
@@ -963,7 +718,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$file = self::$tempDir . DIRECTORY_SEPARATOR . 'garbage_' . uniqid() . '.dat';
 		file_put_contents($file, 'THIS IS NOT VALID SERIALIZED DATA');
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->setBackingFile($file);
 		$cache->init(null);
@@ -981,7 +736,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 		$file = self::$tempDir . DIRECTORY_SEPARATOR . 'not_used_' . uniqid() . '.dat';
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setID('memcache');
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId('backingCache');
@@ -994,7 +749,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertFileDoesNotExist($file);
 
 		// Reload — data comes from module, not file.
-		$cache2 = new TMemoryCacheTestAccessor();
+		$cache2 = new TTestMemoryCache();
 		$cache2->setID('memcache');
 		$cache2->setPrimaryCache(false);
 		$cache2->setBackingCacheId('backingCache');
@@ -1017,7 +772,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 		// Fresh instance already has 'shared' in memory from init() load.
 		// Simulate a manual second load after writing 'shared' locally.
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setID('memcache');
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId('backingCache');
@@ -1046,7 +801,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$seed->set('key', 'backing-value');
 		$seed->save();
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setID('memcache');
 		$cache->setPrimaryCache(false);
 		$cache->setBackingCacheId('backingCache');
@@ -1075,7 +830,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$cache->handleSaveState($this->app, null);
 
 		// Verify the backing cache now contains the store.
-		$raw = $backing->getRawData();
+		$raw = $backing->store;
 		$this->assertNotEmpty($raw, 'Backing cache must contain data after handleSaveState().');
 
 		// Reload into a fresh instance to confirm round-trip.
@@ -1382,54 +1137,61 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSetHashKeysToTrue(): void
 	{
-		$this->cache->setHashKeys(true);
-		$this->assertTrue($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys(true);
+		$this->assertTrue($cache->getHashKeys());
 	}
 
 	public function testSetHashKeysToFalse(): void
 	{
-		$this->cache->setHashKeys(false);
-		$this->assertFalse($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys(false);
+		$this->assertFalse($cache->getHashKeys());
 	}
 
 	public function testSetHashKeysToNullResetsToAuto(): void
 	{
-		$this->cache->setHashKeys(true);
-		$this->cache->setHashKeys(null);
-		$this->assertNull($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys(true);
+		$cache->setHashKeys(null);
+		$this->assertNull($cache->getHashKeys());
 	}
 
 	public function testSetHashKeysFromStringTrue(): void
 	{
-		$this->cache->setHashKeys('true');
-		$this->assertTrue($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys('true');
+		$this->assertTrue($cache->getHashKeys());
 	}
 
 	public function testSetHashKeysFromStringFalse(): void
 	{
-		$this->cache->setHashKeys('false');
-		$this->assertFalse($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys('false');
+		$this->assertFalse($cache->getHashKeys());
 	}
 
 	public function testSetHashKeysFromStringNull(): void
 	{
-		$this->cache->setHashKeys(true);
-		$this->cache->setHashKeys('null');
-		$this->assertNull($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys(true);
+		$cache->setHashKeys('null');
+		$this->assertNull($cache->getHashKeys());
 	}
 
 	public function testSetHashKeysFromEmptyString(): void
 	{
-		$this->cache->setHashKeys(true);
-		$this->cache->setHashKeys('');
-		$this->assertNull($this->cache->getHashKeys());
+		$cache = new TTestMemoryCache();
+		$cache->setHashKeys(true);
+		$cache->setHashKeys('');
+		$this->assertNull($cache->getHashKeys());
 	}
 
 	// ── generateUniqueKey (hash on/off/auto) ──────────────────────────────────
 
 	public function testGenerateUniqueKeyWithHashEnabled(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setKeyPrefix('pfx_');
 		$cache->setPrimaryCache(false);
 		$cache->setHashKeys(true);
@@ -1441,7 +1203,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testGenerateUniqueKeyWithHashDisabled(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setKeyPrefix('pfx_');
 		$cache->setPrimaryCache(false);
 		$cache->setHashKeys(false);
@@ -1456,7 +1218,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		// TApplication defaults to Debug mode — hash must be off.
 		$this->assertSame(TApplicationMode::Debug, $this->app->getMode());
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setKeyPrefix('pfx_');
 		$cache->setPrimaryCache(false);
 		// HashKeys is null (auto).
@@ -1471,7 +1233,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	{
 		$this->app->setMode(TApplicationMode::Normal);
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setKeyPrefix('pfx_');
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
@@ -1485,7 +1247,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	{
 		$this->app->setMode(TApplicationMode::Performance);
 
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setKeyPrefix('pfx_');
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
@@ -1499,7 +1261,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 	{
 		// true and false are non-default — they must survive serialization.
 		foreach ([true, false] as $setting) {
-			$cache = new TMemoryCacheTestAccessor();
+			$cache = new TTestMemoryCache();
 			$cache->setPrimaryCache(false);
 			$cache->setHashKeys($setting);
 			$cache->init(null);
@@ -1529,7 +1291,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testConstructSetsBackingCacheKeyToDefaultConstant(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$this->assertSame(
 			TMemoryCache::DEFAULT_BACKING_CACHE_KEY,
 			$cache->getBackingCacheKey(),
@@ -1539,7 +1301,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSubclassCanOverrideDefaultBackingCacheKey(): void
 	{
-		$cache = new TMemoryCacheCustomKeyAccessor();
+		$cache = new TTestMemoryCacheCustomKey();
 		$this->assertSame(
 			'custom.key',
 			$cache->getBackingCacheKey(),
@@ -1556,7 +1318,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testConstructSetsMergePolicyToDefaultConstant(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$this->assertSame(
 			TMemoryCache::DEFAULT_MERGE_POLICY,
 			$cache->getMergePolicy(),
@@ -1566,7 +1328,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testSubclassCanOverrideDefaultMergePolicy(): void
 	{
-		$cache = new TMemoryCacheCustomMergePolicyAccessor();
+		$cache = new TTestMemoryCacheCustomMergePolicy();
 		$this->assertSame(
 			TMemoryCache::REPLACE,
 			$cache->getMergePolicy(),
@@ -1578,7 +1340,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testGetModuleDependenciesUsesIsPreInitParameter(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setBackingCacheId('someId');
 
 		// TMemoryCache does not differentiate by phase — both calls must return
@@ -1608,7 +1370,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testMaximumSizeDefaultsToZero(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$this->assertSame(0, $cache->getMaximumSize(),
 			'MaximumSize must default to 0 (unlimited).');
 	}
@@ -1694,7 +1456,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testGetCurrentSizeReturnsSizeNotComputedWhenInactiveAndNoMaximumSize(): void
 	{
-		$cache = new TMemoryCacheTestAccessor();
+		$cache = new TTestMemoryCache();
 		$cache->setPrimaryCache(false);
 		$cache->init(null);
 		// MaximumSize is 0 by default; size tracking is inactive, sentinel stays SIZE_NOT_COMPUTED.
@@ -1940,5 +1702,86 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertSame(0, $this->cache->getMaximumSize());
 		$this->assertTrue($this->cache->set('large', str_repeat('x', 1_000_000)),
 			'set() must succeed for any payload when MaximumSize is 0 (unlimited).');
+	}
+
+	// ── SerializeValues ───────────────────────────────────────────────────────
+
+	public function testSerializeValuesDefaultsToFalse(): void
+	{
+		$this->assertFalse($this->cache->getSerializeValues());
+	}
+
+	public function testReferenceStorageSharesObjectByDefault(): void
+	{
+		$obj = new \stdClass();
+		$obj->n = 1;
+		$this->cache->set('k', $obj);
+		$obj->n = 2; // mutate the original after storing
+
+		$got = $this->cache->get('k');
+		$this->assertSame($obj, $got, 'With SerializeValues=false, get() returns the same instance.');
+		$this->assertSame(2, $got->n, 'A mutation to the stored object is visible through the cache.');
+	}
+
+	public function testSerializeValuesIsolatesStoredObject(): void
+	{
+		$cache = new TTestMemoryCache();
+		$cache->setPrimaryCache(false);
+		$cache->setSerializeValues(true);
+		$cache->init(null);
+
+		$obj = new \stdClass();
+		$obj->n = 1;
+		$cache->set('k', $obj);
+		$obj->n = 2; // mutate the original after storing
+
+		$got = $cache->get('k');
+		$this->assertNotSame($obj, $got, 'With SerializeValues=true, get() returns an independent copy.');
+		$this->assertSame(1, $got->n, 'The cached copy is unaffected by later mutation of the original.');
+	}
+
+	public function testSerializeValuesRoundTripsScalarsAndArrays(): void
+	{
+		$cache = new TTestMemoryCache();
+		$cache->setPrimaryCache(false);
+		$cache->setSerializeValues(true);
+		$cache->init(null);
+
+		$cache->set('k', ['a' => 1, 'b' => [2, 3]]);
+		$this->assertSame(['a' => 1, 'b' => [2, 3]], $cache->get('k'));
+	}
+
+	public function testNonSerializableValueAllowedWhenNotSerializingAndNoMaxSize(): void
+	{
+		// With SerializeValues=false and MaximumSize=0, no serialize() is performed for
+		// storage or size measurement, so a closure (which serialize() cannot handle) caches.
+		$fn = static fn (): int => 42;
+		$this->assertTrue($this->cache->set('fn', $fn));
+		$this->assertSame($fn, $this->cache->get('fn'));
+	}
+
+	public function testSerializeValuesIsATSerializingCache(): void
+	{
+		$this->assertInstanceOf(\Prado\Caching\TSerializingCache::class, $this->cache);
+	}
+
+	public function testSerializeValuesWithEncryptionRoundTrips(): void
+	{
+		// Serializing mode flows through the TSerializingCache pipeline, so the inherited
+		// Encrypt/Encoding options apply.
+		if (!extension_loaded('openssl')) {
+			$this->markTestSkipped('openssl extension required for encryption.');
+		}
+		$cache = new TTestMemoryCache();
+		$cache->setPrimaryCache(false);
+		$cache->setSerializeValues(true);
+		$cache->setEncrypt(true);
+		$cache->setEncoding(TMemoryCache::ENCODING_BASE64);
+		$cache->init(null);
+
+		$secret = 'in-memory-top-secret';
+		$cache->set('k', $secret);
+		$this->assertSame($secret, $cache->get('k'),
+			'Encrypted serializing mode must round-trip the original value.');
 	}
 }

--- a/tests/unit/Caching/TMemoryCacheTest.php
+++ b/tests/unit/Caching/TMemoryCacheTest.php
@@ -218,6 +218,11 @@ class StubBackingCache extends TCache
 {
 	private array $_data = [];
 
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
 	public function init($config): void
 	{
 		parent::init($config);
@@ -1431,7 +1436,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$cache->init(null);
 
 		$key = 'my_key';
-		$this->assertSame(md5('pfx_' . $key), $cache->pubGenerateUniqueKey($key));
+		$this->assertSame(sha1('pfx_' . $key), $cache->pubGenerateUniqueKey($key));
 	}
 
 	public function testGenerateUniqueKeyWithHashDisabled(): void
@@ -1472,7 +1477,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$cache->init(null);
 
 		$key = 'my_key';
-		$this->assertSame(md5('pfx_' . $key), $cache->pubGenerateUniqueKey($key),
+		$this->assertSame(sha1('pfx_' . $key), $cache->pubGenerateUniqueKey($key),
 			'In Normal mode with HashKeys=null, keys must be hashed.');
 	}
 
@@ -1486,7 +1491,7 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$cache->init(null);
 
 		$key = 'my_key';
-		$this->assertSame(md5('pfx_' . $key), $cache->pubGenerateUniqueKey($key),
+		$this->assertSame(sha1('pfx_' . $key), $cache->pubGenerateUniqueKey($key),
 			'In Performance mode with HashKeys=null, keys must be hashed.');
 	}
 

--- a/tests/unit/Caching/TMemoryCacheTest.php
+++ b/tests/unit/Caching/TMemoryCacheTest.php
@@ -1784,4 +1784,30 @@ class TMemoryCacheTest extends PHPUnit\Framework\TestCase
 		$this->assertSame($secret, $cache->get('k'),
 			'Encrypted serializing mode must round-trip the original value.');
 	}
+
+	// ── Config props frozen after init ──────────────────────────────────────────
+
+	/**
+	 * @dataProvider frozenSetterProvider
+	 */
+	public function testConfigPropertiesCannotChangeAfterInit(string $setter, mixed $value): void
+	{
+		$cache = new TTestMemoryCache();
+		$cache->setPrimaryCache(false);
+		$cache->init(null);
+		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
+		$cache->$setter($value);
+	}
+
+	public static function frozenSetterProvider(): array
+	{
+		return [
+			'BackingCacheId'  => ['setBackingCacheId', 'someModule'],
+			'BackingFile'     => ['setBackingFile', '/tmp/x.cache'],
+			'BackingCacheKey' => ['setBackingCacheKey', 'k'],
+			'MergePolicy'     => ['setMergePolicy', 'all'],
+			'HashKeys'        => ['setHashKeys', true],
+			'SerializeValues' => ['setSerializeValues', true],
+		];
+	}
 }

--- a/tests/unit/Caching/TRedisCacheTest.php
+++ b/tests/unit/Caching/TRedisCacheTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * TRedisCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TRedisCache;
+use Prado\Exceptions\TConfigurationException;
+
+/**
+ * Unit tests for {@see TRedisCache}, via the {@see TTestRedisCache} harness. Connection
+ * properties, availability, and the backend-handle seam are tested without a server;
+ * live operations are exercised only when the `redis` extension and a server are present
+ * (otherwise skipped).
+ */
+class TRedisCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestRedisCache
+	{
+		$cache = new TTestRedisCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsAvailableReturnsBool(): void
+	{
+		$this->assertIsBool(TRedisCache::getIsAvailable());
+	}
+
+	public function testConnectionPropertyDefaults(): void
+	{
+		$cache = $this->newCache();
+		$this->assertSame('localhost', $cache->getHost());
+		$this->assertSame(6379, $cache->getPort());
+		$this->assertSame(0, $cache->getIndex());
+	}
+
+	public function testConnectionPropertyRoundTripBeforeInit(): void
+	{
+		$cache = $this->newCache();
+		$cache->setHost('redis.example.test');
+		$cache->setPort(6380);
+		$cache->setSocket('/var/run/redis/redis.sock');
+		$cache->setIndex(2);
+		$this->assertSame('redis.example.test', $cache->getHost());
+		$this->assertSame(6380, $cache->getPort());
+		$this->assertSame('/var/run/redis/redis.sock', $cache->getSocket());
+		$this->assertSame(2, $cache->getIndex());
+	}
+
+	public function testInitThrowsWhenExtensionUnavailable(): void
+	{
+		if (TRedisCache::getIsAvailable()) {
+			$this->markTestSkipped('redis extension present; cannot exercise the unavailable path.');
+		}
+		$this->expectException(TConfigurationException::class);
+		$this->newCache()->init(null);
+	}
+
+	public function testCacheDirectHandleInjection(): void
+	{
+		$cache = $this->newCache();
+		$this->assertNull($cache->pubGetCacheDirect());
+		$handle = new \stdClass();
+		$cache->pubSetCacheDirect($handle);
+		$this->assertSame($handle, $cache->pubGetCacheDirect());
+	}
+
+	public function testNewRedisWhenAvailable(): void
+	{
+		if (!TRedisCache::getIsAvailable()) {
+			$this->markTestSkipped('redis extension not available.');
+		}
+		$this->assertInstanceOf(\Redis::class, $this->newCache()->pubNewRedis());
+	}
+}

--- a/tests/unit/Caching/TSerializingCacheTest.php
+++ b/tests/unit/Caching/TSerializingCacheTest.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * TSerializingCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TSerializingCache;
+use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\Security\TSecurityManager;
+
+/**
+ * Tests for TSerializingCache serialization, encryption, encoding, and security-manager
+ * resolution. Uses the {@see TTestSerializingCache} harness (an array-backed concrete
+ * TSerializingCache that records raw payloads via {@see TTestSerializingCache::onlyStored()}).
+ */
+class TSerializingCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestSerializingCache
+	{
+		$cache = new TTestSerializingCache();
+		$cache->setPrimaryCache(false); // do not register as the application cache
+		return $cache;
+	}
+
+	// ── Format props frozen after init ──────────────────────────────────────────
+
+	/**
+	 * @dataProvider frozenSetterProvider
+	 */
+	public function testFormatPropertiesCannotChangeAfterInit(string $setter, mixed $value): void
+	{
+		$cache = $this->newCache();
+		$cache->init(null);
+		$this->expectException(TInvalidOperationException::class);
+		$cache->$setter($value);
+	}
+
+	public static function frozenSetterProvider(): array
+	{
+		return [
+			'SerializationType' => ['setSerializationType', TSerializingCache::SERIALIZATION_JSON],
+			'Encrypt'           => ['setEncrypt', true],
+			'Encoding'          => ['setEncoding', TSerializingCache::ENCODING_BASE64],
+			'SecurityManager'   => ['setSecurityManager', 'someModule'],
+		];
+	}
+
+	public function testFormatPropertiesAreSettableBeforeInit(): void
+	{
+		$cache = $this->newCache();
+		$cache->setSerializationType(TSerializingCache::SERIALIZATION_JSON);
+		$cache->setEncoding(TSerializingCache::ENCODING_HEX);
+		$cache->init(null); // must not throw
+		$this->assertSame(TSerializingCache::SERIALIZATION_JSON, $cache->getSerializationType());
+		$this->assertSame(TSerializingCache::ENCODING_HEX, $cache->getEncoding());
+	}
+
+	// ── Defaults ──────────────────────────────────────────────────────────────
+
+	public function testDefaults(): void
+	{
+		$cache = $this->newCache();
+		$this->assertFalse($cache->getEncrypt());
+		$this->assertSame(TSerializingCache::ENCODING_NONE, $cache->getEncoding());
+	}
+
+	// ── Encoding round-trips (no encryption) ───────────────────────────────────
+
+	public function testEncodingNoneRoundTrip(): void
+	{
+		$cache = $this->newCache();
+		$cache->init(null);
+		$cache->set('k', ['a' => 1, 'b' => 'two']);
+		$this->assertSame(['a' => 1, 'b' => 'two'], $cache->get('k'));
+	}
+
+	public function testEncodingBase64RoundTripAndStoredForm(): void
+	{
+		$cache = $this->newCache();
+		$cache->setEncoding(TSerializingCache::ENCODING_BASE64);
+		$cache->init(null);
+		$cache->set('k', 'hello-world');
+		$stored = $cache->onlyStored();
+		// The stored payload is valid base64 and decodes back to a serialize() string.
+		$this->assertNotFalse(base64_decode($stored, true));
+		$this->assertStringContainsString('hello-world', (string) base64_decode($stored, true));
+		$this->assertSame('hello-world', $cache->get('k'));
+	}
+
+	public function testEncodingHexRoundTrip(): void
+	{
+		$cache = $this->newCache();
+		$cache->setEncoding(TSerializingCache::ENCODING_HEX);
+		$cache->init(null);
+		$cache->set('k', 'hex-value');
+		$this->assertTrue(ctype_xdigit($cache->onlyStored()));
+		$this->assertSame('hex-value', $cache->get('k'));
+	}
+
+	public function testCorruptHexPayloadIsAMiss(): void
+	{
+		$cache = $this->newCache();
+		$cache->setEncoding(TSerializingCache::ENCODING_HEX);
+		$cache->init(null);
+		$cache->set('k', 'v');
+		// Replace the stored payload with non-hex data → decode() fails → miss.
+		$key = array_key_first($cache->store);
+		$cache->store[$key] = 'not-hex!';
+		$this->assertFalse($cache->get('k'));
+	}
+
+	// ── setEncoding validation ─────────────────────────────────────────────────
+
+	public function testSetEncodingRejectsUnknownValue(): void
+	{
+		$cache = $this->newCache();
+		$this->expectException(TInvalidDataValueException::class);
+		$cache->setEncoding('Rot13');
+	}
+
+	// ── Encryption ─────────────────────────────────────────────────────────────
+
+	public function testEncryptRoundTripHidesPlaintext(): void
+	{
+		if (!extension_loaded('openssl')) {
+			$this->markTestSkipped('openssl extension required for encryption.');
+		}
+		$cache = $this->newCache();
+		$cache->setEncrypt(true);
+		$cache->setEncoding(TSerializingCache::ENCODING_BASE64);
+		$cache->init(null);
+
+		$secret = 'super-secret-value-1234567890';
+		$cache->set('k', $secret);
+
+		$stored = $cache->onlyStored();
+		$this->assertStringNotContainsString($secret, $stored, 'Stored payload must not contain the plaintext.');
+		$this->assertStringNotContainsString($secret, (string) base64_decode($stored, true), 'Decoded ciphertext must not contain the plaintext.');
+		$this->assertSame($secret, $cache->get('k'), 'Decryption must restore the original value.');
+	}
+
+	public function testTamperedCiphertextIsAMiss(): void
+	{
+		if (!extension_loaded('openssl')) {
+			$this->markTestSkipped('openssl extension required for encryption.');
+		}
+		$cache = $this->newCache();
+		$cache->setEncrypt(true); // Encoding=None → raw ciphertext stored
+		$cache->init(null);
+		$cache->set('k', 'value');
+
+		// Overwrite the ciphertext with garbage → decrypt() returns false → miss.
+		$key = array_key_first($cache->store);
+		$cache->store[$key] = 'not a valid ciphertext';
+		$this->assertFalse($cache->get('k'));
+	}
+
+	// ── SecurityManager property ───────────────────────────────────────────────
+
+	public function testSecurityManagerDefaultsToApplicationSecurityManager(): void
+	{
+		$cache = $this->newCache();
+		$this->assertInstanceOf(TSecurityManager::class, $cache->getSecurityManager());
+	}
+
+	public function testSetSecurityManagerRejectsInvalidType(): void
+	{
+		$cache = $this->newCache();
+		$this->expectException(TConfigurationException::class);
+		$cache->setSecurityManager(123);
+	}
+
+	public function testGetSecurityManagerRejectsUnknownModuleId(): void
+	{
+		$cache = $this->newCache();
+		$cache->setSecurityManager('no_such_security_manager_module');
+		$this->expectException(TConfigurationException::class);
+		$cache->getSecurityManager();
+	}
+
+	public function testInitFailsFastWhenEncryptWithBadSecurityManagerId(): void
+	{
+		$cache = $this->newCache();
+		$cache->setEncrypt(true);
+		$cache->setSecurityManager('no_such_security_manager_module');
+		$this->expectException(TConfigurationException::class);
+		$cache->init(null);
+	}
+
+	// ── SerializationType ───────────────────────────────────────────────────────
+
+	public function testSerializationTypeDefaultsToPhp(): void
+	{
+		$this->assertSame(TSerializingCache::SERIALIZATION_PHP, $this->newCache()->getSerializationType());
+	}
+
+	public function testJsonSerializationRoundTrips(): void
+	{
+		$cache = $this->newCache();
+		$cache->setSerializationType(TSerializingCache::SERIALIZATION_JSON);
+		$cache->init(null);
+		$cache->set('k', ['a' => 1, 'b' => ['c' => 2]]);
+		// JSON decodes to arrays; the dependency wrapper is preserved structurally.
+		$this->assertSame(['a' => 1, 'b' => ['c' => 2]], $cache->get('k'));
+		// The persisted payload is JSON, not PHP-serialized.
+		$this->assertStringStartsWith('[', $cache->onlyStored());
+	}
+
+	public function testSetSerializationTypeRejectsUnknownValue(): void
+	{
+		$this->expectException(TInvalidDataValueException::class);
+		$this->newCache()->setSerializationType('YAML');
+	}
+
+	public function testJsonEncodeFailureThrowsRatherThanStoringFalse(): void
+	{
+		// An invalid-UTF-8 string cannot be JSON-encoded; serializeValue() must throw
+		// instead of silently storing the string "false" (which would read back as a miss).
+		$cache = $this->newCache();
+		$cache->setSerializationType(TSerializingCache::SERIALIZATION_JSON);
+		$this->expectException(TInvalidDataValueException::class);
+		$cache->pubSerializeValue("\xB1\x31");
+	}
+
+	// ── Property coercion / encoding defaults ───────────────────────────────────
+
+	public function testSetEncryptCoercesStrings(): void
+	{
+		$cache = $this->newCache();
+		$cache->setEncrypt('true');
+		$this->assertTrue($cache->getEncrypt());
+		$cache->setEncrypt('false');
+		$this->assertFalse($cache->getEncrypt());
+	}
+
+	public function testEncodingDefaultsToNone(): void
+	{
+		$this->assertSame(TSerializingCache::ENCODING_NONE, $this->newCache()->getEncoding());
+	}
+
+	public function testEncryptedThenBase64CorruptionIsAMiss(): void
+	{
+		if (!extension_loaded('openssl')) {
+			$this->markTestSkipped('openssl extension required for encryption.');
+		}
+		$cache = $this->newCache();
+		$cache->setEncrypt(true);
+		$cache->setEncoding(TSerializingCache::ENCODING_BASE64);
+		$cache->init(null);
+		$cache->set('k', 'value');
+
+		// Valid base64 that decrypts to garbage → decrypt() returns false → miss.
+		$key = array_key_first($cache->store);
+		$cache->store[$key] = base64_encode('totally bogus ciphertext bytes');
+		$this->assertFalse($cache->get('k'));
+	}
+}

--- a/tests/unit/Harness/Caching/TTestAPCCache.php
+++ b/tests/unit/Harness/Caching/TTestAPCCache.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * TTestAPCCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TAPCCache;
+
+/**
+ * TTestAPCCache is a {@see TAPCCache} harness exposing its protected value contract. The
+ * clock is fakeable via {@see TTestCacheClockTrait}. Live-store tests still skip when the
+ * `apcu` extension is unavailable.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestAPCCache extends TAPCCache
+{
+	use TTestCacheClockTrait;
+
+	public function pubGetValue(string $key): mixed
+	{
+		return $this->getValue($key);
+	}
+
+	public function pubSetValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->setValue($key, $value, $expire);
+	}
+
+	public function pubAddValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->addValue($key, $value, $expire);
+	}
+
+	public function pubDeleteValue(string $key): bool
+	{
+		return $this->deleteValue($key);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestCache.php
+++ b/tests/unit/Harness/Caching/TTestCache.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * TTestCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TCache;
+
+/**
+ * TTestCache is a concrete, array-backed {@see TCache} harness for unit tests.
+ *
+ * {@see TCache} is abstract; this harness implements the storage contract over a plain
+ * `$store` array so the base-class behavior (key prefixing/hashing, dependency wrapping,
+ * ArrayAccess, primary-cache registration) can be exercised directly. It also exposes the
+ * protected encapsulation seams:
+ * - the clock ({@see time()} / {@see microtime()}) is overridable via {@see $fakeNow} /
+ *   {@see $fakeMicrotime} for deterministic expiry/LRU tests;
+ * - {@see generateUniqueKey()}, {@see generateToken()}, {@see hashToken()},
+ *   {@see getKeyPrefix()}, and {@see setAppCache()} are reachable through `pub*()` accessors.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestCache extends TCache
+{
+	use TTestCacheClockTrait;
+
+	/** @var array<string, array{0: mixed, 1: int}> stored payload + absolute expiry per key */
+	public array $store = [];
+
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
+	protected function getValue($key)
+	{
+		if (!isset($this->store[$key])) {
+			return false;
+		}
+		[$data, $expire] = $this->store[$key];
+		if ($expire > 0 && $expire <= $this->time()) {
+			unset($this->store[$key]);
+			return false;
+		}
+		return $data;
+	}
+
+	protected function setValue($key, $value, $expire)
+	{
+		$this->store[$key] = [$value, (int) $expire > 0 ? $this->time() + (int) $expire : 0];
+		return true;
+	}
+
+	protected function addValue($key, $value, $expire)
+	{
+		if ($this->getValue($key) !== false) {
+			return false;
+		}
+		return $this->setValue($key, $value, $expire);
+	}
+
+	protected function deleteValue($key)
+	{
+		unset($this->store[$key]);
+		return true;
+	}
+
+	public function flush()
+	{
+		$this->store = [];
+		return true;
+	}
+
+	// ---------------------------------------------------------------- exposers
+
+	public function pubGenerateUniqueKey(string $key): string
+	{
+		return $this->generateUniqueKey($key);
+	}
+
+	public function pubGenerateToken(string $key): string
+	{
+		return $this->generateToken($key);
+	}
+
+	public function pubHashToken(string $token): string
+	{
+		return $this->hashToken($token);
+	}
+
+	public function pubGetKeyPrefix(): string
+	{
+		return $this->getKeyPrefix();
+	}
+
+	public function pubSetAppCache(): void
+	{
+		$this->setAppCache();
+	}
+}

--- a/tests/unit/Harness/Caching/TTestCacheClockTrait.php
+++ b/tests/unit/Harness/Caching/TTestCacheClockTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * TTestCacheClockTrait class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+/**
+ * TTestCacheClockTrait provides a fakeable clock for {@see \Prado\Caching\TCache} harnesses.
+ *
+ * It overrides the protected {@see \Prado\Caching\TCache::time()} /
+ * {@see \Prado\Caching\TCache::microtime()} seams behind the public {@see $fakeNow} /
+ * {@see $fakeMicrotime} fields so expiry and LRU behavior can be driven deterministically,
+ * and exposes them via {@see pubTime()} / {@see pubMicrotime()}.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+trait TTestCacheClockTrait
+{
+	/** @var ?int when set, {@see time()} returns this instead of the real clock */
+	public ?int $fakeNow = null;
+
+	/** @var ?float when set, {@see microtime()} returns this instead of the real clock */
+	public ?float $fakeMicrotime = null;
+
+	protected function time(): int
+	{
+		return $this->fakeNow ?? parent::time();
+	}
+
+	protected function microtime(): float
+	{
+		return $this->fakeMicrotime ?? parent::microtime();
+	}
+
+	public function pubTime(): int
+	{
+		return $this->time();
+	}
+
+	public function pubMicrotime(): float
+	{
+		return $this->microtime();
+	}
+}

--- a/tests/unit/Harness/Caching/TTestCacheStub.php
+++ b/tests/unit/Harness/Caching/TTestCacheStub.php
@@ -34,6 +34,11 @@ class TTestCacheStub implements ICache
 	/** @var mixed Value returned by get(); a Closure is invoked with the id; false models a miss. */
 	public mixed $getReturn = false;
 
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
 	public function get($id)
 	{
 		$this->collectCall();

--- a/tests/unit/Harness/Caching/TTestChainedCacheDependency.php
+++ b/tests/unit/Harness/Caching/TTestChainedCacheDependency.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * TTestChainedCacheDependency class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TCacheDependencyList;
+use Prado\Caching\TChainedCacheDependency;
+
+/**
+ * TTestChainedCacheDependency is a {@see TChainedCacheDependency} harness exposing its
+ * protected dependency-list factory and `*Direct` accessor seams.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestChainedCacheDependency extends TChainedCacheDependency
+{
+	public function pubNewCacheDependencyList(): TCacheDependencyList
+	{
+		return $this->newCacheDependencyList();
+	}
+
+	public function pubGetDependenciesDirect(): ?TCacheDependencyList
+	{
+		return $this->getDependenciesDirect();
+	}
+
+	public function pubSetDependenciesDirect(?TCacheDependencyList $value): void
+	{
+		$this->setDependenciesDirect($value);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestDbCache.php
+++ b/tests/unit/Harness/Caching/TTestDbCache.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * TTestDbCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TDbCache;
+use Prado\Data\TDbConnection;
+
+/**
+ * TTestDbCache is a {@see TDbCache} harness exposing its protected cache-initialization,
+ * connection, and serialized-contract seams. The clock is fakeable via
+ * {@see TTestCacheClockTrait}. No fake database is provided; tests that need a live
+ * connection still skip when PDO/SQLite is unavailable.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestDbCache extends TDbCache
+{
+	use TTestCacheClockTrait;
+
+	public function pubGetIsCacheInitialized(): bool
+	{
+		return $this->getIsCacheInitialized();
+	}
+
+	public function pubSetIsCacheInitialized(bool $value): void
+	{
+		$this->setIsCacheInitialized($value);
+	}
+
+	public function pubInitializeCache($force = false)
+	{
+		return $this->initializeCache($force);
+	}
+
+	public function pubGetSqliteDatabaseName(): string
+	{
+		return $this->getSqliteDatabaseName();
+	}
+
+	public function pubGetCustomDbConnection(): ?TDbConnection
+	{
+		return $this->getCustomDbConnection();
+	}
+
+	public function pubGetDbConnectionActivationType(): ?bool
+	{
+		return $this->getDbConnectionActivationType();
+	}
+
+	public function pubGetSerializedValue(string $key): false|string
+	{
+		return $this->getSerializedValue($key);
+	}
+
+	public function pubSetSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->setSerializedValue($key, $value, $expire);
+	}
+
+	public function pubAddSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->addSerializedValue($key, $value, $expire);
+	}
+
+	public function pubDeleteValue(string $key): bool
+	{
+		return $this->deleteValue($key);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestDirectoryCacheDependency.php
+++ b/tests/unit/Harness/Caching/TTestDirectoryCacheDependency.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * TTestDirectoryCacheDependency class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TDirectoryCacheDependency;
+
+/**
+ * TTestDirectoryCacheDependency is a {@see TDirectoryCacheDependency} harness exposing its
+ * protected directory accessor, validation, and timestamp-generation seams.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestDirectoryCacheDependency extends TDirectoryCacheDependency
+{
+	public function pubGetDirectoryDirect(): ?string
+	{
+		return $this->getDirectoryDirect();
+	}
+
+	public function pubSetDirectoryDirect(?string $value): void
+	{
+		$this->setDirectoryDirect($value);
+	}
+
+	public function pubValidateFile(string $fileName): bool
+	{
+		return $this->validateFile($fileName);
+	}
+
+	public function pubValidateDirectory(string $directory): bool
+	{
+		return $this->validateDirectory($directory);
+	}
+
+	public function pubGenerateTimestamps(string $directory, int $level = 0): array
+	{
+		return $this->generateTimestamps($directory, $level);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestEtcdCache.php
+++ b/tests/unit/Harness/Caching/TTestEtcdCache.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * TTestEtcdCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TEtcdCache;
+
+/**
+ * TTestEtcdCache is a {@see TEtcdCache} harness exposing the serialized-string contract and
+ * the protected {@see request()} HTTP seam. The clock is fakeable via
+ * {@see TTestCacheClockTrait}. Live tests still skip when no etcd service / cURL is
+ * available.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestEtcdCache extends TEtcdCache
+{
+	use TTestCacheClockTrait;
+
+	public function pubGetSerializedValue(string $key): false|string
+	{
+		return $this->getSerializedValue($key);
+	}
+
+	public function pubSetSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->setSerializedValue($key, $value, $expire);
+	}
+
+	public function pubAddSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->addSerializedValue($key, $value, $expire);
+	}
+
+	public function pubDeleteValue(string $key): bool
+	{
+		return $this->deleteValue($key);
+	}
+
+	public function pubRequest($method, $key, $value = [])
+	{
+		return $this->request($method, $key, $value);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestFileCache.php
+++ b/tests/unit/Harness/Caching/TTestFileCache.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * TTestFileCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TFileCache;
+
+/**
+ * TTestFileCache is a {@see TFileCache} harness that exposes its protected filesystem,
+ * hashing, sizing, and serialized-contract seams for unit tests.
+ *
+ * The clock is fakeable via {@see TTestCacheClockTrait}; {@see $hashTokenCallback} lets a
+ * test inject a broken {@see hashToken()} after a successful {@see init()}; every other
+ * protected method is reachable through a `pub*()` accessor.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestFileCache extends TFileCache
+{
+	use TTestCacheClockTrait;
+
+	/**
+	 * @var null|callable when set, {@see hashToken()} delegates to this callable instead
+	 *   of the default sha1 implementation, letting tests inject a bad hashToken after
+	 *   init() has already succeeded with the normal implementation.
+	 */
+	public $hashTokenCallback = null;
+
+	protected function hashToken(string $token): string
+	{
+		return $this->hashTokenCallback !== null
+			? ($this->hashTokenCallback)($token)
+			: parent::hashToken($token);
+	}
+
+	// ---------------------------------------------------------------- exposers
+
+	public function pubGenerateUniqueKey(string $key): string
+	{
+		return $this->generateUniqueKey($key);
+	}
+
+	public function pubHashToken(string $token): string
+	{
+		return $this->hashToken($token);
+	}
+
+	public function pubPathFor(string $key): string
+	{
+		return $this->pathFor($key);
+	}
+
+	public function pubGetSerializedValue(string $key): false|string
+	{
+		return $this->getSerializedValue($key);
+	}
+
+	public function pubSetSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->setSerializedValue($key, $value, $expire);
+	}
+
+	public function pubAddSerializedValue(string $key, string $value, int $expire): bool
+	{
+		return $this->addSerializedValue($key, $value, $expire);
+	}
+
+	public function pubGetContents(string $filePath): string|false
+	{
+		return $this->getContents($filePath);
+	}
+
+	public function pubPutContents(string $filePath, string $data, bool $exclusive = false): int|false
+	{
+		return $this->putContents($filePath, $data, $exclusive);
+	}
+
+	public function pubUnlink(string $filePath): bool
+	{
+		return $this->unlink($filePath);
+	}
+
+	public function pubRename(string $srcFilePath, string $destFilePath): bool
+	{
+		return $this->rename($srcFilePath, $destFilePath);
+	}
+
+	public function pubChmod(string $filePath, int $mode): bool
+	{
+		return $this->chmod($filePath, $mode);
+	}
+
+	public function pubTempnam(string $dir, string $prefix): string|false
+	{
+		return $this->tempnam($dir, $prefix);
+	}
+
+	public function pubGetTempFilePrefixDirect(): string
+	{
+		return $this->getTempFilePrefixDirect();
+	}
+
+	public function pubIsFile(string $path): bool
+	{
+		return $this->isFile($path);
+	}
+
+	public function pubTouch(string $filePath): bool
+	{
+		return $this->touch($filePath);
+	}
+
+	public function pubComputeSizeFingerprint(): string
+	{
+		return $this->computeSizeFingerprint();
+	}
+
+	public function pubComputeCurrentSize(): int
+	{
+		return $this->computeCurrentSize();
+	}
+
+	public function pubGetMaximumSizeDirect(): int
+	{
+		return $this->getMaximumSizeDirect();
+	}
+
+	public function pubGetCurrentSizeDirect(): int
+	{
+		return $this->getCurrentSizeDirect();
+	}
+
+	public function pubSetCurrentSizeDirect(int $value): void
+	{
+		$this->setCurrentSizeDirect($value);
+	}
+
+	public function pubGetSizeFingerprintDirect(): string
+	{
+		return $this->getSizeFingerprintDirect();
+	}
+
+	public function pubSetSizeFingerprintDirect(string $value): void
+	{
+		$this->setSizeFingerprintDirect($value);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestFileCacheDependency.php
+++ b/tests/unit/Harness/Caching/TTestFileCacheDependency.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * TTestFileCacheDependency class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TFileCacheDependency;
+
+/**
+ * TTestFileCacheDependency is a {@see TFileCacheDependency} harness exposing its protected
+ * file-name and timestamp seams.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestFileCacheDependency extends TFileCacheDependency
+{
+	public function pubSetFileNameDirect($value): void
+	{
+		$this->setFileNameDirect($value);
+	}
+
+	public function pubSetTimestamp($value): void
+	{
+		$this->setTimestamp($value);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestGlobalStateCacheDependency.php
+++ b/tests/unit/Harness/Caching/TTestGlobalStateCacheDependency.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * TTestGlobalStateCacheDependency class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TGlobalStateCacheDependency;
+
+/**
+ * TTestGlobalStateCacheDependency is a {@see TGlobalStateCacheDependency} harness exposing
+ * its protected state-name accessor seams.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestGlobalStateCacheDependency extends TGlobalStateCacheDependency
+{
+	public function pubGetStateNameDirect(): string
+	{
+		return $this->getStateNameDirect();
+	}
+
+	public function pubSetStateNameDirect(string $value): void
+	{
+		$this->setStateNameDirect($value);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestMemCache.php
+++ b/tests/unit/Harness/Caching/TTestMemCache.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * TTestMemCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TMemCache;
+
+/**
+ * TTestMemCache is a {@see TMemCache} harness exposing the backend-handle seams
+ * ({@see getCacheDirect()} / {@see setCacheDirect()} / {@see newMemcached()}) and the value
+ * contract, so a test can inject a handle or assert wiring. The clock is fakeable via
+ * {@see TTestCacheClockTrait}. Live-server tests still skip when the `memcached` extension
+ * is unavailable.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestMemCache extends TMemCache
+{
+	use TTestCacheClockTrait;
+
+	public function pubGetCacheDirect(): ?object
+	{
+		return $this->getCacheDirect();
+	}
+
+	public function pubSetCacheDirect($value): void
+	{
+		$this->setCacheDirect($value);
+	}
+
+	public function pubNewMemcached($persistentId): object
+	{
+		return $this->newMemcached($persistentId);
+	}
+
+	public function pubGetValue(string $key): mixed
+	{
+		return $this->getValue($key);
+	}
+
+	public function pubSetValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->setValue($key, $value, $expire);
+	}
+
+	public function pubAddValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->addValue($key, $value, $expire);
+	}
+
+	public function pubDeleteValue(string $key): bool
+	{
+		return $this->deleteValue($key);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestMemoryCache.php
+++ b/tests/unit/Harness/Caching/TTestMemoryCache.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * TTestMemoryCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TMemoryCache;
+
+/**
+ * TTestMemoryCache is a {@see TMemoryCache} harness exposing its protected store, sizing,
+ * backing-persistence, serialized-contract, and serialize-helper seams.
+ *
+ * The clock is fakeable via {@see TTestCacheClockTrait}; every other protected method is
+ * reachable through a `pub*()` accessor — including the dual-mode store core
+ * ({@see readStore()} / {@see writeStore()} / {@see addStore()}).
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestMemoryCache extends TMemoryCache
+{
+	use TTestCacheClockTrait;
+
+	// ------------------------------------------------------------- value contract
+
+	public function pubGetValue(string $key): mixed
+	{
+		return $this->getValue($key);
+	}
+
+	public function pubSetValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->setValue($key, $value, $expire);
+	}
+
+	public function pubAddValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->addValue($key, $value, $expire);
+	}
+
+	public function pubDeleteValue(string $key): bool
+	{
+		return $this->deleteValue($key);
+	}
+
+	// ------------------------------------------------------------- store core
+
+	public function pubReadStore(string $key): mixed
+	{
+		return $this->readStore($key);
+	}
+
+	public function pubWriteStore(string $key, mixed $payload, int $expire): bool
+	{
+		return $this->writeStore($key, $payload, $expire);
+	}
+
+	public function pubAddStore(string $key, mixed $payload, int $expire): bool
+	{
+		return $this->addStore($key, $payload, $expire);
+	}
+
+	public function pubGetSerializedValue(string $key): false|string
+	{
+		return $this->getSerializedValue($key);
+	}
+
+	// ------------------------------------------------------------- backing persistence
+
+	public function pubLoad(): bool
+	{
+		return $this->load();
+	}
+
+	public function pubSave(): bool
+	{
+		return $this->save();
+	}
+
+	public function pubLoadFromBacking(): ?array
+	{
+		return $this->loadFromBacking();
+	}
+
+	public function pubSaveToBacking(array $store): bool
+	{
+		return $this->saveToBacking($store);
+	}
+
+	// ------------------------------------------------------------- store directs
+
+	public function pubGenerateUniqueKey(string $key): string
+	{
+		return $this->generateUniqueKey($key);
+	}
+
+	public function pubGetStore(): array
+	{
+		return $this->getStoreDirect();
+	}
+
+	public function &pubGetStoreRef(): array
+	{
+		return $this->getStoreDirect();
+	}
+
+	public function pubSetStore(array $value): void
+	{
+		$this->setStoreDirect($value);
+	}
+
+	public function pubGetStoreEntry(string $key): ?array
+	{
+		return $this->getStoreEntry($key);
+	}
+
+	public function pubHasStoreEntry(string $key): bool
+	{
+		return $this->hasStoreEntry($key);
+	}
+
+	public function pubSetStoreEntry(string $key, array $entry): void
+	{
+		$this->setStoreEntry($key, $entry);
+	}
+
+	public function pubClearStoreEntry(string $key): void
+	{
+		$this->clearStoreEntry($key);
+	}
+
+	// ------------------------------------------------------------- sizing
+
+	public function pubComputeSizeFingerprint(): string
+	{
+		return $this->computeSizeFingerprint();
+	}
+
+	public function pubComputeCurrentSize(): int
+	{
+		return $this->computeCurrentSize();
+	}
+
+	public function pubEvictToFitMaximumSize(): void
+	{
+		$this->evictToFitMaximumSize();
+	}
+
+	public function pubValidateSizeCache(): void
+	{
+		$this->validateSizeCache();
+	}
+
+	public function pubGetMaximumSizeDirect(): int
+	{
+		return $this->getMaximumSizeDirect();
+	}
+
+	public function pubGetCurrentSizeDirect(): int
+	{
+		return $this->getCurrentSizeDirect();
+	}
+
+	public function pubSetCurrentSizeDirect(int $value): void
+	{
+		$this->setCurrentSizeDirect($value);
+	}
+
+	public function pubGetSizeFingerprintDirect(): string
+	{
+		return $this->getSizeFingerprintDirect();
+	}
+
+	public function pubSetSizeFingerprintDirect(string $value): void
+	{
+		$this->setSizeFingerprintDirect($value);
+	}
+
+	// ------------------------------------------------------------- misc seams
+
+	public function pubGetChanged(): bool
+	{
+		return $this->getChanged();
+	}
+
+	public function pubGetHashKeys(): ?bool
+	{
+		return $this->getHashKeys();
+	}
+
+	public function pubGetSerializeValues(): bool
+	{
+		return $this->getSerializeValues();
+	}
+
+	public function pubSerialize(mixed $value): string
+	{
+		return $this->serialize($value);
+	}
+
+	public function pubUnserialize(string $data): mixed
+	{
+		return $this->unserialize($data);
+	}
+
+	public function pubGetContents(string $filePath): string|false
+	{
+		return $this->getContents($filePath);
+	}
+
+	public function pubPutContents(string $filePath, string $data, bool $exclusive = false): int|false
+	{
+		return $this->putContents($filePath, $data, $exclusive);
+	}
+}
+
+/**
+ * A {@see TMemoryCache} fixture overriding DEFAULT_BACKING_CACHE_KEY, to verify that the
+ * constructor seeds the backing cache key via late static binding.
+ */
+class TTestMemoryCacheCustomKey extends TTestMemoryCache
+{
+	public const DEFAULT_BACKING_CACHE_KEY = 'custom.key';
+}
+
+/**
+ * A {@see TMemoryCache} fixture overriding DEFAULT_MERGE_POLICY, to verify that the
+ * constructor seeds the merge policy via late static binding.
+ */
+class TTestMemoryCacheCustomMergePolicy extends TTestMemoryCache
+{
+	public const DEFAULT_MERGE_POLICY = TMemoryCache::REPLACE;
+}

--- a/tests/unit/Harness/Caching/TTestRedisCache.php
+++ b/tests/unit/Harness/Caching/TTestRedisCache.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * TTestRedisCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TRedisCache;
+
+/**
+ * TTestRedisCache is a {@see TRedisCache} harness exposing the backend-handle seams
+ * ({@see getCacheDirect()} / {@see setCacheDirect()} / {@see newRedis()}) and the value
+ * contract. The clock is fakeable via {@see TTestCacheClockTrait}. Live-server tests still
+ * skip when the `redis` extension is unavailable.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestRedisCache extends TRedisCache
+{
+	use TTestCacheClockTrait;
+
+	public function pubGetCacheDirect(): ?object
+	{
+		return $this->getCacheDirect();
+	}
+
+	public function pubSetCacheDirect(?object $value): void
+	{
+		$this->setCacheDirect($value);
+	}
+
+	public function pubNewRedis(): object
+	{
+		return $this->newRedis();
+	}
+
+	public function pubGetValue(string $key): mixed
+	{
+		return $this->getValue($key);
+	}
+
+	public function pubSetValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->setValue($key, $value, $expire);
+	}
+
+	public function pubAddValue(string $key, mixed $value, int $expire): bool
+	{
+		return $this->addValue($key, $value, $expire);
+	}
+
+	public function pubDeleteValue(string $key): bool
+	{
+		return $this->deleteValue($key);
+	}
+}

--- a/tests/unit/Harness/Caching/TTestSerializingCache.php
+++ b/tests/unit/Harness/Caching/TTestSerializingCache.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * TTestSerializingCache class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+require_once __DIR__ . '/TTestCacheClockTrait.php';
+
+use Prado\Caching\TSerializingCache;
+
+/**
+ * TTestSerializingCache is a concrete, array-backed {@see TSerializingCache} harness.
+ *
+ * {@see TSerializingCache} is abstract; this harness implements the serialized-string
+ * storage contract ({@see getSerializedValue()} / {@see setSerializedValue()} /
+ * {@see addSerializedValue()}) over a plain `$store` array, so the base-class
+ * serialize → encrypt → encode pipeline can be exercised and inspected directly.
+ *
+ * Exposed seams:
+ * - clock ({@see time()} / {@see microtime()}) via {@see $fakeNow} / {@see $fakeMicrotime};
+ * - {@see serializeValue()}, {@see unserializeValue()}, {@see encode()}, {@see decode()},
+ *   and {@see getSerializedValue()} through `pub*()` accessors;
+ * - {@see onlyStored()} returns the single stored raw payload so a test can assert how
+ *   encryption/encoding shaped what was persisted.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+class TTestSerializingCache extends TSerializingCache
+{
+	use TTestCacheClockTrait;
+
+	/** @var array<string, string> stored serialized payload per key (raw, inspectable) */
+	public array $store = [];
+
+	/** @var array<string, int> absolute expiry per key (0 = never) */
+	public array $expires = [];
+
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
+
+	/** @return string the single stored raw payload (tests use one key at a time) */
+	public function onlyStored(): string
+	{
+		$payload = reset($this->store);
+		return $payload === false ? '' : (string) $payload;
+	}
+
+	protected function getSerializedValue(string $key): false|string
+	{
+		if (!isset($this->store[$key])) {
+			return false;
+		}
+		$expire = $this->expires[$key] ?? 0;
+		if ($expire > 0 && $expire <= $this->time()) {
+			unset($this->store[$key], $this->expires[$key]);
+			return false;
+		}
+		return $this->store[$key];
+	}
+
+	protected function setSerializedValue(string $key, string $value, int $expire): bool
+	{
+		$this->store[$key] = $value;
+		$this->expires[$key] = $expire > 0 ? $this->time() + $expire : 0;
+		return true;
+	}
+
+	protected function addSerializedValue(string $key, string $value, int $expire): bool
+	{
+		if ($this->getSerializedValue($key) !== false) {
+			return false;
+		}
+		return $this->setSerializedValue($key, $value, $expire);
+	}
+
+	protected function deleteValue($key)
+	{
+		unset($this->store[$key], $this->expires[$key]);
+		return true;
+	}
+
+	public function flush()
+	{
+		$this->store = [];
+		$this->expires = [];
+		return true;
+	}
+
+	// ---------------------------------------------------------------- exposers
+
+	public function pubSerializeValue(mixed $value): string
+	{
+		return $this->serializeValue($value);
+	}
+
+	public function pubUnserializeValue(string $data): mixed
+	{
+		return $this->unserializeValue($data);
+	}
+
+	public function pubEncode(string $data): string
+	{
+		return $this->encode($data);
+	}
+
+	public function pubDecode(string $data): false|string
+	{
+		return $this->decode($data);
+	}
+
+	public function pubGetSerializedValue(string $key): false|string
+	{
+		return $this->getSerializedValue($key);
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestAPCCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestAPCCacheTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * TTestAPCCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TAPCCache;
+
+/**
+ * Tests for {@see TTestAPCCache}. Verifies type, the clock seam, and — only when the
+ * `apcu` extension is available — the value-contract exposers.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestAPCCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestAPCCache
+	{
+		$cache = new TTestAPCCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsAnAPCCache(): void
+	{
+		$this->assertInstanceOf(TAPCCache::class, $this->newCache());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 321;
+		$this->assertSame(321, $cache->pubTime());
+		$cache->fakeMicrotime = 9.5;
+		$this->assertSame(9.5, $cache->pubMicrotime());
+	}
+
+	public function testValueContractExposersWhenAvailable(): void
+	{
+		if (!TAPCCache::getIsAvailable()) {
+			$this->markTestSkipped('apcu extension not available.');
+		}
+		$cache = $this->newCache();
+		$cache->init(null);
+		$key = 'ttest_apc_' . getmypid();
+		$this->assertTrue($cache->pubSetValue($key, 'v', 0));
+		$this->assertSame('v', $cache->pubGetValue($key));
+		$this->assertTrue($cache->pubDeleteValue($key));
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestCacheTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * TTestCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\ICache;
+use Prado\Caching\TCache;
+
+/**
+ * Tests for {@see TTestCache}, the array-backed {@see TCache} harness.
+ *
+ * Verifies the storage contract, the fakeable clock seam, and that the exposers reach
+ * their protected targets (key generation/hashing/prefix).
+ *
+ * @package System.Harness.Caching
+ */
+class TTestCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestCache
+	{
+		$cache = new TTestCache();
+		$cache->setPrimaryCache(false);
+		$cache->init(null);
+		return $cache;
+	}
+
+	public function testIsACache(): void
+	{
+		$this->assertInstanceOf(TCache::class, new TTestCache());
+		$this->assertInstanceOf(ICache::class, new TTestCache());
+		$this->assertTrue(TTestCache::getIsAvailable());
+	}
+
+	public function testSetGetDeleteFlushRoundTrip(): void
+	{
+		$cache = $this->newCache();
+		$this->assertTrue($cache->set('k', ['v' => 1]));
+		$this->assertSame(['v' => 1], $cache->get('k'));
+		$this->assertTrue($cache->delete('k'));
+		$this->assertFalse($cache->get('k'));
+
+		$cache->set('a', 1);
+		$cache->flush();
+		$this->assertFalse($cache->get('a'));
+	}
+
+	public function testAddOnlyStoresWhenAbsent(): void
+	{
+		$cache = $this->newCache();
+		$this->assertTrue($cache->add('k', 'first'));
+		$this->assertFalse($cache->add('k', 'second'));
+		$this->assertSame('first', $cache->get('k'));
+	}
+
+	public function testFakeNowDrivesExpiry(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 1_000_000;
+		$cache->set('k', 'v', 10); // expires at 1_000_010
+		$this->assertSame('v', $cache->get('k'));
+
+		$cache->fakeNow = 1_000_011; // one second past expiry
+		$this->assertFalse($cache->get('k'));
+	}
+
+	public function testFakeMicrotimeOverride(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeMicrotime = 123.5;
+		$this->assertSame(123.5, $cache->pubMicrotime());
+	}
+
+	public function testKeyGenerationExposers(): void
+	{
+		$cache = $this->newCache();
+		$cache->setKeyPrefix('pfx_');
+		$this->assertSame('pfx_my_key', $cache->pubGenerateToken('my_key'));
+		$this->assertSame(sha1('pfx_my_key'), $cache->pubHashToken('pfx_my_key'));
+		$this->assertSame(sha1('pfx_my_key'), $cache->pubGenerateUniqueKey('my_key'));
+		$this->assertSame('pfx_', $cache->pubGetKeyPrefix());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestChainedCacheDependencyTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestChainedCacheDependencyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * TTestChainedCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TCacheDependencyList;
+use Prado\Caching\TChainedCacheDependency;
+
+/**
+ * Tests for {@see TTestChainedCacheDependency}: the dependency-list factory and `*Direct`
+ * accessor seams.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestChainedCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	public function testIsAChainedCacheDependency(): void
+	{
+		$this->assertInstanceOf(TChainedCacheDependency::class, new TTestChainedCacheDependency());
+	}
+
+	public function testNewCacheDependencyListReturnsList(): void
+	{
+		$dep = new TTestChainedCacheDependency();
+		$this->assertInstanceOf(TCacheDependencyList::class, $dep->pubNewCacheDependencyList());
+	}
+
+	public function testDependenciesDirectRoundTrips(): void
+	{
+		$dep = new TTestChainedCacheDependency();
+		$this->assertNull($dep->pubGetDependenciesDirect());
+
+		$list = $dep->pubNewCacheDependencyList();
+		$dep->pubSetDependenciesDirect($list);
+		$this->assertSame($list, $dep->pubGetDependenciesDirect());
+
+		$dep->pubSetDependenciesDirect(null);
+		$this->assertNull($dep->pubGetDependenciesDirect());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestDbCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestDbCacheTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * TTestDbCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TDbCache;
+
+/**
+ * Tests for {@see TTestDbCache}. Exercises the seams that need no live database
+ * (the cache-initialized flag, connection-activation type, clock); the serialized
+ * contract is covered by the live TDbCacheTest.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestDbCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestDbCache
+	{
+		$cache = new TTestDbCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsADbCache(): void
+	{
+		$this->assertInstanceOf(TDbCache::class, $this->newCache());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 555;
+		$cache->fakeMicrotime = 1.5;
+		$this->assertSame(555, $cache->pubTime());
+		$this->assertSame(1.5, $cache->pubMicrotime());
+	}
+
+	public function testCacheInitializedFlagRoundTrips(): void
+	{
+		$cache = $this->newCache();
+		$this->assertFalse($cache->pubGetIsCacheInitialized());
+		$cache->pubSetIsCacheInitialized(true);
+		$this->assertTrue($cache->pubGetIsCacheInitialized());
+	}
+
+	public function testConnectionActivationTypeDefaultsToTrue(): void
+	{
+		$this->assertTrue($this->newCache()->pubGetDbConnectionActivationType());
+	}
+
+	public function testCustomDbConnectionDefaultsToNull(): void
+	{
+		$this->assertNull($this->newCache()->pubGetCustomDbConnection());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestDirectoryCacheDependencyTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestDirectoryCacheDependencyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * TTestDirectoryCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TDirectoryCacheDependency;
+
+/**
+ * Tests for {@see TTestDirectoryCacheDependency}: directory `*Direct` accessor,
+ * validation, and timestamp-generation exposers.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestDirectoryCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_ttestdirdep_' . getmypid();
+		@mkdir($this->dir, 0o755, true);
+		file_put_contents($this->dir . DIRECTORY_SEPARATOR . 'a.txt', 'a');
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . DIRECTORY_SEPARATOR . '*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	private function newDependency(): TTestDirectoryCacheDependency
+	{
+		return new TTestDirectoryCacheDependency($this->dir);
+	}
+
+	public function testIsADirectoryCacheDependency(): void
+	{
+		$this->assertInstanceOf(TDirectoryCacheDependency::class, $this->newDependency());
+	}
+
+	public function testDirectoryDirectAccessor(): void
+	{
+		$dep = $this->newDependency();
+		$this->assertNotNull($dep->pubGetDirectoryDirect());
+		$dep->pubSetDirectoryDirect(null);
+		$this->assertNull($dep->pubGetDirectoryDirect());
+	}
+
+	public function testGenerateTimestampsIncludesFile(): void
+	{
+		$dep = $this->newDependency();
+		$timestamps = $dep->pubGenerateTimestamps($this->dir);
+		$this->assertIsArray($timestamps);
+		$this->assertArrayHasKey($this->dir . DIRECTORY_SEPARATOR . 'a.txt', $timestamps);
+	}
+
+	public function testValidateExposersReturnBool(): void
+	{
+		$dep = $this->newDependency();
+		$this->assertIsBool($dep->pubValidateDirectory($this->dir));
+		$this->assertIsBool($dep->pubValidateFile($this->dir . DIRECTORY_SEPARATOR . 'a.txt'));
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestEtcdCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestEtcdCacheTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * TTestEtcdCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TEtcdCache;
+
+/**
+ * Tests for {@see TTestEtcdCache}. Verifies type and the clock seam; the serialized
+ * contract and {@see request()} require a live etcd service / cURL and are exercised by
+ * the live TEtcdCacheTest.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestEtcdCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestEtcdCache
+	{
+		$cache = new TTestEtcdCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsAnEtcdCache(): void
+	{
+		$this->assertInstanceOf(TEtcdCache::class, $this->newCache());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 33;
+		$this->assertSame(33, $cache->pubTime());
+		$cache->fakeMicrotime = 4.5;
+		$this->assertSame(4.5, $cache->pubMicrotime());
+	}
+
+	public function testDirDefault(): void
+	{
+		$this->assertSame('pradocache', $this->newCache()->getDir());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestFileCacheDependencyTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestFileCacheDependencyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * TTestFileCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TFileCacheDependency;
+
+/**
+ * Tests for {@see TTestFileCacheDependency}: the file-name and timestamp `*Direct` seams.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestFileCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	private string $file;
+
+	protected function setUp(): void
+	{
+		$this->file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_ttestfiledep_' . getmypid() . '.txt';
+		file_put_contents($this->file, 'x');
+	}
+
+	protected function tearDown(): void
+	{
+		@unlink($this->file);
+	}
+
+	public function testIsAFileCacheDependency(): void
+	{
+		$this->assertInstanceOf(TFileCacheDependency::class, new TTestFileCacheDependency($this->file));
+	}
+
+	public function testSetFileNameDirect(): void
+	{
+		$dep = new TTestFileCacheDependency($this->file);
+		$dep->pubSetFileNameDirect('/some/other/path');
+		$this->assertSame('/some/other/path', $dep->getFileName());
+	}
+
+	public function testSetTimestamp(): void
+	{
+		$dep = new TTestFileCacheDependency($this->file);
+		$dep->pubSetTimestamp(123456);
+		$this->assertSame(123456, $dep->getTimestamp());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestFileCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestFileCacheTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * TTestFileCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TFileCache;
+use Prado\Exceptions\TConfigurationException;
+
+/**
+ * Tests for {@see TTestFileCache} (and the hash fixtures), verifying the harness exposers,
+ * the fakeable clock, and the {@see TTestFileCache::$hashTokenCallback} injection.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestFileCacheTest extends PHPUnit\Framework\TestCase
+{
+	private string $dir;
+	private TTestFileCache $cache;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_ttestfilecache_' . getmypid();
+		@mkdir($this->dir, 0o755, true);
+		$this->cache = new TTestFileCache($this->dir);
+		$this->cache->setPrimaryCache(false);
+		$this->cache->init(null);
+	}
+
+	protected function tearDown(): void
+	{
+		$this->cache->flush();
+		foreach (glob($this->dir . DIRECTORY_SEPARATOR . '*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	public function testIsAFileCache(): void
+	{
+		$this->assertInstanceOf(TFileCache::class, $this->cache);
+		$this->assertTrue(TTestFileCache::getIsAvailable());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$this->cache->fakeNow = 4242;
+		$this->cache->fakeMicrotime = 99.5;
+		$this->assertSame(4242, $this->cache->pubTime());
+		$this->assertSame(99.5, $this->cache->pubMicrotime());
+	}
+
+	public function testHashTokenCallbackOverridesHashing(): void
+	{
+		$this->assertSame(sha1('tok'), $this->cache->pubHashToken('tok'));
+		$this->cache->hashTokenCallback = static fn (string $t): string => 'X' . strlen($t);
+		$this->assertSame('X3', $this->cache->pubHashToken('tok'));
+	}
+
+	public function testFileSeamRoundTrips(): void
+	{
+		$file = $this->dir . DIRECTORY_SEPARATOR . 'seam.tmp';
+		$this->assertNotFalse($this->cache->pubPutContents($file, 'hello'));
+		$this->assertTrue($this->cache->pubIsFile($file));
+		$this->assertSame('hello', $this->cache->pubGetContents($file));
+		$dst = $file . '.moved';
+		$this->assertTrue($this->cache->pubRename($file, $dst));
+		$this->assertTrue($this->cache->pubChmod($dst, 0o600));
+		$this->assertTrue($this->cache->pubTouch($dst));
+		$this->assertTrue($this->cache->pubUnlink($dst));
+		$this->assertFalse($this->cache->pubIsFile($dst));
+	}
+
+	public function testTempnamCreatesFileInDir(): void
+	{
+		$dir = $this->cache->getDirectory(); // realpath-resolved (handles /tmp → /private/tmp)
+		$tmp = $this->cache->pubTempnam($dir, 'pfx-');
+		$this->assertNotFalse($tmp);
+		$this->assertStringStartsWith($dir, $tmp);
+		@unlink($tmp);
+	}
+
+	public function testSerializedContractExposers(): void
+	{
+		$key = $this->cache->pubGenerateUniqueKey('k');
+		$this->assertTrue($this->cache->pubSetSerializedValue($key, 'payload', 0));
+		$this->assertSame('payload', $this->cache->pubGetSerializedValue($key));
+		// add fails when present, succeeds when absent
+		$this->assertFalse($this->cache->pubAddSerializedValue($key, 'other', 0));
+		$key2 = $this->cache->pubGenerateUniqueKey('k2');
+		$this->assertTrue($this->cache->pubAddSerializedValue($key2, 'fresh', 0));
+	}
+
+	public function testPathForUsesCacheDirectory(): void
+	{
+		$path = $this->cache->pubPathFor('abc');
+		$this->assertStringStartsWith($this->cache->getDirectory(), $path);
+		$this->assertStringEndsWith('.cache', $path);
+	}
+
+	public function testSizeDirectExposers(): void
+	{
+		$this->cache->pubSetCurrentSizeDirect(123);
+		$this->assertSame(123, $this->cache->pubGetCurrentSizeDirect());
+		$this->cache->pubSetSizeFingerprintDirect('fp');
+		$this->assertSame('fp', $this->cache->pubGetSizeFingerprintDirect());
+		$this->assertIsInt($this->cache->pubComputeCurrentSize());
+		$this->assertIsString($this->cache->pubComputeSizeFingerprint());
+	}
+
+	public function testIdentityHashCallbackRejectedByInit(): void
+	{
+		$cache = new TTestFileCache($this->dir);
+		$cache->setPrimaryCache(false);
+		$cache->hashTokenCallback = static fn (string $token): string => $token; // identity
+		$this->expectException(TConfigurationException::class);
+		$cache->init(null);
+	}
+
+	public function testSlashHashCallbackRejectedByInit(): void
+	{
+		$cache = new TTestFileCache($this->dir);
+		$cache->setPrimaryCache(false);
+		$cache->hashTokenCallback = static fn (string $token): string => 'sub/dir/' . sha1($token);
+		$this->expectException(TConfigurationException::class);
+		$cache->init(null);
+	}
+
+	public function testBackslashHashCallbackRejectedByInit(): void
+	{
+		$cache = new TTestFileCache($this->dir);
+		$cache->setPrimaryCache(false);
+		$cache->hashTokenCallback = static fn (string $token): string => 'sub\\dir\\' . sha1($token);
+		$this->expectException(TConfigurationException::class);
+		$cache->init(null);
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestGlobalStateCacheDependencyTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestGlobalStateCacheDependencyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * TTestGlobalStateCacheDependencyTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TGlobalStateCacheDependency;
+
+/**
+ * Tests for {@see TTestGlobalStateCacheDependency}: the state-name `*Direct` seams.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestGlobalStateCacheDependencyTest extends PHPUnit\Framework\TestCase
+{
+	public function testIsAGlobalStateCacheDependency(): void
+	{
+		$dep = new TTestGlobalStateCacheDependency('MyState');
+		$this->assertInstanceOf(TGlobalStateCacheDependency::class, $dep);
+	}
+
+	public function testStateNameDirectRoundTrips(): void
+	{
+		$dep = new TTestGlobalStateCacheDependency('MyState');
+		$this->assertSame('MyState', $dep->pubGetStateNameDirect());
+		$dep->pubSetStateNameDirect('Other');
+		$this->assertSame('Other', $dep->pubGetStateNameDirect());
+		$this->assertSame('Other', $dep->getStateName());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestMemCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestMemCacheTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * TTestMemCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TMemCache;
+
+/**
+ * Tests for {@see TTestMemCache}. The handle seam (getCacheDirect/setCacheDirect) is
+ * verified with an injected dummy object — no extension required; {@see newMemcached()} is
+ * exercised only when the `memcached` extension is available.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestMemCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestMemCache
+	{
+		$cache = new TTestMemCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsAMemCache(): void
+	{
+		$this->assertInstanceOf(TMemCache::class, $this->newCache());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 11;
+		$this->assertSame(11, $cache->pubTime());
+	}
+
+	public function testCacheDirectHandleRoundTrips(): void
+	{
+		$cache = $this->newCache();
+		$handle = new \stdClass();
+		$cache->pubSetCacheDirect($handle);
+		$this->assertSame($handle, $cache->pubGetCacheDirect());
+	}
+
+	public function testNewMemcachedWhenAvailable(): void
+	{
+		if (!TMemCache::getIsAvailable()) {
+			$this->markTestSkipped('memcached extension not available.');
+		}
+		$this->assertInstanceOf(\Memcached::class, $this->newCache()->pubNewMemcached(null));
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestMemoryCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestMemoryCacheTest.php
@@ -93,11 +93,15 @@ class TTestMemoryCacheTest extends PHPUnit\Framework\TestCase
 	{
 		$file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_ttestmem_backing_' . getmypid() . '.bin';
 		@unlink($file);
-		$this->cache->setBackingFile($file);
+		// BackingFile is frozen after init(), so configure a fresh cache before init().
+		$cache = new TTestMemoryCache();
+		$cache->setPrimaryCache(false);
+		$cache->setBackingFile($file);
+		$cache->init(null);
 
 		$store = ['k' => ['data' => 'v', 'expire' => 0]];
-		$this->assertTrue($this->cache->pubSaveToBacking($store));
-		$this->assertSame($store, $this->cache->pubLoadFromBacking());
+		$this->assertTrue($cache->pubSaveToBacking($store));
+		$this->assertSame($store, $cache->pubLoadFromBacking());
 		@unlink($file);
 	}
 

--- a/tests/unit/HarnessTests/Caching/TTestMemoryCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestMemoryCacheTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * TTestMemoryCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TMemoryCache;
+
+/**
+ * Tests for {@see TTestMemoryCache}, verifying the harness exposers for the store core,
+ * serialize helpers, backing persistence, and the late-static-binding fixture subclasses.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestMemoryCacheTest extends PHPUnit\Framework\TestCase
+{
+	private TTestMemoryCache $cache;
+
+	protected function setUp(): void
+	{
+		$this->cache = new TTestMemoryCache();
+		$this->cache->setPrimaryCache(false);
+		$this->cache->init(null);
+	}
+
+	public function testIsAMemoryCache(): void
+	{
+		$this->assertInstanceOf(TMemoryCache::class, $this->cache);
+		$this->assertTrue(TTestMemoryCache::getIsAvailable());
+		$this->assertFalse($this->cache->pubGetSerializeValues());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$this->cache->fakeNow = 7000;
+		$this->cache->fakeMicrotime = 12.25;
+		$this->assertSame(7000, $this->cache->pubTime());
+		$this->assertSame(12.25, $this->cache->pubMicrotime());
+	}
+
+	public function testStoreCoreRoundTrips(): void
+	{
+		$key = $this->cache->pubGenerateUniqueKey('k');
+		$this->assertTrue($this->cache->pubWriteStore($key, 'payload', 0));
+		$this->assertSame('payload', $this->cache->pubReadStore($key));
+		$this->assertSame('payload', $this->cache->pubGetSerializedValue($key));
+		$this->assertFalse($this->cache->pubAddStore($key, 'other', 0));
+		$this->assertTrue($this->cache->pubAddStore($this->cache->pubGenerateUniqueKey('k2'), 'fresh', 0));
+	}
+
+	public function testStoreCoreExpiry(): void
+	{
+		$this->cache->fakeNow = 1_000_000;
+		$key = $this->cache->pubGenerateUniqueKey('k');
+		$this->cache->pubWriteStore($key, 'v', 10);
+		$this->assertSame('v', $this->cache->pubReadStore($key));
+		$this->cache->fakeNow = 1_000_011;
+		$this->assertFalse($this->cache->pubReadStore($key));
+	}
+
+	public function testValueContractExposers(): void
+	{
+		$key = $this->cache->pubGenerateUniqueKey('vk');
+		$this->assertTrue($this->cache->pubSetValue($key, 'rawpayload', 0));
+		$this->assertSame('rawpayload', $this->cache->pubGetValue($key));
+		$this->assertFalse($this->cache->pubAddValue($key, 'other', 0));
+		$this->assertTrue($this->cache->pubDeleteValue($key));
+		$this->assertFalse($this->cache->pubGetValue($key));
+	}
+
+	public function testStoreDirectExposers(): void
+	{
+		$this->cache->pubSetStore([]);
+		$this->assertSame([], $this->cache->pubGetStore());
+		$this->cache->pubSetStoreEntry('e', ['data' => 'd', 'expire' => 0]);
+		$this->assertTrue($this->cache->pubHasStoreEntry('e'));
+		$this->assertSame(['data' => 'd', 'expire' => 0], $this->cache->pubGetStoreEntry('e'));
+		$this->cache->pubClearStoreEntry('e');
+		$this->assertFalse($this->cache->pubHasStoreEntry('e'));
+	}
+
+	public function testSerializeHelperExposers(): void
+	{
+		$s = $this->cache->pubSerialize(['a' => 1]);
+		$this->assertSame(['a' => 1], $this->cache->pubUnserialize($s));
+	}
+
+	public function testBackingFileSaveLoadRoundTrip(): void
+	{
+		$file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_ttestmem_backing_' . getmypid() . '.bin';
+		@unlink($file);
+		$this->cache->setBackingFile($file);
+
+		$store = ['k' => ['data' => 'v', 'expire' => 0]];
+		$this->assertTrue($this->cache->pubSaveToBacking($store));
+		$this->assertSame($store, $this->cache->pubLoadFromBacking());
+		@unlink($file);
+	}
+
+	public function testFileSeamExclusiveLockParam(): void
+	{
+		$file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'prado_ttestmem_seam_' . getmypid() . '.bin';
+		$this->assertNotFalse($this->cache->pubPutContents($file, 'x', true));
+		$this->assertSame('x', $this->cache->pubGetContents($file));
+		@unlink($file);
+	}
+
+	public function testSizeExposers(): void
+	{
+		$this->cache->pubSetCurrentSizeDirect(50);
+		$this->assertSame(50, $this->cache->pubGetCurrentSizeDirect());
+		$this->cache->pubSetSizeFingerprintDirect('fp');
+		$this->assertSame('fp', $this->cache->pubGetSizeFingerprintDirect());
+		$this->assertIsInt($this->cache->pubComputeCurrentSize());
+	}
+
+	public function testCustomConstantFixturesUseLateStaticBinding(): void
+	{
+		$ck = new TTestMemoryCacheCustomKey();
+		$this->assertStringStartsWith('custom.key', $ck->getBackingCacheKey());
+
+		$mp = new TTestMemoryCacheCustomMergePolicy();
+		$this->assertSame(TMemoryCache::REPLACE, $mp->getMergePolicy());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestRedisCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestRedisCacheTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * TTestRedisCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TRedisCache;
+
+/**
+ * Tests for {@see TTestRedisCache}. The handle seam is verified with an injected dummy
+ * object — no extension required; {@see newRedis()} is exercised only when the `redis`
+ * extension is available.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestRedisCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestRedisCache
+	{
+		$cache = new TTestRedisCache();
+		$cache->setPrimaryCache(false);
+		return $cache;
+	}
+
+	public function testIsARedisCache(): void
+	{
+		$this->assertInstanceOf(TRedisCache::class, $this->newCache());
+	}
+
+	public function testFakeClockOverrides(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 22;
+		$this->assertSame(22, $cache->pubTime());
+	}
+
+	public function testCacheDirectHandleRoundTrips(): void
+	{
+		$cache = $this->newCache();
+		$handle = new \stdClass();
+		$cache->pubSetCacheDirect($handle);
+		$this->assertSame($handle, $cache->pubGetCacheDirect());
+	}
+
+	public function testNewRedisWhenAvailable(): void
+	{
+		if (!TRedisCache::getIsAvailable()) {
+			$this->markTestSkipped('redis extension not available.');
+		}
+		$this->assertInstanceOf(\Redis::class, $this->newCache()->pubNewRedis());
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestSerializingCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestSerializingCacheTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * TTestSerializingCacheTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\Caching\TSerializingCache;
+
+/**
+ * Tests for {@see TTestSerializingCache}, the array-backed {@see TSerializingCache} harness.
+ *
+ * Verifies the serialized-string storage contract, the fakeable clock, and that the
+ * pipeline exposers ({@see TTestSerializingCache::pubSerializeValue()} etc.) reach their
+ * protected targets, including encode/decode round-trips.
+ *
+ * @package System.Harness.Caching
+ */
+class TTestSerializingCacheTest extends PHPUnit\Framework\TestCase
+{
+	private function newCache(): TTestSerializingCache
+	{
+		$cache = new TTestSerializingCache();
+		$cache->setPrimaryCache(false);
+		$cache->init(null);
+		return $cache;
+	}
+
+	public function testIsASerializingCache(): void
+	{
+		$this->assertInstanceOf(TSerializingCache::class, new TTestSerializingCache());
+		$this->assertTrue(TTestSerializingCache::getIsAvailable());
+	}
+
+	public function testRoundTripThroughPipeline(): void
+	{
+		$cache = $this->newCache();
+		$cache->set('k', ['a' => 1, 'b' => [2, 3]]);
+		$this->assertSame(['a' => 1, 'b' => [2, 3]], $cache->get('k'));
+		// The persisted payload is the serialized string, inspectable via onlyStored().
+		$this->assertSame(serialize([['a' => 1, 'b' => [2, 3]], null]), $cache->onlyStored());
+	}
+
+	public function testSerializeUnserializeExposers(): void
+	{
+		$cache = $this->newCache();
+		$s = $cache->pubSerializeValue(['x' => 1]);
+		$this->assertSame(['x' => 1], $cache->pubUnserializeValue($s));
+	}
+
+	public function testEncodeDecodeRoundTrips(): void
+	{
+		$cache = $this->newCache();
+
+		$cache->setEncoding(TSerializingCache::ENCODING_BASE64);
+		$this->assertSame(base64_encode('raw'), $cache->pubEncode('raw'));
+		$this->assertSame('raw', $cache->pubDecode(base64_encode('raw')));
+		$this->assertFalse($cache->pubDecode('@@@not-base64@@@'));
+
+		$cache->setEncoding(TSerializingCache::ENCODING_HEX);
+		$this->assertSame(bin2hex('raw'), $cache->pubEncode('raw'));
+		$this->assertSame('raw', $cache->pubDecode(bin2hex('raw')));
+		$this->assertFalse($cache->pubDecode('xyz')); // odd-length / non-hex
+
+		$cache->setEncoding(TSerializingCache::ENCODING_NONE);
+		$this->assertSame('raw', $cache->pubEncode('raw'));
+		$this->assertSame('raw', $cache->pubDecode('raw'));
+	}
+
+	public function testFakeNowDrivesExpiry(): void
+	{
+		$cache = $this->newCache();
+		$cache->fakeNow = 1_000_000;
+		$cache->set('k', 'v', 10);
+		$this->assertSame('v', $cache->get('k'));
+		$cache->fakeNow = 1_000_011;
+		$this->assertFalse($cache->get('k'));
+		$this->assertFalse($cache->pubGetSerializedValue('k'));
+	}
+}

--- a/tests/unit/HarnessTests/Caching/TTestSerializingCacheTest.php
+++ b/tests/unit/HarnessTests/Caching/TTestSerializingCacheTest.php
@@ -53,7 +53,9 @@ class TTestSerializingCacheTest extends PHPUnit\Framework\TestCase
 
 	public function testEncodeDecodeRoundTrips(): void
 	{
-		$cache = $this->newCache();
+		// Encoding is frozen after init(), so use an un-initialized cache to vary it.
+		$cache = new TTestSerializingCache();
+		$cache->setPrimaryCache(false);
 
 		$cache->setEncoding(TSerializingCache::ENCODING_BASE64);
 		$this->assertSame(base64_encode('raw'), $cache->pubEncode('raw'));

--- a/tests/unit/IO/HttpClient/TCachedHttpClientTest.php
+++ b/tests/unit/IO/HttpClient/TCachedHttpClientTest.php
@@ -15,6 +15,10 @@ class CachedClientTestCache implements \Prado\Caching\ICache
 	public int $setCalls = 0;
 	public int $deleteCalls = 0;
 
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
 	public function get($id)
 	{
 		$this->getCalls++;

--- a/tests/unit/IO/Rest/TRestClientTest.php
+++ b/tests/unit/IO/Rest/TRestClientTest.php
@@ -49,6 +49,10 @@ class InMemoryCache implements ICache
 	public int $getCalls = 0;
 	public int $setCalls = 0;
 
+	public static function getIsAvailable(): bool
+	{
+		return true;
+	}
 	public function get($id)
 	{
 		$this->getCalls++;

--- a/tests/unit/Shell/TShellApplicationTest.php
+++ b/tests/unit/Shell/TShellApplicationTest.php
@@ -29,11 +29,11 @@ class ShellTestCacheModule extends TModule implements ICache
 {
 	public function init($config) {}
 	public static function getIsAvailable(): bool { return true; }
-	public function get(string $id): mixed { return false; }
-	public function set(string $id, mixed $value, int $expire = 0, ?\Prado\Caching\ICacheDependency $dependency = null): bool { return true; }
-	public function add(string $id, mixed $value, int $expire = 0, ?\Prado\Caching\ICacheDependency $dependency = null): bool { return true; }
-	public function delete(string $id): bool { return true; }
-	public function flush(): void {}
+	public function get($id) { return false; }
+	public function set($id, $value, $expire = 0, $dependency = null) { return true; }
+	public function add($id, $value, $expire = 0, $dependency = null) { return true; }
+	public function delete($id) { return true; }
+	public function flush() { return true; }
 }
 
 /**

--- a/tests/unit/Shell/TShellApplicationTest.php
+++ b/tests/unit/Shell/TShellApplicationTest.php
@@ -28,11 +28,12 @@ use Prado\TModule;
 class ShellTestCacheModule extends TModule implements ICache
 {
 	public function init($config) {}
-	public function get($id) { return false; }
-	public function set($id, $value, $expire = 0, $dependency = null) { return true; }
-	public function add($id, $value, $expire = 0, $dependency = null) { return true; }
-	public function delete($id) { return true; }
-	public function flush() {}
+	public static function getIsAvailable(): bool { return true; }
+	public function get(string $id): mixed { return false; }
+	public function set(string $id, mixed $value, int $expire = 0, ?\Prado\Caching\ICacheDependency $dependency = null): bool { return true; }
+	public function add(string $id, mixed $value, int $expire = 0, ?\Prado\Caching\ICacheDependency $dependency = null): bool { return true; }
+	public function delete(string $id): bool { return true; }
+	public function flush(): void {}
 }
 
 /**


### PR DESCRIPTION
Added features
- ICache::getIsAvailable - runtime time check if the cache is available.
- General Uniform Access Principal / Self Encapsulation on all Caching classes.
- TCache - clock methods, hashing method
- TSerializingCache - Encoding and Encryption 
- TDbCache, TFileCache and TMemoryCache subclass TSerializingCache
- TMemoryCache can store direct and serialized values
- TDbCache - uses TCache clock seam
- TCacheFileTrait - get and put Content for file access
- TCacheSizeTrait - limits the size of a cache
- Harness and HarnessTests for Caching classes
- Updated TSqlMap*Cache classes to ICache