### PR TITLE
TCallChain::stopped property and stopImmediatePropagation

### DIFF
--- a/agents/framework/Util/TCallChain.md
+++ b/agents/framework/Util/TCallChain.md
@@ -35,6 +35,8 @@ AOP-style call chain for `dy*` dynamic events. When a `[TComponent](../TComponen
 $chain = new TCallChain('dyMethodName');
 $chain->addCall($callable, $args);  // add a behavior+method pair
 $chain->call($method, $args);       // invoke the chain (usually via magic)
+$chain->setStopped(true);           // end the handler loop from within a behavior
+$chain->stopImmediatePropagation(); // same as setStopped(true)
 ```
 
 The `__call()` on `TCallChain` (via `[IDynamicMethods](IDynamicMethods.md)`) catches any `dy*` method call and routes it to `call()`, enabling the fluent chain syntax.
@@ -70,7 +72,8 @@ public function dyValidate($owner, $value, [TCallChain](TCallChain.md) $chain)
 ## Patterns & Gotchas
 
 - **Return value** — the final value returned from `raiseEvent()` is whatever the last-called behavior returns (or the initial return from the component if no chain handlers ran).
-- **Short-circuit** — returning without calling `$chain` stops propagation. Subsequent behaviors don't run.
+- **Short-circuit (filter)** — returning without calling `$chain` stops *this* branch, but the handler loop still calls the following behaviors so none is left uncalled ("does not act as a parameter filter").
+- **Stop the loop** — a handler calls `$chain->setStopped(true)` (property `Stopped`, bool, default false), or the equivalent `$chain->stopImmediatePropagation()`, to end the handler loop entirely. No further behaviors run, whether or not the handler also calls `$chain`. Once set, `call()` returns immediately.
 - **`TCallChain` extends `[TList](../Collections/TList.md)`** — all standard list operations are available, but the chain is consumed (single-pass iterator).
 - **`[IDynamicMethods](IDynamicMethods.md)` magic** — `__call()` on `TCallChain` catches `dy*` calls; do not confuse with regular method dispatch.
 - **Not reusable** — a `TCallChain` instance is built fresh for each `dy*` event raise.

--- a/framework/Util/TCallChain.php
+++ b/framework/Util/TCallChain.php
@@ -33,6 +33,11 @@ class TCallChain extends TList implements IDynamicMethods
 	private $_method;
 
 	/**
+	 *	@var bool whether the chain has been stopped, ending the handler loop
+	 */
+	private bool $_stopped = false;
+
+	/**
 	 * This initializes the list and the name of the method to be called
 	 *	@param string $method the name of the function call
 	 */
@@ -92,11 +97,14 @@ class TCallChain extends TList implements IDynamicMethods
 	 * When there are no handlers or no handlers left, it returns the first parameter of the
 	 * argument list.
 	 *
+	 * A handler stops the chain by setting {@see setStopped Stopped} to true.  The handler
+	 * loop then ends and no further handlers are called.
+	 *
 	 * @param array $args The parameters to send the function chain.
 	 */
 	public function call(...$args)
 	{
-		if ($this->getCount() === 0) {
+		if ($this->_stopped || $this->getCount() === 0) {
 			return $args[0] ?? null;
 		}
 
@@ -114,11 +122,42 @@ class TCallChain extends TList implements IDynamicMethods
 				}
 				$handler[1][] = $this;
 				$result = call_user_func_array($handler[0], $handler[1]);
-			} while ($this->_iterator->valid());
+			} while (!$this->_stopped && $this->_iterator->valid());
 		} else {
 			$result = $args[0] ?? null;
 		}
 		return $result;
+	}
+
+
+	/**
+	 * @return bool whether the chain has been stopped. Defaults to false.
+	 * @since 4.4.0
+	 */
+	public function getStopped(): bool
+	{
+		return $this->_stopped;
+	}
+
+	/**
+	 * Sets whether the chain is stopped. When set to true from within a handler,
+	 * the handler loop ends and no further handlers in the chain are called.
+	 * @param bool $value whether to stop the chain.
+	 * @since 4.4.0
+	 */
+	public function setStopped(bool $value): void
+	{
+		$this->_stopped = $value;
+	}
+
+	/**
+	 * Stops the chain from within a handler by setting {@see setStopped Stopped} to true.
+	 * The handler loop ends and no further handlers in the chain are called.
+	 * @since 4.4.0
+	 */
+	public function stopImmediatePropagation(): void
+	{
+		$this->setStopped(true);
 	}
 
 

--- a/tests/unit/Util/TCallChainTest.php
+++ b/tests/unit/Util/TCallChainTest.php
@@ -55,6 +55,81 @@ class TCallChainTest extends PHPUnit\Framework\TestCase
 		$this->assertEquals([0, 0, 6, 9], $this->_order[8]);
 	}
 	
+	public function testStopped()
+	{
+		$chain = new TCallChain('dyMyMethod');
+		self::assertFalse($chain->getStopped());
+		$chain->setStopped(true);
+		self::assertTrue($chain->getStopped());
+		$chain->setStopped(false);
+		self::assertFalse($chain->getStopped());
+		$chain->stopImmediatePropagation();
+		self::assertTrue($chain->getStopped());
+	}
+
+	protected $_stopOrder = [];
+	public function testStopChain()
+	{
+		$chain = new TCallChain('dyMyMethod');
+
+		$chain->addCall([$this, 'myTestStopCallback1'], [1]);
+		$chain->addCall([$this, 'myTestStopCallback2'], [2]);
+		$chain->addCall([$this, 'myTestStopCallback3'], [3]);
+		$chain->call(0);
+
+		$this->assertEquals([1, 2], $this->_stopOrder);
+	}
+
+	public function myTestStopCallback1($param1, $callchain)
+	{
+		$this->_stopOrder[] = 1;
+		return $callchain->dyMyMethod($param1);
+	}
+
+	public function myTestStopCallback2($param1, $callchain)
+	{
+		$this->_stopOrder[] = 2;
+		$callchain->stopImmediatePropagation();
+		return $callchain->dyMyMethod($param1);
+	}
+
+	public function myTestStopCallback3($param1, $callchain)
+	{
+		$this->_stopOrder[] = 3;
+		return $callchain->dyMyMethod($param1);
+	}
+
+	protected $_filterOrder = [];
+	public function testStopFilterChain()
+	{
+		$chain = new TCallChain('dyMyMethod');
+
+		$chain->addCall([$this, 'myTestFilterCallback1'], [1]);
+		$chain->addCall([$this, 'myTestFilterCallback2'], [2]);
+		$chain->addCall([$this, 'myTestFilterCallback3'], [3]);
+		$chain->call(0);
+
+		// Handlers do not chain, so the loop would normally call all three; the
+		// second stops it, so the third is never reached.
+		$this->assertEquals([1, 2], $this->_filterOrder);
+	}
+
+	public function myTestFilterCallback1($param1, $callchain)
+	{
+		$this->_filterOrder[] = 1;
+	}
+
+	public function myTestFilterCallback2($param1, $callchain)
+	{
+		$this->_filterOrder[] = 2;
+		$callchain->setStopped(true);
+	}
+
+	public function myTestFilterCallback3($param1, $callchain)
+	{
+		$this->_filterOrder[] = 3;
+	}
+
 	public function myTestCallback1($param1, $param2, $param3, $callchain)
 	{
 		$args = func_get_args();


### PR DESCRIPTION
This allows for the TCallChain to immediately stop the chain propagation.
Fixes #1249