### PR TITLE
SqlMap update for #1168

### DIFF
--- a/framework/Data/Common/Mssql/TMssqlCommandBuilder.php
+++ b/framework/Data/Common/Mssql/TMssqlCommandBuilder.php
@@ -82,9 +82,23 @@ class TMssqlCommandBuilder extends TDbCommandBuilder
 		$limit = $limit !== null ? (int) $limit : -1;
 		$offset = $offset !== null ? (int) $offset : -1;
 		if ($limit > 0 && $offset <= 0) { //just limit
-			$sql = preg_replace('/^([\s(])*SELECT( DISTINCT)?(?!\s*TOP\s*\()/i', "\\1SELECT\\2 TOP $limit", $sql);
-		} elseif ($limit > 0 && $offset > 0) {
-			$sql = $this->rewriteLimitOffsetSql($sql, $limit, $offset);
+			return preg_replace('/^([\s(])*SELECT( DISTINCT)?(?!\s*TOP\s*\()/i', "\\1SELECT\\2 TOP $limit", $sql);
+		}
+		if ($offset > 0) {
+			// SQL Server 2012+ OFFSET/FETCH. Unlike the TOP-nesting rewrite, this
+			// does not re-project columns, so it works with arbitrary SQL including
+			// queries that alias their ORDER BY column (e.g. "Account_ID as ID").
+			// OFFSET/FETCH requires an ORDER BY; inject a stable no-op ordering
+			// when the query has none.
+			$result = rtrim($sql);
+			if (stripos($result, 'ORDER BY') === false) {
+				$result .= ' ORDER BY (SELECT NULL)';
+			}
+			$result .= ' OFFSET ' . $offset . ' ROWS';
+			if ($limit > 0) {
+				$result .= ' FETCH NEXT ' . $limit . ' ROWS ONLY';
+			}
+			return $result;
 		}
 		return $sql;
 	}

--- a/framework/Data/Common/Mysql/TMysqlMetaData.php
+++ b/framework/Data/Common/Mysql/TMysqlMetaData.php
@@ -86,6 +86,11 @@ class TMysqlMetaData extends TDbMetaData
 	protected function createTableInfo($table)
 	{
 		[$schemaName, $tableName] = $this->getSchemaTableName($table);
+		// Resolve the table name to its actual stored case. On Linux, MySQL is
+		// case-sensitive for table names (lower_case_table_names=0), so a lookup
+		// for `accounts` must find the `Accounts` table.
+		$tableName = $this->resolveTableNameCase($schemaName, $tableName);
+		$table = $schemaName === null ? $tableName : $schemaName . '.' . $tableName;
 		$find = $schemaName === null ? "`{$tableName}`" : "`{$schemaName}`.`{$tableName}`";
 		$colCase = $this->getDbConnection()->getColumnCase();
 		if ($colCase != TDbColumnCaseMode::Preserved) {
@@ -218,6 +223,44 @@ class TMysqlMetaData extends TDbMetaData
 			}
 		}
 		return count($result) > 1 ? $result : [null, $result[0]];
+	}
+
+	/**
+	 * Resolves a table name to its actual stored case via information_schema.
+	 *
+	 * MySQL on Linux is case-sensitive for table names
+	 * (lower_case_table_names=0), so a metadata lookup using a different case
+	 * than the stored name (e.g. `accounts` for a table created as `Accounts`)
+	 * fails.  This performs a case-insensitive match and returns the real name.
+	 * The input name is returned unchanged when no match is found (the caller
+	 * then raises the usual "invalid table" error) or when the lookup fails.
+	 *
+	 * @param ?string $schemaName database name, null to use the connection default.
+	 * @param string $tableName the requested table name, possibly mis-cased.
+	 * @return string the actual stored table name, or the input when unresolved.
+	 * @since 4.4.0
+	 */
+	protected function resolveTableNameCase($schemaName, $tableName)
+	{
+		try {
+			$conn = $this->getDbConnection();
+			$conn->setActive(true);
+			if ($schemaName === null) {
+				$sql = 'SELECT TABLE_NAME FROM information_schema.TABLES'
+					. ' WHERE TABLE_SCHEMA = DATABASE() AND LOWER(TABLE_NAME) = LOWER(:t)';
+				$command = $conn->createCommand($sql);
+			} else {
+				$sql = 'SELECT TABLE_NAME FROM information_schema.TABLES'
+					. ' WHERE TABLE_SCHEMA = :s AND LOWER(TABLE_NAME) = LOWER(:t)';
+				$command = $conn->createCommand($sql);
+				$command->bindValue(':s', $schemaName);
+			}
+			$command->bindValue(':t', $tableName);
+			$actual = $command->queryScalar();
+		} catch (\Exception $e) {
+			return $tableName;
+		}
+		return ($actual === false || $actual === null) ? $tableName : (string) $actual;
 	}
 
 	/**

--- a/framework/Data/Common/Oracle/TOracleCommandBuilder.php
+++ b/framework/Data/Common/Oracle/TOracleCommandBuilder.php
@@ -85,17 +85,39 @@ class TOracleCommandBuilder extends TDbCommandBuilder
 			return $sql;
 		}
 
+		// When called from SqlMap (e.g. queryForList with skip/max), no specific
+		// table is known so getTableInfo() returns an empty stub without a table
+		// name or columns.  In that case, use Oracle 12c+ OFFSET/FETCH NEXT
+		// syntax which handles arbitrary SQL without column or table metadata.
+		$tableInfo = $this->getTableInfo();
+		$tableName = $tableInfo !== null ? $tableInfo->getTableName() : null;
+		if ($tableInfo === null || $tableName === null || $tableName === '') {
+			$result = rtrim($sql);
+			$offset = (int) $offset;
+			$limit = (int) $limit;
+			if ($offset > 0) {
+				$result .= ' OFFSET ' . $offset . ' ROWS';
+			}
+			if ($limit > 0) {
+				$result .= ' FETCH NEXT ' . $limit . ' ROWS ONLY';
+			}
+			return $result;
+		}
+
 		$pradoNUMLIN = 'pradoNUMLIN';
 		$fieldsALIAS = 'xyz';
 
 		$nfimDaSQL = strlen($sql);
-		$nfimDoWhere = (strpos($sql, 'ORDER') !== false ? strpos($sql, 'ORDER') : $nfimDaSQL);
-		$niniDoSelect = strpos($sql, 'SELECT') + 6;
-		$nfimDoSelect = (strpos($sql, 'FROM') !== false ? strpos($sql, 'FROM') : $nfimDaSQL);
+		$nfimDoWhere = (stripos($sql, 'ORDER') !== false ? stripos($sql, 'ORDER') : $nfimDaSQL);
+		$selectPos = stripos($sql, 'SELECT');
+		$niniDoSelect = ($selectPos !== false ? $selectPos : 0) + 6;
+		$nfimDoSelect = (stripos($sql, 'FROM') !== false ? stripos($sql, 'FROM') : $nfimDaSQL);
 
 		$WhereInSubSelect = "";
-		if (strpos($sql, 'WHERE') !== false) {
-			$WhereInSubSelect = "WHERE " . substr($sql, strpos($sql, 'WHERE') + 5, $nfimDoWhere);
+		$wherePos = stripos($sql, 'WHERE');
+		if ($wherePos !== false) {
+			$whereStart = $wherePos + 5;
+			$WhereInSubSelect = "WHERE " . substr($sql, $whereStart, $nfimDoWhere - $whereStart);
 		}
 
 		$sORDERBY = '';

--- a/framework/Data/Common/Oracle/TOracleMetaData.php
+++ b/framework/Data/Common/Oracle/TOracleMetaData.php
@@ -26,7 +26,14 @@ use Prado\Prado;
  */
 class TOracleMetaData extends TDbMetaData
 {
-	private $_defaultSchema = 'system';
+	/**
+	 * @var ?string Default schema (owner).  null = not yet resolved;
+	 *                  resolved lazily from {@see SELECT USER FROM DUAL} on
+	 *                  first use so that unquoted table names are found under
+	 *                  the connected user's schema rather than the hardcoded
+	 *                  'system' schema that existed in earlier versions.
+	 */
+	private $_defaultSchema;
 
 
 	/**
@@ -46,10 +53,24 @@ class TOracleMetaData extends TDbMetaData
 	}
 
 	/**
-	 * @return string default schema.
+	 * Returns the default schema (owner) used when no explicit schema is given.
+	 *
+	 * The value is resolved lazily from {@see SELECT USER FROM DUAL} on first
+	 * use so that unquoted table names resolve to the connected user's schema.
+	 * Call {@see setDefaultSchema()} to override before any table lookup.
+	 *
+	 * @return string default schema (lowercase; callers uppercase it for SQL).
 	 */
 	public function getDefaultSchema()
 	{
+		if ($this->_defaultSchema === null) {
+			try {
+				$user = $this->getDbConnection()->createCommand('SELECT USER FROM DUAL')->queryScalar();
+				$this->_defaultSchema = $user !== false ? strtolower((string) $user) : 'system';
+			} catch (\Exception $e) {
+				$this->_defaultSchema = 'system';
+			}
+		}
 		return $this->_defaultSchema;
 	}
 

--- a/tests/unit/Caching/TDbCacheTest.php
+++ b/tests/unit/Caching/TDbCacheTest.php
@@ -14,6 +14,7 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 	private $_dbDir;
 	private $_dbFile;
 	private $_dbFiles = [];
+	private ?TTestApplication $_app = null;
 
 	protected function setUp(): void
 	{
@@ -24,8 +25,8 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 		$this->_dbFile = $this->_dbDir . '/test_cache.db';
 		$this->_dbFiles = [$this->_dbFile];
 
-		$app = new TTestApplication();
-		$app->setRuntimePath($this->_dbDir);
+		$this->_app = new TTestApplication();
+		$this->_app->setRuntimePath($this->_dbDir);
 
 		$this->_cache = new TDbCache();
 		$this->_cache->setPrimaryCache(false);
@@ -41,6 +42,8 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 		foreach($this->_dbFiles as $dbFile) {
 			@unlink($dbFile);
 		}
+		$this->_app?->restoreApplication();
+		$this->_app = null;
 	}
 
 	protected function initCache(): void

--- a/tests/unit/Caching/TDbCacheTest.php
+++ b/tests/unit/Caching/TDbCacheTest.php
@@ -3,7 +3,6 @@
 use Prado\Caching\TDbCache;
 use Prado\Data\TDbConnection;
 use Prado\Exceptions\TConfigurationException;
-use Prado\TApplication;
 
 if (!defined('TEST_CACHE_DB_DIR')) {
 	define('TEST_CACHE_DB_DIR', __DIR__ . '/../Data/db');
@@ -25,7 +24,7 @@ class TDbCacheTest extends PHPUnit\Framework\TestCase
 		$this->_dbFile = $this->_dbDir . '/test_cache.db';
 		$this->_dbFiles = [$this->_dbFile];
 
-		$app = new TApplication(__DIR__ . '/../Data/SqlMap/app', false, TApplication::CONFIG_TYPE_PHP);
+		$app = new TTestApplication();
 		$app->setRuntimePath($this->_dbDir);
 
 		$this->_cache = new TDbCache();

--- a/tests/unit/Data/DbSpecific/Mssql/CommandBuilderMssqlTest.php
+++ b/tests/unit/Data/DbSpecific/Mssql/CommandBuilderMssqlTest.php
@@ -21,20 +21,22 @@ class CommandBuilderMssqlTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals($expect, $sql);
 
 
+		// SQL Server 2012+ OFFSET/FETCH. A no-op ORDER BY is injected when the
+		// source query has none (OFFSET/FETCH requires an ORDER BY).
 		$sql = $builder->applyLimitOffset(self::$sql['simple'], 3, 2);
-		$expect = 'SELECT * FROM (SELECT TOP 3 * FROM (SELECT TOP 5 username, age FROM accounts) as [__inner top table__] ) as [__outer top table__] ';
+		$expect = 'SELECT username, age FROM accounts ORDER BY (SELECT NULL) OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY';
 		$this->assertEquals($expect, $sql);
 
 		$sql = $builder->applyLimitOffset(self::$sql['multiple'], 3, 2);
-		$expect = 'SELECT * FROM (SELECT TOP 3 * FROM (SELECT TOP 5 a.username, b.name from accounts a, table1 b where a.age = b.id1) as [__inner top table__] ) as [__outer top table__] ';
+		$expect = 'select a.username, b.name from accounts a, table1 b where a.age = b.id1 ORDER BY (SELECT NULL) OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY';
 		$this->assertEquals($sql, $expect);
 
 		$sql = $builder->applyLimitOffset(self::$sql['ordering'], 3, 2);
-		$expect = 'SELECT * FROM (SELECT TOP 3 * FROM (SELECT TOP 5 a.username, b.name, a.age from accounts a, table1 b where a.age = b.id1 order by age DESC, name) as [__inner top table__] ORDER BY age ASC, name DESC) as [__outer top table__] ORDER BY age DESC, name ASC';
+		$expect = 'select a.username, b.name, a.age from accounts a, table1 b where a.age = b.id1 order by age DESC, name OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY';
 		$this->assertEquals($sql, $expect);
 
 		$sql = $builder->applyLimitOffset(self::$sql['index'], 3, 2);
-		$expect = 'SELECT * FROM (SELECT TOP 3 * FROM (SELECT TOP 5 a.username, b.name, a.age from accounts a, table1 b where a.age = b.id1 ORDER BY 1 DESC, 2 ASC) as [__inner top table__] ORDER BY 1 ASC, 2 DESC) as [__outer top table__] ORDER BY 1 DESC, 2 ASC';
+		$expect = 'select a.username, b.name, a.age from accounts a, table1 b where a.age = b.id1 ORDER BY 1 DESC, 2 ASC OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY';
 		$this->assertEquals($expect, $sql);
 
 		//	$sql = $builder->applyLimitOffset(self::$sql['compute'], 3, 2);


### PR DESCRIPTION
Part of #1168
These are necessary to fix SqlMap for Oracle, SqlSrv, and MySql.
TDbCache uses a test SqlMap app, changed to use TTestApplication instead.