### PR TITLE
IO - TStreamHelper::copyRange - copies a range of bytes from one sourcce (with offset/length) to another (in place)

### DIFF
--- a/framework/IO/Util/TStreamHelper.php
+++ b/framework/IO/Util/TStreamHelper.php
@@ -93,6 +93,45 @@ class TStreamHelper
 	}
 
 	/**
+	 * Copies an exact byte range of a seekable source stream to a destination.  The source is
+	 * seeked to $offset and exactly $length bytes are copied, in {@see CHUNK_SIZE} passes, so a
+	 * payload far larger than memory moves from one stream to another without materializing.  It
+	 * copies an exact count and throws when the source ends before $length bytes are read.
+	 * @param StreamInterface $source The seekable stream to read from.
+	 * @param int $offset The absolute byte offset in the source to start at.
+	 * @param int $length The number of bytes to copy.
+	 * @param StreamInterface $dest The stream to write to.
+	 * @throws \InvalidArgumentException When $length is negative.
+	 * @throws \RuntimeException When the source is not seekable, ends before the range does, or the destination stops accepting bytes.
+	 * @return int The number of bytes copied (equal to $length).
+	 */
+	public static function copyRange(StreamInterface $source, int $offset, int $length, StreamInterface $dest): int
+	{
+		if ($length < 0) {
+			throw new \InvalidArgumentException('copyRange length cannot be negative');
+		}
+		$source->seek($offset);
+		$copied = 0;
+		while ($copied < $length) {
+			$chunk = $source->read(min(static::CHUNK_SIZE, $length - $copied));
+			if ($chunk === '') {
+				throw new \RuntimeException('copyRange source ended after ' . $copied . ' of ' . $length . ' bytes');
+			}
+			$pos = 0;
+			$chunkLength = strlen($chunk);
+			while ($pos < $chunkLength) {
+				$written = $dest->write($pos === 0 ? $chunk : substr($chunk, $pos));
+				if ($written <= 0) {
+					throw new \RuntimeException('copyRange destination stopped accepting bytes at ' . ($copied + $pos));
+				}
+				$pos += $written;
+			}
+			$copied += $chunkLength;
+		}
+		return $copied;
+	}
+
+	/**
 	 * Hashes a stream's contents.  A seekable stream is hashed in full from the beginning and
 	 * its position restored; a non-seekable stream is hashed from its current position.
 	 * @param StreamInterface $stream The stream to hash.

--- a/tests/unit/IO/Util/TStreamHelperTest.php
+++ b/tests/unit/IO/Util/TStreamHelperTest.php
@@ -37,6 +37,64 @@ class TStreamHelperTest extends PHPUnit\Framework\TestCase
 		self::assertSame('', $dst->getContents());
 	}
 
+	// ---- copyRange ------------------------------------------------------------
+
+	public function testCopyRangeCopiesAnExactWindow()
+	{
+		$src = TStream::fromString('HEADER' . 'PAYLOAD' . 'TRAILER');
+		$dst = TStream::fromMemory();
+		self::assertSame(7, TStreamHelper::copyRange($src, 6, 7, $dst));
+		$dst->rewind();
+		self::assertSame('PAYLOAD', $dst->getContents());
+	}
+
+	public function testCopyRangeSpansMultipleChunks()
+	{
+		$payload = random_bytes(3 * TStreamHelper::CHUNK_SIZE + 123);
+		$src = TStream::fromString('..' . $payload . '..');
+		$dst = TStream::fromMemory();
+		self::assertSame(strlen($payload), TStreamHelper::copyRange($src, 2, strlen($payload), $dst));
+		$dst->rewind();
+		self::assertSame($payload, $dst->getContents(), 'Every byte of a many-chunk range arrives in order.');
+	}
+
+	public function testCopyRangeCopiesNothingForAZeroLength()
+	{
+		$src = TStream::fromString('HEADER');
+		$dst = TStream::fromMemory();
+		self::assertSame(0, TStreamHelper::copyRange($src, 3, 0, $dst), 'A zero-length range copies zero bytes.');
+		$dst->rewind();
+		self::assertSame('', $dst->getContents());
+	}
+
+	public function testCopyRangeCopiesToTheSourceEnd()
+	{
+		$src = TStream::fromString('HEADER' . 'PAYLOAD');
+		$dst = TStream::fromMemory();
+		self::assertSame(7, TStreamHelper::copyRange($src, 6, 7, $dst), 'A range ending exactly at end of stream copies without throwing.');
+		$dst->rewind();
+		self::assertSame('PAYLOAD', $dst->getContents());
+	}
+
+	public function testCopyRangeRejectsANegativeLength()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		TStreamHelper::copyRange(TStream::fromString('abc'), 0, -1, TStream::fromMemory());
+	}
+
+	public function testCopyRangeThrowsWhenTheSourceEndsBeforeTheRange()
+	{
+		$this->expectException(\RuntimeException::class);
+		TStreamHelper::copyRange(TStream::fromString('short'), 0, 999, TStream::fromMemory());
+	}
+
+	public function testCopyRangeThrowsOnANonSeekableSource()
+	{
+		$pump = new TPumpStream(fn (int $n): string => str_repeat('x', $n));
+		$this->expectException(\RuntimeException::class);
+		TStreamHelper::copyRange($pump, 4, 4, TStream::fromMemory());
+	}
+
 	public function testHashMatchesNativeAndRestoresPosition()
 	{
 		$data = 'The quick brown fox';


### PR DESCRIPTION
Adds IO TStreamHelper::copyRange
   Copies a range of bytes from one source (with offset/length) to another (in place)