### PR TITLE
Use sha1 - btw sha1 was deprecated in 2022 by NIST, still much better than md5

### DIFF
--- a/framework/Caching/TMemoryCache.php
+++ b/framework/Caching/TMemoryCache.php
@@ -88,7 +88,7 @@ use Prado\TPropertyValue;
  * ## Key hashing
  *
  * By default ({@see getHashKeys HashKeys}`= null`), cache keys are hashed with
- * MD5 in production modes ({@see TApplicationMode::Normal},
+ * SHA-1 in production modes ({@see TApplicationMode::Normal},
  * {@see TApplicationMode::Performance}) and left readable in
  * {@see TApplicationMode::Debug} mode, matching the typical developer workflow.
  * Set `HashKeys="true"` to force hashing in all modes, or `HashKeys="false"` to
@@ -547,7 +547,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 * Converts a raw application cache key into the internal storage key.
 	 *
 	 * When hashing is enabled (per {@see getHashKeys HashKeys}), delegates to
-	 * {@see TCache::generateUniqueKey()} which returns `md5(prefix . key)`.
+	 * {@see TCache::generateUniqueKey()} which returns `sha1(prefix . key)`.
 	 * When disabled, returns `prefix . key` verbatim for human-readable store keys.
 	 *
 	 * @param string $key the raw application key
@@ -799,7 +799,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	/**
 	 * Computes a fingerprint of the current in-memory key set.
 	 *
-	 * The fingerprint is an MD5 hash of the null-separated sorted internal keys.
+	 * The fingerprint is a SHA-1 hash of the null-separated sorted internal keys.
 	 * It changes whenever a key is added or removed, allowing {@see validateSizeCache()}
 	 * to detect backing-store reloads and other out-of-band modifications.
 	 *
@@ -809,7 +809,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	{
 		$keys = array_keys($this->getStoreDirect());
 		sort($keys);
-		return md5(implode("\0", $keys));
+		return sha1(implode("\0", $keys));
 	}
 
 	/**
@@ -1062,7 +1062,7 @@ class TMemoryCache extends TSerializingCache implements IModuleDependency, ICach
 	 *
 	 * - `null` *(default)* — automatic: off in {@see TApplicationMode::Debug},
 	 *   on in {@see TApplicationMode::Normal} and {@see TApplicationMode::Performance}.
-	 * - `true` — always hash (MD5 via {@see TCache::generateUniqueKey()}).
+	 * - `true` — always hash (SHA-1 via {@see TCache::generateUniqueKey()}).
 	 * - `false` — never hash; the raw key (with prefix) is used as-is.
 	 *
 	 * @return ?bool the current HashKeys setting

--- a/framework/Data/ActiveRecord/TActiveRecord.php
+++ b/framework/Data/ActiveRecord/TActiveRecord.php
@@ -125,8 +125,8 @@ use Prado\Util\Traits\TReflectionClassTrait;
  *      {
  *          //parent method should be called to raise the event
  *          parent::OnInsert($param);
- *          $this->nounce = md5(time());
- *          $this->password = md5($this->password.$this->nounce);
+ *          $this->nounce = sha1(time());
+ *          $this->password = sha1($this->password . $this->nounce);
  *      }
  * }
  * ```

--- a/framework/Security/TAuthManager.php
+++ b/framework/Security/TAuthManager.php
@@ -296,7 +296,7 @@ class TAuthManager extends \Prado\TModule
 	 */
 	protected function generateUserKey()
 	{
-		return md5($this->getApplication()->getUniqueID() . 'prado:user');
+		return sha1($this->getApplication()->getUniqueID() . 'prado:user');
 	}
 
 	/**

--- a/framework/Security/TUserManager.php
+++ b/framework/Security/TUserManager.php
@@ -89,7 +89,7 @@ class TUserManager extends \Prado\TModule implements IUserManager
 	/**
 	 * @var TUserManagerPasswordMode password mode
 	 */
-	private $_passwordMode = TUserManagerPasswordMode::MD5;
+	private $_passwordMode = TUserManagerPasswordMode::SHA1;
 	/**
 	 * @var bool whether the module has been initialized
 	 */
@@ -330,7 +330,7 @@ class TUserManager extends \Prado\TModule implements IUserManager
 			$data = unserialize($data);
 			if (is_array($data) && count($data) === 2) {
 				[$username, $token] = $data;
-				if (isset($this->_users[$username]) && $token === md5($username . $this->_users[$username])) {
+				if (isset($this->_users[$username]) && $token === sha1($username . $this->_users[$username])) {
 					return $this->getUser($username);
 				}
 			}
@@ -348,7 +348,7 @@ class TUserManager extends \Prado\TModule implements IUserManager
 		$user = $this->getApplication()->getUser();
 		$username = strtolower($user->getName());
 		if (isset($this->_users[$username])) {
-			$data = [$username, md5($username . $this->_users[$username])];
+			$data = [$username, sha1($username . $this->_users[$username])];
 			$cookie->setValue(serialize($data));
 		}
 	}

--- a/framework/Shell/TShellApplication.php
+++ b/framework/Shell/TShellApplication.php
@@ -296,7 +296,7 @@ class TShellApplication extends \Prado\TApplication
 
 		// Level 2: stable temp directory keyed by the real base path.
 		$runtimePath = sys_get_temp_dir()
-			. DIRECTORY_SEPARATOR . 'prado-' . md5($basePath)
+			. DIRECTORY_SEPARATOR . 'prado-' . sha1($basePath)
 			. DIRECTORY_SEPARATOR . static::SHELL_RUNTIME_PATH;
 		if (!is_dir($runtimePath)) {
 			if (@mkdir($runtimePath, Prado::getDefaultDirPermissions(), true) === false) {

--- a/framework/TApplication.php
+++ b/framework/TApplication.php
@@ -1041,11 +1041,10 @@ class TApplication extends TComponent implements ISingleton
 	 * @param string $token the value to hash; normally the absolute runtime path.
 	 * @return string a unique ID derived from the token.
 	 * @since 4.3.3
-	 * @todo v4.4 change md5 to sha1
 	 */
 	protected function generateAppUniqueId(string $token): string
 	{
-		return md5($token);
+		return sha1($token);
 	}
 
 	/**

--- a/framework/Util/Cron/TCronModule.php
+++ b/framework/Util/Cron/TCronModule.php
@@ -237,7 +237,7 @@ class TCronModule extends \Prado\TModule implements IPermissions
 			if (!($properties[self::NAME_KEY] ?? null)) {
 				$class = $properties[self::TASK_KEY] ?? '';
 				$schedule = $properties[self::SCHEDULE_KEY] ?? '';
-				$name = $properties[self::NAME_KEY] = substr(md5($schedule . $class), 0, 7);
+				$name = $properties[self::NAME_KEY] = substr(sha1($schedule . $class), 0, 7);
 			} else {
 				$name = $properties[self::NAME_KEY];
 			}

--- a/framework/Web/TAssetManager.php
+++ b/framework/Web/TAssetManager.php
@@ -893,7 +893,7 @@ class TAssetManager extends \Prado\TModule
 			$normalized[$key] = is_object($value) ? 'object#' . spl_object_id($value) : $value;
 		}
 		ksort($normalized);
-		return $path . '#' . md5(serialize($normalized));
+		return $path . '#' . sha1(serialize($normalized));
 	}
 
 	/**
@@ -1020,7 +1020,7 @@ class TAssetManager extends \Prado\TModule
 
 	/**
 	 * Generates the asset sub-directory name for a path. CRC32 produces a much
-	 * smaller string than MD5 at the cost of a higher collision rate.
+	 * smaller string than MD5/SHA1 at the cost of a higher collision rate.
 	 * When a {@see setHashCallback HashCallback} is set, it produces the name
 	 * instead. Otherwise a file path is reduced to its directory, the framework
 	 * version is mixed in so an upgrade republishes, and {@see setLinkAssets

--- a/framework/Web/UI/TTemplate.php
+++ b/framework/Web/UI/TTemplate.php
@@ -154,7 +154,7 @@ class TTemplate extends \Prado\TApplicationComponent implements ITemplate
 		$this->_tplFile = $tplFile;
 		$this->_startingLine = $startingLine;
 		$this->_content = $template;
-		$this->_hashCode = md5($template);
+		$this->_hashCode = sha1($template);
 		parent::__construct();
 		$this->parse($template);
 		$this->_content = null; // reset to save memory

--- a/tests/unit/Security/TAuthManagerTest.php
+++ b/tests/unit/Security/TAuthManagerTest.php
@@ -615,8 +615,8 @@ class TAuthManagerTest extends PHPUnit\Framework\TestCase
 		$authManager = new TAuthManager();
 		$authManager->setUserManager('users');
 		$authManager->init(null);
-		$md5 = md5($authManager->getApplication()->getUniqueID() . 'prado:user');
-		self::assertEquals($md5, $authManager->getUserKey());
+		$sha1 = sha1($authManager->getApplication()->getUniqueID() . 'prado:user');
+		self::assertEquals($sha1, $authManager->getUserKey());
 	}
 
 	public function testUpdateSessionUser()

--- a/tests/unit/TApplicationTest.php
+++ b/tests/unit/TApplicationTest.php
@@ -222,11 +222,11 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 		$this->assertNotEmpty($uid);
 	}
 
-	public function testGetUniqueId_isMd5HashFormat(): void
+	public function testGetUniqueId_IsSha1HashFormat(): void
 	{
 		$uid = $this->_app->getUniqueID();
-		// md5 produces a 32-character hex string
-		$this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $uid);
+		// sha1 produces a 40-character hex string
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{40}$/', $uid);
 	}
 
 	public function testGetUniqueId_changesWhenRuntimePathChanges(): void
@@ -313,7 +313,7 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 
 		$this->_app->setRuntimePath($originalPath . '/variant');
 		$this->assertNotSame($originalUid, $this->_app->getUniqueID());
-		$this->assertSame(md5($originalPath . '/variant'), $this->_app->getUniqueID());
+		$this->assertSame(sha1($originalPath . '/variant'), $this->_app->getUniqueID());
 	}
 
 	public function testSetRuntimePath_updatesCacheFileWhenOneIsSet(): void
@@ -2027,11 +2027,11 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 	// generateAppUniqueId()
 	// -----------------------------------------------------------------------
 
-	public function testGenerateAppUniqueId_returnsMd5Format(): void
+	public function testGenerateAppUniqueId_returnsSha1Format(): void
 	{
 		$acc = $this->newAccessor();
 		$id  = $acc->pubGenerateAppUniqueId('/some/path');
-		$this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $id);
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{40}$/', $id);
 	}
 
 	public function testGenerateAppUniqueId_samTokenSameResult(): void
@@ -2052,11 +2052,11 @@ class TApplicationTest extends PHPUnit\Framework\TestCase
 		);
 	}
 
-	public function testGenerateAppUniqueId_matchesMd5OfToken(): void
+	public function testGenerateAppUniqueId_matchesSha1OfToken(): void
 	{
 		$acc   = $this->newAccessor();
 		$token = '/runtime/abc';
-		$this->assertSame(md5($token), $acc->pubGenerateAppUniqueId($token));
+		$this->assertSame(sha1($token), $acc->pubGenerateAppUniqueId($token));
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/Util/Cron/TCronModuleTest.php
+++ b/tests/unit/Util/Cron/TCronModuleTest.php
@@ -183,8 +183,8 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			
 			self::assertNotNull($tasks);
 			self::assertEquals(5, count($tasks));
-			self::assertEquals('0 * * * *', $tasks['277f1f7']['schedule']);
-			self::assertEquals('TTestCronModuleTask', $tasks['277f1f7']['task']);
+			self::assertEquals('0 * * * *', $tasks['8a7106b']['schedule']);
+			self::assertEquals('TTestCronModuleTask', $tasks['8a7106b']['task']);
 			self::assertEquals('1 * * * *', $tasks['testTask1']['schedule']);
 			self::assertEquals('TTestCronModuleTask1', $tasks['testTask1']['task']);
 			self::assertEquals('value1', $tasks['testTask1']['propertya']);
@@ -220,8 +220,8 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			
 			self::assertNotNull($tasks);
 			self::assertEquals(5, count($tasks));
-			self::assertEquals('0 * * * *', $tasks['277f1f7']['schedule']);
-			self::assertEquals('TTestCronModuleTask', $tasks['277f1f7']['task']);
+			self::assertEquals('0 * * * *', $tasks['8a7106b']['schedule']);
+			self::assertEquals('TTestCronModuleTask', $tasks['8a7106b']['task']);
 			self::assertEquals('1 * * * *', $tasks['testTask1']['schedule']);
 			self::assertEquals('TTestCronModuleTask1', $tasks['testTask1']['task']);
 			self::assertEquals('value1', $tasks['testTask1']['propertya']);
@@ -248,8 +248,8 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			
 			self::assertNotNull($tasks);
 			self::assertEquals(5, count($tasks));
-			self::assertEquals('0 * * * *', $tasks['277f1f7']['schedule']);
-			self::assertEquals('TTestCronModuleTask', $tasks['277f1f7']['task']);
+			self::assertEquals('0 * * * *', $tasks['8a7106b']['schedule']);
+			self::assertEquals('TTestCronModuleTask', $tasks['8a7106b']['task']);
 			self::assertEquals('1 * * * *', $tasks['testTask1']['schedule']);
 			self::assertEquals('TTestCronModuleTask1', $tasks['testTask1']['task']);
 			self::assertEquals('value1', $tasks['testTask1']['propertya']);
@@ -277,8 +277,8 @@ class TCronModuleTest extends PHPUnit\Framework\TestCase
 			
 			self::assertNotNull($tasks);
 			self::assertEquals(5, count($tasks));
-			self::assertEquals('0 * * * *', $tasks['277f1f7']['schedule']);
-			self::assertEquals('TTestCronModuleTask', $tasks['277f1f7']['task']);
+			self::assertEquals('0 * * * *', $tasks['8a7106b']['schedule']);
+			self::assertEquals('TTestCronModuleTask', $tasks['8a7106b']['task']);
 			self::assertEquals('1 * * * *', $tasks['testTask1']['schedule']);
 			self::assertEquals('TTestCronModuleTask1', $tasks['testTask1']['task']);
 			self::assertEquals('value1', $tasks['testTask1']['propertya']);

--- a/tests/unit/Web/UI/TTemplateInstantiateInTest.php
+++ b/tests/unit/Web/UI/TTemplateInstantiateInTest.php
@@ -254,7 +254,7 @@ class TTemplateInstantiateInTest extends PHPUnit\Framework\TestCase
 			'_startingLine' => 0,
 			'_content' => $template,
 			'_attributevalidation' => false,
-			'_hashCode' => md5($template),
+			'_hashCode' => sha1($template),
 		];
 		foreach ($props as $name => $val) {
 			PradoUnit::setProp($tplObj, $name, $val);
@@ -1540,8 +1540,8 @@ class TTemplateInstantiateInTest extends PHPUnit\Framework\TestCase
 		// TOutputCache has setCacheKeyPrefix() but no getter; read via reflection.
 		$prefix = PradoUnit::getProp($cache, '_keyPrefix');
 		$this->assertNotEmpty($prefix);
-		// TTemplate sets the prefix to $this->_hashCode . $tplKey; hashCode = md5 of the template string.
-		$this->assertStringStartsWith(md5($templateStr), $prefix);
+		// TTemplate sets the prefix to $this->_hashCode . $tplKey; hashCode = sha1 of the template string.
+		$this->assertStringStartsWith(sha1($templateStr), $prefix);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/unit/Web/UI/TTemplateTest.php
+++ b/tests/unit/Web/UI/TTemplateTest.php
@@ -56,7 +56,7 @@ class TTemplateTest extends PHPUnit\Framework\TestCase
 			'_startingLine' => 0,
 			'_content' => $template,
 			'_attributevalidation' => false,
-			'_hashCode' => md5($template),
+			'_hashCode' => sha1($template),
 		];
 		foreach ($props as $name => $val) {
 			PradoUnit::setProp($tplObj, $name, $val);
@@ -102,7 +102,7 @@ class TTemplateTest extends PHPUnit\Framework\TestCase
 
 	public function testGetHashCode()
 	{
-		$this->assertEquals(md5('hello'), $this->newTemplate('hello')->getHashCode());
+		$this->assertEquals(sha1('hello'), $this->newTemplate('hello')->getHashCode());
 	}
 
 	public function testAttributeValidation()


### PR DESCRIPTION
https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html

This may take an unreasonable amount of time to "hack" a website using sha1 today. but in 5 years?   sha1 will be a problem.

https://csrc.nist.gov/news/2022/nist-transitioning-away-from-sha-1-for-all-apps
