### PR TITLE
Rest Client Update and Hardening

### DIFF
--- a/framework/Exceptions/messages/messages.txt
+++ b/framework/Exceptions/messages/messages.txt
@@ -353,6 +353,9 @@ csmanager_invalid_packages				= Unkownn packages '{1}' for javascript packages d
 httpclient_transport_error				= HTTP client transport error (code {0}): {1}
 httpclient_http_error						= HTTP error response with status {0}.
 
+restclient_invalid_header				= TRestClient header '{0}' has an invalid name or a value containing CR/LF.
+restclient_basicauth_username_colon		= TRestClient Basic-auth username must not contain a colon (RFC 7617 credential separator).
+
 contentplaceholder_id_required			= TContentPlaceHolder must have an ID.
 
 content_id_required						= TContent must have an ID.

--- a/framework/IO/HttpClient/THttpClient.php
+++ b/framework/IO/HttpClient/THttpClient.php
@@ -263,6 +263,12 @@ abstract class THttpClient extends TApplicationComponent
 	/**
 	 * Flattens an associative header map into the `Name: value` lines that
 	 * both cURL and stream contexts expect.
+	 *
+	 * CR and LF characters are stripped from every name and value as a
+	 * last-resort guard against header injection / request splitting, so a
+	 * splittable header cannot reach the wire even if a caller bypasses
+	 * higher-level validation.
+	 *
 	 * @param array<string,string> $headers Header map.
 	 * @return string[] Flat list of `Name: value` strings.
 	 */
@@ -270,7 +276,7 @@ abstract class THttpClient extends TApplicationComponent
 	{
 		$out = [];
 		foreach ($headers as $name => $value) {
-			$out[] = $name . ': ' . $value;
+			$out[] = str_replace(["\r", "\n"], '', $name . ': ' . $value);
 		}
 		return $out;
 	}

--- a/framework/IO/Rest/TRestClient.php
+++ b/framework/IO/Rest/TRestClient.php
@@ -10,6 +10,7 @@
 
 namespace Prado\IO\Rest;
 
+use Prado\Exceptions\TInvalidDataValueException;
 use Prado\IO\HttpClient\THttpClientException;
 use Prado\IO\HttpClient\THttpClientResponse;
 use Prado\IO\HttpClient\THttpClient;
@@ -265,6 +266,11 @@ abstract class TRestClient extends TApplicationComponent
 	 * ignored. `$query` is appended as a URL-encoded query string built by
 	 * {@see buildQuery()}.
 	 *
+	 * `$path` is treated as a trusted template owned by the subclass. Only the
+	 * placeholder values may be untrusted; they are URL-encoded. Do not build
+	 * `$path` itself from untrusted input, as it is joined to the base URL
+	 * without origin validation.
+	 *
 	 * @param string $path Path pattern.
 	 * @param array<string,scalar> $pathParams Placeholder values.
 	 * @param array<string,array|scalar> $query Query string parameters.
@@ -283,9 +289,10 @@ abstract class TRestClient extends TApplicationComponent
 
 		$url = rtrim($this->getBaseUrl(), '/') . '/' . ltrim((string) $expanded, '/');
 
-		if ($query !== []) {
+		$queryString = $this->buildQuery($query);
+		if ($queryString !== '') {
 			$separator = str_contains($url, '?') ? '&' : '?';
-			$url .= $separator . $this->buildQuery($query);
+			$url .= $separator . $queryString;
 		}
 
 		return $url;
@@ -300,6 +307,9 @@ abstract class TRestClient extends TApplicationComponent
 	 * `http_build_query()` unchanged. Override this method when an API needs
 	 * a different array convention.
 	 *
+	 * A `null` value and an empty list produce no output. Empty fragments are
+	 * skipped so the result never contains a dangling or doubled `&`.
+	 *
 	 * @param array<string,array|scalar> $query Query string parameters.
 	 * @return string URL-encoded query string without a leading `?`.
 	 */
@@ -307,12 +317,12 @@ abstract class TRestClient extends TApplicationComponent
 	{
 		$parts = [];
 		foreach ($query as $key => $value) {
-			if (is_array($value) && array_is_list($value)) {
-				foreach ($value as $item) {
-					$parts[] = http_build_query([$key => $item]);
+			$items = (is_array($value) && array_is_list($value)) ? $value : [$value];
+			foreach ($items as $item) {
+				$fragment = http_build_query([$key => $item]);
+				if ($fragment !== '') {
+					$parts[] = $fragment;
 				}
-			} else {
-				$parts[] = http_build_query([$key => $value]);
 			}
 		}
 		return implode('&', $parts);
@@ -320,12 +330,41 @@ abstract class TRestClient extends TApplicationComponent
 
 	/**
 	 * Merges default headers with per-call headers; per-call entries win.
+	 *
+	 * Each per-call name and value is validated by {@see assertHeaderSafe()} so
+	 * that a CR/LF in a caller-supplied header cannot inject or split the request.
+	 *
 	 * @param array<string,string> $perCall Per-call header map.
+	 * @throws TInvalidDataValueException when a per-call header name or value
+	 *   contains a CR/LF or the name is not a valid token.
 	 * @return array<string,string> Effective header map.
 	 */
 	protected function mergeHeaders(array $perCall): array
 	{
+		foreach ($perCall as $name => $value) {
+			$this->assertHeaderSafe((string) $name, (string) $value);
+		}
 		return array_merge($this->getDefaultHeaders(), $perCall);
+	}
+
+	/**
+	 * Validates that a header name and value are free of header-injection
+	 * characters.
+	 *
+	 * Rejects any value containing a carriage return or line feed, and any name
+	 * that is empty or contains a character outside the RFC 7230 `token`
+	 * grammar. Centralizes the boundary check so the client never forwards a
+	 * splittable header to the transport.
+	 *
+	 * @param string $name Header name.
+	 * @param string $value Header value.
+	 * @throws TInvalidDataValueException when the name or value is unsafe.
+	 */
+	protected function assertHeaderSafe(string $name, string $value): void
+	{
+		if ($name === '' || preg_match('/[^!#$%&\'*+\-.^_`|~0-9A-Za-z]/', $name) || preg_match('/[\r\n]/', $value)) {
+			throw new TInvalidDataValueException('restclient_invalid_header', $name);
+		}
 	}
 
 	/**
@@ -357,9 +396,11 @@ abstract class TRestClient extends TApplicationComponent
 	}
 
 	/**
+	 * Returns whether a header is present in the map, comparing names
+	 * case-insensitively.
 	 * @param array<string,string> $headers Header map.
 	 * @param string $name Header to look for (case-insensitive).
-	 * @return bool
+	 * @return bool Whether a header with that name exists.
 	 */
 	protected function hasHeaderCaseInsensitive(array $headers, string $name): bool
 	{
@@ -468,7 +509,7 @@ abstract class TRestClient extends TApplicationComponent
 
 	/**
 	 * Returns the active downloader, creating a default one on first access.
-	 * @return THttpClient
+	 * @return THttpClient The transport instance used for requests.
 	 */
 	public function getDownloader(): THttpClient
 	{
@@ -507,11 +548,17 @@ abstract class TRestClient extends TApplicationComponent
 
 	/**
 	 * Adds or overwrites a single default header.
+	 *
+	 * The name and value are validated by {@see assertHeaderSafe()} to prevent
+	 * header injection.
+	 *
 	 * @param string $name Header name.
 	 * @param string $value Header value.
+	 * @throws TInvalidDataValueException when the name or value is unsafe.
 	 */
 	public function setDefaultHeader(string $name, string $value): void
 	{
+		$this->assertHeaderSafe($name, $value);
 		$headers = $this->getDefaultHeadersDirect();
 		$headers[$name] = $value;
 		$this->setDefaultHeadersDirect($headers);
@@ -519,7 +566,13 @@ abstract class TRestClient extends TApplicationComponent
 
 	/**
 	 * Sets the default `Authorization` header to an OAuth2-style bearer token.
+	 *
+	 * The header is a default, so it is sent to whatever host {@see buildUrl()}
+	 * resolves for every request. Use one client instance per API origin so a
+	 * token is not disclosed to an unintended host.
+	 *
 	 * @param string $token Bearer token, without the `Bearer ` prefix.
+	 * @throws TInvalidDataValueException when the token contains a CR/LF.
 	 */
 	public function setBearerToken(string $token): void
 	{
@@ -528,11 +581,21 @@ abstract class TRestClient extends TApplicationComponent
 
 	/**
 	 * Sets the default `Authorization` header to HTTP Basic credentials.
-	 * @param string $username User name.
+	 *
+	 * The username must not contain a colon, which RFC 7617 reserves as the
+	 * credential separator. Like {@see setBearerToken()}, the resulting header
+	 * is sent to every host the client targets.
+	 *
+	 * @param string $username User name (must not contain `:`).
 	 * @param string $password Password.
+	 * @throws TInvalidDataValueException when the username contains a colon, or
+	 *   a credential contains a CR/LF.
 	 */
 	public function setBasicAuth(string $username, string $password): void
 	{
+		if (str_contains($username, ':')) {
+			throw new TInvalidDataValueException('restclient_basicauth_username_colon');
+		}
 		$this->setDefaultHeader(THttpHeaderName::Authorization, 'Basic ' . base64_encode($username . ':' . $password));
 	}
 }

--- a/framework/Web/THttpResponse.php
+++ b/framework/Web/THttpResponse.php
@@ -94,15 +94,16 @@ class THttpResponse extends \Prado\TModule implements \Prado\IO\ITextWriter
 	public const DEFAULT_CHARSET = 'UTF-8';
 
 	/**
-	 * @var array<int, string> The status codes defined in RFC 2616
-	 * @see http://www.faqs.org/rfcs/rfc2616
+	 * @var array<int, string> The HTTP status codes and their reason phrases,
+	 *   per the IANA HTTP Status Code Registry (RFC 9110 and related).
+	 * @see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 	 */
 	private static $HTTP_STATUS_CODES = [
-		100 => 'Continue', 101 => 'Switching Protocols',
-		200 => 'OK', 201 => 'Created', 202 => 'Accepted', 203 => 'Non-Authoritative Information', 204 => 'No Content', 205 => 'Reset Content', 206 => 'Partial Content',
-		300 => 'Multiple Choices', 301 => 'Moved Permanently', 302 => 'Found', 303 => 'See Other', 304 => 'Not Modified', 305 => 'Use Proxy', 307 => 'Temporary Redirect',
-		400 => 'Bad Request', 401 => 'Unauthorized', 402 => 'Payment Required', 403 => 'Forbidden', 404 => 'Not Found', 405 => 'Method Not Allowed', 406 => 'Not Acceptable', 407 => 'Proxy Authentication Required', 408 => 'Request Time-out', 409 => 'Conflict', 410 => 'Gone', 411 => 'Length Required', 412 => 'Precondition Failed', 413 => 'Request Entity Too Large', 414 => 'Request-URI Too Large', 415 => 'Unsupported Media Type', 416 => 'Requested range not satisfiable', 417 => 'Expectation Failed',
-		500 => 'Internal Server Error', 501 => 'Not Implemented', 502 => 'Bad Gateway', 503 => 'Service Unavailable', 504 => 'Gateway Time-out', 505 => 'HTTP Version not supported',
+		100 => 'Continue', 101 => 'Switching Protocols', 102 => 'Processing', 103 => 'Early Hints',
+		200 => 'OK', 201 => 'Created', 202 => 'Accepted', 203 => 'Non-Authoritative Information', 204 => 'No Content', 205 => 'Reset Content', 206 => 'Partial Content', 207 => 'Multi-Status', 208 => 'Already Reported', 226 => 'IM Used',
+		300 => 'Multiple Choices', 301 => 'Moved Permanently', 302 => 'Found', 303 => 'See Other', 304 => 'Not Modified', 305 => 'Use Proxy', 307 => 'Temporary Redirect', 308 => 'Permanent Redirect',
+		400 => 'Bad Request', 401 => 'Unauthorized', 402 => 'Payment Required', 403 => 'Forbidden', 404 => 'Not Found', 405 => 'Method Not Allowed', 406 => 'Not Acceptable', 407 => 'Proxy Authentication Required', 408 => 'Request Time-out', 409 => 'Conflict', 410 => 'Gone', 411 => 'Length Required', 412 => 'Precondition Failed', 413 => 'Request Entity Too Large', 414 => 'Request-URI Too Large', 415 => 'Unsupported Media Type', 416 => 'Requested range not satisfiable', 417 => 'Expectation Failed', 421 => 'Misdirected Request', 422 => 'Unprocessable Entity', 423 => 'Locked', 424 => 'Failed Dependency', 425 => 'Too Early', 426 => 'Upgrade Required', 428 => 'Precondition Required', 429 => 'Too Many Requests', 431 => 'Request Header Fields Too Large', 451 => 'Unavailable For Legal Reasons',
+		500 => 'Internal Server Error', 501 => 'Not Implemented', 502 => 'Bad Gateway', 503 => 'Service Unavailable', 504 => 'Gateway Time-out', 505 => 'HTTP Version not supported', 506 => 'Variant Also Negotiates', 507 => 'Insufficient Storage', 508 => 'Loop Detected', 510 => 'Not Extended', 511 => 'Network Authentication Required',
 	];
 
 	/**

--- a/tests/unit/IO/HttpClient/THttpClientTest.php
+++ b/tests/unit/IO/HttpClient/THttpClientTest.php
@@ -107,6 +107,47 @@ class THttpClientTest extends PHPUnit\Framework\TestCase
 		$this->assertSame([], $this->client->exposeFormatHeaderLines([]));
 	}
 
+	public function testFormatHeaderLinesStripsCrlfFromValues(): void
+	{
+		// A request-splitting payload in a value collapses onto one line with the CR/LF removed.
+		$lines = $this->client->exposeFormatHeaderLines([
+			'Content-Type' => "application/json\r\nX-Injected: evil",
+		]);
+		$this->assertSame(['Content-Type: application/jsonX-Injected: evil'], $lines);
+	}
+
+	public function testFormatHeaderLinesStripsCrlfFromNames(): void
+	{
+		$lines = $this->client->exposeFormatHeaderLines([
+			"X-Test\r\nX-Injected" => 'value',
+		]);
+		$this->assertSame(['X-TestX-Injected: value'], $lines);
+	}
+
+	public function testFormatHeaderLinesStripsBareCrAndLf(): void
+	{
+		$lines = $this->client->exposeFormatHeaderLines([
+			'A' => "1\r2",   // a bare carriage return
+			'B' => "3\n4",   // a bare line feed
+		]);
+		$this->assertSame(['A: 12', 'B: 34'], $lines);
+	}
+
+	public function testFormatHeaderLinesNeverEmitsCrOrLf(): void
+	{
+		// No produced line may carry a CR or LF, so a second header cannot reach the wire.
+		$lines = $this->client->exposeFormatHeaderLines([
+			'Set-Cookie' => "a=1\r\nSet-Cookie: b=2",
+			"Bad\nName" => "x\ry",
+			'Normal' => 'ok',
+		]);
+		$this->assertCount(3, $lines, 'The split attempt does not add a header line.');
+		foreach ($lines as $line) {
+			$this->assertDoesNotMatchRegularExpression('/[\r\n]/', $line, 'A flattened header line must not contain CR or LF.');
+		}
+		$this->assertContains('Set-Cookie: a=1Set-Cookie: b=2', $lines, 'The injected header folds into the original line.');
+	}
+
 	// ── Property accessors ────────────────────────────────────────────────────
 
 	public function testTimeoutAccessor(): void

--- a/tests/unit/IO/Rest/TRestClientTest.php
+++ b/tests/unit/IO/Rest/TRestClientTest.php
@@ -76,6 +76,28 @@ class TestApiClient extends TRestClient
 	{
 		return $this->buildUrl($path, $params, $query);
 	}
+
+	public function exposeBuildQuery(array $query): string
+	{
+		return $this->buildQuery($query);
+	}
+
+	/** @return array{0: ?string, 1: array} [rawBody, augmentedHeaders] */
+	public function exposeEncodeBody(mixed $body, array $headers = []): array
+	{
+		$raw = $this->encodeBody($body, $headers);
+		return [$raw, $headers];
+	}
+
+	public function exposeHandleResponse(THttpClientResponse $response): mixed
+	{
+		return $this->handleResponse($response);
+	}
+
+	public function exposeMergeHeaders(array $perCall): array
+	{
+		return $this->mergeHeaders($perCall);
+	}
 }
 
 /**
@@ -128,8 +150,7 @@ class TRestClientTest extends PHPUnit\Framework\TestCase
 	public function testBuildUrlAppendsQueryWithExistingQueryString(): void
 	{
 		$url = $this->client->exposeBuildUrl('search?lang=en', [], ['q' => 'x']);
-		$this->assertStringContainsString('?lang=en', $url);
-		$this->assertStringContainsString('&q=x', $url);
+		$this->assertSame('https://api.example.test/search?lang=en&q=x', $url);
 	}
 
 	// ── Verb dispatch ─────────────────────────────────────────────────────────
@@ -378,5 +399,262 @@ class TRestClientTest extends PHPUnit\Framework\TestCase
 		$c->setDefaultHeaders(['Accept' => 'application/json']);
 		$c->setDefaultHeaders(['User-Agent' => 'Test/1.0']);
 		$this->assertSame(['User-Agent' => 'Test/1.0'], $c->getDefaultHeaders());
+	}
+
+	public function testSetDefaultHeaderAddsWithoutDroppingPrior(): void
+	{
+		$c = new TestApiClient();
+		$c->setDefaultHeader('Accept', 'application/json');
+		$c->setDefaultHeader('User-Agent', 'Test/1.0');
+		$this->assertSame(['Accept' => 'application/json', 'User-Agent' => 'Test/1.0'], $c->getDefaultHeaders());
+	}
+
+	public function testSetDownloaderInjectsAndGetterReturnsSameInstance(): void
+	{
+		$c = new TestApiClient();
+		$mock = new MockHttpClient();
+		$c->setDownloader($mock);
+		$this->assertSame($mock, $c->getDownloader());
+	}
+
+	// ── buildQuery edge cases ──────────────────────────────────────────────────
+
+	public function testBuildQueryEmptyMapReturnsEmptyString(): void
+	{
+		$this->assertSame('', $this->client->exposeBuildQuery([]));
+	}
+
+	public function testBuildQueryNullValueIsOmittedWithNoDanglingSeparator(): void
+	{
+		// A null scalar produces no fragment; the surviving keys must not be
+		// separated by a doubled or trailing '&'.
+		$this->assertSame('a=1&b=2', $this->client->exposeBuildQuery(['a' => 1, 'x' => null, 'b' => 2]));
+		$this->assertSame('', $this->client->exposeBuildQuery(['x' => null]));
+	}
+
+	public function testBuildQueryEmptyListIsOmitted(): void
+	{
+		$this->assertSame('keep=1', $this->client->exposeBuildQuery(['tags' => [], 'keep' => 1]));
+	}
+
+	public function testBuildQueryBooleanValuesEncodeAsOneAndZero(): void
+	{
+		$this->assertSame('active=1&inactive=0', $this->client->exposeBuildQuery(['active' => true, 'inactive' => false]));
+	}
+
+	public function testBuildQueryNestedListEmitsRepeatedKeys(): void
+	{
+		$this->assertSame('id=1&id=2&id=3', $this->client->exposeBuildQuery(['id' => [1, 2, 3]]));
+	}
+
+	public function testBuildUrlWithEmptyQueryAppendsNothing(): void
+	{
+		$this->assertSame('https://api.example.test/search', $this->client->exposeBuildUrl('search', [], []));
+		// A query whose only value is null must not append a bare '?'.
+		$this->assertSame('https://api.example.test/search', $this->client->exposeBuildUrl('search', [], ['x' => null]));
+	}
+
+	// ── buildUrl base-URL joining edge cases ───────────────────────────────────
+
+	public function testBuildUrlJoinsBaseWithoutTrailingSlash(): void
+	{
+		$c = new TestApiClient();
+		$c->setBaseUrl('https://h.test/api');
+		$this->assertSame('https://h.test/api/users', $c->exposeBuildUrl('users'));
+	}
+
+	public function testBuildUrlWithEmptyBaseProducesRootRelative(): void
+	{
+		$c = new TestApiClient();
+		$c->setBaseUrl('');
+		$this->assertSame('/users', $c->exposeBuildUrl('users'));
+	}
+
+	public function testBuildUrlWithEmptyPathYieldsBaseRoot(): void
+	{
+		$this->assertSame('https://api.example.test/', $this->client->exposeBuildUrl(''));
+	}
+
+	public function testBuildUrlWithLeadingSlashPathDoesNotDoubleSlash(): void
+	{
+		$this->assertSame('https://api.example.test/users', $this->client->exposeBuildUrl('/users'));
+	}
+
+	// ── buildUrl placeholder edge cases ────────────────────────────────────────
+
+	public function testBuildUrlPlaceholderZeroAndEmptyString(): void
+	{
+		$this->assertSame('https://api.example.test/users/0', $this->client->exposeBuildUrl('users/{id}', ['id' => 0]));
+		$this->assertSame('https://api.example.test/users/', $this->client->exposeBuildUrl('users/{id}', ['id' => '']));
+	}
+
+	public function testBuildUrlPlaceholderNullLeavesTokenIntact(): void
+	{
+		// isset() is false for null, so an explicit null does NOT substitute.
+		$this->assertSame('https://api.example.test/users/{id}', $this->client->exposeBuildUrl('users/{id}', ['id' => null]));
+	}
+
+	public function testBuildUrlDuplicatePlaceholderSubstitutesBoth(): void
+	{
+		$this->assertSame(
+			'https://api.example.test/a/7/b/7',
+			$this->client->exposeBuildUrl('a/{id}/b/{id}', ['id' => 7])
+		);
+	}
+
+	public function testBuildUrlMultibytePlaceholderIsEncoded(): void
+	{
+		$this->assertSame(
+			'https://api.example.test/u/caf%C3%A9',
+			$this->client->exposeBuildUrl('u/{name}', ['name' => 'café'])
+		);
+	}
+
+	// ── encodeBody edge cases ──────────────────────────────────────────────────
+
+	public function testEncodeBodyNullReturnsNullAndAddsNoContentType(): void
+	{
+		[$raw, $headers] = $this->client->exposeEncodeBody(null);
+		$this->assertNull($raw);
+		$this->assertArrayNotHasKey('Content-Type', $headers);
+	}
+
+	public function testEncodeBodyEmptyStringPassesThrough(): void
+	{
+		[$raw, $headers] = $this->client->exposeEncodeBody('');
+		$this->assertSame('', $raw);
+		$this->assertArrayNotHasKey('Content-Type', $headers);
+	}
+
+	public function testEncodeBodyEmptyArrayEncodesAsJsonObjectOrArray(): void
+	{
+		[$raw, $headers] = $this->client->exposeEncodeBody([]);
+		$this->assertSame('[]', $raw);
+		$this->assertSame('application/json', $headers['Content-Type']);
+	}
+
+	public function testEncodeBodyUppercaseExistingContentTypeIsNotOverwritten(): void
+	{
+		[$raw, $headers] = $this->client->exposeEncodeBody(['a' => 1], ['CONTENT-TYPE' => 'application/xml']);
+		$this->assertSame('{"a":1}', $raw);
+		$this->assertSame('application/xml', $headers['CONTENT-TYPE']);
+		$this->assertArrayNotHasKey('Content-Type', $headers);
+	}
+
+	// ── handleResponse edge cases ──────────────────────────────────────────────
+
+	public function testHandleResponseLiteralJsonNullDecodesToNull(): void
+	{
+		// A body of the four bytes "null" is valid JSON and must decode to null,
+		// not be mistaken for the raw-string fallback.
+		$this->assertNull($this->client->exposeHandleResponse(new THttpClientResponse(200, [], 'null')));
+	}
+
+	public function testHandleResponseScalarJsonBodiesDecode(): void
+	{
+		$this->assertFalse($this->client->exposeHandleResponse(new THttpClientResponse(200, [], 'false')));
+		$this->assertSame(0, $this->client->exposeHandleResponse(new THttpClientResponse(200, [], '0')));
+		$this->assertSame(42, $this->client->exposeHandleResponse(new THttpClientResponse(200, [], '42')));
+	}
+
+	public function testHandleResponseEmptyBodyReturnsNull(): void
+	{
+		$this->assertNull($this->client->exposeHandleResponse(new THttpClientResponse(204, [], '')));
+	}
+
+	public function testHandleResponseSuccessBoundary299Decodes(): void
+	{
+		$this->assertSame(['ok' => true], $this->client->exposeHandleResponse(new THttpClientResponse(299, [], '{"ok":true}')));
+	}
+
+	public function testHandleResponse300ThrowsAsError(): void
+	{
+		$this->expectException(THttpClientException::class);
+		$this->client->exposeHandleResponse(new THttpClientResponse(300, [], 'redirect'));
+	}
+
+	// ── mergeHeaders ────────────────────────────────────────────────────────────
+
+	public function testMergeHeadersPerCallWinsAndDefaultsSurvive(): void
+	{
+		$this->client->setDefaultHeader('Accept', 'application/json');
+		$this->client->setDefaultHeader('X-Keep', 'yes');
+		$merged = $this->client->exposeMergeHeaders(['Accept' => 'text/plain']);
+		$this->assertSame('text/plain', $merged['Accept']);
+		$this->assertSame('yes', $merged['X-Keep']);
+	}
+
+	// ── Header injection guards (HIGH) ─────────────────────────────────────────
+
+	public function testSetDefaultHeaderRejectsCrlfInValue(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		$this->client->setDefaultHeader('X-Test', "ok\r\nX-Injected: evil");
+	}
+
+	public function testSetDefaultHeaderRejectsInvalidName(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		$this->client->setDefaultHeader("Bad Name", 'value');
+	}
+
+	public function testPerCallHeaderWithCrlfIsRejected(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		$this->client->get('users', [], [], ['X-Evil' => "a\r\nHost: evil"]);
+	}
+
+	public function testSetBearerTokenRejectsCrlf(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		$this->client->setBearerToken("tok\r\nX-Injected: 1");
+	}
+
+	public function testSetBasicAuthRejectsColonInUsername(): void
+	{
+		$this->expectException(\Prado\Exceptions\TInvalidDataValueException::class);
+		$this->client->setBasicAuth('al:ice', 'pw');
+	}
+
+	public function testSetBasicAuthEmptyCredentialsEncode(): void
+	{
+		$this->client->setBasicAuth('', '');
+		$this->downloader->queue(new THttpClientResponse(200, [], '{}'));
+		$this->client->fetchUser('1');
+		$this->assertSame('Basic ' . base64_encode(':'), $this->downloader->calls[0]['headers']['Authorization']);
+	}
+
+	public function testBearerThenBasicAuthLastOneWins(): void
+	{
+		$this->client->setBearerToken('tok');
+		$this->client->setBasicAuth('u', 'p');
+		$this->downloader->queue(new THttpClientResponse(200, [], '{}'));
+		$this->client->fetchUser('1');
+		$this->assertSame('Basic ' . base64_encode('u:p'), $this->downloader->calls[0]['headers']['Authorization']);
+	}
+
+	// ── requestRaw default-argument paths ──────────────────────────────────────
+
+	public function testRequestRawMinimalArgsMergesDefaultsNoBody(): void
+	{
+		$this->client->setDefaultHeader('Accept', 'application/json');
+		$this->downloader->queue(new THttpClientResponse(200, [], '{}'));
+		$this->client->requestRaw('GET', 'ping');
+		$call = $this->downloader->calls[0];
+		$this->assertSame('https://api.example.test/ping', $call['url']);
+		$this->assertNull($call['body']);
+		$this->assertSame('application/json', $call['headers']['Accept']);
+	}
+
+	// ── Verb helpers carry both pathParams and body+query ──────────────────────
+
+	public function testPutCarriesPathParamsBodyAndQuery(): void
+	{
+		$this->downloader->queue(new THttpClientResponse(200, [], '{}'));
+		$this->client->put('users/{id}', ['id' => '5'], ['name' => 'Z'], ['notify' => 1]);
+		$call = $this->downloader->calls[0];
+		$this->assertSame('PUT', $call['method']);
+		$this->assertSame('https://api.example.test/users/5?notify=1', $call['url']);
+		$this->assertSame('{"name":"Z"}', $call['body']);
 	}
 }

--- a/tests/unit/Web/THttpResponseTest.php
+++ b/tests/unit/Web/THttpResponseTest.php
@@ -136,6 +136,20 @@ class THttpResponseTest extends PHPUnit\Framework\TestCase
 		ob_end_flush();
 	}
 
+	public function testSetStatusCodeAcceptsModernCodesWithoutReason()
+	{
+		// Regression: 422 and 429 (and other IANA codes) must be known so that
+		// setStatusCode() supplies their reason phrase instead of throwing when
+		// no explicit reason is given (the path TRestService error responses use).
+		$response = new TTestHttpResponse();
+		$response->init(null);
+		foreach ([422, 429, 451, 428, 431, 507, 511] as $code) {
+			$response->setStatusCode($code);
+			self::assertEquals($code, $response->getStatusCode());
+		}
+		ob_end_flush();
+	}
+
 	public function testGetCookies()
 	{
 		$response = new TTestHttpResponse();


### PR DESCRIPTION
THttpClient::formatHeaderLines - remove \r and \n from outgoing headers because they are automatically added.
TRestClient - General Hardening
THttpResponse - adds Status Codes for Rest