### PR TITLE
Added TEventParameter::stopped property and TComponent::raisedEvent update

### DIFF
--- a/framework/IEventStoppableParameter.php
+++ b/framework/IEventStoppableParameter.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * IEventStoppableParameter interface.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @link https://github.com/pradosoft/prado
+ * @license https://github.com/pradosoft/prado/blob/master/LICENSE
+ */
+
+namespace Prado;
+
+/**
+ * IEventStoppableParameter interface.
+ *
+ * Extends {@see IEventParameter} to let an event handler halt the remaining
+ * handlers of a {@see TComponent::raiseEvent} call. After a handler stops the
+ * parameter with {@see stopImmediatePropagation}, {@see TComponent::raiseEvent} finishes
+ * the current handler and then skips every handler still queued. Handlers that
+ * already ran, and the post-processing of their responses, are unaffected.
+ *
+ * The behavior matches the DOM `stopImmediatePropagation()`: because a Prado
+ * event dispatches to a flat list of handlers rather than a bubbling tree,
+ * stopping propagation stops the remaining handlers in that list. This is
+ * distinct from the control-tree bubbling of {@see TControl::raiseBubbleEvent};
+ * it does not affect that chain.
+ *
+ * @author Brad Anderson <belisoful@icloud.com>
+ * @since 4.4.0
+ * @see TComponent::raiseEvent
+ * @see TEventParameter
+ */
+interface IEventStoppableParameter extends IEventParameter
+{
+	/**
+	 * @return bool whether propagation to the remaining event handlers is stopped.
+	 */
+	public function getStopped(): bool;
+
+	/**
+	 * Stops propagation to the remaining event handlers. The current handler
+	 * still completes; handlers still queued for this event are skipped.
+	 */
+	public function stopImmediatePropagation(): void;
+}

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1743,6 +1743,11 @@ class TComponent
 	 * {@see \Prado\IEventCycleParameter::postRaiseEvent} are called for pre- and
 	 * post-processing of the event lifecycle.
 	 *
+	 * If `$param` implements {@see \Prado\IEventStoppableParameter} and a handler
+	 * stops it (via {@see \Prado\IEventStoppableParameter::stopImmediatePropagation}), the
+	 * current handler completes and the remaining handlers are skipped. Response
+	 * post-processing still runs on the handlers that already ran.
+	 *
 	 * @param string $name the event name
 	 * @param mixed $sender the event sender object
 	 * @param \Prado\TEventParameter $param the event parameter
@@ -1843,6 +1848,10 @@ class TComponent
 					$responses[] = ['sender' => $sender, 'param' => $param, 'response' => $response];
 				} else {
 					$responses[] = $response;
+				}
+
+				if ((($param instanceof TComponent && $param->isa(IEventStoppableParameter::class)) || $param instanceof IEventStoppableParameter) && $param->getStopped()) {
+					break;
 				}
 
 				if ($response !== null && ($responsetype & TEventResults::EVENT_RESULT_FEED_FORWARD)) {

--- a/framework/TComponent.php
+++ b/framework/TComponent.php
@@ -1746,7 +1746,9 @@ class TComponent
 	 * If `$param` implements {@see \Prado\IEventStoppableParameter} and a handler
 	 * stops it (via {@see \Prado\IEventStoppableParameter::stopImmediatePropagation}), the
 	 * current handler completes and the remaining handlers are skipped. Response
-	 * post-processing still runs on the handlers that already ran.
+	 * post-processing still runs on the handlers that already ran. Under
+	 * {@see TEventResults::EVENT_RESULT_FEED_FORWARD}, the stop is read from the
+	 * forwarded value that becomes the current `$param`, not the original parameter.
 	 *
 	 * @param string $name the event name
 	 * @param mixed $sender the event sender object
@@ -1793,6 +1795,7 @@ class TComponent
 			if ($responsetype & TEventResults::EVENT_REVERSE) {
 				$handlerArray = array_reverse($handlerArray);
 			}
+			$stoppable = $param instanceof IEventStoppableParameter;
 			foreach ($handlerArray as $handler) {
 				$this->callBehaviorsMethod('dyIntraRaiseEventTestHandler', $return, $handler, $sender, $param, $name);
 				if ($return === false) {
@@ -1850,12 +1853,14 @@ class TComponent
 					$responses[] = $response;
 				}
 
-				if ((($param instanceof TComponent && $param->isa(IEventStoppableParameter::class)) || $param instanceof IEventStoppableParameter) && $param->getStopped()) {
-					break;
-				}
-
 				if ($response !== null && ($responsetype & TEventResults::EVENT_RESULT_FEED_FORWARD)) {
 					$param = $response;
+					// The forwarded value becomes the current parameter, so re-validate.
+					$stoppable = $param instanceof IEventStoppableParameter;
+				}
+
+				if ($stoppable && $param->getStopped()) {
+					break;
 				}
 			}
 		} elseif (strncasecmp($name, 'on', 2) === 0 && !$this->hasEvent($name)) {

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -41,6 +41,12 @@ use Prado\Exceptions\TInvalidOperationException;
  * {@see offsetUnset} — will throw a {@see \Prado\Exceptions\TInvalidOperationException}.
  * Reads are always permitted regardless of ReadOnly state.
  *
+ * As an {@see IEventStoppableParameter}, a handler can call {@see stopImmediatePropagation}
+ * (or set the {@see setStopped Stopped} property) to halt the remaining event handlers of
+ * a {@see TComponent::raiseEvent} call. The stop flag is control flow rather than
+ * parameter data, so it is settable even when ReadOnly is true, and it resets to false
+ * at the start of each raise via {@see setEventName}.
+ *
  * Subclasses may implement {@see IEventCycleParameter} to participate in the event raising
  * process via {@see IEventCycleParameter::preRaiseEvent} and
  * {@see IEventCycleParameter::postRaiseEvent} lifecycle hooks.
@@ -49,11 +55,12 @@ use Prado\Exceptions\TInvalidOperationException;
  * @author Brad Anderson <belisoful@icloud.com> ArrayAccess, ParameterChanged, Event Life Cycle
  * @since 3.0
  */
-class TEventParameter extends \Prado\TComponent implements IEventParameter, ArrayAccess
+class TEventParameter extends \Prado\TComponent implements IEventParameter, IEventStoppableParameter, ArrayAccess
 {
 	private string $_eventName = '';
 	private mixed $_param = null;
 	private bool $_parameterChanged = false;
+	private bool $_stopped = false;
 	private ?bool $_readOnly = null;
 
 	/**
@@ -90,6 +97,7 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	{
 		$this->_eventName = $value;
 		$this->resetParameterChanged();
+		$this->_stopped = false;
 	}
 
 	/**
@@ -142,6 +150,40 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, Arra
 	public function resetParameterChanged()
 	{
 		$this->_parameterChanged = false;
+	}
+
+	/**
+	 * @return bool whether propagation to the remaining event handlers is stopped.
+	 * @since 4.4.0
+	 */
+	public function getStopped(): bool
+	{
+		return $this->_stopped;
+	}
+
+	/**
+	 * Sets whether propagation to the remaining event handlers is stopped.
+	 * This flag is control flow, not parameter data, so it is settable regardless
+	 * of the {@see getReadOnly ReadOnly} state. It is reset to false at the start
+	 * of each {@see TComponent::raiseEvent} through {@see setEventName}.
+	 * @param bool $value whether to stop propagation to the remaining handlers.
+	 * @since 4.4.0
+	 */
+	public function setStopped(bool $value)
+	{
+		$this->_stopped = $value;
+	}
+
+	/**
+	 * Stops propagation to the remaining event handlers. The handler that calls
+	 * this still completes; handlers still queued for the event are skipped by
+	 * {@see TComponent::raiseEvent}. Equivalent to setting {@see setStopped Stopped}
+	 * to true.
+	 * @since 4.4.0
+	 */
+	public function stopImmediatePropagation(): void
+	{
+		$this->setStopped(true);
 	}
 
 	/**

--- a/framework/TEventParameter.php
+++ b/framework/TEventParameter.php
@@ -87,17 +87,28 @@ class TEventParameter extends \Prado\TComponent implements IEventParameter, IEve
 	}
 
 	/**
-	 * Setting the Event Name also resets the ParameterChanged back to false.
-	 * This method is called by {@see TComponent::raiseEvent} to set the EventName
-	 * before the event handlers are processed.
+	 * Setting the Event Name also resets the per-raise event properties through
+	 * {@see resetEventProperties}. This method is called by {@see TComponent::raiseEvent}
+	 * to set the EventName before the event handlers are processed.
 	 * @param string $value name of the event
 	 * @since 4.3.0
 	 */
 	public function setEventName(string $value)
 	{
 		$this->_eventName = $value;
+		$this->resetEventProperties();
+	}
+
+	/**
+	 * Resets the per-raise event properties to their defaults at the start of each
+	 * {@see TComponent::raiseEvent}: {@see resetParameterChanged ParameterChanged} back
+	 * to false and {@see setStopped Stopped} back to false.
+	 * @since 4.4.0
+	 */
+	public function resetEventProperties()
+	{
 		$this->resetParameterChanged();
-		$this->_stopped = false;
+		$this->setStopped(false);
 	}
 
 	/**

--- a/framework/classes.php
+++ b/framework/classes.php
@@ -263,6 +263,7 @@ return [
 'IEnumerable' => 'Prado\IEnumerable',
 'IEventCycleParameter' => 'Prado\IEventCycleParameter',
 'IEventParameter' => 'Prado\IEventParameter',
+'IEventStoppableParameter' => 'Prado\IEventStoppableParameter',
 'IModule' => 'Prado\IModule',
 'IModuleDependency' => 'Prado\IModuleDependency',
 'TBinaryStreamBehavior' => 'Prado\IO\Behaviors\TBinaryStreamBehavior',

--- a/tests/unit/TComponentRaiseEventTest.php
+++ b/tests/unit/TComponentRaiseEventTest.php
@@ -299,6 +299,111 @@ class TComponentRaiseEventTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals(2, $count);
 	}
 
+	public function testRaiseEventFeedForwardStopReadsForwardedValue()
+	{
+		$component = new NewComponent();
+		$order = [];
+
+		// This forwarded parameter is already stopped; setEventName only resets the
+		// original parameter, so the forwarded value keeps its stopped flag.
+		$forwarded = new \Prado\TEventParameter();
+		$forwarded->setStopped(true);
+
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order, $forwarded) {
+			$order[] = 1;
+			return $forwarded;
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 2;
+		});
+
+		$param = new \Prado\TEventParameter();
+		$component->raiseEvent('OnMyEvent', $this, $param, TEventResults::EVENT_RESULT_FEED_FORWARD);
+
+		// The stop is read from the forwarded value (the current $param), not the
+		// original parameter, so the second handler is skipped.
+		$this->assertEquals([1], $order);
+		$this->assertFalse($param->getStopped());
+		$this->assertTrue($forwarded->getStopped());
+	}
+
+	public function testRaiseEventFeedForwardHandlerStopsForwardedParam()
+	{
+		$component = new NewComponent();
+		$order = [];
+
+		// Each handler returns the parameter it received, so the same stoppable
+		// object is fed forward through the chain.
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 1;
+			return $param;
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 2;
+			$param->stopImmediatePropagation();
+			return $param;
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 3;
+			return $param;
+		});
+
+		$param = new \Prado\TEventParameter();
+		$component->raiseEvent('OnMyEvent', $this, $param, TEventResults::EVENT_RESULT_FEED_FORWARD);
+
+		$this->assertEquals([1, 2], $order);
+		$this->assertTrue($param->getStopped());
+	}
+
+	public function testRaiseEventFeedForwardScalarResponseDoesNotStop()
+	{
+		$component = new NewComponent();
+		$count = 0;
+
+		// A scalar forwarded value has no stop flag, so the chain runs to the end.
+		$component->attachEventHandler('OnMyEvent', function () use (&$count) {
+			$count++;
+			return 'r1';
+		});
+		$component->attachEventHandler('OnMyEvent', function () use (&$count) {
+			$count++;
+			return 'r2';
+		});
+
+		$param = new \Prado\TEventParameter();
+		$component->raiseEvent('OnMyEvent', $this, $param, TEventResults::EVENT_RESULT_FEED_FORWARD);
+		$this->assertEquals(2, $count);
+	}
+
+	public function testRaiseEventStopWithResultAllResponseType()
+	{
+		$component = new NewComponent();
+		$order = [];
+
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 1;
+			return 'r1';
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 2;
+			$param->stopImmediatePropagation();
+			return 'r2';
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 3;
+			return 'r3';
+		});
+
+		$param = new \Prado\TEventParameter();
+		$responses = $component->raiseEvent('OnMyEvent', $this, $param, TEventResults::EVENT_RESULT_ALL);
+
+		// EVENT_RESULT_ALL records a per-handler structure; only the two that ran appear.
+		$this->assertEquals([1, 2], $order);
+		$this->assertCount(2, $responses);
+		$this->assertEquals('r1', $responses[0]['response']);
+		$this->assertEquals('r2', $responses[1]['response']);
+	}
+
 	public function testGlobalEventListenerInRaiseEvent()
 	{
 		//TODO Test the Global Event Listener

--- a/tests/unit/TComponentRaiseEventTest.php
+++ b/tests/unit/TComponentRaiseEventTest.php
@@ -212,6 +212,93 @@ class TComponentRaiseEventTest extends PHPUnit\Framework\TestCase
 		return $param * 4;
 	}
 
+	public function testRaiseEventStopPropagationSkipsRemainingHandlers()
+	{
+		$component = new NewComponent();
+		$order = [];
+
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 1;
+			return 'r1';
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 2;
+			$param->stopImmediatePropagation();
+			return 'r2';
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 3;
+			return 'r3';
+		});
+
+		$param = new \Prado\TEventParameter();
+		$responses = $component->raiseEvent('OnMyEvent', $this, $param);
+
+		// The third handler is skipped once the second stops propagation.
+		$this->assertEquals([1, 2], $order);
+		$this->assertEquals(['r1', 'r2'], $responses);
+		$this->assertTrue($param->getStopped());
+	}
+
+	public function testRaiseEventStopResetsForEachRaise()
+	{
+		$component = new NewComponent();
+		$count = 0;
+		$component->attachEventHandler('OnMyEvent', function () use (&$count) {
+			$count++;
+		});
+		$component->attachEventHandler('OnMyEvent', function () use (&$count) {
+			$count++;
+		});
+
+		$param = new \Prado\TEventParameter();
+		// A stale stop flag must not carry into a fresh raise; setEventName clears it.
+		$param->setStopped(true);
+		$component->raiseEvent('OnMyEvent', $this, $param);
+
+		$this->assertEquals(2, $count);
+		$this->assertFalse($param->getStopped());
+	}
+
+	public function testRaiseEventStopPropagationHonorsReverseOrder()
+	{
+		$component = new NewComponent();
+		$order = [];
+
+		$component->attachEventHandler('OnMyEvent', function () use (&$order) {
+			$order[] = 1;
+		});
+		$component->attachEventHandler('OnMyEvent', function ($sender, $param) use (&$order) {
+			$order[] = 2;
+			$param->stopImmediatePropagation();
+		});
+		$component->attachEventHandler('OnMyEvent', function () use (&$order) {
+			$order[] = 3;
+		});
+
+		$param = new \Prado\TEventParameter();
+		$component->raiseEvent('OnMyEvent', $this, $param, TEventResults::EVENT_REVERSE);
+
+		// Reversed order is 3, 2, 1; handler 2 stops before handler 1 runs.
+		$this->assertEquals([3, 2], $order);
+	}
+
+	public function testRaiseEventNonStoppableParameterRunsAllHandlers()
+	{
+		$component = new NewComponent();
+		$count = 0;
+		$component->attachEventHandler('OnMyEvent', function () use (&$count) {
+			$count++;
+		});
+		$component->attachEventHandler('OnMyEvent', function () use (&$count) {
+			$count++;
+		});
+
+		// A null (non-stoppable) parameter is unaffected by the stop mechanism.
+		$component->raiseEvent('OnMyEvent', $this, null);
+		$this->assertEquals(2, $count);
+	}
+
 	public function testGlobalEventListenerInRaiseEvent()
 	{
 		//TODO Test the Global Event Listener

--- a/tests/unit/TEventParameterTest.php
+++ b/tests/unit/TEventParameterTest.php
@@ -883,4 +883,58 @@ class TEventParameterTest extends TestCase
 		$this->expectException(\Prado\Exceptions\TInvalidOperationException::class);
 		$param->offsetUnset('key');
 	}
+
+	// ================================================================================
+	// Stopped / stopImmediatePropagation Tests
+	// ================================================================================
+
+	public function testStoppedDefaultIsFalse()
+	{
+		$param = new TEventParameter();
+		$this->assertFalse($param->getStopped());
+	}
+
+	public function testImplementsIEventStoppableParameter()
+	{
+		$param = new TEventParameter();
+		$this->assertInstanceOf(\Prado\IEventStoppableParameter::class, $param);
+	}
+
+	public function testSetStopped()
+	{
+		$param = new TEventParameter();
+		$param->setStopped(true);
+		$this->assertTrue($param->getStopped());
+		$param->setStopped(false);
+		$this->assertFalse($param->getStopped());
+	}
+
+	public function testStopPropagationSetsStopped()
+	{
+		$param = new TEventParameter();
+		$param->stopImmediatePropagation();
+		$this->assertTrue($param->getStopped());
+	}
+
+	public function testSetEventNameResetsStopped()
+	{
+		$param = new TEventParameter();
+		$param->stopImmediatePropagation();
+		$this->assertTrue($param->getStopped());
+		// raiseEvent sets the event name at the start of each raise.
+		$param->setEventName('OnSomething');
+		$this->assertFalse($param->getStopped());
+	}
+
+	public function testSetStoppedIsNotGatedByReadOnly()
+	{
+		// A read-only parameter forbids data mutation but still allows stopping,
+		// which is control flow rather than parameter data.
+		$param = $this->makeExposed('value', true);
+		$this->assertTrue($param->getReadOnly());
+		$param->stopImmediatePropagation();
+		$this->assertTrue($param->getStopped());
+		$param->setStopped(false);
+		$this->assertFalse($param->getStopped());
+	}
 }

--- a/tests/unit/TEventParameterTest.php
+++ b/tests/unit/TEventParameterTest.php
@@ -937,4 +937,17 @@ class TEventParameterTest extends TestCase
 		$param->setStopped(false);
 		$this->assertFalse($param->getStopped());
 	}
+
+	public function testResetEventPropertiesResetsChangedAndStopped()
+	{
+		$param = new TEventParameter();
+		$param->setParameterChanged(true);
+		$param->stopImmediatePropagation();
+		$this->assertTrue($param->getParameterChanged());
+		$this->assertTrue($param->getStopped());
+
+		$param->resetEventProperties();
+		$this->assertFalse($param->getParameterChanged());
+		$this->assertFalse($param->getStopped());
+	}
 }


### PR DESCRIPTION
Fixes #1250.

Adds "stopped" property to TEventParameter.
Adds IEventStoppedParameter contract.
Updates TComponent::raiseEvent to break when the Event should be stopped.