### PR TITLE
Adds composer.json extra.branch-alias of "dev-master" from "4.4.x-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,11 @@
 		"ext-zlib" : "Enables compression to reduce page size",
 		"pradosoft/prado-demos" : "Demo applications for Prado"
 	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "4.4.x-dev"
+		}
+	},
     "autoload": {
         "psr-4": {
             "Prado\\": "framework"

--- a/framework/Prado.php
+++ b/framework/Prado.php
@@ -109,7 +109,7 @@ class Prado
 	 */
 	public static function getVersion(): string
 	{
-		return '4.3.3';
+		return '4.4.0';
 	}
 
 	/**

--- a/framework/Web/Javascripts/source/prado/prado.js
+++ b/framework/Web/Javascripts/source/prado/prado.js
@@ -99,7 +99,7 @@ var Prado =
 	 * Version of Prado clientscripts
 	 * @var Version
 	 */
-	Version: '4.3.3',
+	Version: '4.4.0',
 
 	/**
 	 * Registry for Prado components

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://www.phpdoc.org"
 >
-    <title>Prado 4.3.3 API Manual</title>
+    <title>Prado 4.4.0 API Manual</title>
     <paths>
         <output>build/docs</output>
         <cache>build/cache</cache>


### PR DESCRIPTION
The branch alias "4.4.x-dev" allows plugins to require `"pradosoft/prado": "^4.4"` rather than the union of `"^4.4 || dev-master"`

```json
{
"require-dev": { "pradosoft/prado": "^4.4" },
"minimum-stability": "dev",
"prefer-stable": true
}
```

`minimum-stability` still needs to be dev when the minor version is not yet released. It can be removed after.
`prefer-stable` as `true` will relink prado when v4.4.0 is tagged.  It can stay regardless of `minimum-stability`.

For the full write up, see issue #1242.