### PR TITLE
TModuleConfigurationFileTrait - modules with config files (Users, Permissions, etc) may use this trait to read the config files

### DIFF
--- a/framework/Util/Traits/TModuleConfigurationFileTrait.php
+++ b/framework/Util/Traits/TModuleConfigurationFileTrait.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * TModuleConfigurationFileTrait class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Util\Traits;
+
+use Prado\TApplication;
+use Prado\Xml\TXmlDocument;
+
+/**
+ * TModuleConfigurationFileTrait trait
+ *
+ * Reads a Prado configuration file into the shape its loader expects.  PHP
+ * files are `include`'d (and validated to return an array); XML files load
+ * into a {@see TXmlDocument}.  When `$type` is `null` the format is detected
+ * from the file extension (`.php` → PHP, else XML).
+ *
+ * Used by modules that load supplemental configuration from disk
+ * (e.g. {@see \Prado\Security\TUserManager}'s `UserFile`,
+ * {@see \Prado\TApplicationConfiguration}'s `loadFromFile()`).  The trait
+ * holds only the raw read; shape dispatch (`array` → PHP loader,
+ * `TXmlDocument` → XML loader) lives on the using class:
+ *
+ * ```php
+ * $type    = $this->getApplication()?->getConfigurationType();
+ * $content = $this->readConfigurationFile($type, $fname);
+ * if ($content instanceof TXmlDocument) {
+ *     $this->loadFromXml($content, dirname($fname));
+ * } elseif (is_array($content)) {
+ *     $this->loadFromPhp($content, dirname($fname));
+ * }
+ * ```
+ *
+ * Subclasses may override {@see readConfigurationFile()} to add formats
+ * (JSON, YAML, …); the shape contract is "return an array, a
+ * `TXmlDocument`, or `null`."
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ */
+trait TModuleConfigurationFileTrait
+{
+	/**
+	 * Reads a configuration file into the shape its loader expects.  `null`
+	 * `$type` auto-detects by extension (`.php` → PHP, else XML).  Override
+	 * to add formats (JSON, YAML, …).
+	 * @param ?string $type {@see \Prado\TApplication::CONFIG_TYPE_PHP},
+	 *   {@see \Prado\TApplication::CONFIG_TYPE_XML}, or `null` to
+	 *   auto-detect.
+	 * @param string $fname configuration file name.
+	 * @return null|array|TXmlDocument array for the PHP-form loader,
+	 *   `TXmlDocument` for the XML-form loader, `null` when the include
+	 *   returned a non-array (PHP path) so the caller can skip.
+	 * @since 4.4.0
+	 */
+	protected function readConfigurationFile(?string $type, string $fname): null|array|TXmlDocument
+	{
+		if ($type === null) {
+			$type = strtolower(pathinfo($fname, PATHINFO_EXTENSION)) === 'php'
+				? TApplication::CONFIG_TYPE_PHP
+				: TApplication::CONFIG_TYPE_XML;
+		}
+		if ($type === TApplication::CONFIG_TYPE_PHP) {
+			$content = include $fname;
+			return is_array($content) ? $content : null;
+		}
+		$dom = new TXmlDocument();
+		$dom->loadFromFile($fname);
+		return $dom;
+	}
+}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -434,6 +434,7 @@ return [
 'TArrayIteratorTrait' => 'Prado\Util\Traits\TArrayIteratorTrait',
 'TConstantReflectionTrait' => 'Prado\Util\Traits\TConstantReflectionTrait',
 'TInitializedTrait' => 'Prado\Util\Traits\TInitializedTrait',
+'TModuleConfigurationFileTrait' => 'Prado\Util\Traits\TModuleConfigurationFileTrait',
 'TReflectionClassTrait' => 'Prado\Util\Traits\TReflectionClassTrait',
 'TRpcClient' => 'Prado\Util\TRpcClient',
 'TRpcClientRequestException' => 'Prado\Util\TRpcClientRequestException',

--- a/tests/unit/Util/Traits/TModuleConfigurationFileTraitTest.php
+++ b/tests/unit/Util/Traits/TModuleConfigurationFileTraitTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * TModuleConfigurationFileTraitTest class file.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+use Prado\TApplication;
+use Prado\Util\Traits\TModuleConfigurationFileTrait;
+use Prado\Xml\TXmlDocument;
+
+/**
+ * Consumer exposing the trait's protected reader for testing.
+ */
+class TModuleConfigurationFileTraitConsumer
+{
+	use TModuleConfigurationFileTrait;
+
+	public function read(?string $type, string $fname): null|array|TXmlDocument
+	{
+		return $this->readConfigurationFile($type, $fname);
+	}
+}
+
+/**
+ * Unit tests for {@see \Prado\Util\Traits\TModuleConfigurationFileTrait}.
+ */
+class TModuleConfigurationFileTraitTest extends PHPUnit\Framework\TestCase
+{
+	private TModuleConfigurationFileTraitConsumer $consumer;
+
+	/** Temp file paths created during a test, removed in tearDown. */
+	private array $_tempFiles = [];
+
+	protected function setUp(): void
+	{
+		$this->consumer = new TModuleConfigurationFileTraitConsumer();
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->_tempFiles as $path) {
+			if (is_file($path)) {
+				@unlink($path);
+			}
+		}
+		$this->_tempFiles = [];
+	}
+
+	/** Writes $content to a uniquely named temp file with the given extension. */
+	private function tempFile(string $extension, string $content): string
+	{
+		$path = sys_get_temp_dir() . '/prado_modcfg_' . uniqid('', true) . '.' . $extension;
+		file_put_contents($path, $content);
+		$this->_tempFiles[] = $path;
+		return $path;
+	}
+
+	// ── Auto-detection by extension (type === null) ────────────────────────
+
+	public function testAutoDetect_phpExtensionIsIncludedAsArray(): void
+	{
+		$path = $this->tempFile('php', "<?php return ['a' => 1, 'b' => 2];");
+		self::assertSame(['a' => 1, 'b' => 2], $this->consumer->read(null, $path));
+	}
+
+	public function testAutoDetect_xmlExtensionLoadsXmlDocument(): void
+	{
+		$path = $this->tempFile('xml', '<config><item id="x"/></config>');
+		$result = $this->consumer->read(null, $path);
+		self::assertInstanceOf(TXmlDocument::class, $result);
+		self::assertSame('config', $result->getTagName());
+	}
+
+	public function testAutoDetect_unknownExtensionFallsBackToXml(): void
+	{
+		// Any non-`.php` extension is treated as XML.
+		$path = $this->tempFile('conf', '<root/>');
+		self::assertInstanceOf(TXmlDocument::class, $this->consumer->read(null, $path));
+	}
+
+	public function testAutoDetect_phpExtensionCaseInsensitive(): void
+	{
+		$path = $this->tempFile('PHP', "<?php return ['k' => 'v'];");
+		self::assertSame(['k' => 'v'], $this->consumer->read(null, $path));
+	}
+
+	// ── Explicit type overrides the extension ──────────────────────────────
+
+	public function testExplicitPhpType_overridesXmlExtension(): void
+	{
+		// A file named `.xml` but holding PHP is included when the type says PHP.
+		$path = $this->tempFile('xml', "<?php return ['forced' => true];");
+		self::assertSame(['forced' => true], $this->consumer->read(TApplication::CONFIG_TYPE_PHP, $path));
+	}
+
+	public function testExplicitXmlType_overridesPhpExtension(): void
+	{
+		$path = $this->tempFile('php', '<data><x/></data>');
+		$result = $this->consumer->read(TApplication::CONFIG_TYPE_XML, $path);
+		self::assertInstanceOf(TXmlDocument::class, $result);
+		self::assertSame('data', $result->getTagName());
+	}
+
+	// ── PHP include contract ───────────────────────────────────────────────
+
+	public function testPhpInclude_nonArrayReturnYieldsNull(): void
+	{
+		// The include returns a scalar, so the reader yields null.
+		$path = $this->tempFile('php', "<?php return 'a scalar';");
+		self::assertNull($this->consumer->read(TApplication::CONFIG_TYPE_PHP, $path));
+	}
+
+	public function testPhpInclude_noReturnYieldsNull(): void
+	{
+		// A PHP file with no `return` evaluates to 1 (non-array) → null.
+		$path = $this->tempFile('php', '<?php $x = 1;');
+		self::assertNull($this->consumer->read(TApplication::CONFIG_TYPE_PHP, $path));
+	}
+
+	public function testPhpInclude_emptyArrayReturnsEmptyArray(): void
+	{
+		$path = $this->tempFile('php', '<?php return [];');
+		self::assertSame([], $this->consumer->read(TApplication::CONFIG_TYPE_PHP, $path));
+	}
+
+	public function testPhpInclude_nestedArrayPreserved(): void
+	{
+		$path = $this->tempFile('php', "<?php return ['users' => [['name' => 'Joe']]];");
+		self::assertSame(['users' => [['name' => 'Joe']]], $this->consumer->read(TApplication::CONFIG_TYPE_PHP, $path));
+	}
+
+	// ── XML load contract ──────────────────────────────────────────────────
+
+	public function testXml_parsesElementsAndAttributes(): void
+	{
+		$path = $this->tempFile('xml', '<users><user name="Joe"/><user name="John"/></users>');
+		$result = $this->consumer->read(TApplication::CONFIG_TYPE_XML, $path);
+		self::assertInstanceOf(TXmlDocument::class, $result);
+		self::assertSame('users', $result->getTagName());
+		self::assertCount(2, $result->getElementsByTagName('user'));
+	}
+}


### PR DESCRIPTION
This is to help standardize this feature in modules.