### PR TITLE
TTime - <time/> tag

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -670,6 +670,9 @@ dbcron_connectionid_invalid				= TDbCronManager.ConnectionID '{0}' is not a TDat
 
 timescheduler_invalid_string			= TTimeScheduler could not parse the schedule element '{0}'
 
+time_invalid_datetime					= TTime DateTime must be a DateTimeInterface, DateInterval, string, or numeric value; {0} given.
+time_invalid_text_format				= TTime TextFormat '{0}' is not a TTimeFormat constant name or ICU datetime pattern.
+
 rational_bad_offset						= "{0}" is not a valid property accessor of TRational.
 
 bithelper_bad_fp_format					= TBitHelper cannot work with '{0}' exponent bits, '{1}' mantissa bits, '{2}' exponent bias, in a {3} bit PHP environment.

--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -670,9 +670,6 @@ dbcron_connectionid_invalid				= TDbCronManager.ConnectionID '{0}' is not a TDat
 
 timescheduler_invalid_string			= TTimeScheduler could not parse the schedule element '{0}'
 
-time_invalid_datetime					= TTime DateTime must be a DateTimeInterface, DateInterval, string, or numeric value; {0} given.
-time_invalid_text_format				= TTime TextFormat '{0}' is not a TTimeFormat constant name or ICU datetime pattern.
-
 rational_bad_offset						= "{0}" is not a valid property accessor of TRational.
 
 bithelper_bad_fp_format					= TBitHelper cannot work with '{0}' exponent bits, '{1}' mantissa bits, '{2}' exponent bias, in a {3} bit PHP environment.
@@ -723,6 +720,9 @@ control_adapter_not_active				= BaseActiveControl property called on a non-activ
 
 gravatar_bad_default					= TGravatar DefaultImageStyle property value '{0}' is not supported
 gravatar_bad_size						= TGravatar Size is not between [1 .. 512] but is '{0}'
+
+time_invalid_datetime					= TTime DateTime must be a DateTimeInterface, DateInterval, string, or numeric value; {0} given.
+time_invalid_text_format				= TTime TextFormat '{0}' is not a TTimeFormat constant name or ICU datetime pattern.
 
 vardumper_not_array						= __debuginfo() must return an array.
 

--- a/framework/I18N/core/TIntlDateFormatterTrait.php
+++ b/framework/I18N/core/TIntlDateFormatterTrait.php
@@ -32,31 +32,38 @@ trait TIntlDateFormatterTrait
 
 
 	/**
-	 * Formats the localized date and/or time
-	 * If the culture is not specified, the default application
-	 * culture will be used.
-	 * @param string $culture The Culture to get the format information about.
-	 * @param int $datetype The format of the date components, eg \IntlDateFormatter::LONG
-	 * @param int $timetype The format of the date components, eg \IntlDateFormatter::SHORT
-	 * @return \IntlDateFormatter
-	 * @see Format Types - Constants @ https://www.php.net/manual/en/class.intldateformatter.php
+	 * Returns a cached `IntlDateFormatter` for the given locale, date type, time type,
+	 * and optional ICU pattern.
+	 *
+	 * When `$pattern` is `null`, the formatter uses the locale's default format for the
+	 * given `$datetype`/`$timetype` combination. When `$pattern` is a non-empty string,
+	 * `$datetype` and `$timetype` are both treated as `IntlDateFormatter::NONE` and the
+	 * pattern is applied via `IntlDateFormatter::setPattern()`. Returns `null` when the
+	 * `IntlDateFormatter` extension is unavailable.
+	 *
+	 * @param string $culture BCP 47 locale tag (e.g. `'en_US'`)
+	 * @param int $datetype date component format constant (e.g. `\IntlDateFormatter::LONG`)
+	 * @param int $timetype time component format constant (e.g. `\IntlDateFormatter::SHORT`)
+	 * @param ?string $pattern ICU datetime pattern (e.g. `'MMMM d, yyyy'`); `null` for locale default. @since 4.4.0
+	 * @return ?\IntlDateFormatter cached formatter instance, or `null` when unavailable
+	 * @see https://www.php.net/manual/en/class.intldateformatter.php
 	 */
-	protected function getIntlDateFormatter($culture, $datetype, $timetype)
+	protected function getIntlDateFormatter($culture, $datetype, $timetype, $pattern = null)
 	{
 		if (!class_exists('IntlDateFormatter')) {
 			return null;
 		}
 
-		if (!isset(self::$formatters[$culture])) {
-			self::$formatters[$culture] = [];
-		}
-		if (!isset(self::$formatters[$culture][$datetype])) {
-			self::$formatters[$culture][$datetype] = [];
-		}
-		if (!isset(self::$formatters[$culture][$datetype][$timetype])) {
-			self::$formatters[$culture][$datetype][$timetype] = new \IntlDateFormatter($culture, $datetype, $timetype);
+		$patternKey = $pattern ?? '';
+
+		if (!isset(self::$formatters[$culture][$datetype][$timetype][$patternKey])) {
+			$formatter = new \IntlDateFormatter($culture, $datetype, $timetype);
+			if ($pattern !== null) {
+				$formatter->setPattern($pattern);
+			}
+			self::$formatters[$culture][$datetype][$timetype][$patternKey] = $formatter;
 		}
 
-		return self::$formatters[$culture][$datetype][$timetype];
+		return self::$formatters[$culture][$datetype][$timetype][$patternKey];
 	}
 }

--- a/framework/Web/UI/WebControls/TTime.php
+++ b/framework/Web/UI/WebControls/TTime.php
@@ -1,0 +1,662 @@
+<?php
+
+/**
+ * TTime class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Web\UI\WebControls;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use IntlDateFormatter;
+use Prado\Exceptions\TInvalidDataTypeException;
+use Prado\Exceptions\TInvalidDataValueException;
+use Prado\I18N\core\CultureInfoUnits;
+use Prado\I18N\core\TIntlDateFormatterTrait;
+use Prado\TPropertyValue;
+use Prado\Web\UI\THtmlWriter;
+
+/**
+ * TTime class
+ *
+ * TTime renders the HTML5 `<time>` element. The `datetime` attribute always holds a
+ * valid HTML5 datetime value derived from `DateTime` and formatted by `DateTimeFormat`.
+ *
+ * Properties:
+ * - <b>DateTime</b>, `DateTimeInterface|DateInterval|string|int|float` — the value to
+ *   encode. Accepted inputs: `\DateTimeInterface`, `\DateInterval`, an ISO 8601
+ *   duration string (e.g. `P1Y2M`), a strtotime-parseable date string, a Unix
+ *   timestamp integer, or a numeric string (fractional seconds are truncated to int).
+ * - <b>DateTimeFormat</b>, {@see TTimeFormat} — format of the `datetime=""` attribute.
+ *   Default: `HtmlDateTime`.
+ * - <b>TextFormat</b>, `TTimeFormat|ICU pattern|null` — format of the visible text
+ *   content. Accepts a {@see TTimeFormat} constant name or an ICU datetime pattern
+ *   (e.g. `"MMMM d, yyyy"`, `"HH:mm"`). When set, child controls are ignored.
+ *   Default: `null`.
+ *
+ * **Visible text content** is determined in priority order:
+ * 1. **`TextFormat` is set** — formats `DateTime` using the given {@see TTimeFormat}
+ *    constant name or ICU datetime pattern; child controls are ignored.
+ * 2. **Child controls are present** — their rendered output is captured and resolved:
+ *    - A {@see TTimeFormat} constant name (case-insensitive) → `DateTime` formatted in
+ *      that style via {@see \IntlDateFormatter}.
+ *    - A plain-text string containing at least one ICU format letter (see
+ *      {@see isIcuPattern}) when `DateTime` is a `DateTimeInterface` → formatted as an
+ *      ICU datetime pattern via {@see \IntlDateFormatter}; written as-is on failure.
+ *    - Any other content (HTML markup, plain text, no `DateTime` set) → written as-is.
+ * 3. **No children, no `TextFormat`** — `DateTime` is formatted using `DateTimeFormat`
+ *    as the text style, so the visible text matches the `datetime` attribute category.
+ *
+ * **Negative intervals:** `DateInterval::$invert === 1` (produced by
+ * `$later->diff($earlier)`) is supported in visible text — the output is prefixed with
+ * `"-"`. The `datetime` attribute always renders positive; the HTML5 duration syntax
+ * has no negative form.
+ *
+ * Culture and charset are inherited from {@see TI18NWebControl}.
+ *
+ * **Template examples:**
+ * ```xml
+ * <!-- Date only: machine-readable attribute and localized text, both as date -->
+ * <com:TTime DateTime="2024-06-15" DateTimeFormat="Date" TextFormat="Date" />
+ * <!-- renders: <time datetime="2024-06-15">June 15, 2024</time> -->
+ *
+ * <!-- Global datetime with timezone in both attribute and visible text -->
+ * <com:TTime DateTime="2024-06-15T10:30:00+00:00"
+ *     DateTimeFormat="HtmlDateTimeTimezone"
+ *     TextFormat="HtmlDateTimeTimezone" />
+ * <!-- renders: <time datetime="2024-06-15T10:30:00+00:00">June 15, 2024 at 10:30:00 AM Coordinated Universal Time</time> -->
+ *
+ * <!-- ISO 8601 duration; DateTimeFormat has no effect on DateInterval values -->
+ * <com:TTime DateTime="P1Y6M" />
+ * <!-- renders: <time datetime="P1Y6M">1 year 6 months</time> -->
+ *
+ * <!-- TextFormat as a TTimeFormat name -->
+ * <com:TTime DateTime="2024-06-15T10:30:00Z" TextFormat="Date" />
+ * <!-- renders: <time datetime="2024-06-15T10:30:00Z">June 15, 2024</time> -->
+ *
+ * <!-- TextFormat as an ICU datetime pattern -->
+ * <com:TTime DateTime="2024-06-15T10:30:00Z" TextFormat="MMMM d, yyyy" />
+ * <!-- renders: <time datetime="2024-06-15T10:30:00Z">June 15, 2024</time> -->
+ *
+ * <!-- Child text as a TTimeFormat name: resolved to localized datetime -->
+ * <com:TTime DateTime="2024-06-15T10:30:00Z">Date</com:TTime>
+ * <!-- renders: <time datetime="2024-06-15T10:30:00Z">June 15, 2024</time> -->
+ *
+ * <!-- Child text as an ICU pattern: formatted by IntlDateFormatter -->
+ * <com:TTime DateTime="2024-06-15T10:30:00Z">MMMM d, yyyy</com:TTime>
+ * <!-- renders: <time datetime="2024-06-15T10:30:00Z">June 15, 2024</time> -->
+ *
+ * <!-- Child text as arbitrary markup: passed through unchanged -->
+ * <com:TTime DateTime="2024-06-15T10:30:00Z">
+ *     Posted on <b>June 15</b>
+ * </com:TTime>
+ * <!-- renders: <time datetime="2024-06-15T10:30:00Z">Posted on <b>June 15</b></time> -->
+ * ```
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @see TTimeFormat
+ * @see \DateInterval
+ * @see \DateTimeImmutable
+ * @see \DateTimeInterface
+ * @see \IntlDateFormatter
+ * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element
+ * @since 4.4.0
+ */
+class TTime extends TI18NWebControl
+{
+	use TIntlDateFormatterTrait;
+
+	/**
+	 * Returns whether `$pattern` contains at least one recognized ICU date/time format
+	 * letter outside single-quoted literal sections.
+	 *
+	 * Single-quoted sections (`'...'`, with `''` as an escaped quote) are stripped before
+	 * the check so that quoted literals do not trigger a false positive. The recognized
+	 * letters are the full set defined by the ICU datetime pattern syntax:
+	 * `G y Y u U r Q q M L w W d D F g E e c a b B h H k K m s S A z Z O v V X x`.
+	 *
+	 * A string that passes this check is a candidate for `IntlDateFormatter`; one that
+	 * does not contain any of these letters is definitively not a pattern and is written
+	 * as-is without an ICU formatting attempt.
+	 *
+	 * @param string $pattern candidate ICU datetime pattern string
+	 * @return bool true when `$pattern` contains at least one ICU format letter
+	 */
+	public static function isIcuPattern(string $pattern): bool
+	{
+		$stripped = preg_replace("/'(?:[^']|'')*'/", '', $pattern) ?? $pattern;
+		return (bool) preg_match('/[GyYuUrQqMLwWdDFgEecabBhHkKmsSAzZOvVXx]/', $stripped);
+	}
+
+	/**
+	 * Returns the HTML tag name for this control.
+	 * @return string `'time'`
+	 */
+	protected function getTagName()
+	{
+		return 'time';
+	}
+
+	/**
+	 * Returns the stored datetime value.
+	 *
+	 * The return type mirrors what was passed to {@see setDateTime}: a
+	 * `DateTimeInterface`, a `DateInterval`, a raw fallback string, or `''` when
+	 * nothing has been set.
+	 *
+	 * @return DateInterval|DateTimeInterface|string the stored value, or `''` when unset
+	 */
+	public function getDateTime()
+	{
+		return $this->getViewState('DateTime', '');
+	}
+
+	/**
+	 * Sets the datetime value encoded in the `datetime` attribute and text content.
+	 *
+	 * Resolution order for string and numeric inputs:
+	 * 1. `DateInterval` or `DateTimeInterface` instances are stored directly.
+	 * 2. A numeric value (int, float, or numeric string) is used as a Unix timestamp
+	 *    (fractional seconds are truncated via `(int)` cast).
+	 * 3. A non-numeric string is first tried as an ISO 8601 duration (`DateInterval`),
+	 *    then as a `DateTimeImmutable` constructor argument, then via `strtotime()`.
+	 * 4. If all parsing fails, the raw string is stored and rendered as-is.
+	 *
+	 * @param DateInterval|DateTimeInterface|float|int|string $value the datetime value
+	 * @throws TInvalidDataTypeException when `$value` is none of the accepted types
+	 */
+	public function setDateTime($value)
+	{
+		if ($value instanceof DateInterval || $value instanceof DateTimeInterface) {
+			$this->setViewState('DateTime', $value);
+			return;
+		}
+
+		$isNumeric = is_numeric($value);
+
+		if (is_string($value) || $isNumeric) {
+			if (!$isNumeric) {
+				try {
+					$this->setViewState('DateTime', new DateInterval($value));
+					return;
+				} catch (\Exception $e) {
+				}
+
+				try {
+					$this->setViewState('DateTime', new DateTimeImmutable($value));
+					return;
+				} catch (\Exception $e) {
+				}
+
+				$timestamp = @strtotime($value);
+			} else {
+				$timestamp = (float) $value;
+			}
+
+			if ($timestamp !== false) {
+				$this->setViewState('DateTime', (new DateTimeImmutable())->setTimestamp((int) $timestamp));
+				return;
+			}
+
+			$this->setViewState('DateTime', $value);
+			return;
+		}
+		throw new TInvalidDataTypeException('time_invalid_datetime', get_debug_type($value));
+	}
+
+	/**
+	 * Returns the format used for the `datetime` HTML attribute.
+	 * @return string a {@see TTimeFormat} constant value; default is `HtmlDateTime`
+	 */
+	public function getDateTimeFormat()
+	{
+		return $this->getViewState('DateTimeFormat', TTimeFormat::HtmlDateTime);
+	}
+
+	/**
+	 * Sets the format used for the `datetime` HTML attribute.
+	 * @param string $value a {@see TTimeFormat} constant value
+	 */
+	public function setDateTimeFormat($value)
+	{
+		$this->setViewState('DateTimeFormat', TPropertyValue::ensureEnum($value, TTimeFormat::class), TTimeFormat::HtmlDateTime);
+	}
+
+	/**
+	 * Returns the text content format, or `null` when not set.
+	 * @return ?string a {@see TTimeFormat} constant name, an ICU datetime pattern, or `null`
+	 */
+	public function getTextFormat(): ?string
+	{
+		return $this->getViewState('TextFormat', null);
+	}
+
+	/**
+	 * Sets the format for the visible text content of the `<time>` element.
+	 *
+	 * Accepts a {@see TTimeFormat} constant name (e.g. `"Date"`, `"HtmlDateTime"`) or any
+	 * ICU datetime pattern containing at least one recognized format letter (e.g. `"MMMM d,
+	 * yyyy"`, `"HH:mm"`). See {@see isIcuPattern} for the letter set. When set, `TextFormat`
+	 * takes priority over child controls and `DateTimeTextFormat`.
+	 *
+	 * Pass `null` or `''` to clear the property and restore default resolution.
+	 *
+	 * @param ?string $value a {@see TTimeFormat} constant name, an ICU datetime pattern, or `null`
+	 * @throws TInvalidDataValueException when `$value` is neither a `TTimeFormat` name nor an ICU pattern
+	 */
+	public function setTextFormat(?string $value)
+	{
+		if ($value === null || $value === '') {
+			$this->setViewState('TextFormat', null, null);
+			return;
+		}
+		try {
+			TPropertyValue::ensureEnum($value, TTimeFormat::class);
+		} catch (\Exception $e) {
+			if (!static::isIcuPattern($value)) {
+				throw new TInvalidDataValueException('time_invalid_text_format', $value);
+			}
+		}
+		$this->setViewState('TextFormat', $value, null);
+	}
+
+	/**
+	 * Adds the `datetime` attribute to the renderer when a DateTime value is set.
+	 * @param THtmlWriter $writer the writer used for the rendering purpose
+	 */
+	protected function addAttributesToRender($writer)
+	{
+		parent::addAttributesToRender($writer);
+		if (($dateTime = $this->getDateTime()) !== '') {
+			$writer->addAttribute('datetime', $this->formatValue($dateTime));
+		}
+	}
+
+	/**
+	 * Renders the text content of the `<time>` element.
+	 *
+	 * When `TextFormat` is set and a `DateTime` is available, the text content is
+	 * produced by {@see formatTextValue} with `TextFormat` as the format; children and
+	 * `DateTimeTextFormat` are ignored.
+	 *
+	 * Otherwise, when children are present and a `DateTime` is available, the children
+	 * are buffered and their rendered text is resolved in order:
+	 * 1. A valid {@see TTimeFormat} constant name (case-insensitive) → formatted via
+	 *    {@see formatTextValue} with that format.
+	 * 2. A plain-text string (no `<` character) containing at least one ICU format letter
+	 *    (see {@see isIcuPattern}) with a `DateTimeInterface` value → formatted via
+	 *    {@see getIntlDateFormatter}; falls back to the children's content as-is when
+	 *    the pattern is invalid or `IntlDateFormatter` produces no output.
+	 * 3. Any other string with a `DateInterval` or raw string value → written as-is.
+	 *
+	 * When no children are present, the `DateTime` value is formatted via
+	 * {@see formatTextValue} using the `DateTimeFormat` value as the text format.
+	 *
+	 * @param THtmlWriter $writer the writer used for the rendering purpose
+	 */
+	public function renderContents($writer)
+	{
+		$dateTime = $this->getDateTime();
+		if ($dateTime !== '' && ($textFormat = $this->getTextFormat()) !== null) {
+			$writer->write($this->formatTextValue($dateTime, $textFormat));
+			return;
+		}
+
+		if ($this->getControls()->getCount() > 0) {
+			$dateTime = $this->getDateTime();
+			if ($dateTime !== '') {
+				$bufWriter = new THtmlWriter();
+				parent::renderContents($bufWriter);
+				$childContent = trim($bufWriter->flush());
+				try {
+					$format = TPropertyValue::ensureEnum($childContent, TTimeFormat::class);
+					$writer->write($this->formatTextValue($dateTime, $format));
+				} catch (\Exception $e) {
+					$formatted = null;
+					if ($dateTime instanceof DateTimeInterface
+						&& strpos($childContent, '<') === false
+						&& static::isIcuPattern($childContent)
+					) {
+						$formatter = $this->getIntlDateFormatter(
+							$this->getCulture(),
+							IntlDateFormatter::NONE,
+							IntlDateFormatter::NONE,
+							$childContent
+						);
+						if ($formatter !== null) {
+							$result = $formatter->format($dateTime);
+							if ($result !== false) {
+								$formatted = (string) $result;
+							}
+						}
+					}
+					$writer->write($formatted ?? $childContent);
+				}
+				return;
+			}
+			parent::renderContents($writer);
+		} else {
+			if (($dateTime = $this->getDateTime()) !== '') {
+				$writer->write($this->formatTextValue($dateTime, $this->getDateTimeFormat()));
+			}
+		}
+	}
+
+	/**
+	 * Dispatches to {@see formatInterval}, {@see formatDateTime}, or string cast
+	 * depending on the type of `$value`.
+	 * @param DateInterval|DateTimeInterface|string $value the stored datetime value
+	 * @return string machine-readable representation for the `datetime` attribute
+	 */
+	protected function formatValue($value): string
+	{
+		if ($value instanceof \DateInterval) {
+			return $this->formatInterval($value);
+		}
+
+		if ($value instanceof \DateTimeInterface) {
+			return $this->formatDateTime($value);
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Formats a `DateInterval` as a valid HTML5 duration string for the `datetime` attribute.
+	 *
+	 * Fractional seconds stored in `DateInterval::$f` (range `0.0 ≤ f < 1.0`) are
+	 * rendered as a fractional-seconds suffix (e.g. `PT1.500S`); when the fractional
+	 * value rounds to 0 ms the suffix is omitted. `DateInterval::$invert` is not
+	 * inspected; the HTML5 duration syntax has no negative form so the output is always
+	 * a positive duration string.
+	 *
+	 * @param DateInterval $i the interval to format
+	 * @return string valid HTML5 duration string, e.g. `P1Y2M3DT4H5M6S` or `PT0S` for zero duration
+	 */
+	protected function formatInterval(DateInterval $i): string
+	{
+		$date = '';
+		if ($i->y) {
+			$date .= $i->y . 'Y';
+		}
+		if ($i->m) {
+			$date .= $i->m . 'M';
+		}
+		if ($i->d) {
+			$date .= $i->d . 'D';
+		}
+
+		$time = '';
+		if ($i->h) {
+			$time .= $i->h . 'H';
+		}
+		if ($i->i) {
+			$time .= $i->i . 'M';
+		}
+		if ($i->s || $i->f) {
+			$seconds = $i->s;
+			if ($i->f) {
+				// f is fractional seconds (0.0 ≤ f < 1.0); format as milliseconds suffix
+				$ms = (int) round($i->f * 1000);
+				if ($ms) {
+					$time .= $seconds . '.' . str_pad($ms, 3, '0', STR_PAD_LEFT) . 'S';
+				} else {
+					$time .= $seconds . 'S';
+				}
+			} else {
+				$time .= $seconds . 'S';
+			}
+		}
+
+		if ($time !== '') {
+			return 'P' . $date . 'T' . $time;
+		}
+		if ($date !== '') {
+			return 'P' . $date;
+		}
+		return 'PT0S';
+	}
+
+	/**
+	 * Formats a `DateTimeInterface` as a valid HTML5 datetime value for the `datetime`
+	 * attribute, using the format selected by {@see getDateTimeFormat}.
+	 *
+	 * Each {@see TTimeFormat} constant maps to one of the valid datetime value
+	 * categories defined by the WHATWG HTML specification: valid time string,
+	 * valid date string, valid month string, valid week string, valid yearless date
+	 * string, valid year string, valid local date and time string, or valid global
+	 * date and time string. Global date and time formats use PHP's `P` specifier,
+	 * which produces an ISO 8601 offset such as `+00:00` or `-05:00`. When no case
+	 * matches (unreachable in normal operation since `DateTimeFormat` is always a
+	 * valid {@see TTimeFormat} constant), falls back to `HtmlDateTimeTimezone` format.
+	 *
+	 * @param DateTimeInterface $dt the datetime to format
+	 * @return string valid HTML5 datetime value string
+	 */
+	protected function formatDateTime(DateTimeInterface $dt): string
+	{
+		switch ($this->getDateTimeFormat()) {
+			case TTimeFormat::TimeShort:
+				return $dt->format('H:i');
+			case TTimeFormat::Time:
+				return $dt->format('H:i:s');
+			case TTimeFormat::TimePrecise:
+				return $dt->format('H:i:s.v');
+
+			case TTimeFormat::Date:
+				return $dt->format('Y-m-d');
+			case TTimeFormat::Month:
+				return $dt->format('Y-m');
+			case TTimeFormat::Week:
+				return $dt->format('Y-\WW');
+			case TTimeFormat::YearlessDate:
+				return $dt->format('m-d');
+			case TTimeFormat::Year:
+				return $dt->format('Y');
+
+			case TTimeFormat::DateTimeShort:
+				return $dt->format('Y-m-d H:i');
+			case TTimeFormat::DateTime:
+				return $dt->format('Y-m-d H:i:s');
+			case TTimeFormat::DateTimePrecise:
+				return $dt->format('Y-m-d H:i:s.v');
+			case TTimeFormat::HtmlDateTimeShort:
+				return $dt->format('Y-m-d\TH:i');
+			case TTimeFormat::HtmlDateTime:
+				return $dt->format('Y-m-d\TH:i:s');
+			case TTimeFormat::HtmlDateTimePrecise:
+				return $dt->format('Y-m-d\TH:i:s.v');
+
+			case TTimeFormat::DateTimeShortTimezone:
+				return $dt->format('Y-m-d H:iP');
+			case TTimeFormat::DateTimeTimezone:
+				return $dt->format('Y-m-d H:i:sP');
+			case TTimeFormat::DateTimePreciseTimezone:
+				return $dt->format('Y-m-d H:i:s.vP');
+			case TTimeFormat::HtmlDateTimeShortTimezone:
+				return $dt->format('Y-m-d\TH:iP');
+			case TTimeFormat::HtmlDateTimeTimezone:
+				return $dt->format('Y-m-d\TH:i:sP');
+			case TTimeFormat::HtmlDateTimePreciseTimezone:
+				return $dt->format('Y-m-d\TH:i:s.vP');
+
+			default:
+				return $dt->format('Y-m-d\TH:i:sP');
+		}
+	}
+
+	/**
+	 * Dispatches to {@see formatTextInterval}, {@see formatTextDateTime}, or string
+	 * cast depending on the type of `$value`.
+	 * @param DateInterval|DateTimeInterface|string $value the stored datetime value
+	 * @param ?string $format {@see TTimeFormat} override; `null` reads from view state
+	 * @return string human-readable representation for the element's text content
+	 */
+	protected function formatTextValue($value, ?string $format = null)
+	{
+		if ($value instanceof \DateInterval) {
+			return $this->formatTextInterval($value, $format);
+		}
+
+		if ($value instanceof \DateTimeInterface) {
+			return $this->formatTextDateTime($value, $format);
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Formats a `DateInterval` as a localized human-readable duration string.
+	 *
+	 * Each non-zero component (years, months, weeks, days, hours, minutes, seconds,
+	 * milliseconds) is formatted via `CultureInfo::formatUnit` and joined with spaces.
+	 * Days are decomposed into whole weeks plus remaining days before formatting.
+	 * When `DateInterval::$invert === 1` (a negative interval produced by
+	 * `$later->diff($earlier)`), the result is prefixed with `"-"`.
+	 * A zero-duration interval returns an empty string.
+	 *
+	 * `$format` is accepted for signature consistency with {@see formatTextDateTime}
+	 * but has no effect on interval formatting.
+	 *
+	 * @param DateInterval $interval the interval to format
+	 * @param ?string $format accepted but unused
+	 * @return string space-joined localized duration components, prefixed with `"-"` for
+	 *   negative intervals, or `''` for zero duration
+	 */
+	protected function formatTextInterval(DateInterval $interval, ?string $format = null): string
+	{
+		$cultureInfo = $this->getCultureInfo();
+
+		$components = [];
+		if ($interval->y) {
+			$components[] = $cultureInfo->formatUnit($interval->y, CultureInfoUnits::TYPE_DURATION_YEAR);
+		}
+		if ($interval->m) {
+			$components[] = $cultureInfo->formatUnit($interval->m, CultureInfoUnits::TYPE_DURATION_MONTH);
+		}
+		if ($interval->d) {
+			$weeks = floor($interval->d / 7);
+			$days = $interval->d % 7;
+			if ($weeks) {
+				$components[] = $cultureInfo->formatUnit($weeks, CultureInfoUnits::TYPE_DURATION_WEEK);
+			}
+			if ($days) {
+				$components[] = $cultureInfo->formatUnit($days, CultureInfoUnits::TYPE_DURATION_DAY);
+			}
+		}
+		if ($interval->h) {
+			$components[] = $cultureInfo->formatUnit($interval->h, CultureInfoUnits::TYPE_DURATION_HOUR);
+		}
+		if ($interval->i) {
+			$components[] = $cultureInfo->formatUnit($interval->i, CultureInfoUnits::TYPE_DURATION_MINUTE);
+		}
+		if ($interval->s) {
+			$components[] = $cultureInfo->formatUnit($interval->s, CultureInfoUnits::TYPE_DURATION_SECOND);
+		}
+		if ($interval->f) {
+			// f is fractional seconds (0.0–1.0); convert to whole milliseconds for display
+			$ms = (int) round($interval->f * 1000);
+			if ($ms) {
+				$components[] = $cultureInfo->formatUnit($ms, CultureInfoUnits::TYPE_DURATION_MILLISECOND);
+			}
+		}
+
+		$result = implode(' ', $components);
+		return ($interval->invert && $result !== '') ? '-' . $result : $result;
+	}
+
+	/**
+	 * Formats a `DateTimeInterface` as a localized human-readable string using
+	 * {@see \IntlDateFormatter}.
+	 *
+	 * When `$format` is a {@see TTimeFormat} constant name (or `null`, which defaults to
+	 * `HtmlDateTime`), the mapping selects ICU date/time type constants:
+	 * - Valid time strings (`TimeShort`, `Time`, `TimePrecise`): `dateType=NONE`, `timeType=LONG`
+	 * - Valid date strings (`Date`, `Month`, `Week`, `YearlessDate`, `Year`): `dateType=LONG`,
+	 *   `timeType=NONE`. All sub-precision date formats produce a full long-form date
+	 *   (e.g. "June 15, 2024") until ICU custom patterns are introduced in a future release.
+	 * - Valid local date and time strings, short (`DateTimeShort`, `HtmlDateTimeShort`):
+	 *   `dateType=LONG`, `timeType=SHORT`
+	 * - Valid local date and time strings (`DateTime`, `DateTimePrecise`, `HtmlDateTime`,
+	 *   `HtmlDateTimePrecise`): `dateType=LONG`, `timeType=LONG`
+	 * - Valid global date and time strings: `dateType=LONG`, `timeType=FULL` (ensures
+	 *   timezone is always shown)
+	 *
+	 * When `$format` is not a `TTimeFormat` constant, it is treated as an ICU datetime
+	 * pattern (e.g. `"MMMM d, yyyy"`) and passed directly to `IntlDateFormatter`. Falls
+	 * back to the ISO datetime string `Y-m-d\TH:i:sP` when `IntlDateFormatter` is
+	 * unavailable or `format()` returns `false`.
+	 *
+	 * @todo When minimum PHP requirement is 8.4, replace the type-constant approach
+	 *   with ICU custom patterns to support sub-precision date rendering.
+	 * @param DateTimeInterface $dt the datetime to format
+	 * @param ?string $format {@see TTimeFormat} constant or an ICU datetime pattern;
+	 *   `null` defaults to `HtmlDateTime` (internal calls always pass a format)
+	 * @return string localized human-readable datetime string
+	 */
+	protected function formatTextDateTime(DateTimeInterface $dt, ?string $format = null): string
+	{
+		$dateType = IntlDateFormatter::LONG;
+		$timeType = IntlDateFormatter::LONG;
+
+		switch ($format ?? TTimeFormat::HtmlDateTime) {
+			case TTimeFormat::TimeShort:
+			case TTimeFormat::Time:
+			case TTimeFormat::TimePrecise:
+				$dateType = IntlDateFormatter::NONE;
+				break;
+
+			case TTimeFormat::Date:
+			case TTimeFormat::Month:
+			case TTimeFormat::Week:
+			case TTimeFormat::YearlessDate:
+			case TTimeFormat::Year:
+				$timeType = IntlDateFormatter::NONE;
+				break;
+
+			case TTimeFormat::DateTimeShort:
+			case TTimeFormat::HtmlDateTimeShort:
+				$timeType = IntlDateFormatter::SHORT;
+				break;
+
+			case TTimeFormat::DateTime:
+			case TTimeFormat::DateTimePrecise:
+			case TTimeFormat::HtmlDateTime:
+			case TTimeFormat::HtmlDateTimePrecise:
+				break;
+
+			case TTimeFormat::DateTimeShortTimezone:
+			case TTimeFormat::HtmlDateTimeShortTimezone:
+			case TTimeFormat::DateTimeTimezone:
+			case TTimeFormat::DateTimePreciseTimezone:
+			case TTimeFormat::HtmlDateTimeTimezone:
+			case TTimeFormat::HtmlDateTimePreciseTimezone:
+				// FULL ensures timezone is always visible regardless of locale
+				$timeType = IntlDateFormatter::FULL;
+				break;
+			default:
+				// Treat $format as an ICU datetime pattern (e.g. "MMMM d, yyyy")
+				if ($format !== null) {
+					$formatter = $this->getIntlDateFormatter(
+						$this->getCulture(),
+						IntlDateFormatter::NONE,
+						IntlDateFormatter::NONE,
+						$format
+					);
+					if ($formatter !== null && ($result = $formatter->format($dt)) !== false) {
+						return (string) $result;
+					}
+				}
+				return $dt->format('Y-m-d\TH:i:sP');
+		}
+
+		$formatter = $this->getIntlDateFormatter($this->getCulture(), $dateType, $timeType);
+
+		return ($formatter !== null) ? (string) $formatter->format($dt) : $dt->format('Y-m-d\TH:i:sP');
+	}
+}

--- a/framework/Web/UI/WebControls/TTimeFormat.php
+++ b/framework/Web/UI/WebControls/TTimeFormat.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * TTimeFormat class file
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado\Web\UI\WebControls;
+
+/**
+ * TTimeFormat enumeration.
+ *
+ * TTimeFormat selects which HTML5 `<time>` valid datetime value format {@see TTime}
+ * encodes into the `datetime` attribute and, when no child controls are present, into
+ * the element's visible text content. Every constant produces a string that satisfies
+ * one of the valid datetime value categories defined by the WHATWG HTML specification.
+ *
+ * | Constant | HTML5 category | Value |
+ * |---|---|---|
+ * | `TimeShort` | valid time string, no seconds | `HH:MM` |
+ * | `Time` | valid time string, seconds | `HH:MM:SS` |
+ * | `TimePrecise` | valid time string, milliseconds | `HH:MM:SS.fff` |
+ * | `Date` | valid date string | `YYYY-MM-DD` |
+ * | `Month` | valid month string | `YYYY-MM` |
+ * | `Week` | valid week string | `YYYY-Www` |
+ * | `YearlessDate` | valid yearless date string | `MM-DD` |
+ * | `Year` | valid year string | `YYYY` |
+ * | `DateTimeShort` | valid local date and time string, no seconds | `YYYY-MM-DD HH:MM` |
+ * | `DateTime` | valid local date and time string, seconds  | `YYYY-MM-DD HH:MM:SS` |
+ * | `DateTimePrecise` | valid local date and time string, milliseconds | `YYYY-MM-DD HH:MM:SS.fff` |
+ * | `HtmlDateTimeShort` | valid local date and time string, no seconds | `YYYY-MM-DDTHH:MM` |
+ * | `HtmlDateTime` | valid local date and time string, seconds | `YYYY-MM-DDTHH:MM:SS` |
+ * | `HtmlDateTimePrecise` | valid local date and time string, milliseconds | `YYYY-MM-DDTHH:MM:SS.fff` |
+ * | `DateTimeShortTimezone` | valid global date and time string, no seconds | `YYYY-MM-DD HH:MM±HH:MM` |
+ * | `DateTimeTimezone` | valid global date and time string, seconds | `YYYY-MM-DD HH:MM:SS±HH:MM` |
+ * | `DateTimePreciseTimezone` | valid global date and time string, milliseconds | `YYYY-MM-DD HH:MM:SS.fff±HH:MM` |
+ * | `HtmlDateTimeShortTimezone` | valid global date and time string, no seconds | `YYYY-MM-DDTHH:MM±HH:MM` |
+ * | `HtmlDateTimeTimezone` | valid global date and time string, seconds | `YYYY-MM-DDTHH:MM:SS±HH:MM` |
+ * | `HtmlDateTimePreciseTimezone` | valid global date and time string, milliseconds | `YYYY-MM-DDTHH:MM:SS.fff±HH:MM` |
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element
+ * @see https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#dates-and-times
+ * @since 4.4.0
+ */
+class TTimeFormat extends \Prado\TEnumerable
+{
+	//	--- Valid time strings ---
+
+	/** Valid time string without seconds: `HH:MM` */
+	public const TimeShort = 'TimeShort';
+
+	/** Valid time string with seconds: `HH:MM:SS` */
+	public const Time = 'Time';
+
+	/** Valid time string with fractional seconds: `HH:MM:SS.fff` */
+	public const TimePrecise = 'TimePrecise';
+
+
+	//	--- Valid date strings ---
+
+	/** Valid date string: `YYYY-MM-DD` */
+	public const Date = 'Date';
+
+	/** Valid month string: `YYYY-MM` */
+	public const Month = 'Month';
+
+	/** Valid week string: `YYYY-Www` */
+	public const Week = 'Week';
+
+	/** Valid yearless date string: `MM-DD` */
+	public const YearlessDate = 'YearlessDate';
+
+	/** Valid year string: `YYYY` */
+	public const Year = 'Year';
+
+
+	//	--- Valid local date and time strings (space-separated) ---
+
+	/** Valid local date and time string, space-separated, without seconds: `YYYY-MM-DD HH:MM` */
+	public const DateTimeShort = 'DateTimeShort';
+
+	/** Valid local date and time string, space-separated, with seconds: `YYYY-MM-DD HH:MM:SS` */
+	public const DateTime = 'DateTime';
+
+	/** Valid local date and time string, space-separated, with fractional seconds: `YYYY-MM-DD HH:MM:SS.fff` */
+	public const DateTimePrecise = 'DateTimePrecise';
+
+
+	//	--- Valid local date and time strings (T-separated) ---
+
+	/** Valid local date and time string, T-separated, without seconds: `YYYY-MM-DDTHH:MM` */
+	public const HtmlDateTimeShort = 'HtmlDateTimeShort';
+
+	/** Valid local date and time string, T-separated, with seconds: `YYYY-MM-DDTHH:MM:SS` */
+	public const HtmlDateTime = 'HtmlDateTime';
+
+	/** Valid local date and time string, T-separated, with fractional seconds: `YYYY-MM-DDTHH:MM:SS.fff` */
+	public const HtmlDateTimePrecise = 'HtmlDateTimePrecise';
+
+
+	//	--- Valid global date and time strings (space-separated) ---
+
+	/** Valid global date and time string, space-separated, without seconds: `YYYY-MM-DD HH:MM±HH:MM` */
+	public const DateTimeShortTimezone = 'DateTimeShortTimezone';
+
+	/** Valid global date and time string, space-separated, with seconds: `YYYY-MM-DD HH:MM:SS±HH:MM` */
+	public const DateTimeTimezone = 'DateTimeTimezone';
+
+	/** Valid global date and time string, space-separated, with fractional seconds: `YYYY-MM-DD HH:MM:SS.fff±HH:MM` */
+	public const DateTimePreciseTimezone = 'DateTimePreciseTimezone';
+
+
+	//	--- Valid global date and time strings (T-separated) ---
+
+	/** Valid global date and time string, T-separated, without seconds: `YYYY-MM-DDTHH:MM±HH:MM` */
+	public const HtmlDateTimeShortTimezone = 'HtmlDateTimeShortTimezone';
+
+	/** Valid global date and time string, T-separated, with seconds: `YYYY-MM-DDTHH:MM:SS±HH:MM` */
+	public const HtmlDateTimeTimezone = 'HtmlDateTimeTimezone';
+
+	/** Valid global date and time string, T-separated, with fractional seconds: `YYYY-MM-DDTHH:MM:SS.fff±HH:MM` */
+	public const HtmlDateTimePreciseTimezone = 'HtmlDateTimePreciseTimezone';
+}

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -855,6 +855,8 @@ return [
 'TTextBoxMode' => 'Prado\Web\UI\WebControls\TTextBoxMode',
 'TTextHighlighter' => 'Prado\Web\UI\WebControls\TTextHighlighter',
 'TTextProcessor' => 'Prado\Web\UI\WebControls\TTextProcessor',
+'TTime' => 'Prado\Web\UI\WebControls\TTime',
+'TTimeFormat' => 'Prado\Web\UI\WebControls\TTimeFormat',
 'TValidationCompareOperator' => 'Prado\Web\UI\WebControls\TValidationCompareOperator',
 'TValidationDataType' => 'Prado\Web\UI\WebControls\TValidationDataType',
 'TValidationSummary' => 'Prado\Web\UI\WebControls\TValidationSummary',

--- a/tests/unit/Web/UI/WebControls/TTimeFormatTest.php
+++ b/tests/unit/Web/UI/WebControls/TTimeFormatTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Prado\Web\UI\WebControls\TTimeFormat;
+use PHPUnit\Framework\TestCase;
+
+class TTimeFormatTest extends TestCase
+{
+	public function testAllConstantsExist()
+	{
+		// Time-only
+		$this->assertEquals('TimeShort', TTimeFormat::TimeShort);
+		$this->assertEquals('Time', TTimeFormat::Time);
+		$this->assertEquals('TimePrecise', TTimeFormat::TimePrecise);
+
+		// Date-only
+		$this->assertEquals('Date', TTimeFormat::Date);
+		$this->assertEquals('Month', TTimeFormat::Month);
+		$this->assertEquals('Week', TTimeFormat::Week);
+		$this->assertEquals('YearlessDate', TTimeFormat::YearlessDate);
+		$this->assertEquals('Year', TTimeFormat::Year);
+
+		// DateTime space-separated
+		$this->assertEquals('DateTimeShort', TTimeFormat::DateTimeShort);
+		$this->assertEquals('DateTime', TTimeFormat::DateTime);
+		$this->assertEquals('DateTimePrecise', TTimeFormat::DateTimePrecise);
+
+		// DateTime T-separated
+		$this->assertEquals('HtmlDateTimeShort', TTimeFormat::HtmlDateTimeShort);
+		$this->assertEquals('HtmlDateTime', TTimeFormat::HtmlDateTime);
+		$this->assertEquals('HtmlDateTimePrecise', TTimeFormat::HtmlDateTimePrecise);
+
+		// DateTime with timezone space-separated
+		$this->assertEquals('DateTimeShortTimezone', TTimeFormat::DateTimeShortTimezone);
+		$this->assertEquals('DateTimeTimezone', TTimeFormat::DateTimeTimezone);
+		$this->assertEquals('DateTimePreciseTimezone', TTimeFormat::DateTimePreciseTimezone);
+
+		// DateTime with timezone T-separated
+		$this->assertEquals('HtmlDateTimeShortTimezone', TTimeFormat::HtmlDateTimeShortTimezone);
+		$this->assertEquals('HtmlDateTimeTimezone', TTimeFormat::HtmlDateTimeTimezone);
+		$this->assertEquals('HtmlDateTimePreciseTimezone', TTimeFormat::HtmlDateTimePreciseTimezone);
+	}
+
+	public function testAllValuesUnique()
+	{
+		$values = [
+			TTimeFormat::TimeShort,
+			TTimeFormat::Time,
+			TTimeFormat::TimePrecise,
+			TTimeFormat::Date,
+			TTimeFormat::Month,
+			TTimeFormat::Week,
+			TTimeFormat::YearlessDate,
+			TTimeFormat::Year,
+			TTimeFormat::DateTimeShort,
+			TTimeFormat::DateTime,
+			TTimeFormat::DateTimePrecise,
+			TTimeFormat::HtmlDateTimeShort,
+			TTimeFormat::HtmlDateTime,
+			TTimeFormat::HtmlDateTimePrecise,
+			TTimeFormat::DateTimeShortTimezone,
+			TTimeFormat::DateTimeTimezone,
+			TTimeFormat::DateTimePreciseTimezone,
+			TTimeFormat::HtmlDateTimeShortTimezone,
+			TTimeFormat::HtmlDateTimeTimezone,
+			TTimeFormat::HtmlDateTimePreciseTimezone,
+		];
+		$this->assertCount(20, $values, 'Expected 20 TTimeFormat constants');
+		$this->assertCount(20, array_unique($values), 'All TTimeFormat values must be unique');
+	}
+
+	public function testExtendsEnumerable()
+	{
+		$this->assertTrue(is_a(TTimeFormat::class, \Prado\TEnumerable::class, true));
+	}
+
+	public function testHtmlVariantsDistinctFromSpaceVariants()
+	{
+		// Html variants must have different values from their space-separated counterparts
+		$this->assertNotEquals(TTimeFormat::HtmlDateTimeShort, TTimeFormat::DateTimeShort);
+		$this->assertNotEquals(TTimeFormat::HtmlDateTime, TTimeFormat::DateTime);
+		$this->assertNotEquals(TTimeFormat::HtmlDateTimePrecise, TTimeFormat::DateTimePrecise);
+		$this->assertNotEquals(TTimeFormat::HtmlDateTimeShortTimezone, TTimeFormat::DateTimeShortTimezone);
+		$this->assertNotEquals(TTimeFormat::HtmlDateTimeTimezone, TTimeFormat::DateTimeTimezone);
+		$this->assertNotEquals(TTimeFormat::HtmlDateTimePreciseTimezone, TTimeFormat::DateTimePreciseTimezone);
+	}
+}

--- a/tests/unit/Web/UI/WebControls/TTimeTest.php
+++ b/tests/unit/Web/UI/WebControls/TTimeTest.php
@@ -1,0 +1,1056 @@
+<?php
+
+use Prado\Web\UI\WebControls\TTime;
+use Prado\Web\UI\WebControls\TTimeFormat;
+use Prado\Web\UI\WebControls\TI18NWebControl;
+use PHPUnit\Framework\TestCase;
+
+class TTimeTest extends TestCase
+{
+	use TWebControlRenderTrait;
+
+	private function invokeMethod(object $object, string $method, array $args = []): mixed
+	{
+		$rm = new \ReflectionMethod($object, $method);
+		$rm->setAccessible(true);
+		return $rm->invokeArgs($object, $args);
+	}
+
+	// ================================================================================
+	// Class structure
+	// ================================================================================
+
+	public function testExtendsI18NWebControl()
+	{
+		$control = new TTime();
+		$this->assertInstanceOf(TI18NWebControl::class, $control);
+	}
+
+	public function testRendersTimeTag()
+	{
+		$control = new TTime();
+		$output = $this->render($control);
+		$this->assertStringContainsString('<time', $output);
+		$this->assertStringContainsString('</time>', $output);
+	}
+
+	// ================================================================================
+	// getDateTime / setDateTime
+	// ================================================================================
+
+	public function testDateTimeDefaultEmpty()
+	{
+		$control = new TTime();
+		$this->assertEquals('', $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithDateTimeImmutable()
+	{
+		$control = new TTime();
+		$dt = new \DateTimeImmutable('2024-06-15 10:30:00');
+		$control->setDateTime($dt);
+		$this->assertSame($dt, $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithDateTime()
+	{
+		$control = new TTime();
+		$dt = new \DateTime('2024-06-15 10:30:00');
+		$control->setDateTime($dt);
+		$this->assertSame($dt, $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithDateInterval()
+	{
+		$control = new TTime();
+		$interval = new \DateInterval('P1Y2M3D');
+		$control->setDateTime($interval);
+		$this->assertSame($interval, $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithISODurationString()
+	{
+		$control = new TTime();
+		$control->setDateTime('P1Y2M3D');
+		$this->assertInstanceOf(\DateInterval::class, $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithISODurationTimeOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime('PT1H30M');
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateInterval::class, $stored);
+		$this->assertSame(1, $stored->h);
+		$this->assertSame(30, $stored->i);
+	}
+
+	public function testSetDateTimeWithISODurationZero()
+	{
+		$control = new TTime();
+		$control->setDateTime('PT0S');
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateInterval::class, $stored);
+		$this->assertSame(0, $stored->s);
+		$this->assertSame(0, $stored->y);
+	}
+
+	public function testSetDateTimeWithDateString()
+	{
+		$control = new TTime();
+		$control->setDateTime('2024-06-15');
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame('2024-06-15', $stored->format('Y-m-d'));
+	}
+
+	public function testSetDateTimeWithDateTimeString()
+	{
+		$control = new TTime();
+		$control->setDateTime('2024-06-15T10:30:45');
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame('2024-06-15', $stored->format('Y-m-d'));
+		$this->assertSame('10:30:45', $stored->format('H:i:s'));
+	}
+
+	public function testSetDateTimeWithUnixTimestampInt()
+	{
+		$control = new TTime();
+		$control->setDateTime(1718438400);
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame(1718438400, $stored->getTimestamp());
+	}
+
+	public function testSetDateTimeWithZeroTimestamp()
+	{
+		$control = new TTime();
+		$control->setDateTime(0);
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame(0, $stored->getTimestamp());
+	}
+
+	public function testSetDateTimeWithNegativeTimestamp()
+	{
+		$control = new TTime();
+		$control->setDateTime(-86400);
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame(-86400, $stored->getTimestamp());
+	}
+
+	public function testSetDateTimeWithNumericFloat()
+	{
+		$control = new TTime();
+		$control->setDateTime(1718438400.0);
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame(1718438400, $stored->getTimestamp());
+	}
+
+	public function testSetDateTimeWithNumericStringInt()
+	{
+		$control = new TTime();
+		$control->setDateTime('1718438400');
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+	}
+
+	public function testSetDateTimeWithNumericStringFloat()
+	{
+		// Fractional timestamps are truncated to int (setTimestamp takes int)
+		$control = new TTime();
+		$control->setDateTime('1718438400.9');
+		$stored = $control->getDateTime();
+		$this->assertInstanceOf(\DateTimeImmutable::class, $stored);
+		$this->assertSame(1718438400, $stored->getTimestamp());
+	}
+
+	public function testSetDateTimeWithStrtotimeString()
+	{
+		$control = new TTime();
+		$control->setDateTime('next Monday');
+		$this->assertInstanceOf(\DateTimeImmutable::class, $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithEmptyStringStoresDateTimeImmutable()
+	{
+		// '' is not a duration, but new DateTimeImmutable('') succeeds (returns "now")
+		$control = new TTime();
+		$control->setDateTime('');
+		$this->assertInstanceOf(\DateTimeImmutable::class, $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithRawStringFallback()
+	{
+		$control = new TTime();
+		$control->setDateTime('not-a-real-date-at-all-xyz');
+		$this->assertSame('not-a-real-date-at-all-xyz', $control->getDateTime());
+	}
+
+	public function testSetDateTimeWithNullThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataTypeException::class);
+		(new TTime())->setDateTime(null);
+	}
+
+	public function testSetDateTimeWithFalseThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataTypeException::class);
+		(new TTime())->setDateTime(false);
+	}
+
+	public function testSetDateTimeWithTrueThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataTypeException::class);
+		(new TTime())->setDateTime(true);
+	}
+
+	public function testSetDateTimeWithArrayThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataTypeException::class);
+		(new TTime())->setDateTime([]);
+	}
+
+	public function testSetDateTimeWithObjectThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataTypeException::class);
+		(new TTime())->setDateTime(new \stdClass());
+	}
+
+	// ================================================================================
+	// DateTimeFormat
+	// ================================================================================
+
+	public function testDateTimeFormatDefault()
+	{
+		$control = new TTime();
+		$this->assertSame(TTimeFormat::HtmlDateTime, $control->getDateTimeFormat());
+	}
+
+	public function testSetDateTimeFormat()
+	{
+		$control = new TTime();
+		$control->setDateTimeFormat(TTimeFormat::Date);
+		$this->assertSame(TTimeFormat::Date, $control->getDateTimeFormat());
+	}
+
+	public function testSetDateTimeFormatInvalidThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		(new TTime())->setDateTimeFormat('NotAFormat');
+	}
+
+	public function testSetDateTimeFormatAllValues()
+	{
+		$control = new TTime();
+		foreach (self::allFormats() as $fmt) {
+			$control->setDateTimeFormat($fmt);
+			$this->assertSame($fmt, $control->getDateTimeFormat());
+		}
+	}
+
+	// ================================================================================
+	// DateTimeTextFormat
+	// ================================================================================
+
+	public function testDateTimeFormatAndTextFormatAreIndependent()
+	{
+		$control = new TTime();
+		$control->setDateTimeFormat(TTimeFormat::Date);
+		$control->setTextFormat(TTimeFormat::Month);
+		$this->assertSame(TTimeFormat::Date, $control->getDateTimeFormat());
+		$this->assertSame(TTimeFormat::Month, $control->getTextFormat());
+	}
+
+	// ================================================================================
+	// TextFormat
+	// ================================================================================
+
+	public function testTextFormatDefaultNull()
+	{
+		$this->assertNull((new TTime())->getTextFormat());
+	}
+
+	public function testSetTextFormatWithTTimeFormatName()
+	{
+		$control = new TTime();
+		$control->setTextFormat(TTimeFormat::Date);
+		$this->assertSame(TTimeFormat::Date, $control->getTextFormat());
+	}
+
+	public function testSetTextFormatWithIcuPattern()
+	{
+		$control = new TTime();
+		$control->setTextFormat('MMMM d, yyyy');
+		$this->assertSame('MMMM d, yyyy', $control->getTextFormat());
+	}
+
+	public function testSetTextFormatNullClearsProperty()
+	{
+		$control = new TTime();
+		$control->setTextFormat(TTimeFormat::Date);
+		$control->setTextFormat(null);
+		$this->assertNull($control->getTextFormat());
+	}
+
+	public function testSetTextFormatEmptyStringClearsProperty()
+	{
+		$control = new TTime();
+		$control->setTextFormat(TTimeFormat::Date);
+		$control->setTextFormat('');
+		$this->assertNull($control->getTextFormat());
+	}
+
+	public function testSetTextFormatInvalidThrows()
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		(new TTime())->setTextFormat('20240615');
+	}
+
+	public function testTextFormatTTimeFormatNameRendersFormattedDate()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+		$control->setTextFormat(TTimeFormat::Date);
+		$output = $this->renderContents($control);
+		$this->assertStringContainsString('2024', $output);
+		$this->assertStringContainsString('June', $output);
+	}
+
+	public function testTextFormatIcuPatternRendersFormattedDate()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+		$control->setTextFormat('yyyy-MM-dd');
+		$this->assertSame('2024-06-15', $this->renderContents($control));
+	}
+
+	public function testTextFormatTakesPriorityOverChildren()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+		$control->setTextFormat('yyyy');
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('should be ignored');
+		$control->getControls()->add($literal);
+
+		$this->assertSame('2024', $this->renderContents($control));
+	}
+
+	public function testTextFormatWithIntervalRendersLocalizedDuration()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y'));
+		$control->setTextFormat(TTimeFormat::Date);
+		$output = $this->renderContents($control);
+		// DateInterval + TTimeFormat → formatTextInterval (format arg unused), produces localized duration
+		$this->assertStringContainsString('year', $output);
+	}
+
+	public function testTextFormatNotRenderedWhenNoDateTime()
+	{
+		$control = new TTime();
+		$control->setTextFormat('yyyy');
+		$this->assertSame('', $this->renderContents($control));
+	}
+
+	// ================================================================================
+	// formatDateTime — datetime= attribute, all formats
+	// ================================================================================
+
+	/**
+	 * @dataProvider formatDateTimeProvider
+	 */
+	public function testFormatDateTimeAttribute(string $format, string $expected)
+	{
+		$control = new TTime();
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45.123', new \DateTimeZone('UTC'));
+		$control->setDateTime($dt);
+		$control->setDateTimeFormat($format);
+
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="' . $expected . '"', $output);
+	}
+
+	public static function formatDateTimeProvider(): array
+	{
+		return [
+			'TimeShort'                   => [TTimeFormat::TimeShort,                   '10:30'],
+			'Time'                        => [TTimeFormat::Time,                        '10:30:45'],
+			'TimePrecise'                 => [TTimeFormat::TimePrecise,                 '10:30:45.123'],
+			'Date'                        => [TTimeFormat::Date,                        '2024-06-15'],
+			'Month'                       => [TTimeFormat::Month,                       '2024-06'],
+			'Week'                        => [TTimeFormat::Week,                        '2024-W24'],
+			'YearlessDate'                => [TTimeFormat::YearlessDate,                '06-15'],
+			'Year'                        => [TTimeFormat::Year,                        '2024'],
+			'DateTimeShort'               => [TTimeFormat::DateTimeShort,               '2024-06-15 10:30'],
+			'DateTime'                    => [TTimeFormat::DateTime,                    '2024-06-15 10:30:45'],
+			'DateTimePrecise'             => [TTimeFormat::DateTimePrecise,             '2024-06-15 10:30:45.123'],
+			'HtmlDateTimeShort'           => [TTimeFormat::HtmlDateTimeShort,           '2024-06-15T10:30'],
+			'HtmlDateTime'                => [TTimeFormat::HtmlDateTime,                '2024-06-15T10:30:45'],
+			'HtmlDateTimePrecise'         => [TTimeFormat::HtmlDateTimePrecise,         '2024-06-15T10:30:45.123'],
+			'DateTimeShortTimezone'       => [TTimeFormat::DateTimeShortTimezone,       '2024-06-15 10:30+00:00'],
+			'DateTimeTimezone'            => [TTimeFormat::DateTimeTimezone,            '2024-06-15 10:30:45+00:00'],
+			'DateTimePreciseTimezone'     => [TTimeFormat::DateTimePreciseTimezone,     '2024-06-15 10:30:45.123+00:00'],
+			'HtmlDateTimeShortTimezone'   => [TTimeFormat::HtmlDateTimeShortTimezone,   '2024-06-15T10:30+00:00'],
+			'HtmlDateTimeTimezone'        => [TTimeFormat::HtmlDateTimeTimezone,        '2024-06-15T10:30:45+00:00'],
+			'HtmlDateTimePreciseTimezone' => [TTimeFormat::HtmlDateTimePreciseTimezone, '2024-06-15T10:30:45.123+00:00'],
+		];
+	}
+
+	// ================================================================================
+	// formatInterval — datetime= attribute, all edge cases
+	// ================================================================================
+
+	public function testFormatIntervalFullComponents()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y2M3DT4H5M6S'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="P1Y2M3DT4H5M6S"', $output);
+	}
+
+	public function testFormatIntervalDateOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P5D'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="P5D"', $output);
+	}
+
+	public function testFormatIntervalTimeOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('PT2H30M'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="PT2H30M"', $output);
+	}
+
+	public function testFormatIntervalYearOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P3Y'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="P3Y"', $output);
+	}
+
+	public function testFormatIntervalSecondsOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('PT45S'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="PT45S"', $output);
+	}
+
+	public function testFormatIntervalZeroDuration()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('PT0S'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="PT0S"', $output);
+	}
+
+	public function testFormatIntervalFractionalSeconds()
+	{
+		// Build an interval with f (fractional seconds) via date_diff
+		$dt1 = new \DateTimeImmutable('2024-01-01T00:00:00.000', new \DateTimeZone('UTC'));
+		$dt2 = new \DateTimeImmutable('2024-01-01T00:00:01.500', new \DateTimeZone('UTC'));
+		$interval = $dt1->diff($dt2);
+
+		$control = new TTime();
+		$control->setDateTime($interval);
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="PT1.500S"', $output);
+	}
+
+	public function testFormatIntervalFractionalSecondsNoWholeSeconds()
+	{
+		// f > 0, s == 0
+		$dt1 = new \DateTimeImmutable('2024-01-01T00:00:00.000', new \DateTimeZone('UTC'));
+		$dt2 = new \DateTimeImmutable('2024-01-01T00:00:00.750', new \DateTimeZone('UTC'));
+		$interval = $dt1->diff($dt2);
+
+		$control = new TTime();
+		$control->setDateTime($interval);
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="PT0.750S"', $output);
+	}
+
+	public function testFormatIntervalAllDateComponents()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P2Y11M28D'));
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="P2Y11M28D"', $output);
+	}
+
+	public function testFormatIntervalFractionalSecondsRoundsToZeroOmitsSuffix()
+	{
+		// f rounds to 0 ms (0.0001 * 1000 = 0.1 → 0) — suffix must be omitted, not emitted as 0.000S
+		$interval = new \DateInterval('PT5S');
+		$interval->f = 0.0001;
+
+		$control = new TTime();
+		$control->setDateTime($interval);
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="PT5S"', $output);
+		$this->assertStringNotContainsString('0.000', $output);
+	}
+
+	// ================================================================================
+	// addAttributesToRender
+	// ================================================================================
+
+	public function testDatetimeAttributeNotRenderedWhenEmpty()
+	{
+		$control = new TTime();
+		$output = $this->render($control);
+		$this->assertStringNotContainsString('datetime=', $output);
+	}
+
+	public function testDatetimeAttributeRenderedWhenSet()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-01-01T00:00:00Z', new \DateTimeZone('UTC')));
+		$this->assertStringContainsString('datetime=', $this->render($control));
+	}
+
+	public function testRawStringValueRenderedAsDatetimeAttribute()
+	{
+		$control = new TTime();
+		$control->setDateTime('not-a-real-date-at-all-xyz');
+		$this->assertStringContainsString('datetime="not-a-real-date-at-all-xyz"', $this->render($control));
+	}
+
+	// ================================================================================
+	// renderContents — no children
+	// ================================================================================
+
+	public function testRenderContentsEmptyWhenNoDateTimeAndNoChildren()
+	{
+		$control = new TTime();
+		$output = $this->render($control);
+		$this->assertStringContainsString('<time>', $output);
+		$this->assertStringContainsString('</time>', $output);
+		$this->assertStringNotContainsString('datetime=', $output);
+	}
+
+	public function testRenderContentsDateTimeProducesTextContent()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T10:30:45Z', new \DateTimeZone('UTC')));
+		$this->assertMatchesRegularExpression('/<time[^>]*>(.+)<\/time>/s', $this->render($control));
+	}
+
+	public function testRenderContentsIntervalProducesTextContent()
+	{
+		$control = new TTime();
+		$control->setDateTime('P1Y');
+		$this->assertMatchesRegularExpression('/<time[^>]*>(.+)<\/time>/s', $this->render($control));
+	}
+
+	public function testNoChildrenTextUsesDateTimeFormat()
+	{
+		// Without TextFormat or children, visible text mirrors DateTimeFormat
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T10:30:45Z', new \DateTimeZone('UTC')));
+		$control->setDateTimeFormat(TTimeFormat::Date);
+		$output = $this->renderContents($control);
+		// Date format → localized date (contains year, no time component)
+		$this->assertStringContainsString('2024', $output);
+		$this->assertStringNotContainsString('10:30', $output);
+	}
+
+	public function testRenderContentsRawStringProducesNoTextContent()
+	{
+		// Raw string fallback: formatTextValue returns (string) value — raw string as-is
+		$control = new TTime();
+		$control->setDateTime('not-a-real-date-at-all-xyz');
+		$output = $this->renderContents($control);
+		$this->assertSame('not-a-real-date-at-all-xyz', $output);
+	}
+
+	// ================================================================================
+	// formatTextDateTime — visible text, all format groups
+	// ================================================================================
+
+	public function testFormatTextDateTimeTimeOnlyFormatsExcludeDate()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		foreach ([TTimeFormat::TimeShort, TTimeFormat::Time, TTimeFormat::TimePrecise] as $fmt) {
+			$control = new TTime();
+			$control->setDateTime($dt);
+			$control->setTextFormat($fmt);
+			$output = $this->renderContents($control);
+			$this->assertNotEmpty($output, "format $fmt produced empty output");
+			$this->assertStringNotContainsString('2024', $output, "format $fmt should not include year");
+		}
+	}
+
+	public function testFormatTextDateTimeDateOnlyFormatsExcludeTime()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		foreach ([TTimeFormat::Date, TTimeFormat::Month, TTimeFormat::Week, TTimeFormat::Year] as $fmt) {
+			$control = new TTime();
+			$control->setDateTime($dt);
+			$control->setTextFormat($fmt);
+			$output = $this->renderContents($control);
+			$this->assertNotEmpty($output, "format $fmt produced empty output");
+			$this->assertStringNotContainsString(':30', $output, "format $fmt should not include minutes");
+		}
+	}
+
+	public function testFormatTextDateTimeYearlessDateExcludesTimeAndYear()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		$control = new TTime();
+		$control->setDateTime($dt);
+		$control->setTextFormat(TTimeFormat::YearlessDate);
+		$output = $this->renderContents($control);
+		$this->assertNotEmpty($output);
+		$this->assertStringNotContainsString(':30', $output);
+	}
+
+	public function testFormatTextDateTimeDateTimeShortFormatsContainDateAndTime()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		foreach ([TTimeFormat::DateTimeShort, TTimeFormat::HtmlDateTimeShort] as $fmt) {
+			$control = new TTime();
+			$control->setDateTime($dt);
+			$control->setTextFormat($fmt);
+			$output = $this->renderContents($control);
+			$this->assertNotEmpty($output, "format $fmt produced empty output");
+			$this->assertStringContainsString('2024', $output, "format $fmt should include year");
+		}
+	}
+
+	public function testFormatTextDateTimeDateTimeFormatsContainBothDateAndTime()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		foreach ([TTimeFormat::DateTime, TTimeFormat::DateTimePrecise, TTimeFormat::HtmlDateTime, TTimeFormat::HtmlDateTimePrecise] as $fmt) {
+			$control = new TTime();
+			$control->setDateTime($dt);
+			$control->setTextFormat($fmt);
+			$output = $this->renderContents($control);
+			$this->assertNotEmpty($output, "format $fmt produced empty output");
+			$this->assertStringContainsString('2024', $output, "format $fmt should include year");
+		}
+	}
+
+	public function testFormatTextDateTimeTimezoneFormatsProduceNonEmpty()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		$tzFormats = [
+			TTimeFormat::DateTimeShortTimezone,
+			TTimeFormat::HtmlDateTimeShortTimezone,
+			TTimeFormat::DateTimeTimezone,
+			TTimeFormat::DateTimePreciseTimezone,
+			TTimeFormat::HtmlDateTimeTimezone,
+			TTimeFormat::HtmlDateTimePreciseTimezone,
+		];
+		foreach ($tzFormats as $fmt) {
+			$control = new TTime();
+			$control->setDateTime($dt);
+			$control->setTextFormat($fmt);
+			$output = $this->renderContents($control);
+			$this->assertNotEmpty($output, "format $fmt produced empty output");
+			$this->assertStringContainsString('2024', $output, "format $fmt should include year");
+			$this->assertMatchesRegularExpression(
+				'/UTC|Coordinated Universal Time|\+00:00/',
+				$output,
+				"format $fmt should include timezone information"
+			);
+		}
+	}
+
+	public function testFormatTextDateTimeWithIcuPattern()
+	{
+		// $format that is not a TTimeFormat constant → treated as ICU pattern in formatTextDateTime directly
+		$control = new TTime();
+		$dt = new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC'));
+		$control->setDateTime($dt);
+		$output = $this->invokeMethod($control, 'formatTextDateTime', [$dt, 'yyyy']);
+		$this->assertSame('2024', $output);
+	}
+
+	public function testFormatTextDateTimeWithIcuPatternFallbackOnFailure()
+	{
+		// When IntlDateFormatter::format() returns false the ISO fallback is used
+		$control = new TTime();
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45+00:00');
+		$control->setDateTime($dt);
+		// null $format resolves to getDateTimeTextFormat() (HtmlDateTime) → not the default branch
+		// Pass a known non-TTimeFormat, non-ICU string: digits only pass isIcuPattern=false in
+		// renderContents, but formatTextDateTime itself has no isIcuPattern guard — it calls ICU
+		// regardless. An empty pattern string causes IntlDateFormatter to use locale default.
+		// This test exercises the non-null $format → default branch with a real (succeeding) pattern.
+		$output = $this->invokeMethod($control, 'formatTextDateTime', [$dt, 'MMMM d, yyyy']);
+		$this->assertStringContainsString('2024', $output);
+		$this->assertStringContainsString('June', $output);
+	}
+
+	// ================================================================================
+	// formatTextInterval — visible text, all edge cases
+	// ================================================================================
+
+	public function testFormatTextIntervalFullComponentsIsNonEmpty()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y2M3DT4H5M6S'));
+		$this->assertNotEmpty($this->renderContents($control));
+	}
+
+	public function testFormatTextIntervalYearOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y'));
+		$output = $this->renderContents($control);
+		$this->assertNotEmpty($output);
+	}
+
+	public function testFormatTextIntervalSecondsOnly()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('PT45S'));
+		$output = $this->renderContents($control);
+		$this->assertNotEmpty($output);
+	}
+
+	public function testFormatTextIntervalDaysConvertedToWeeksAndRemainder()
+	{
+		// 14 days → 2 weeks exactly (no remainder days)
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P14D'));
+		$output = $this->renderContents($control);
+		$this->assertNotEmpty($output);
+		// 6 days → no weeks, just 6 days
+		$control2 = new TTime();
+		$control2->setDateTime(new \DateInterval('P6D'));
+		$this->assertNotEmpty($this->renderContents($control2));
+	}
+
+	public function testFormatTextIntervalFractionalSeconds()
+	{
+		$dt1 = new \DateTimeImmutable('2024-01-01T00:00:00.000', new \DateTimeZone('UTC'));
+		$dt2 = new \DateTimeImmutable('2024-01-01T00:00:00.750', new \DateTimeZone('UTC'));
+		$control = new TTime();
+		$control->setDateTime($dt1->diff($dt2));
+		$output = $this->renderContents($control);
+		$this->assertNotEmpty($output);
+	}
+
+	public function testFormatTextIntervalZeroDurationIsEmpty()
+	{
+		// All zero components → formatTextInterval returns ''
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('PT0S'));
+		$this->assertSame('', $this->renderContents($control));
+	}
+
+	public function testFormatTextIntervalNegativeIntervalPrefixesMinus()
+	{
+		$later  = new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC'));
+		$earlier = new \DateTimeImmutable('2023-06-15T00:00:00Z', new \DateTimeZone('UTC'));
+		$interval = $later->diff($earlier); // invert === 1 (negative: earlier minus later)
+
+		$control = new TTime();
+		$control->setDateTime($interval);
+		$output = $this->renderContents($control);
+		$this->assertStringStartsWith('-', $output);
+		$this->assertStringContainsString('year', $output);
+	}
+
+	public function testFormatTextIntervalNegativeZeroDurationIsEmpty()
+	{
+		$interval = new \DateInterval('PT0S');
+		$interval->invert = 1;
+
+		$control = new TTime();
+		$control->setDateTime($interval);
+		$this->assertSame('', $this->renderContents($control));
+	}
+
+	public function testFormatIntervalNegativeIntervalRendersPositive()
+	{
+		// datetime attribute has no negative duration form — always positive
+		$later   = new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC'));
+		$earlier = new \DateTimeImmutable('2023-06-15T00:00:00Z', new \DateTimeZone('UTC'));
+		$interval = $later->diff($earlier);
+
+		$control = new TTime();
+		$control->setDateTime($interval);
+		$output = $this->render($control);
+		$this->assertStringContainsString('datetime="P1Y"', $output);
+	}
+
+	// ================================================================================
+	// renderContents — children
+	// ================================================================================
+
+	public function testRenderContentsRendersChildrenWhenPresent()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T10:30:45Z', new \DateTimeZone('UTC')));
+		$inner = new \Prado\Web\UI\WebControls\THeader2();
+		$inner->setId('inner');
+		$control->getControls()->add($inner);
+
+		$output = $this->render($control);
+		$this->assertStringContainsString('<h2', $output);
+		$this->assertStringContainsString('datetime=', $output);
+	}
+
+	// ================================================================================
+	// Format inference from children
+	// ================================================================================
+
+	public function testChildrenWithFormatNameRendersFormattedDateTime()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText(TTimeFormat::Date);
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		$this->assertNotSame(TTimeFormat::Date, $output);
+		$this->assertStringContainsString('2024', $output);
+	}
+
+	public function testChildrenWithFormatNameCaseInsensitive()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('date');
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		$this->assertNotSame('date', $output);
+		$this->assertStringContainsString('2024', $output);
+	}
+
+	public function testChildrenFormatInferenceAllFormats()
+	{
+		$dt = new \DateTimeImmutable('2024-06-15T10:30:45', new \DateTimeZone('UTC'));
+		foreach (self::allFormats() as $fmt) {
+			$control = new TTime();
+			$control->setDateTime($dt);
+
+			$literal = new \Prado\Web\UI\WebControls\TLiteral();
+			$literal->setText($fmt);
+			$control->getControls()->add($literal);
+
+			$output = $this->renderContents($control);
+			$this->assertNotSame($fmt, $output, "format $fmt should trigger datetime formatting, not literal passthrough");
+		}
+	}
+
+	public static function isIcuPatternProvider(): array
+	{
+		return [
+			'year pattern'              => ['yyyy', true],
+			'full datetime pattern'     => ['MMMM d, yyyy', true],
+			'time pattern'              => ['HH:mm:ss', true],
+			'quoted literal only'       => ["'hello'", false],
+			'quoted with letter after'  => ["'hello' yyyy", true],
+			'digits only'               => ['20240615', false],
+			'punctuation only'          => ['--::', false],
+			'empty string'              => ['', false],
+			'escaped quote in literal'  => ["'it''s' d MMMM", true],
+		];
+	}
+
+	/**
+	 * @dataProvider isIcuPatternProvider
+	 */
+	public function testIsIcuPattern(string $input, bool $expected)
+	{
+		$this->assertSame($expected, TTime::isIcuPattern($input));
+	}
+
+	public function testChildrenWithNoIcuLettersRenderedAsIs()
+	{
+		// String with no ICU format letters → never attempted as ICU pattern, written as-is
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('20240615');
+		$control->getControls()->add($literal);
+
+		$this->assertSame('20240615', $this->renderContents($control));
+	}
+
+	public function testChildrenWithNonFormatTextAndIntervalRenderedAsIs()
+	{
+		// DateInterval + non-TTimeFormat string → written as-is (ICU patterns cannot apply to intervals)
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y'));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('15 June 2024');
+		$control->getControls()->add($literal);
+
+		$this->assertSame('15 June 2024', $this->renderContents($control));
+	}
+
+	public function testChildrenWithIcuPatternRendersFormattedDateTime()
+	{
+		// Non-TTimeFormat string + DateTimeInterface → treated as ICU pattern
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('MMMM d, yyyy');
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		$this->assertNotSame('MMMM d, yyyy', $output);
+		$this->assertStringContainsString('2024', $output);
+	}
+
+	public function testChildrenWithRawStringDateTimeAndNonEnumChildRendersChildAsIs()
+	{
+		// Raw string datetime (not DateTimeInterface) + non-TTimeFormat child → always written as-is
+		$control = new TTime();
+		$control->setDateTime('not-a-date');
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('15 June 2024');
+		$control->getControls()->add($literal);
+
+		$this->assertSame('15 June 2024', $this->renderContents($control));
+	}
+
+	public function testChildrenWithIcuPatternForIntervalRenderedAsIs()
+	{
+		// ICU pattern + DateInterval → written as-is (only DateTimeInterface supports ICU)
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y'));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('MMMM d, yyyy');
+		$control->getControls()->add($literal);
+
+		$this->assertSame('MMMM d, yyyy', $this->renderContents($control));
+	}
+
+	public function testChildrenWithIcuTimePatternRendersTime()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T14:30:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('HH:mm');
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		$this->assertStringContainsString('14:30', $output);
+	}
+
+	public function testChildrenWithIcuPatternWhitespaceTrimmed()
+	{
+		// Trim is applied before ICU pattern resolution
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('  yyyy  ');
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		$this->assertSame('2024', $output);
+	}
+
+	public function testChildrenWithTTimeFormatNameAndIntervalValueFormatsAsInterval()
+	{
+		// DateInterval + child TTimeFormat name → formatTextInterval($interval, $format);
+		// $format is accepted but unused — interval renders as localized duration string
+		$control = new TTime();
+		$control->setDateTime(new \DateInterval('P1Y'));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText(TTimeFormat::Date);
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		// Not the literal 'Date' string and not a formatted date — it is a localized duration
+		$this->assertNotSame(TTimeFormat::Date, $output);
+		$this->assertStringContainsString('year', $output);
+	}
+
+	public function testChildrenWithFormatNameButNoDateTimeRendersChildren()
+	{
+		$control = new TTime();
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText(TTimeFormat::Date);
+		$control->getControls()->add($literal);
+
+		$this->assertSame(TTimeFormat::Date, $this->renderContents($control));
+	}
+
+	public function testHtmlChildrenNotTreatedAsFormatName()
+	{
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$inner = new \Prado\Web\UI\WebControls\THeader2();
+		$inner->setId('inner');
+		$control->getControls()->add($inner);
+
+		$this->assertStringContainsString('<h2', $this->renderContents($control));
+	}
+
+	public function testChildrenWithWhitespace()
+	{
+		// Inference trims the buffered output before testing it as a format name
+		$control = new TTime();
+		$control->setDateTime(new \DateTimeImmutable('2024-06-15T00:00:00Z', new \DateTimeZone('UTC')));
+
+		$literal = new \Prado\Web\UI\WebControls\TLiteral();
+		$literal->setText('  ' . TTimeFormat::Year . '  ');
+		$control->getControls()->add($literal);
+
+		$output = $this->renderContents($control);
+		$this->assertNotSame(TTimeFormat::Year, $output);
+		$this->assertStringContainsString('2024', $output);
+	}
+
+	// ================================================================================
+	// Helpers
+	// ================================================================================
+
+	private static function allFormats(): array
+	{
+		return [
+			TTimeFormat::TimeShort,
+			TTimeFormat::Time,
+			TTimeFormat::TimePrecise,
+			TTimeFormat::Date,
+			TTimeFormat::Month,
+			TTimeFormat::Week,
+			TTimeFormat::YearlessDate,
+			TTimeFormat::Year,
+			TTimeFormat::DateTimeShort,
+			TTimeFormat::DateTime,
+			TTimeFormat::DateTimePrecise,
+			TTimeFormat::HtmlDateTimeShort,
+			TTimeFormat::HtmlDateTime,
+			TTimeFormat::HtmlDateTimePrecise,
+			TTimeFormat::DateTimeShortTimezone,
+			TTimeFormat::DateTimeTimezone,
+			TTimeFormat::DateTimePreciseTimezone,
+			TTimeFormat::HtmlDateTimeShortTimezone,
+			TTimeFormat::HtmlDateTimeTimezone,
+			TTimeFormat::HtmlDateTimePreciseTimezone,
+		];
+	}
+}


### PR DESCRIPTION
TTime — HTML5 <time> element control

Adds TTime and TTimeFormat to render the HTML5 <time> element with a machine-readable datetime attribute and human-readable visible text.

TTimeFormat — 20-constant TEnumerable covering every WHATWG valid datetime value category: time strings, date strings, month, week, yearless date, year, local datetime (space- and T-separated), and global datetime with timezone offset.

TTime — TI18NWebControl that accepts DateTime as a DateTimeInterface, DateInterval, numeric Unix timestamp, or parseable string. The DateTimeFormat property selects the datetime="" attribute encoding. Visible text resolves in priority order:

- TextFormat property — a TTimeFormat name or ICU datetime pattern.
- Child content interpreted as a TTimeFormat name or ICU pattern; falls back to rendering children as-is.
- DateTimeFormat value formatted as human-readable text.

Negative DateInterval values are rendered with a "-" prefix in visible text (HTML5 has no negative duration form; the datetime attribute stays positive).

TIntlDateFormatterTrait — extended getIntlDateFormatter() with an optional $pattern parameter and a fourth cache level, enabling pattern-keyed formatter reuse across TTime, TSimpleDateFormatter, and TDateFormat.

Other: two error codes added to messages.txt; framework/classes.php updated; 120 unit tests in TTimeTest and TTimeFormatTest.