### PR TITLE
Prado::registerClassMap so extensions can be included

### DIFF
--- a/framework/Prado.php
+++ b/framework/Prado.php
@@ -132,6 +132,18 @@ class Prado
 	}
 
 	/**
+	 * Merges a Prado3-namespace class map (short/dot name → PHP FQN) into the
+	 * autoloader's map, the way an extension joins its own `classes.php` with
+	 * Prado's. Existing entries win, so an extension cannot shadow a core class.
+	 * @param array $map the class map to merge, keyed by Prado3 namespace.
+	 * @since 4.4.0
+	 */
+	public static function registerClassMap(array $map): void
+	{
+		self::$classMap += $map;
+	}
+
+	/**
 	 * Initializes error handlers.
 	 * This method set error and exception handlers to be functions
 	 * defined in this class.

--- a/framework/Util/TComposer.php
+++ b/framework/Util/TComposer.php
@@ -11,6 +11,7 @@
 namespace Prado\Util;
 
 use Composer\Autoload\ClassLoader;
+use Composer\InstalledVersions;
 use Prado\Caching\ICacheDependency;
 use Prado\Caching\TChainedCacheDependency;
 use Prado\Caching\TFileCacheDependency;
@@ -172,6 +173,25 @@ class TComposer extends \Prado\TComponent
 			return $prado;
 		}
 		return $prado[$key] ?? null;
+	}
+
+	/**
+	 * Returns the absolute filesystem path of an installed Composer package, the
+	 * base directory used to resolve package-relative file references.
+	 * @param string $name the package name, for example `vendor/package`.
+	 * @return null|string the absolute install path, or null when the package is
+	 *   not installed.
+	 */
+	public static function getPackagePath(string $name): ?string
+	{
+		if (!InstalledVersions::isInstalled($name)) {
+			return null;
+		}
+		$path = InstalledVersions::getInstallPath($name);
+		if ($path === null) {
+			return null;
+		}
+		return realpath($path) ?: $path;
 	}
 
 	/**

--- a/tests/unit/PradoBaseTest.php
+++ b/tests/unit/PradoBaseTest.php
@@ -1435,4 +1435,22 @@ class PradoBaseTest extends PHPUnit\Framework\TestCase
 		$this->assertStringContainsString('<a', $result);
 		$this->assertStringContainsString('powered2', $result);
 	}
+
+	public function testRegisterClassMap_mergesAndCoreWins(): void
+	{
+		$saved = Prado::$classMap;
+		try {
+			$coreKey = array_key_first($saved);
+			Prado::registerClassMap([
+				'TExtensionOnlyClass' => 'Vendor\\Ext\\TExtensionOnlyClass',
+				$coreKey => 'Vendor\\Ext\\ShouldNotWin',
+			]);
+			// New extension key is added.
+			$this->assertSame('Vendor\\Ext\\TExtensionOnlyClass', Prado::$classMap['TExtensionOnlyClass']);
+			// Existing core key is preserved (core wins).
+			$this->assertSame($saved[$coreKey], Prado::$classMap[$coreKey]);
+		} finally {
+			Prado::$classMap = $saved;
+		}
+	}
 }

--- a/tests/unit/Util/TComposerTest.php
+++ b/tests/unit/Util/TComposerTest.php
@@ -540,4 +540,17 @@ class TComposerTest extends PHPUnit\Framework\TestCase
 			'Default seam must contribute a file dependency per manifest'
 		);
 	}
+
+	public function testGetPackagePath_installedPackage_returnsAbsoluteDir(): void
+	{
+		// phpunit/phpunit is a dev dependency, reliably installed during tests.
+		$path = TComposer::getPackagePath('phpunit/phpunit');
+		$this->assertNotNull($path);
+		$this->assertDirectoryExists($path);
+	}
+
+	public function testGetPackagePath_unknownPackage_returnsNull(): void
+	{
+		$this->assertNull(TComposer::getPackagePath('no-such-vendor/no-such-package'));
+	}
 }


### PR DESCRIPTION
This is to enable extensions to participate in the Prado3 namespace and single class name discovery