### PR TITLE
TIntegrityManager - Manages Javascript remote integrity for script validation

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -271,6 +271,14 @@ authorizationrulecollection_authorizationrule_required = TAuthorizationRuleColle
 usermanager_userfile_invalid			= TUserManager.UserFile '{0}' is not a valid file.
 usermanager_userfile_unchangeable		= TUserManager.UserFile cannot be modified. The user module has been initialized already.
 
+integritymanager_entry_invalid			= TIntegrityManager integrity entry for URL '{0}' requires a non-empty url and hash.
+integritymanager_algorithm_invalid		= TIntegrityManager algorithm '{0}' is not supported; use one of: {1}.
+integritymanager_file_unreadable		= TIntegrityManager cannot read file '{0}' to calculate its integrity.
+integritymanager_integrityfile_invalid		= TIntegrityManager.IntegrityFile '{0}' is not a valid file.
+integritymanager_integrityfile_unchangeable	= {1}.{0} cannot be modified. The integrity module has been initialized already.
+
+javascript_script_integrity_required		= No Subresource Integrity is registered for the remote script '{0}', but integrity is required.
+
 authmanager_usermanager_required		= TAuthManager.UserManager must be assigned a value.
 authmanager_usermanager_inexistent		= TAuthManager.UserManager '{0}' does not refer to an ID of application module.
 authmanager_usermanager_invalid			= TAuthManager.UserManager '{0}' does not refer to a valid TUserManager application module.

--- a/framework/Web/Javascripts/TJavaScript.php
+++ b/framework/Web/Javascripts/TJavaScript.php
@@ -10,6 +10,7 @@
 
 namespace Prado\Web\Javascripts;
 
+use Prado\Exceptions\TConfigurationException;
 use Prado\Web\THttpUtility;
 use Prado\Prado;
 
@@ -68,6 +69,45 @@ class TJavaScript
 	 * @since 4.4.0
 	 */
 	private static $_scriptIntegrity = [];
+
+	/**
+	 * @var bool When `true`, rendering a remote `<script src>` that has no registered
+	 * SRI value throws a {@see TConfigurationException} instead of emitting a tag with
+	 * no `integrity` attribute. Defaults to `false`. Toggled via
+	 * {@see setRequireScriptIntegrity()}, typically from
+	 * {@see \Prado\Web\TIntegrityManager}.
+	 * @since 4.4.0
+	 */
+	private static $_requireScriptIntegrity = false;
+
+	/**
+	 * Returns whether remote scripts are required to carry a registered SRI value.
+	 * @return bool `true` when {@see renderScriptFile()} and {@see TJavaScriptAsset::__toString()}
+	 *   throw for a remote URL without a registered integrity, `false` when they
+	 *   render the tag without the attribute
+	 * @since 4.4.0
+	 */
+	public static function getRequireScriptIntegrity(): bool
+	{
+		return self::$_requireScriptIntegrity;
+	}
+
+	/**
+	 * Sets whether remote scripts must carry a registered SRI value to be rendered.
+	 *
+	 * When enabled, {@see renderScriptFile()} and {@see TJavaScriptAsset::__toString()}
+	 * throw a {@see TConfigurationException} for any remote URL (per
+	 * {@see THttpUtility::isLocalUrl()}) that has no integrity available, instead of
+	 * emitting a `<script>` tag that a strict `Content-Security-Policy` would block.
+	 * Local URLs and assets that explicitly suppress integrity are unaffected.
+	 *
+	 * @param bool $value `true` to enforce, `false` (default) to render leniently
+	 * @since 4.4.0
+	 */
+	public static function setRequireScriptIntegrity(bool $value): void
+	{
+		self::$_requireScriptIntegrity = $value;
+	}
 
 	/**
 	 * Returns the per-request CSP nonce currently registered with this class,
@@ -278,6 +318,9 @@ class TJavaScript
 		$integrity = null;
 		if (!THttpUtility::isLocalUrl($url)) {
 			$integrity = self::getScriptIntegrity($url);
+			if ($integrity === null && self::$_requireScriptIntegrity) {
+				throw new TConfigurationException('javascript_script_integrity_required', $url);
+			}
 		}
 		$attrs = THttpUtility::buildHtmlAttributes([
 			'src' => $url,

--- a/framework/Web/Javascripts/TJavaScriptAsset.php
+++ b/framework/Web/Javascripts/TJavaScriptAsset.php
@@ -10,6 +10,7 @@
 
 namespace Prado\Web\Javascripts;
 
+use Prado\Exceptions\TConfigurationException;
 use Prado\Web\THttpUtility;
 
 /**
@@ -74,6 +75,9 @@ class TJavaScriptAsset
 	 * a non-null value (either from the asset itself or the {@see TJavaScript}
 	 * registry). No trailing newline is appended; {@see TJavaScript::renderScriptFile()}
 	 * adds one when delegating here.
+	 * @throws TConfigurationException when {@see TJavaScript::getRequireScriptIntegrity()}
+	 *   is enabled and this is a remote URL with no integrity available and integrity
+	 *   has not been explicitly suppressed via {@see setIntegrity()}
 	 * @return string the rendered `<script>` tag without a trailing newline
 	 */
 	public function __toString(): string
@@ -82,6 +86,9 @@ class TJavaScriptAsset
 		$integrity = null;
 		if (!THttpUtility::isLocalUrl($url)) {
 			$integrity = $this->getIntegrity();
+			if ($integrity === null && $this->getIntegrityDirect() !== false && TJavaScript::getRequireScriptIntegrity()) {
+				throw new TConfigurationException('javascript_script_integrity_required', $url);
+			}
 		}
 		$attrs = THttpUtility::buildHtmlAttributes([
 			'src' => $url,

--- a/framework/Web/TIntegrityManager.php
+++ b/framework/Web/TIntegrityManager.php
@@ -1,0 +1,309 @@
+<?php
+
+/**
+ * TIntegrityManager class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Web;
+
+use Prado\Exceptions\TConfigurationException;
+use Prado\Prado;
+use Prado\TApplication;
+use Prado\TModule;
+use Prado\TPropertyValue;
+use Prado\Util\Traits\TInitializedTrait;
+use Prado\Web\Javascripts\TJavaScript;
+use Prado\Xml\TXmlDocument;
+use Prado\Xml\TXmlElement;
+
+/**
+ * TIntegrityManager class
+ *
+ * TIntegrityManager registers Subresource Integrity (SRI) values for external
+ * script URLs so that a strict `Content-Security-Policy` can require an
+ * `integrity` attribute on every third-party `<script>` tag. Each configured
+ * entry is pushed into the per-request registry on {@see TJavaScript} via
+ * {@see TJavaScript::setScriptIntegrity()}; the registry is consumed by
+ * {@see TJavaScript::renderScriptFile()} and {@see \Prado\Web\Javascripts\TJavaScriptAsset},
+ * which emit the `integrity` and `crossorigin="anonymous"` attributes for matching
+ * remote URLs.
+ *
+ * XML configuration style:
+ * ```xml
+ * <modules>
+ *     <module id="integrity" class="Prado\Web\TIntegrityManager" RequireIntegrity="true">
+ *         <integrity url="https://cdn.example.com/jquery-3.7.1.min.js" hash="sha384-AAAA..." />
+ *         <integrity url="https://cdn.example.com/lib.js" hash="BBBB..." method="sha512" />
+ *     </module>
+ * </modules>
+ * ```
+ *
+ * PHP configuration style:
+ * ```php
+ * [
+ *   'integrity' => [
+ *      'class' => 'Prado\Web\TIntegrityManager',
+ *      'properties' => [
+ *         'RequireIntegrity' => 'true',
+ *      ],
+ *      'integrities' => [
+ *         ['url' => 'https://cdn.example.com/jquery-3.7.1.min.js', 'hash' => 'sha384-AAAA...'],
+ *         ['url' => 'https://cdn.example.com/lib.js', 'hash' => 'BBBB...', 'method' => 'sha512'],
+ *      ],
+ *   ],
+ * ]
+ * ```
+ *
+ * An entry's `hash` may be a fully-formed `algo-digest` SRI string (e.g.
+ * `sha384-AAAA…`) or a bare base64 digest, in which case `method` supplies the
+ * algorithm prefix (defaults to `sha384`).
+ *
+ * Integrity entries may also be loaded from an external file specified by the
+ * {@see setIntegrityFile IntegrityFile} property. The property only accepts a file
+ * path in namespace format. The file extension matches the application
+ * configuration type (`.xml` or `.php`).
+ *
+ * XML integrity file (e.g. `integrity.xml`):
+ * ```xml
+ * <integrities>
+ *     <integrity url="https://cdn.example.com/jquery-3.7.1.min.js" hash="sha384-AAAA..." />
+ *     <integrity url="https://cdn.example.com/lib.js" hash="BBBB..." method="sha512" />
+ * </integrities>
+ * ```
+ *
+ * PHP integrity file (e.g. `integrity.php`):
+ * ```php
+ * <?php
+ * return [
+ *     'integrities' => [
+ *         ['url' => 'https://cdn.example.com/jquery-3.7.1.min.js', 'hash' => 'sha384-AAAA...'],
+ *         ['url' => 'https://cdn.example.com/lib.js', 'hash' => 'BBBB...', 'method' => 'sha512'],
+ *     ],
+ * ];
+ * ```
+ *
+ * When {@see setRequireIntegrity RequireIntegrity} is enabled, a remote
+ * `<script src>` with no registered integrity raises a {@see TConfigurationException}
+ * at render time. A strict CSP would otherwise block such a tag silently.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ * @todo Stylesheet Integrity
+ */
+class TIntegrityManager extends TModule
+{
+	use TInitializedTrait;
+
+	/**
+	 * @var array<string, string> registry of normalized URL → full SRI string managed by this module
+	 */
+	private array $_integrities = [];
+	/**
+	 * @var ?string integrity information file
+	 */
+	private ?string $_integrityFile = null;
+
+	/**
+	 * Initializes the module.
+	 * This method is required by IModule and is invoked by the application.
+	 * It loads integrity information from the module configuration and any
+	 * external {@see getIntegrityFile IntegrityFile}, registers each entry with
+	 * {@see TJavaScript}, and applies the {@see getRequireIntegrity RequireIntegrity}
+	 * setting.
+	 * @param null|array|\Prado\Xml\TXmlElement $config module configuration
+	 */
+	public function init($config)
+	{
+		$this->loadIntegrityData($this->normalizeConfig($config));
+		if (($integrityFile = $this->getIntegrityFile()) !== null) {
+			if ($this->getApplication()->getConfigurationType() == TApplication::CONFIG_TYPE_PHP) {
+				$fileConfig = include $integrityFile;
+			} else {
+				$fileConfig = new TXmlDocument();
+				$fileConfig->loadFromFile($integrityFile);
+			}
+			$this->loadIntegrityData($this->normalizeConfig($fileConfig));
+		}
+		parent::init($config);
+		$this->markInitialized();
+	}
+
+	/**
+	 * Normalizes a module configuration into the canonical PHP array form so a
+	 * single code path loads it. A {@see \Prado\Xml\TXmlElement} is converted via
+	 * {@see \Prado\Xml\TXmlElement::getElementsAttrArrayByTagName()}, mapping each
+	 * `<integrity>` element's attributes to an entry under the `integrities` key.
+	 * An array is returned unchanged.
+	 * @param mixed $config module configuration, either a PHP array or an XML node
+	 * @return array the configuration in PHP array form
+	 */
+	private function normalizeConfig($config): array
+	{
+		if ($config instanceof TXmlElement) {
+			return ['integrities' => $config->getElementsAttrArrayByTagName('integrity')];
+		}
+		return is_array($config) ? $config : [];
+	}
+
+	/**
+	 * Loads integrity information from a normalized PHP array and registers each
+	 * entry. Use {@see normalizeConfig()} to convert XML configuration first.
+	 * @param array $config the array containing the integrity information
+	 */
+	private function loadIntegrityData(array $config): void
+	{
+		if (isset($config['integrities']) && is_array($config['integrities'])) {
+			foreach ($config['integrities'] as $entry) {
+				$method = trim((string) ($entry['method'] ?? '')) ?: 'sha384';
+				$this->addIntegrity($entry['url'] ?? '', $entry['hash'] ?? '', $method);
+			}
+		}
+	}
+
+	/**
+	 * The hash algorithms permitted by the Subresource Integrity specification.
+	 * @var string[]
+	 */
+	public const SRI_ALGORITHMS = ['sha256', 'sha384', 'sha512'];
+
+	/**
+	 * Calculates the Subresource Integrity value for a string of content.
+	 *
+	 * The result is the fully-formed `algo-digest` SRI string where `digest` is the
+	 * base64 encoding of the raw binary hash of `$content`, as required by the
+	 * Subresource Integrity specification.
+	 *
+	 * @param string $content the content to hash, such as a script or stylesheet body
+	 * @param string $method the SRI hash algorithm, one of {@see SRI_ALGORITHMS} (default `sha384`)
+	 * @throws TConfigurationException if `$method` is not an SRI-supported algorithm
+	 * @return string the fully-formed `algo-digest` SRI string (e.g. `sha384-…`)
+	 * @since 4.4.0
+	 */
+	public static function calculateIntegrity(string $content, string $method = 'sha384'): string
+	{
+		$method = strtolower(trim($method));
+		if (!in_array($method, self::SRI_ALGORITHMS, true)) {
+			throw new TConfigurationException('integritymanager_algorithm_invalid', $method, implode(', ', self::SRI_ALGORITHMS));
+		}
+		return $method . '-' . base64_encode(hash($method, $content, true));
+	}
+
+	/**
+	 * Calculates the Subresource Integrity value for the contents of a file.
+	 *
+	 * Reads the file at `$path` and delegates to {@see calculateIntegrity()}. The
+	 * hash covers the exact bytes on disk, so the file must hold the same content
+	 * the browser fetches for the resulting SRI value to validate.
+	 *
+	 * @param string $path filesystem path to the file to hash
+	 * @param string $method the SRI hash algorithm, one of {@see SRI_ALGORITHMS} (default `sha384`)
+	 * @throws TConfigurationException if the file does not exist or cannot be read,
+	 *   or if `$method` is not an SRI-supported algorithm
+	 * @return string the fully-formed `algo-digest` SRI string (e.g. `sha384-…`)
+	 * @since 4.4.0
+	 */
+	public static function calculateIntegrityForFile(string $path, string $method = 'sha384'): string
+	{
+		if (!is_file($path) || ($content = @file_get_contents($path)) === false) {
+			throw new TConfigurationException('integritymanager_file_unreadable', $path);
+		}
+		return self::calculateIntegrity($content, $method);
+	}
+
+	/**
+	 * Registers a single integrity entry with this module and with {@see TJavaScript}.
+	 * @param string $url the script URL; normalized before storage
+	 * @param string $hash fully-formed `algo-digest` SRI string or a bare base64 digest
+	 * @param string $method algorithm prefix prepended to a bare digest (default `sha384`)
+	 * @throws TConfigurationException if the URL or hash is empty
+	 */
+	public function addIntegrity(string $url, string $hash, string $method = 'sha384'): void
+	{
+		if (($url = trim($url)) === '' || ($hash = trim($hash)) === '') {
+			throw new TConfigurationException('integritymanager_entry_invalid', $url);
+		}
+		$key = THttpUtility::normalizeIntegrityUrl($url);
+		TJavaScript::setScriptIntegrity($key, $hash, $method);
+		$this->_integrities[$key] = TJavaScript::getScriptIntegrity($key);
+	}
+
+	/**
+	 * Returns the SRI strings managed by this module.
+	 * The array key is the normalized URL and the value is the fully-formed
+	 * `algo-digest` SRI string.
+	 * @return array<string, string> list of integrity entries
+	 */
+	public function getIntegrities(): array
+	{
+		return $this->_integrities;
+	}
+
+	/**
+	 * Returns the registered SRI string for the given URL, or `null` when none
+	 * is managed by this module. The URL is normalized before the lookup.
+	 * @param string $url script URL to look up
+	 * @return ?string the fully-formed `algo-digest` SRI string, or `null`
+	 */
+	public function getIntegrity(string $url): ?string
+	{
+		return $this->_integrities[THttpUtility::normalizeIntegrityUrl($url)] ?? null;
+	}
+
+	/**
+	 * @return ?string the full path to the file storing integrity information
+	 */
+	public function getIntegrityFile(): ?string
+	{
+		return $this->_integrityFile;
+	}
+
+	/**
+	 * @param string $value integrity data file path (in namespace form). The file
+	 * is XML or PHP depending on the application configuration type; see the class
+	 * documentation for the file format.
+	 * @throws \Prado\Exceptions\TInvalidOperationException if the module is already initialized
+	 * @throws TConfigurationException if the file is not in proper namespace format
+	 */
+	public function setIntegrityFile($value)
+	{
+		$this->assertUninitialized('IntegrityFile');
+		if (($this->_integrityFile = Prado::getPathOfNamespace($value, $this->getApplication()->getConfigurationFileExt())) === null || !is_file($this->_integrityFile)) {
+			throw new TConfigurationException('integritymanager_integrityfile_invalid', $value);
+		}
+	}
+
+	/**
+	 * This is an alias for {@see TJavaScript::getRequireScriptIntegrity()}.
+	 * @return bool whether remote scripts must carry a registered integrity, defaults to false
+	 */
+	public function getRequireIntegrity(): bool
+	{
+		return TJavaScript::getRequireScriptIntegrity();
+	}
+
+	/**
+	 * Sets whether remote scripts must carry a registered integrity. The value is
+	 * stored on {@see TJavaScript::setRequireScriptIntegrity()}, which the render
+	 * helpers consult. When enabled, rendering a remote script with no registered
+	 * integrity throws a {@see TConfigurationException}.
+	 * @param mixed $value whether remote scripts must carry a registered integrity
+	 */
+	public function setRequireIntegrity($value)
+	{
+		TJavaScript::setRequireScriptIntegrity(TPropertyValue::ensureBoolean($value));
+	}
+
+	/**
+	 * Returns the PRADO error message catalogue key used when a configuration
+	 * property is changed after the module is initialized.
+	 * @return string the message catalogue key
+	 */
+	protected function getIsInitializedExceptionKey(): string
+	{
+		return 'integritymanager_integrityfile_unchangeable';
+	}
+}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -447,6 +447,7 @@ return [
 'TAssetManager' => 'Prado\Web\TAssetManager',
 'TCacheHttpSession' => 'Prado\Web\TCacheHttpSession',
 'TContentDisposition' => 'Prado\Web\TContentDisposition',
+'TIntegrityManager' => 'Prado\Web\TIntegrityManager',
 'THttpCookie' => 'Prado\Web\THttpCookie',
 'THttpCookieCollection' => 'Prado\Web\THttpCookieCollection',
 'THttpCookieSameSite' => 'Prado\Web\THttpCookieSameSite',

--- a/tests/harness/HttpHeaders/protected/pages/SriPage.page
+++ b/tests/harness/HttpHeaders/protected/pages/SriPage.page
@@ -1,0 +1,22 @@
+<%@ MasterClass="" %><!DOCTYPE html>
+<html data-page="sri-test">
+<head>
+<meta charset="UTF-8">
+<title>SRI Test – <%= $this->Action %></title>
+
+<!-- Record any CSP violation so the test can prove an SRI failure is NOT a CSP violation. -->
+<script>
+window.__cspViolations = [];
+document.addEventListener('securitypolicyviolation', function (e) {
+	window.__cspViolations.push(e.violatedDirective);
+});
+</script>
+
+<!-- The script under test: integrity matches (runs) or is tampered (blocked). -->
+<%= $this->ScriptTag %>
+</head>
+<body>
+<div id="action"><%= $this->Action %></div>
+<div id="ready">ready</div>
+</body>
+</html>

--- a/tests/harness/HttpHeaders/protected/pages/SriPage.php
+++ b/tests/harness/HttpHeaders/protected/pages/SriPage.php
@@ -1,0 +1,58 @@
+<?php
+
+use Prado\Web\Javascripts\TJavaScript;
+use Prado\Web\TIntegrityManager;
+use Prado\Web\UI\TPage;
+
+/**
+ * SriPage — harness page for Subresource Integrity functional tests.
+ *
+ * Pins an SRI value for a cross-origin test asset through {@see TIntegrityManager}
+ * and renders the `<script>` tag with {@see TJavaScript::renderScriptFile()}, the
+ * same emission path the framework uses. The asset is requested via `localhost`
+ * while the page is served from `127.0.0.1`, so it is cross-origin (and "remote"
+ * to {@see \Prado\Web\THttpUtility::isLocalUrl()}), which is what makes the
+ * `integrity` and `crossorigin` attributes emit.
+ *
+ * Query parameters:
+ *   action — `correct` (default) pins the real hash; `wrong` pins a mismatching
+ *            hash so the browser blocks the script.
+ */
+class SriPage extends TPage
+{
+	/** @var string The active action, exposed to the template. */
+	private string $_action = 'correct';
+
+	/** @var string The rendered `<script>` tag, exposed to the template. */
+	private string $_scriptTag = '';
+
+	public function onLoad($param): void
+	{
+		parent::onLoad($param);
+
+		$this->_action = ($this->Request->itemAt('action') === 'wrong') ? 'wrong' : 'correct';
+
+		$content = include dirname(__DIR__, 2) . '/sri-content.php';
+		$port = (string) ($_SERVER['SERVER_PORT'] ?? '8037');
+		$url = 'http://localhost:' . $port . '/tests/harness/HttpHeaders/sri-asset.php';
+
+		$hash = ($this->_action === 'wrong')
+			? 'sha384-' . base64_encode(str_repeat("\0", 48))
+			: TIntegrityManager::calculateIntegrity($content);
+
+		$manager = new TIntegrityManager();
+		$manager->addIntegrity($url, $hash);
+
+		$this->_scriptTag = TJavaScript::renderScriptFile($url);
+	}
+
+	public function getAction(): string
+	{
+		return $this->_action;
+	}
+
+	public function getScriptTag(): string
+	{
+		return $this->_scriptTag;
+	}
+}

--- a/tests/harness/HttpHeaders/sri-asset.php
+++ b/tests/harness/HttpHeaders/sri-asset.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Subresource Integrity test asset for Playwright functional tests.
+ *
+ * The PHP built-in server serves this file directly (outside Prado routing).
+ * It returns a small JavaScript body with an `Access-Control-Allow-Origin: *`
+ * header so the script can be loaded cross-origin (the test page is served from
+ * 127.0.0.1 while this asset is requested via localhost) with
+ * `crossorigin="anonymous"`, which Subresource Integrity requires for
+ * cross-origin resources.
+ *
+ * The body is sourced from sri-content.php so SriPage can hash the identical
+ * bytes when pinning the integrity value.
+ */
+
+$js = include __DIR__ . '/sri-content.php';
+
+header('Content-Type: application/javascript');
+header('Access-Control-Allow-Origin: *');
+header('Cache-Control: no-store');
+echo $js;

--- a/tests/harness/HttpHeaders/sri-content.php
+++ b/tests/harness/HttpHeaders/sri-content.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Shared body of the SRI test asset.
+ *
+ * Both the asset endpoint (sri-asset.php) and the page that pins its integrity
+ * (SriPage) include this file, so the hash the page computes always matches the
+ * exact bytes the asset serves.
+ *
+ * The script records its own execution on the document element; the functional
+ * test asserts the marker is present when the integrity matches and absent when
+ * it is tampered (the browser blocks execution).
+ */
+
+return "document.documentElement.dataset.sriRan = '1';\n";

--- a/tests/playwright/web/HttpHeaders/TIntegrityManagerTestCase.spec.js
+++ b/tests/playwright/web/HttpHeaders/TIntegrityManagerTestCase.spec.js
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { GENERIC_BASE_URL } from '../../helpers.js';
+
+/**
+ * Functional tests for Subresource Integrity emitted by TIntegrityManager.
+ *
+ * SriPage pins an SRI value for a cross-origin asset (served via localhost while
+ * the page is served from 127.0.0.1) and renders the <script> tag through the
+ * framework's own TJavaScript::renderScriptFile() path.
+ *
+ * What these tests establish:
+ *   - A matching integrity lets the script execute.
+ *   - A tampered integrity makes the browser block the script.
+ *   - An SRI failure is NOT a CSP violation: no securitypolicyviolation event
+ *     fires, so it never reaches a CSP report-uri / report-to collector. SRI and
+ *     CSP are separate mechanisms with separate reporting.
+ */
+const SRI_PAGE = GENERIC_BASE_URL + 'HttpHeaders/index.php?page=SriPage';
+
+test.describe('TIntegrityManagerTestCase', () => {
+
+	/**
+	 * 1. A matching integrity allows the script to run; no CSP violation fires.
+	 */
+	test('matching integrity allows the script to execute', async ({ page }) => {
+		await page.goto(SRI_PAGE + '&action=correct', { waitUntil: 'load' });
+
+		const ran = await page.evaluate(() => document.documentElement.dataset.sriRan);
+		expect(ran).toBe('1');
+
+		const violations = await page.evaluate(() => window.__cspViolations);
+		expect(violations).toEqual([]);
+	});
+
+	/**
+	 * 2. A tampered integrity blocks the script. The failure is reported by the
+	 *    browser as an SRI error (console), and crucially does NOT raise a CSP
+	 *    securitypolicyviolation event.
+	 */
+	test('tampered integrity blocks the script and is not a CSP violation', async ({ page }) => {
+		const consoleErrors = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') {
+				consoleErrors.push(msg.text());
+			}
+		});
+
+		await page.goto(SRI_PAGE + '&action=wrong', { waitUntil: 'load' });
+
+		// Blocked: the asset never executed, so its marker is absent.
+		const ran = await page.evaluate(() => document.documentElement.dataset.sriRan);
+		expect(ran).toBeUndefined();
+
+		// SRI failure is not a CSP violation — no securitypolicyviolation event.
+		const violations = await page.evaluate(() => window.__cspViolations);
+		expect(violations).toEqual([]);
+
+		// The browser logs an SRI error mentioning integrity.
+		expect(consoleErrors.join('\n').toLowerCase()).toContain('integrity');
+	});
+
+	/**
+	 * 3. The emitted tag carries the integrity and crossorigin attributes that a
+	 *    strict CSP requires for third-party scripts.
+	 */
+	test('the emitted tag carries integrity and crossorigin attributes', async ({ page }) => {
+		await page.goto(SRI_PAGE + '&action=correct', { waitUntil: 'load' });
+
+		const script = page.locator('script[src*="sri-asset.php"]');
+		await expect(script).toHaveAttribute('integrity', /^sha384-/);
+		await expect(script).toHaveAttribute('crossorigin', 'anonymous');
+	});
+});

--- a/tests/unit/Web/Javascripts/TJavaScriptAssetTest.php
+++ b/tests/unit/Web/Javascripts/TJavaScriptAssetTest.php
@@ -8,6 +8,7 @@
  * @author Brad Anderson <belisoful@icloud.com>
  */
 
+use Prado\Exceptions\TConfigurationException;
 use Prado\Web\Javascripts\TJavaScript;
 use Prado\Web\Javascripts\TJavaScriptAsset;
 
@@ -44,12 +45,52 @@ class TJavaScriptAssetTest extends PHPUnit\Framework\TestCase
 		// Clear global nonce and integrity registry so rendering is deterministic.
 		TJavaScript::setScriptNonce(null);
 		TJavaScript::setScriptIntegrity(self::REMOTE, null);
+		TJavaScript::setRequireScriptIntegrity(false);
 	}
 
 	protected function tearDown(): void
 	{
 		TJavaScript::setScriptNonce(null);
 		TJavaScript::setScriptIntegrity(self::REMOTE, null);
+		TJavaScript::setRequireScriptIntegrity(false);
+	}
+
+	// -----------------------------------------------------------------------
+	// RequireScriptIntegrity enforcement
+	// -----------------------------------------------------------------------
+
+	/**
+	 * With enforcement on, a remote asset lacking an integrity must throw on render.
+	 */
+	public function testRenderRemoteWithoutIntegrityThrowsWhenRequired(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		$this->expectException(TConfigurationException::class);
+		(new TJavaScriptAsset(self::REMOTE))->__toString();
+	}
+
+	/**
+	 * An asset that explicitly suppresses integrity via `setIntegrity(false)` must
+	 * render without throwing even when enforcement is on.
+	 */
+	public function testRenderRemoteWithSuppressedIntegrityDoesNotThrowWhenRequired(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		$asset = new TJavaScriptAsset(self::REMOTE);
+		$asset->setIntegrity(false);
+		$output = $asset->__toString();
+		$this->assertStringContainsString('src="' . self::REMOTE . '"', $output);
+		$this->assertStringNotContainsString('integrity', $output);
+	}
+
+	/**
+	 * A local asset is exempt from enforcement and renders without throwing.
+	 */
+	public function testRenderLocalWithoutIntegrityDoesNotThrowWhenRequired(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		$output = (new TJavaScriptAsset(self::LOCAL))->__toString();
+		$this->assertStringContainsString('src="' . self::LOCAL . '"', $output);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/Web/Javascripts/TJavaScriptTest.php
+++ b/tests/unit/Web/Javascripts/TJavaScriptTest.php
@@ -10,6 +10,7 @@
 
 require_once __DIR__ . '/../../PradoUnitRequires.php';
 
+use Prado\Exceptions\TConfigurationException;
 use Prado\Web\Javascripts\TJavaScript;
 use Prado\Web\Javascripts\TJavaScriptAsset;
 use Prado\Web\Javascripts\TJavaScriptLiteral;
@@ -27,12 +28,14 @@ class TJavaScriptTest extends PHPUnit\Framework\TestCase
 	protected function setUp(): void
 	{
 		TJavaScript::setScriptNonce(null);
+		TJavaScript::setRequireScriptIntegrity(false);
 		$this->resetScriptIntegrity();
 	}
 
 	protected function tearDown(): void
 	{
 		TJavaScript::setScriptNonce(null);
+		TJavaScript::setRequireScriptIntegrity(false);
 		$this->resetScriptIntegrity();
 	}
 
@@ -405,6 +408,52 @@ class TJavaScriptTest extends PHPUnit\Framework\TestCase
 		$output = TJavaScript::renderScriptFile(self::LOCAL);
 		$this->assertStringNotContainsString('integrity', $output);
 		$this->assertStringNotContainsString('crossorigin', $output);
+	}
+
+	// -----------------------------------------------------------------------
+	// getRequireScriptIntegrity / setRequireScriptIntegrity
+	// -----------------------------------------------------------------------
+
+	public function testRequireScriptIntegrityDefaultsToFalse(): void
+	{
+		$this->assertFalse(TJavaScript::getRequireScriptIntegrity());
+	}
+
+	public function testSetAndGetRequireScriptIntegrity(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		$this->assertTrue(TJavaScript::getRequireScriptIntegrity());
+	}
+
+	/**
+	 * With enforcement on, a remote URL lacking a registered integrity must throw.
+	 */
+	public function testRenderScriptFileRemoteWithoutIntegrityThrowsWhenRequired(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		$this->expectException(TConfigurationException::class);
+		TJavaScript::renderScriptFile(self::REMOTE);
+	}
+
+	/**
+	 * With enforcement on, a remote URL that has a registered integrity renders.
+	 */
+	public function testRenderScriptFileRemoteWithIntegrityRendersWhenRequired(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		TJavaScript::setScriptIntegrity(self::REMOTE, 'sha384-HASH');
+		$output = TJavaScript::renderScriptFile(self::REMOTE);
+		$this->assertStringContainsString('integrity="sha384-HASH"', $output);
+	}
+
+	/**
+	 * Enforcement applies to remote URLs only; a local URL renders without throwing.
+	 */
+	public function testRenderScriptFileLocalWithoutIntegrityDoesNotThrowWhenRequired(): void
+	{
+		TJavaScript::setRequireScriptIntegrity(true);
+		$output = TJavaScript::renderScriptFile(self::LOCAL);
+		$this->assertStringContainsString('src="' . self::LOCAL . '"', $output);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/Web/TIntegrityManagerIntegrationTest.php
+++ b/tests/unit/Web/TIntegrityManagerIntegrationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Prado\IO\TTextWriter;
+use Prado\Prado;
+use Prado\Web\Javascripts\TJavaScript;
+use Prado\Web\Services\TPageService;
+use Prado\Web\TIntegrityManager;
+use Prado\Web\UI\THtmlWriter;
+use Prado\Web\UI\TPage;
+use Prado\Xml\TXmlDocument;
+
+/**
+ * Integration test: a TIntegrityManager configured as a module feeds the
+ * Subresource Integrity registry that {@see TClientScriptManager} consults when
+ * it renders registered script files. Exercises the module → TJavaScript →
+ * TClientScriptManager render path together, without a browser.
+ */
+class TIntegrityManagerIntegrationTest extends PHPUnit\Framework\TestCase
+{
+	private const REMOTE = 'https://cdn.example.com/lib.js';
+	private const HASH = 'sha384-AAAABBBBCCCC';
+
+	private $originalService;
+
+	protected function setUp(): void
+	{
+		TJavaScript::setScriptIntegrity(self::REMOTE, null);
+		TJavaScript::setRequireScriptIntegrity(false);
+		$app = Prado::getApplication();
+		$this->originalService = $app->getService();
+		$app->setService(new TPageService());
+	}
+
+	protected function tearDown(): void
+	{
+		TJavaScript::setScriptIntegrity(self::REMOTE, null);
+		TJavaScript::setRequireScriptIntegrity(false);
+		Prado::getApplication()->setService($this->originalService);
+	}
+
+	private function configuredManager(): TIntegrityManager
+	{
+		$config = new TXmlDocument('1.0', 'utf8');
+		$config->loadFromString('<integrity><integrity url="' . self::REMOTE . '" hash="' . self::HASH . '" /></integrity>');
+		$manager = new TIntegrityManager();
+		$manager->init($config);
+		return $manager;
+	}
+
+	private function renderHeadScriptFiles(TPage $page): string
+	{
+		$textWriter = new TTextWriter();
+		$page->getClientScript()->renderHeadScriptFiles(new THtmlWriter($textWriter));
+		return $textWriter->flush();
+	}
+
+	public function testConfiguredManagerRendersIntegrityOnRemoteScript()
+	{
+		$this->configuredManager();
+		$page = new TPage();
+		$page->getClientScript()->registerHeadScriptFile('lib', self::REMOTE);
+
+		$output = $this->renderHeadScriptFiles($page);
+
+		self::assertStringContainsString('src="' . self::REMOTE . '"', $output);
+		self::assertStringContainsString('integrity="' . self::HASH . '"', $output);
+		self::assertStringContainsString('crossorigin="anonymous"', $output);
+	}
+
+	public function testUnregisteredRemoteScriptRendersWithoutIntegrity()
+	{
+		$this->configuredManager();
+		$page = new TPage();
+		$page->getClientScript()->registerHeadScriptFile('other', 'https://cdn.example.com/other.js');
+
+		$output = $this->renderHeadScriptFiles($page);
+
+		self::assertStringContainsString('src="https://cdn.example.com/other.js"', $output);
+		self::assertStringNotContainsString('integrity', $output);
+	}
+
+	public function testRequireIntegrityThrowsForUnpinnedRemoteScriptAtRender()
+	{
+		$manager = $this->configuredManager();
+		$manager->setRequireIntegrity(true);
+		$page = new TPage();
+		$page->getClientScript()->registerHeadScriptFile('unpinned', 'https://cdn.example.com/unpinned.js');
+
+		$this->expectException(\Prado\Exceptions\TConfigurationException::class);
+		$this->renderHeadScriptFiles($page);
+	}
+}

--- a/tests/unit/Web/TIntegrityManagerTest.php
+++ b/tests/unit/Web/TIntegrityManagerTest.php
@@ -95,7 +95,7 @@ class TIntegrityManagerTest extends PHPUnit\Framework\TestCase
 		try {
 			$manager = new TIntegrityManager();
 			$manager->setIntegrityFile('App.integrity');
-			self::assertEquals($file, $manager->getIntegrityFile());
+			self::assertEquals(realpath($file), realpath($manager->getIntegrityFile()));
 			$manager->init($this->config(''));
 			self::assertEquals(self::HASH, $manager->getIntegrity(self::REMOTE));
 			self::assertEquals('sha512-CCCC', $manager->getIntegrity('https://cdn.example.com/lib2.js'));

--- a/tests/unit/Web/TIntegrityManagerTest.php
+++ b/tests/unit/Web/TIntegrityManagerTest.php
@@ -1,0 +1,305 @@
+<?php
+
+use Prado\Exceptions\TConfigurationException;
+use Prado\Exceptions\TInvalidOperationException;
+use Prado\Prado;
+use Prado\TApplication;
+use Prado\Web\Javascripts\TJavaScript;
+use Prado\Web\TIntegrityManager;
+use Prado\Xml\TXmlDocument;
+
+class TIntegrityManagerTest extends PHPUnit\Framework\TestCase
+{
+	private const REMOTE = 'https://cdn.example.com/lib.js';
+	private const HASH = 'sha384-AAAA';
+
+	protected ?TTestApplication $app = null;
+
+	protected function setUp(): void
+	{
+		$this->app = new TTestApplication(__DIR__ . '/../Security/app');
+		Prado::setPathOfAlias('App', __DIR__);
+		TJavaScript::setScriptIntegrity(self::REMOTE, null);
+		TJavaScript::setRequireScriptIntegrity(false);
+	}
+
+	protected function tearDown(): void
+	{
+		TJavaScript::setScriptIntegrity(self::REMOTE, null);
+		TJavaScript::setRequireScriptIntegrity(false);
+		if ($this->app !== null) {
+			$this->app->restoreApplication();
+			$this->app = null;
+		}
+	}
+
+	private function config(string $inner): TXmlDocument
+	{
+		$doc = new TXmlDocument('1.0', 'utf8');
+		$doc->loadFromString('<integrity>' . $inner . '</integrity>');
+		return $doc;
+	}
+
+	public function testInitRegistersIntegrity()
+	{
+		$manager = new TIntegrityManager();
+		$manager->init($this->config('<integrity url="' . self::REMOTE . '" hash="' . self::HASH . '" />'));
+		self::assertEquals(self::HASH, $manager->getIntegrity(self::REMOTE));
+		self::assertEquals(self::HASH, TJavaScript::getScriptIntegrity(self::REMOTE));
+	}
+
+	public function testBareDigestGetsMethodPrefix()
+	{
+		$manager = new TIntegrityManager();
+		$manager->init($this->config('<integrity url="' . self::REMOTE . '" hash="BBBB" method="sha512" />'));
+		self::assertEquals('sha512-BBBB', $manager->getIntegrity(self::REMOTE));
+	}
+
+	public function testEmptyHashThrows()
+	{
+		$manager = new TIntegrityManager();
+		self::expectException(TConfigurationException::class);
+		$manager->init($this->config('<integrity url="' . self::REMOTE . '" hash="" />'));
+	}
+
+	public function testRequireIntegrityEnforcedAtRender()
+	{
+		$manager = new TIntegrityManager();
+		$manager->setRequireIntegrity(true);
+		$manager->init($this->config(''));
+		self::assertTrue(TJavaScript::getRequireScriptIntegrity());
+		self::expectException(TConfigurationException::class);
+		TJavaScript::renderScriptFile('https://cdn.example.com/unpinned.js');
+	}
+
+	public function testRequireIntegrityAllowsPinnedRemote()
+	{
+		$manager = new TIntegrityManager();
+		$manager->setRequireIntegrity(true);
+		$manager->init($this->config('<integrity url="' . self::REMOTE . '" hash="' . self::HASH . '" />'));
+		$html = TJavaScript::renderScriptFile(self::REMOTE);
+		self::assertStringContainsString('integrity="' . self::HASH . '"', $html);
+		self::assertStringContainsString('crossorigin="anonymous"', $html);
+	}
+
+	public function testInitFromXmlFile()
+	{
+		if (!is_writable(__DIR__)) {
+			self::markTestSkipped(__DIR__ . ' is not writable');
+		}
+		$file = __DIR__ . '/integrity.xml';
+		file_put_contents($file, '<integrities>'
+			. '<integrity url="' . self::REMOTE . '" hash="' . self::HASH . '" />'
+			. '<integrity url="https://cdn.example.com/lib2.js" hash="CCCC" method="sha512" />'
+			. '</integrities>');
+		try {
+			$manager = new TIntegrityManager();
+			$manager->setIntegrityFile('App.integrity');
+			self::assertEquals($file, $manager->getIntegrityFile());
+			$manager->init($this->config(''));
+			self::assertEquals(self::HASH, $manager->getIntegrity(self::REMOTE));
+			self::assertEquals('sha512-CCCC', $manager->getIntegrity('https://cdn.example.com/lib2.js'));
+		} finally {
+			unlink($file);
+			TJavaScript::setScriptIntegrity('https://cdn.example.com/lib2.js', null);
+		}
+	}
+
+	public function testInitFromPhpFile()
+	{
+		if (!is_writable(__DIR__)) {
+			self::markTestSkipped(__DIR__ . ' is not writable');
+		}
+		$this->app->setConfigurationType(TApplication::CONFIG_TYPE_PHP);
+		$file = __DIR__ . '/integrity.php';
+		file_put_contents($file, "<?php\nreturn ['integrities' => ["
+			. "['url' => '" . self::REMOTE . "', 'hash' => '" . self::HASH . "'],"
+			. "['url' => 'https://cdn.example.com/lib2.js', 'hash' => 'CCCC', 'method' => 'sha512'],"
+			. "]];\n");
+		try {
+			$manager = new TIntegrityManager();
+			$manager->setIntegrityFile('App.integrity');
+			$manager->init([]);
+			self::assertEquals(self::HASH, $manager->getIntegrity(self::REMOTE));
+			self::assertEquals('sha512-CCCC', $manager->getIntegrity('https://cdn.example.com/lib2.js'));
+		} finally {
+			unlink($file);
+			TJavaScript::setScriptIntegrity('https://cdn.example.com/lib2.js', null);
+		}
+	}
+
+	public function testBareDigestDefaultMethodWhenMethodOmitted()
+	{
+		$manager = new TIntegrityManager();
+		$manager->init($this->config('<integrity url="' . self::REMOTE . '" hash="ZZZZ" />'));
+		self::assertEquals('sha384-ZZZZ', $manager->getIntegrity(self::REMOTE));
+	}
+
+	public function testLoadFromPhpArray()
+	{
+		$manager = new TIntegrityManager();
+		$config = [
+			'integrities' => [
+				['url' => self::REMOTE, 'hash' => self::HASH],
+				['url' => 'https://cdn.example.com/lib2.js', 'hash' => 'CCCC', 'method' => 'sha512'],
+			],
+		];
+		PradoUnit::invoke($manager, 'loadIntegrityData', $config);
+		self::assertEquals(self::HASH, $manager->getIntegrity(self::REMOTE));
+		self::assertEquals('sha512-CCCC', $manager->getIntegrity('https://cdn.example.com/lib2.js'));
+		TJavaScript::setScriptIntegrity('https://cdn.example.com/lib2.js', null);
+	}
+
+	public function testAddIntegrityFullSriStoredAsIs()
+	{
+		$manager = new TIntegrityManager();
+		$manager->addIntegrity(self::REMOTE, 'sha256-DDDD', 'sha512');
+		self::assertEquals('sha256-DDDD', $manager->getIntegrity(self::REMOTE));
+	}
+
+	public function testAddIntegrityEmptyUrlThrows()
+	{
+		$manager = new TIntegrityManager();
+		self::expectException(TConfigurationException::class);
+		$manager->addIntegrity('   ', self::HASH);
+	}
+
+	public function testAddIntegrityEmptyHashThrows()
+	{
+		$manager = new TIntegrityManager();
+		self::expectException(TConfigurationException::class);
+		$manager->addIntegrity(self::REMOTE, '   ');
+	}
+
+	public function testGetIntegrityUnknownReturnsNull()
+	{
+		$manager = new TIntegrityManager();
+		self::assertNull($manager->getIntegrity('https://cdn.example.com/missing.js'));
+	}
+
+	public function testGetIntegritiesReturnsFullMap()
+	{
+		$manager = new TIntegrityManager();
+		$manager->addIntegrity(self::REMOTE, self::HASH);
+		$map = $manager->getIntegrities();
+		self::assertCount(1, $map);
+		self::assertContains(self::HASH, $map);
+	}
+
+	public function testGetIntegrityNormalizesUrl()
+	{
+		$manager = new TIntegrityManager();
+		$manager->addIntegrity('//CDN.example.com/lib.js', self::HASH);
+		// Protocol-relative + mixed case resolves to the same normalized key.
+		self::assertEquals(self::HASH, $manager->getIntegrity('https://cdn.example.com/lib.js'));
+	}
+
+	public function testRequireIntegrityStringCoercedToBool()
+	{
+		$manager = new TIntegrityManager();
+		$manager->setRequireIntegrity('true');
+		self::assertTrue($manager->getRequireIntegrity());
+	}
+
+	public function testRequireIntegrityDefaultsToFalse()
+	{
+		$manager = new TIntegrityManager();
+		$manager->init($this->config(''));
+		self::assertFalse($manager->getRequireIntegrity());
+		self::assertFalse(TJavaScript::getRequireScriptIntegrity());
+	}
+
+	public function testRequireIntegrityChangeAfterInitPropagates()
+	{
+		$manager = new TIntegrityManager();
+		$manager->init($this->config(''));
+		self::assertFalse(TJavaScript::getRequireScriptIntegrity());
+		$manager->setRequireIntegrity(true);
+		self::assertTrue(TJavaScript::getRequireScriptIntegrity());
+	}
+
+	public function testNonArrayConfigLoadsNothing()
+	{
+		$manager = new TIntegrityManager();
+		PradoUnit::invoke($manager, 'loadIntegrityData', PradoUnit::invoke($manager, 'normalizeConfig', null));
+		self::assertSame([], $manager->getIntegrities());
+	}
+
+	public function testCalculateIntegrityDefaultSha384()
+	{
+		$expected = 'sha384-' . base64_encode(hash('sha384', 'content', true));
+		self::assertEquals($expected, TIntegrityManager::calculateIntegrity('content'));
+	}
+
+	public function testCalculateIntegritySha256()
+	{
+		$expected = 'sha256-' . base64_encode(hash('sha256', 'content', true));
+		self::assertEquals($expected, TIntegrityManager::calculateIntegrity('content', 'sha256'));
+	}
+
+	public function testCalculateIntegritySha512()
+	{
+		$expected = 'sha512-' . base64_encode(hash('sha512', 'content', true));
+		self::assertEquals($expected, TIntegrityManager::calculateIntegrity('content', 'sha512'));
+	}
+
+	public function testCalculateIntegrityNormalizesMethodCase()
+	{
+		self::assertEquals(
+			TIntegrityManager::calculateIntegrity('content', 'sha512'),
+			TIntegrityManager::calculateIntegrity('content', ' SHA512 ')
+		);
+	}
+
+	public function testCalculateIntegrityRendersValidSriForRemote()
+	{
+		$hash = TIntegrityManager::calculateIntegrity('alert(1)');
+		$manager = new TIntegrityManager();
+		$manager->addIntegrity(self::REMOTE, $hash);
+		self::assertStringContainsString('integrity="' . $hash . '"', TJavaScript::renderScriptFile(self::REMOTE));
+	}
+
+	public function testCalculateIntegrityInvalidAlgorithmThrows()
+	{
+		self::expectException(TConfigurationException::class);
+		TIntegrityManager::calculateIntegrity('content', 'md5');
+	}
+
+	public function testCalculateIntegrityForFileMatchesContent()
+	{
+		if (!is_writable(__DIR__)) {
+			self::markTestSkipped(__DIR__ . ' is not writable');
+		}
+		$file = __DIR__ . '/asset.js';
+		file_put_contents($file, 'alert(1)');
+		try {
+			self::assertEquals(
+				TIntegrityManager::calculateIntegrity('alert(1)', 'sha512'),
+				TIntegrityManager::calculateIntegrityForFile($file, 'sha512')
+			);
+		} finally {
+			unlink($file);
+		}
+	}
+
+	public function testCalculateIntegrityForFileMissingThrows()
+	{
+		self::expectException(TConfigurationException::class);
+		TIntegrityManager::calculateIntegrityForFile(__DIR__ . '/does_not_exist.js');
+	}
+
+	public function testIntegrityFileInvalidThrows()
+	{
+		$manager = new TIntegrityManager();
+		self::expectException(TConfigurationException::class);
+		$manager->setIntegrityFile('App.does_not_exist');
+	}
+
+	public function testIntegrityFileUnchangeableAfterInit()
+	{
+		$manager = new TIntegrityManager();
+		$manager->init($this->config(''));
+		self::expectException(TInvalidOperationException::class);
+		$manager->setIntegrityFile('App.integrity');
+	}
+}


### PR DESCRIPTION
This is the next part of the THttpHeadersManager for `script` tags after `nonce`.

If/when this is merged, we can extend it to stylesheets as well.